### PR TITLE
Windows installer fix.

### DIFF
--- a/application/src/main/java/org/thingsboard/server/ThingsboardInstallApplication.java
+++ b/application/src/main/java/org/thingsboard/server/ThingsboardInstallApplication.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 public class ThingsboardInstallApplication {
 
     private static final String SPRING_CONFIG_NAME_KEY = "--spring.config.name";
-    private static final String DEFAULT_SPRING_CONFIG_PARAM = SPRING_CONFIG_NAME_KEY + "=" + "thingsboard";
+    private static final String DEFAULT_SPRING_CONFIG_PARAM = SPRING_CONFIG_NAME_KEY + "=" + "conf/thingsboard";
 
     public static void main(String[] args) {
         SpringApplication application = new SpringApplication(ThingsboardInstallApplication.class);


### PR DESCRIPTION
Currently in the Windows installer package there is winsw config file - thingsboard.xml and conf/thingsboard.yaml file. When the ThingsboardInstallApplication is started, it passes DEFAULT_SPRING_CONFIG_PARAM to SpringApplication class. SpringApplication starts to look for the Spring configuration file named 'thingsboard' (with no extension), finds thingsboard.xml and tries to parse it as Spring xml configuration, and fails obviously. 
The fix proposed makes Spring look for configuration in conf/ directory and avoids collision 