### PR TITLE
Fix for error during customer description update

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/customer/CustomerServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/customer/CustomerServiceImpl.java
@@ -154,7 +154,7 @@ public class CustomerServiceImpl extends AbstractEntityService implements Custom
                 protected void validateUpdate(Customer customer) {
                     customerDao.findCustomersByTenantIdAndTitle(customer.getTenantId().getId(), customer.getTitle()).ifPresent(
                             c -> {
-                                if (!c.getId().equals(customer.getUuidId())) {
+                                if (!c.getId().equals(customer.getId())) {
                                     throw new DataValidationException("Customer with such title already exists!");
                                 }
                             }


### PR DESCRIPTION
In version 1.3.0, if we update customer entity description or any other field and do a save, it gives error saying customer title already exists. This fix addresses the issue. 