### PR TITLE
improve: get language from browser

### DIFF
--- a/ui/src/app/app.config.js
+++ b/ui/src/app/app.config.js
@@ -58,14 +58,14 @@ export default function AppConfig($provide,
     addLocaleSpanish(locales);
 
     var $window = angular.injector(['ng']).get('$window');
-    var lang = $window.navigator.language || $window.navigator.userLanguage;
-    if (lang === 'ko') {
+    var lang = ($window.navigator.language || $window.navigator.userLanguage).toLowerCase();
+    if (lang === 'ko' || lang === 'ko_kr') {
         $translateProvider.useSanitizeValueStrategy(null);
         $translateProvider.preferredLanguage('ko_KR');
-    } else if (lang === 'zh') {
+    } else if (lang === 'zh' || lang === 'zh-cn') {
         $translateProvider.useSanitizeValueStrategy(null);
         $translateProvider.preferredLanguage('zh_CN');
-    } else if (lang === 'es') {
+    } else if (lang === 'es' || lang === 'es_es') {
         $translateProvider.useSanitizeValueStrategy(null);
         $translateProvider.preferredLanguage('es_ES');
     }


### PR DESCRIPTION
see [mozilla NavigatorLanguage](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages)

```javascript
<script>
document.write('navigator.language:'+navigator.language);
document.write('<br>navigator.userLanguage:'+navigator.userLanguage);
document.write('<br>navigator.browserLanguage:'+navigator.browserLanguage);
document.write('<br>navigator.systemLanguage:'+navigator.systemLanguage);
</script>
```


  | IE6 IE7 IE8 | Firefox Chrome Safari | Opera
-- | -- | -- | --
navigator.language | undefined | zh-CN | zh-CN
navigator.userLanguage | zh-cn | undefined | zh-cn
navigator.browserLanguage | zh-cn | undefined | zh-cn
navigator.systemLanguage | zh-cn | undefined | undefined
