### PR TITLE
add  "Deny device creation via gateway" option for gateway

### DIFF
--- a/application/src/main/java/org/thingsboard/server/install/ThingsboardInstallService.java
+++ b/application/src/main/java/org/thingsboard/server/install/ThingsboardInstallService.java
@@ -73,20 +73,13 @@ public class ThingsboardInstallService {
 
                         databaseUpgradeService.upgradeDatabase("1.2.3");
 
-                        log.info("Updating system data...");
-
-                        systemDataLoaderService.deleteSystemWidgetBundle("charts");
-                        systemDataLoaderService.deleteSystemWidgetBundle("cards");
-                        systemDataLoaderService.deleteSystemWidgetBundle("maps");
-                        systemDataLoaderService.deleteSystemWidgetBundle("analogue_gauges");
-                        systemDataLoaderService.deleteSystemWidgetBundle("digital_gauges");
-                        systemDataLoaderService.deleteSystemWidgetBundle("gpio_widgets");
-                        systemDataLoaderService.deleteSystemWidgetBundle("alarm_widgets");
-
-                    case "1.3.0":
+                    case "1.3.0":  //NOSONAR, Need to execute gradual upgrade starting from upgradeFromVersion
                         log.info("Upgrading ThingsBoard from version 1.3.0 to 1.3.1 ...");
 
                         databaseUpgradeService.upgradeDatabase("1.3.0");
+
+                    case "1.3.1":
+                        log.info("Upgrading ThingsBoard from version 1.3.1 to 1.4.0 ...");
 
                         log.info("Updating system data...");
 

--- a/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionCtx.java
+++ b/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionCtx.java
@@ -90,11 +90,8 @@ public class GatewaySessionCtx {
         if (!devices.containsKey(deviceName)) {
             Optional<Device> deviceOpt = deviceService.findDeviceByTenantIdAndName(gateway.getTenantId(), deviceName);
             Device device = deviceOpt.orElseGet(() -> {
-                JsonNode infoNode = gateway.getAdditionalInfo();
-                if (infoNode == null)
-                    return null;
-                JsonNode allowCreateDevice = infoNode.get("allow_create_device");
-                if (allowCreateDevice == null || !allowCreateDevice.asBoolean())
+                JsonNode forbidCreateDevice = gateway.getAdditionalInfo().get("forbid_create_device");
+                if (forbidCreateDevice != null && forbidCreateDevice.asBoolean())
                     return null;
                 Device newDevice = new Device();
                 newDevice.setTenantId(gateway.getTenantId());

--- a/ui/src/app/device/device-fieldset.tpl.html
+++ b/ui/src/app/device/device-fieldset.tpl.html
@@ -80,7 +80,7 @@
         </md-input-container>
         <md-input-container class="md-block">
             <md-checkbox ng-hide="loading || !device.additionalInfo.gateway || !(deviceScope === 'tenant')"  ng-disabled="loading || !isEdit" flex aria-label="{{ 'device.is-gateway' | translate }}"
-                         ng-model="device.additionalInfo.allow_create_device">{{ 'device.allow-gateway-create-device' | translate }}
+                         ng-model="device.additionalInfo.forbid_create_device">{{ 'device.forbid-gateway-create-device' | translate }}
             </md-checkbox>
         </md-input-container>
         <md-input-container class="md-block">

--- a/ui/src/app/device/device-fieldset.tpl.html
+++ b/ui/src/app/device/device-fieldset.tpl.html
@@ -79,6 +79,11 @@
             </md-checkbox>
         </md-input-container>
         <md-input-container class="md-block">
+            <md-checkbox ng-hide="loading || !device.additionalInfo.gateway || !(deviceScope === 'tenant')"  ng-disabled="loading || !isEdit" flex aria-label="{{ 'device.is-gateway' | translate }}"
+                         ng-model="device.additionalInfo.allow_create_device">{{ 'device.allow-gateway-create-device' | translate }}
+            </md-checkbox>
+        </md-input-container>
+        <md-input-container class="md-block">
             <label translate>device.description</label>
             <textarea ng-model="device.additionalInfo.description" rows="2"></textarea>
         </md-input-container>

--- a/ui/src/app/device/device-fieldset.tpl.html
+++ b/ui/src/app/device/device-fieldset.tpl.html
@@ -80,7 +80,7 @@
         </md-input-container>
         <md-input-container class="md-block">
             <md-checkbox ng-hide="loading || !device.additionalInfo.gateway || !(deviceScope === 'tenant')"  ng-disabled="loading || !isEdit" flex aria-label="{{ 'device.is-gateway' | translate }}"
-                         ng-model="device.additionalInfo.forbid_create_device">{{ 'device.forbid-gateway-create-device' | translate }}
+                         ng-model="device.additionalInfo.denyDeviceCreation">{{ 'device.deny-device-creation-via-gateway' | translate }}
             </md-checkbox>
         </md-input-container>
         <md-input-container class="md-block">

--- a/ui/src/app/locale/locale.constant-zh.js
+++ b/ui/src/app/locale/locale.constant-zh.js
@@ -609,7 +609,7 @@ export default function addLocaleChinese(locales) {
             "unable-delete-device-alias-title": "无法删除设备别名",
             "unable-delete-device-alias-text": "设备别名 '{{deviceAlias}}' 不能够被删除，因为它被下列部件所使用: <br/> {{widgetsList}}",
             "is-gateway": "网关",
-            "forbid-gateway-create-device": "禁止通过网关创建设备",
+            "deny-device-creation-via-gateway": "禁止通过网关创建设备",
             "public": "公开",
             "device-public": "设备公开",
             "select-device": "选择设备"

--- a/ui/src/app/locale/locale.constant-zh.js
+++ b/ui/src/app/locale/locale.constant-zh.js
@@ -608,7 +608,8 @@ export default function addLocaleChinese(locales) {
             "assignedToCustomer": "分配给客户",
             "unable-delete-device-alias-title": "无法删除设备别名",
             "unable-delete-device-alias-text": "设备别名 '{{deviceAlias}}' 不能够被删除，因为它被下列部件所使用: <br/> {{widgetsList}}",
-            "is-gateway": "是网关",
+            "is-gateway": "网关",
+            "allow-gateway-create-device": "允许网关创建设备",
             "public": "公开",
             "device-public": "设备公开",
             "select-device": "选择设备"

--- a/ui/src/app/locale/locale.constant-zh.js
+++ b/ui/src/app/locale/locale.constant-zh.js
@@ -609,7 +609,7 @@ export default function addLocaleChinese(locales) {
             "unable-delete-device-alias-title": "无法删除设备别名",
             "unable-delete-device-alias-text": "设备别名 '{{deviceAlias}}' 不能够被删除，因为它被下列部件所使用: <br/> {{widgetsList}}",
             "is-gateway": "网关",
-            "allow-gateway-create-device": "允许网关创建设备",
+            "forbid-gateway-create-device": "禁止通过网关创建设备",
             "public": "公开",
             "device-public": "设备公开",
             "select-device": "选择设备"

--- a/ui/src/app/locale/locale.constant.js
+++ b/ui/src/app/locale/locale.constant.js
@@ -615,7 +615,7 @@ export default angular.module('thingsboard.locale', [])
                     "unable-delete-device-alias-title": "Unable to delete device alias",
                     "unable-delete-device-alias-text": "Device alias '{{deviceAlias}}' can't be deleted as it used by the following widget(s):<br/>{{widgetsList}}",
                     "is-gateway": "Is gateway",
-                    "allow-gateway-create-device": "Allow gateway create device",
+                    "forbid-gateway-create-device": "Forbid create device via gateway",
                     "public": "Public",
                     "device-public": "Device is public",
                     "select-device": "Select device"

--- a/ui/src/app/locale/locale.constant.js
+++ b/ui/src/app/locale/locale.constant.js
@@ -615,6 +615,7 @@ export default angular.module('thingsboard.locale', [])
                     "unable-delete-device-alias-title": "Unable to delete device alias",
                     "unable-delete-device-alias-text": "Device alias '{{deviceAlias}}' can't be deleted as it used by the following widget(s):<br/>{{widgetsList}}",
                     "is-gateway": "Is gateway",
+                    "allow-gateway-create-device": "Allow gateway create device",
                     "public": "Public",
                     "device-public": "Device is public",
                     "select-device": "Select device"

--- a/ui/src/app/locale/locale.constant.js
+++ b/ui/src/app/locale/locale.constant.js
@@ -615,7 +615,7 @@ export default angular.module('thingsboard.locale', [])
                     "unable-delete-device-alias-title": "Unable to delete device alias",
                     "unable-delete-device-alias-text": "Device alias '{{deviceAlias}}' can't be deleted as it used by the following widget(s):<br/>{{widgetsList}}",
                     "is-gateway": "Is gateway",
-                    "forbid-gateway-create-device": "Forbid create device via gateway",
+                    "deny-device-creation-via-gateway": "Deny device creation via gateway",
                     "public": "Public",
                     "device-public": "Device is public",
                     "select-device": "Select device"


### PR DESCRIPTION
- gateway can not create device on connect if name not exists when "Deny device creation via gateway" option checked.
- gateway can create device on connect if name not exists for default .
- to define a gateway device, tenant user need to check "is gateway" and "Deny device creation via gateway" option.

<img width="328" alt="wx20171024-110305 2x" src="https://user-images.githubusercontent.com/3170158/31923013-fac5e5f2-b83d-11e7-9362-e28b3ef281b3.png">
