### PR TITLE
If user specifies an interval of 0, convert aggregation to NONE

### DIFF
--- a/extensions-core/src/main/java/org/thingsboard/server/extensions/core/plugin/telemetry/handlers/TelemetryRestMsgHandler.java
+++ b/extensions-core/src/main/java/org/thingsboard/server/extensions/core/plugin/telemetry/handlers/TelemetryRestMsgHandler.java
@@ -133,7 +133,10 @@ public class TelemetryRestMsgHandler extends DefaultRestMsgHandler {
                 msg.getResponseHolder().setResult(new ResponseEntity<>(HttpStatus.BAD_REQUEST));
                 return;
             }
-            Aggregation agg = Aggregation.valueOf(request.getParameter("agg", Aggregation.NONE.name()));
+
+            // If interval is 0, convert this to a NONE aggregation, which is probably what the user really wanted
+            Aggregation agg = (interval.isPresent() && interval.get() == 0) ? Aggregation.valueOf(Aggregation.NONE.name()) :
+                                                                              Aggregation.valueOf(request.getParameter("agg", Aggregation.NONE.name()));
 
             List<TsKvQuery> queries = keys.stream().map(key -> new BaseTsKvQuery(key, startTs.get(), endTs.get(), interval.get(), limit.orElse(TelemetryWebsocketMsgHandler.DEFAULT_LIMIT), agg))
                     .collect(Collectors.toList());


### PR DESCRIPTION
This prevents an endless loop that can hang up the server, and is probably what the user intuitively wanted.