### PR TITLE
UI:fix

### DIFF
--- a/ui/src/scss/animations.scss
+++ b/ui/src/scss/animations.scss
@@ -39,6 +39,6 @@
 @include keyframes(tbMoveToBottomFade) {
   to {
     opacity: 0;
-    @include transform(translate(0, 100%));
+    @include transform(translate(0, 150%));
   }
 }


### PR DESCRIPTION
The buttons ("delete", "scroll to top", "assign to..." ) on the next pages (/widgets, /users, /devices, /assets, /rules, /dashboards) doesn't hide properly, and partly protrude from the bottom (though they remain invisibility) (this allows user to call their tooltips by hovering)