### PR TITLE
Removal of Joda-Time library.

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -126,10 +126,6 @@
             <artifactId>jjwt</artifactId>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity</artifactId>
         </dependency>

--- a/application/src/main/java/org/thingsboard/server/service/security/model/token/JwtTokenFactory.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/model/token/JwtTokenFactory.java
@@ -20,7 +20,6 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.apache.commons.lang3.StringUtils;
-import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.thingsboard.server.common.data.id.CustomerId;
@@ -31,7 +30,9 @@ import org.thingsboard.server.config.JwtSettings;
 import org.thingsboard.server.service.security.model.SecurityUser;
 import org.thingsboard.server.service.security.model.UserPrincipal;
 
-import java.util.Arrays;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -81,13 +82,13 @@ public class JwtTokenFactory {
             claims.put(CUSTOMER_ID, securityUser.getCustomerId().getId().toString());
         }
 
-        DateTime currentTime = new DateTime();
+        ZonedDateTime currentTime = ZonedDateTime.now();
 
         String token = Jwts.builder()
                 .setClaims(claims)
                 .setIssuer(settings.getTokenIssuer())
-                .setIssuedAt(currentTime.toDate())
-                .setExpiration(currentTime.plusSeconds(settings.getTokenExpirationTime()).toDate())
+                .setIssuedAt(Date.from(currentTime.toInstant()))
+                .setExpiration(Date.from(currentTime.plusSeconds(settings.getTokenExpirationTime()).toInstant()))
                 .signWith(SignatureAlgorithm.HS512, settings.getTokenSigningKey())
                 .compact();
 
@@ -129,11 +130,11 @@ public class JwtTokenFactory {
             throw new IllegalArgumentException("Cannot create JWT Token without username/email");
         }
 
-        DateTime currentTime = new DateTime();
+        ZonedDateTime currentTime = ZonedDateTime.now();
 
         UserPrincipal principal = securityUser.getUserPrincipal();
         Claims claims = Jwts.claims().setSubject(principal.getValue());
-        claims.put(SCOPES, Arrays.asList(Authority.REFRESH_TOKEN.name()));
+        claims.put(SCOPES, Collections.singletonList(Authority.REFRESH_TOKEN.name()));
         claims.put(USER_ID, securityUser.getId().getId().toString());
         claims.put(IS_PUBLIC, principal.getType() == UserPrincipal.Type.PUBLIC_ID);
 
@@ -141,8 +142,8 @@ public class JwtTokenFactory {
                 .setClaims(claims)
                 .setIssuer(settings.getTokenIssuer())
                 .setId(UUID.randomUUID().toString())
-                .setIssuedAt(currentTime.toDate())
-                .setExpiration(currentTime.plusSeconds(settings.getRefreshTokenExpTime()).toDate())
+                .setIssuedAt(Date.from(currentTime.toInstant()))
+                .setExpiration(Date.from(currentTime.plusSeconds(settings.getRefreshTokenExpTime()).toInstant()))
                 .signWith(SignatureAlgorithm.HS512, settings.getTokenSigningKey())
                 .compact();
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,7 @@
         <spring.version>4.3.4.RELEASE</spring.version>
         <spring-security.version>4.2.0.RELEASE</spring-security.version>
         <jjwt.version>0.7.0</jjwt.version>
-        <joda-time.version>2.4</joda-time.version>
-        <json-path.version>2.2.0</json-path.version>
+         <json-path.version>2.2.0</json-path.version>
         <junit.version>4.12</junit.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.3</logback.version>
@@ -482,11 +481,6 @@
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt</artifactId>
                 <version>${jjwt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${joda-time.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
From Java SE 8 onwards Joda-Time can be replaced by _java.time_ (JSR-310). 