### PR TITLE
add device online and offline msg which generated from deivce session

### DIFF
--- a/common/message/src/main/java/org/thingsboard/server/common/msg/core/DeviceOfflineMsg.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/core/DeviceOfflineMsg.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright © 2016-2018 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.common.msg.core;
+
+import org.thingsboard.server.common.msg.session.FromDeviceMsg;
+import org.thingsboard.server.common.msg.session.MsgType;
+
+/**
+ * Created by xjz on 3/15/18.
+ */
+public class DeviceOfflineMsg implements FromDeviceMsg {
+    @Override
+    public MsgType getMsgType() {
+        return MsgType.DEVICE_GO_OFFLINE;
+    }
+}

--- a/common/message/src/main/java/org/thingsboard/server/common/msg/core/DeviceOnlineMsg.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/core/DeviceOnlineMsg.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright © 2016-2018 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.common.msg.core;
+
+import org.thingsboard.server.common.msg.session.FromDeviceMsg;
+import org.thingsboard.server.common.msg.session.MsgType;
+
+/**
+ * Created by xjz on 3/15/18.
+ */
+public class DeviceOnlineMsg implements FromDeviceMsg {
+    @Override
+    public MsgType getMsgType() {
+        return MsgType.DEVICE_GO_ONLINE;
+    }
+}

--- a/common/message/src/main/java/org/thingsboard/server/common/msg/session/MsgType.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/session/MsgType.java
@@ -28,7 +28,9 @@ public enum MsgType {
 
     RULE_ENGINE_ERROR,
 
-    SESSION_OPEN, SESSION_CLOSE;
+    SESSION_OPEN, SESSION_CLOSE,
+	
+    DEVICE_GO_ONLINE(true), DEVICE_GO_OFFLINE(true);
 
     private final boolean requiresRulesProcessing;
 


### PR DESCRIPTION
When device goes online or offline,send a msg to rule engine, so that we can do what we want in a plugin.I am not very sure this is the right way, any comments?#642