### PR TITLE
A device created by gateway should be auto assigned to the customer that the gateway is assigned to

### DIFF
--- a/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionCtx.java
+++ b/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionCtx.java
@@ -90,6 +90,7 @@ public class GatewaySessionCtx {
                 device.setTenantId(gateway.getTenantId());
                 device.setName(deviceName);
                 device.setType(deviceType);
+                device.setCustomerId(gateway.getCustomerId());
                 device = deviceService.saveDevice(device);
                 relationService.saveRelationAsync(new EntityRelation(gateway.getId(), device.getId(), "Created"));
                 processor.onDeviceAdded(device);


### PR DESCRIPTION
The device connect to the gateway will be auto created by the thingsboard. If a gateway is assigned to a customer, the auto created device should be auto assigned to the customer too.