### PR TITLE
Changes appeared to be needed while transitioning from v1.3 to v2.0.2.

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/tenant/TenantActor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/tenant/TenantActor.java
@@ -109,15 +109,28 @@ public class TenantActor extends RuleChainManagerActor {
     }
 
     private void onServiceToRuleEngineMsg(ServiceToRuleEngineMsg msg) {
-        ruleChainManager.getRootChainActor().tell(msg, self());
+        try {
+            ruleChainManager.getRootChainActor().tell(msg, self());
+        } catch (Exception e) {
+            logger.error(e, "[{}] Unknown failure", tenantId);            
+        }
+        
     }
 
     private void onDeviceActorToRuleEngineMsg(DeviceActorToRuleEngineMsg msg) {
-        ruleChainManager.getRootChainActor().tell(msg, self());
+        try {
+            ruleChainManager.getRootChainActor().tell(msg, self());
+        } catch (Exception e) {
+            logger.error(e, "[{}] Unknown failure", tenantId);            
+        }
     }
 
     private void onRuleChainMsg(RuleChainToRuleChainMsg msg) {
-        ruleChainManager.getOrCreateActor(context(), msg.getTarget()).tell(msg, self());
+        try {
+            ruleChainManager.getOrCreateActor(context(), msg.getTarget()).tell(msg, self());
+        } catch (Exception e) {
+            logger.error(e, "[{}] Unknown failure", tenantId);                        
+        }
     }
 
 

--- a/application/src/main/java/org/thingsboard/server/controller/DashboardController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/DashboardController.java
@@ -231,16 +231,18 @@ public class DashboardController extends BaseController {
                 for (CustomerId customerId : addedCustomerIds) {
                     savedDashboard = checkNotNull(dashboardService.assignDashboardToCustomer(dashboardId, customerId));
                     ShortCustomerInfo customerInfo = savedDashboard.getAssignedCustomerInfo(customerId);
+                    String customerTitle = (customerInfo == null) ? "Customer with ID " + customerId.toString() : customerInfo.getTitle();
                     logEntityAction(dashboardId, savedDashboard,
                             customerId,
-                            ActionType.ASSIGNED_TO_CUSTOMER, null, strDashboardId, customerId.toString(), customerInfo.getTitle());
+                            ActionType.ASSIGNED_TO_CUSTOMER, null, strDashboardId, customerId.toString(), customerTitle);
                 }
                 for (CustomerId customerId : removedCustomerIds) {
                     ShortCustomerInfo customerInfo = dashboard.getAssignedCustomerInfo(customerId);
                     savedDashboard = checkNotNull(dashboardService.unassignDashboardFromCustomer(dashboardId, customerId));
+                    String customerTitle = (customerInfo == null) ? "Customer with ID " + customerId.toString() : customerInfo.getTitle();
                     logEntityAction(dashboardId, dashboard,
                             customerId,
-                            ActionType.UNASSIGNED_FROM_CUSTOMER, null, strDashboardId, customerId.toString(), customerInfo.getTitle());
+                            ActionType.UNASSIGNED_FROM_CUSTOMER, null, strDashboardId, customerId.toString(), customerTitle);
 
                 }
                 return savedDashboard;

--- a/application/src/main/java/org/thingsboard/server/controller/RuleChainController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/RuleChainController.java
@@ -137,15 +137,19 @@ public class RuleChainController extends BaseController {
             RuleChain ruleChain = checkRuleChain(ruleChainId);
             TenantId tenantId = getCurrentUser().getTenantId();
             RuleChain previousRootRuleChain = ruleChainService.getRootTenantRuleChain(tenantId);
+            
             if (ruleChainService.setRootRuleChain(ruleChainId)) {
 
-                previousRootRuleChain = ruleChainService.findRuleChainById(previousRootRuleChain.getId());
+                if (previousRootRuleChain != null) {
+                    previousRootRuleChain = ruleChainService.findRuleChainById(previousRootRuleChain.getId());
 
-                actorService.onEntityStateChange(previousRootRuleChain.getTenantId(), previousRootRuleChain.getId(),
-                        ComponentLifecycleEvent.UPDATED);
+                    actorService.onEntityStateChange(previousRootRuleChain.getTenantId(), previousRootRuleChain.getId(),
+                            ComponentLifecycleEvent.UPDATED);
 
-                logEntityAction(previousRootRuleChain.getId(), previousRootRuleChain,
-                        null, ActionType.UPDATED, null);
+                    logEntityAction(previousRootRuleChain.getId(), previousRootRuleChain,
+                            null, ActionType.UPDATED, null);
+
+                }
 
                 ruleChain = ruleChainService.findRuleChainById(ruleChainId);
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/ShortCustomerInfo.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/ShortCustomerInfo.java
@@ -19,11 +19,15 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.thingsboard.server.common.data.id.CustomerId;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 
 /**
  * Created by igor on 2/27/18.
  */
 
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 @AllArgsConstructor
 public class ShortCustomerInfo {
 
@@ -35,6 +39,11 @@ public class ShortCustomerInfo {
 
     @Getter @Setter
     private boolean isPublic;
+
+    public ShortCustomerInfo() {
+        isPublic = false;
+        title = "";
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
@@ -87,12 +87,14 @@ public class BaseRuleChainService extends AbstractEntityService implements RuleC
         RuleChain ruleChain = ruleChainDao.findById(ruleChainId.getId());
         if (!ruleChain.isRoot()) {
             RuleChain previousRootRuleChain = getRootTenantRuleChain(ruleChain.getTenantId());
-            if (!previousRootRuleChain.getId().equals(ruleChain.getId())) {
+            if (previousRootRuleChain == null || !previousRootRuleChain.getId().equals(ruleChain.getId())) {
                 try {
-                    deleteRelation(new EntityRelation(previousRootRuleChain.getTenantId(), previousRootRuleChain.getId(),
-                            EntityRelation.CONTAINS_TYPE, RelationTypeGroup.RULE_CHAIN));
-                    previousRootRuleChain.setRoot(false);
-                    ruleChainDao.save(previousRootRuleChain);
+                    if (previousRootRuleChain != null) {
+                        deleteRelation(new EntityRelation(previousRootRuleChain.getTenantId(), previousRootRuleChain.getId(),
+                                EntityRelation.CONTAINS_TYPE, RelationTypeGroup.RULE_CHAIN));
+                        previousRootRuleChain.setRoot(false);
+                        ruleChainDao.save(previousRootRuleChain);
+                    }
                     createRelation(new EntityRelation(ruleChain.getTenantId(), ruleChain.getId(),
                             EntityRelation.CONTAINS_TYPE, RelationTypeGroup.RULE_CHAIN));
                     ruleChain.setRoot(true);


### PR DESCRIPTION
Checking for null was missing in new Rule Engine - perhaps deeper investigation is also needed on why a new Root Rule was not created during transition.
 
Default constructor was causing errors when using Cassandra, so no dashboards could be assigned to customers (reading for customer's list JSON was failing with an exception).