### PR TITLE
Feature/relation server attributes inheritance

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -319,9 +319,9 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
     private ListenableFuture<List<AttributeKvEntry>> getAttributeKvEntries(DeviceId deviceId, String scope, Optional<Set<String>> names) {
         if (names.isPresent()) {
             if (!names.get().isEmpty()) {
-                return systemContext.getAttributesService().find(deviceId, scope, names.get());
+                return systemContext.getAttributesService().find(deviceId, scope, names.get(),0);
             } else {
-                return systemContext.getAttributesService().findAll(deviceId, scope);
+                return systemContext.getAttributesService().findAll(deviceId, scope,0);
             }
         } else {
             return Futures.immediateFuture(Collections.emptyList());

--- a/application/src/main/java/org/thingsboard/server/actors/tenant/TenantActor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/tenant/TenantActor.java
@@ -109,11 +109,15 @@ public class TenantActor extends RuleChainManagerActor {
     }
 
     private void onServiceToRuleEngineMsg(ServiceToRuleEngineMsg msg) {
+    	if (ruleChainManager.getRootChainActor()!=null)
         ruleChainManager.getRootChainActor().tell(msg, self());
+    	else logger.info("[{}] No Root Chain", msg);
     }
 
     private void onDeviceActorToRuleEngineMsg(DeviceActorToRuleEngineMsg msg) {
+    	if (ruleChainManager.getRootChainActor()!=null)
         ruleChainManager.getRootChainActor().tell(msg, self());
+    	else logger.info("[{}] No Root Chain", msg);
     }
 
     private void onRuleChainMsg(RuleChainToRuleChainMsg msg) {

--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -411,7 +411,7 @@ public class DefaultDeviceStateService implements DeviceStateService {
     }
 
     private ListenableFuture<DeviceStateData> fetchDeviceState(Device device) {
-        ListenableFuture<List<AttributeKvEntry>> attributes = attributesService.find(device.getId(), DataConstants.SERVER_SCOPE, PERSISTENT_ATTRIBUTES);
+        ListenableFuture<List<AttributeKvEntry>> attributes = attributesService.find(device.getId(), DataConstants.SERVER_SCOPE, PERSISTENT_ATTRIBUTES,0);
         return Futures.transform(attributes, new Function<List<AttributeKvEntry>, DeviceStateData>() {
             @Nullable
             @Override

--- a/application/src/main/java/org/thingsboard/server/service/telemetry/AttributeData.java
+++ b/application/src/main/java/org/thingsboard/server/service/telemetry/AttributeData.java
@@ -20,12 +20,14 @@ public class AttributeData implements Comparable<AttributeData>{
     private final long lastUpdateTs;
     private final String key;
     private final Object value;
+    private final boolean inherited;
 
-    public AttributeData(long lastUpdateTs, String key, Object value) {
+    public AttributeData(long lastUpdateTs, String key, Object value,boolean inherited) {
         super();
         this.lastUpdateTs = lastUpdateTs;
         this.key = key;
         this.value = value;
+        this.inherited = inherited;
     }
 
     public long getLastUpdateTs() {
@@ -38,6 +40,9 @@ public class AttributeData implements Comparable<AttributeData>{
 
     public Object getValue() {
         return value;
+    }
+    public boolean isInherited() {
+    	return inherited;
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/server/service/telemetry/AttributeKeys.java
+++ b/application/src/main/java/org/thingsboard/server/service/telemetry/AttributeKeys.java
@@ -13,18 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.common.data.kv;
 
-import lombok.Data;
+package org.thingsboard.server.service.telemetry;
 
-import java.io.Serializable;
+public class AttributeKeys implements Comparable<AttributeKeys>{
 
-/**
- * @author Andrew Shvayka
- */
-@Data
-public class AttributeKey implements Serializable {
-    private final String scope;
-    private final String attributeKey;
+    private final String key;
+   
     private final boolean inherited;
+
+    public AttributeKeys(long lastUpdateTs, String key, Object value,boolean inherited) {
+        super();
+        this.key = key;
+        this.inherited = inherited;
+    }
+
+    public String getKey() {
+        return key;
+    }
+   
+    public boolean isInherited() {
+    	return inherited;
+    }
+
+    @Override
+    public int compareTo(AttributeKeys o) {
+        return key.compareTo(o.key);
+    }
+        
 }
+

--- a/application/src/main/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionService.java
@@ -60,6 +60,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -182,25 +183,25 @@ public class DefaultTelemetrySubscriptionService implements TelemetrySubscriptio
     @Override
     public void saveAttrAndNotify(EntityId entityId, String scope, String key, long value, FutureCallback<Void> callback) {
         saveAndNotify(entityId, scope, Collections.singletonList(new BaseAttributeKvEntry(new LongDataEntry(key, value)
-                , System.currentTimeMillis())), callback);
+                , System.currentTimeMillis(),scope)), callback);
     }
 
     @Override
     public void saveAttrAndNotify(EntityId entityId, String scope, String key, String value, FutureCallback<Void> callback) {
         saveAndNotify(entityId, scope, Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry(key, value)
-                , System.currentTimeMillis())), callback);
+                , System.currentTimeMillis(),scope)), callback);
     }
 
     @Override
     public void saveAttrAndNotify(EntityId entityId, String scope, String key, double value, FutureCallback<Void> callback) {
         saveAndNotify(entityId, scope, Collections.singletonList(new BaseAttributeKvEntry(new DoubleDataEntry(key, value)
-                , System.currentTimeMillis())), callback);
+                , System.currentTimeMillis(),scope)), callback);
     }
 
     @Override
     public void saveAttrAndNotify(EntityId entityId, String scope, String key, boolean value, FutureCallback<Void> callback) {
         saveAndNotify(entityId, scope, Collections.singletonList(new BaseAttributeKvEntry(new BooleanDataEntry(key, value)
-                , System.currentTimeMillis())), callback);
+                , System.currentTimeMillis(),scope)), callback);
     }
 
     @Override
@@ -341,7 +342,7 @@ public class DefaultTelemetrySubscriptionService implements TelemetrySubscriptio
         registerSubscription(sessionId, entityId, subscription);
         if (subscription.getType() == TelemetryFeature.ATTRIBUTES) {
             final Map<String, Long> keyStates = subscription.getKeyStates();
-            DonAsynchron.withCallback(attrService.find(entityId, DataConstants.CLIENT_SCOPE, keyStates.keySet()), values -> {
+            DonAsynchron.withCallback(attrService.find(entityId, DataConstants.CLIENT_SCOPE, keyStates.keySet(),0), values -> {
                         List<TsKvEntry> missedUpdates = new ArrayList<>();
                         values.forEach(latestEntry -> {
                             if (latestEntry.getLastUpdateTs() > keyStates.get(latestEntry.getKey())) {
@@ -654,7 +655,7 @@ public class DefaultTelemetrySubscriptionService implements TelemetrySubscriptio
     }
 
     private AttributeKvEntry toAttribute(ClusterAPIProtos.KeyValueProto proto) {
-        return new BaseAttributeKvEntry(getKvEntry(proto), proto.getTs());
+        return new BaseAttributeKvEntry(getKvEntry(proto), proto.getTs(),null);
     }
 
     private TsKvEntry toTimeseries(ClusterAPIProtos.KeyValueProto proto) {

--- a/application/src/test/java/org/thingsboard/server/rules/flow/AbstractRuleEngineFlowIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/rules/flow/AbstractRuleEngineFlowIntegrationTest.java
@@ -142,9 +142,9 @@ public abstract class AbstractRuleEngineFlowIntegrationTest extends AbstractRule
         device = doPost("/api/device", device, Device.class);
 
         attributesService.save(device.getId(), DataConstants.SERVER_SCOPE,
-                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey1", "serverAttributeValue1"), System.currentTimeMillis())));
+                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey1", "serverAttributeValue1"), System.currentTimeMillis(),DataConstants.SERVER_SCOPE)));
         attributesService.save(device.getId(), DataConstants.SERVER_SCOPE,
-                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey2", "serverAttributeValue2"), System.currentTimeMillis())));
+                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey2", "serverAttributeValue2"), System.currentTimeMillis(),DataConstants.SERVER_SCOPE)));
 
 
         Thread.sleep(1000);
@@ -260,9 +260,9 @@ public abstract class AbstractRuleEngineFlowIntegrationTest extends AbstractRule
         device = doPost("/api/device", device, Device.class);
 
         attributesService.save(device.getId(), DataConstants.SERVER_SCOPE,
-                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey1", "serverAttributeValue1"), System.currentTimeMillis())));
+                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey1", "serverAttributeValue1"), System.currentTimeMillis(),DataConstants.SERVER_SCOPE)));
         attributesService.save(device.getId(), DataConstants.SERVER_SCOPE,
-                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey2", "serverAttributeValue2"), System.currentTimeMillis())));
+                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey2", "serverAttributeValue2"), System.currentTimeMillis(),DataConstants.SERVER_SCOPE)));
 
 
         Thread.sleep(1000);

--- a/application/src/test/java/org/thingsboard/server/rules/lifecycle/AbstractRuleEngineLifecycleIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/rules/lifecycle/AbstractRuleEngineLifecycleIntegrationTest.java
@@ -131,7 +131,7 @@ public abstract class AbstractRuleEngineLifecycleIntegrationTest extends Abstrac
         device = doPost("/api/device", device, Device.class);
 
         attributesService.save(device.getId(), DataConstants.SERVER_SCOPE,
-                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey", "serverAttributeValue"), System.currentTimeMillis())));
+                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey", "serverAttributeValue"), System.currentTimeMillis(),DataConstants.SERVER_SCOPE)));
 
         Thread.sleep(1000);
 
@@ -180,7 +180,7 @@ public abstract class AbstractRuleEngineLifecycleIntegrationTest extends Abstrac
         device = doPost("/api/device", device, Device.class);
 
         attributesService.save(device.getId(), DataConstants.SERVER_SCOPE,
-                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey", "serverAttributeValue"), System.currentTimeMillis())));
+                Collections.singletonList(new BaseAttributeKvEntry(new StringDataEntry("serverAttributeKey", "serverAttributeValue"), System.currentTimeMillis(),DataConstants.SERVER_SCOPE)));
 
         // Pushing Message to the system
         TbMsg tbMsg = new TbMsg(UUIDs.timeBased(),

--- a/common/data/src/main/java/org/thingsboard/server/common/data/kv/BaseAttributeKvEntry.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/kv/BaseAttributeKvEntry.java
@@ -23,11 +23,15 @@ import java.util.Optional;
 public class BaseAttributeKvEntry implements AttributeKvEntry {
 
     private final long lastUpdateTs;
+    private boolean isInherited;
+    private long lvl;
+    private String scope;
     private final KvEntry kv;
 
-    public BaseAttributeKvEntry(KvEntry kv, long lastUpdateTs) {
+    public BaseAttributeKvEntry(KvEntry kv, long lastUpdateTs, String scope) {
         this.kv = kv;
         this.lastUpdateTs = lastUpdateTs;
+        this.scope = scope;
     }
 
     @Override
@@ -76,6 +80,10 @@ public class BaseAttributeKvEntry implements AttributeKvEntry {
     }
 
     @Override
+    public String getScope() {
+    	return scope;
+    }
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
@@ -99,6 +107,20 @@ public class BaseAttributeKvEntry implements AttributeKvEntry {
         return "BaseAttributeKvEntry{" +
                 "lastUpdateTs=" + lastUpdateTs +
                 ", kv=" + kv +
-                '}';
+                ", scope=" + scope +
+                ", inheritLvl=" + lvl +
+                "}";
+    }
+    @Override
+    public boolean getIsInherited() {
+        return lvl>0;
+    }
+    @Override
+    public void setInheritanceLevel(long lvl) {
+    	this.lvl = lvl;
+    }
+    @Override
+    public long getInheritanceLevel() {
+    	return lvl;
     }
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/kv/BasicKvEntry.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/kv/BasicKvEntry.java
@@ -52,6 +52,21 @@ public abstract class BasicKvEntry implements KvEntry {
     }
 
     @Override
+    public String getScope() {
+    	return null;
+    }
+    @Override
+	public boolean getIsInherited() {
+		return false;
+	}
+	@Override
+	public long getInheritanceLevel() {
+		return 0;
+	}
+	@Override
+	public void setInheritanceLevel(long lvl) {	
+	}
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof BasicKvEntry)) return false;

--- a/common/data/src/main/java/org/thingsboard/server/common/data/kv/BasicTsKvEntry.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/kv/BasicTsKvEntry.java
@@ -29,6 +29,10 @@ public class BasicTsKvEntry implements TsKvEntry {
     }
 
     @Override
+    public String getScope() {
+    	return kv.getScope();
+    }
+    @Override
     public String getKey() {
         return kv.getKey();
     }
@@ -94,4 +98,16 @@ public class BasicTsKvEntry implements TsKvEntry {
     public String getValueAsString() {
         return kv.getValueAsString();
     }
+	@Override
+	public boolean getIsInherited() {
+		return kv.getIsInherited();
+	}
+	@Override
+	public long getInheritanceLevel() {
+		return kv.getInheritanceLevel();
+	}
+	@Override
+	public void setInheritanceLevel(long lvl) {
+		kv.setInheritanceLevel(lvl);
+	}
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/kv/KvEntry.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/kv/KvEntry.java
@@ -40,4 +40,8 @@ public interface KvEntry extends Serializable {
     String getValueAsString();
 
     Object getValue();
+    boolean getIsInherited();
+    long getInheritanceLevel();
+    void setInheritanceLevel(long lvl);
+    String getScope();
 }

--- a/common/transport/src/main/java/org/thingsboard/server/common/transport/adaptor/JsonConverter.java
+++ b/common/transport/src/main/java/org/thingsboard/server/common/transport/adaptor/JsonConverter.java
@@ -133,7 +133,7 @@ public class JsonConverter {
         if (element.isJsonObject()) {
             BasicAttributesUpdateRequest request = new BasicAttributesUpdateRequest(requestId);
             long ts = System.currentTimeMillis();
-            request.add(parseValues(element.getAsJsonObject()).stream().map(kv -> new BaseAttributeKvEntry(kv, ts)).collect(Collectors.toList()));
+            request.add(parseValues(element.getAsJsonObject()).stream().map(kv -> new BaseAttributeKvEntry(kv, ts, kv.getScope())).collect(Collectors.toList()));
             return request;
         } else {
             throw new JsonSyntaxException(CAN_T_PARSE_VALUE + element);

--- a/dao/src/main/java/org/thingsboard/server/dao/attributes/AttributesDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/attributes/AttributesDao.java
@@ -28,11 +28,11 @@ import java.util.Optional;
  */
 public interface AttributesDao {
 
-    ListenableFuture<Optional<AttributeKvEntry>> find(EntityId entityId, String attributeType, String attributeKey);
+    ListenableFuture<Optional<AttributeKvEntry>> find(EntityId entityId, String attributeType, String attributeKey,long inheritanceLevel);
 
-    ListenableFuture<List<AttributeKvEntry>> find(EntityId entityId, String attributeType, Collection<String> attributeKey);
+    ListenableFuture<List<AttributeKvEntry>> find(EntityId entityId, String attributeType, Collection<String> attributeKey,long inheritanceLevel);
 
-    ListenableFuture<List<AttributeKvEntry>> findAll(EntityId entityId, String attributeType);
+    ListenableFuture<List<AttributeKvEntry>> findAll(EntityId entityId, String attributeType,long inheritanceLevel);
 
     ListenableFuture<Void> save(EntityId entityId, String attributeType, AttributeKvEntry attribute);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/attributes/AttributesService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/attributes/AttributesService.java
@@ -28,11 +28,11 @@ import java.util.Optional;
  */
 public interface AttributesService {
 
-    ListenableFuture<Optional<AttributeKvEntry>> find(EntityId entityId, String scope, String attributeKey);
+    ListenableFuture<Optional<AttributeKvEntry>> find(EntityId entityId, String scope, String attributeKey,long inheritanceLevel);
 
-    ListenableFuture<List<AttributeKvEntry>> find(EntityId entityId, String scope, Collection<String> attributeKeys);
+    ListenableFuture<List<AttributeKvEntry>> find(EntityId entityId, String scope, Collection<String> attributeKeys,long inheritanceLevel);
 
-    ListenableFuture<List<AttributeKvEntry>> findAll(EntityId entityId, String scope);
+    ListenableFuture<List<AttributeKvEntry>> findAll(EntityId entityId, String scope,long inheritanceLevel);
 
     ListenableFuture<List<Void>> save(EntityId entityId, String scope, List<AttributeKvEntry> attributes);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/attributes/BaseAttributesService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/attributes/BaseAttributesService.java
@@ -39,23 +39,23 @@ public class BaseAttributesService implements AttributesService {
     private AttributesDao attributesDao;
 
     @Override
-    public ListenableFuture<Optional<AttributeKvEntry>> find(EntityId entityId, String scope, String attributeKey) {
+    public ListenableFuture<Optional<AttributeKvEntry>> find(EntityId entityId, String scope, String attributeKey,long inheritanceLevel) {
         validate(entityId, scope);
         Validator.validateString(attributeKey, "Incorrect attribute key " + attributeKey);
-        return attributesDao.find(entityId, scope, attributeKey);
+        return attributesDao.find(entityId, scope, attributeKey,inheritanceLevel);
     }
 
     @Override
-    public ListenableFuture<List<AttributeKvEntry>> find(EntityId entityId, String scope, Collection<String> attributeKeys) {
+    public ListenableFuture<List<AttributeKvEntry>> find(EntityId entityId, String scope, Collection<String> attributeKeys,long inheritanceLevel) {
         validate(entityId, scope);
         attributeKeys.forEach(attributeKey -> Validator.validateString(attributeKey, "Incorrect attribute key " + attributeKey));
-        return attributesDao.find(entityId, scope, attributeKeys);
+        return attributesDao.find(entityId, scope, attributeKeys,inheritanceLevel);
     }
 
     @Override
-    public ListenableFuture<List<AttributeKvEntry>> findAll(EntityId entityId, String scope) {
+    public ListenableFuture<List<AttributeKvEntry>> findAll(EntityId entityId, String scope,long inheritanceLevel) {
         validate(entityId, scope);
-        return attributesDao.findAll(entityId, scope);
+        return attributesDao.findAll(entityId, scope,inheritanceLevel);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AttributeKvEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AttributeKvEntity.java
@@ -95,6 +95,6 @@ public class AttributeKvEntity implements ToData<AttributeKvEntry>, Serializable
         } else if (longValue != null) {
             kvEntry = new LongDataEntry(attributeKey, longValue);
         }
-        return new BaseAttributeKvEntry(kvEntry, lastUpdateTs);
+        return new BaseAttributeKvEntry(kvEntry, lastUpdateTs,attributeType);
     }
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/attributes/JpaAttributeDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/attributes/JpaAttributeDao.java
@@ -47,7 +47,7 @@ public class JpaAttributeDao extends JpaAbstractDaoListeningExecutorService impl
     private AttributeKvRepository attributeKvRepository;
 
     @Override
-    public ListenableFuture<Optional<AttributeKvEntry>> find(EntityId entityId, String attributeType, String attributeKey) {
+    public ListenableFuture<Optional<AttributeKvEntry>> find(EntityId entityId, String attributeType, String attributeKey,long inheritanceLevel) {
         AttributeKvCompositeKey compositeKey =
                 getAttributeKvCompositeKey(entityId, attributeType, attributeKey);
         return Futures.immediateFuture(
@@ -55,7 +55,7 @@ public class JpaAttributeDao extends JpaAbstractDaoListeningExecutorService impl
     }
 
     @Override
-    public ListenableFuture<List<AttributeKvEntry>> find(EntityId entityId, String attributeType, Collection<String> attributeKeys) {
+    public ListenableFuture<List<AttributeKvEntry>> find(EntityId entityId, String attributeType, Collection<String> attributeKeys,long inheritanceLevel) {
         List<AttributeKvCompositeKey> compositeKeys =
                 attributeKeys
                         .stream()
@@ -67,7 +67,7 @@ public class JpaAttributeDao extends JpaAbstractDaoListeningExecutorService impl
     }
 
     @Override
-    public ListenableFuture<List<AttributeKvEntry>> findAll(EntityId entityId, String attributeType) {
+    public ListenableFuture<List<AttributeKvEntry>> findAll(EntityId entityId, String attributeType,long inheritanceLevel) {
         return Futures.immediateFuture(
                 DaoUtil.convertDataList(Lists.newArrayList(
                         attributeKvRepository.findAllByEntityTypeAndEntityIdAndAttributeType(

--- a/dao/src/test/java/org/thingsboard/server/dao/service/attributes/BaseAttributesServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/attributes/BaseAttributesServiceTest.java
@@ -49,9 +49,9 @@ public abstract class BaseAttributesServiceTest extends AbstractServiceTest {
     public void saveAndFetch() throws Exception {
         DeviceId deviceId = new DeviceId(UUIDs.timeBased());
         KvEntry attrValue = new StringDataEntry("attribute1", "value1");
-        AttributeKvEntry attr = new BaseAttributeKvEntry(attrValue, 42L);
+        AttributeKvEntry attr = new BaseAttributeKvEntry(attrValue, 42L,DataConstants.CLIENT_SCOPE);
         attributesService.save(deviceId, DataConstants.CLIENT_SCOPE, Collections.singletonList(attr)).get();
-        Optional<AttributeKvEntry> saved = attributesService.find(deviceId, DataConstants.CLIENT_SCOPE, attr.getKey()).get();
+        Optional<AttributeKvEntry> saved = attributesService.find(deviceId, DataConstants.CLIENT_SCOPE, attr.getKey(),0).get();
         Assert.assertTrue(saved.isPresent());
         Assert.assertEquals(attr, saved.get());
     }
@@ -60,19 +60,19 @@ public abstract class BaseAttributesServiceTest extends AbstractServiceTest {
     public void saveMultipleTypeAndFetch() throws Exception {
         DeviceId deviceId = new DeviceId(UUIDs.timeBased());
         KvEntry attrOldValue = new StringDataEntry("attribute1", "value1");
-        AttributeKvEntry attrOld = new BaseAttributeKvEntry(attrOldValue, 42L);
+        AttributeKvEntry attrOld = new BaseAttributeKvEntry(attrOldValue, 42L,DataConstants.CLIENT_SCOPE);
 
         attributesService.save(deviceId, DataConstants.CLIENT_SCOPE, Collections.singletonList(attrOld)).get();
-        Optional<AttributeKvEntry> saved = attributesService.find(deviceId, DataConstants.CLIENT_SCOPE, attrOld.getKey()).get();
+        Optional<AttributeKvEntry> saved = attributesService.find(deviceId, DataConstants.CLIENT_SCOPE, attrOld.getKey(),0).get();
 
         Assert.assertTrue(saved.isPresent());
         Assert.assertEquals(attrOld, saved.get());
 
         KvEntry attrNewValue = new StringDataEntry("attribute1", "value2");
-        AttributeKvEntry attrNew = new BaseAttributeKvEntry(attrNewValue, 73L);
+        AttributeKvEntry attrNew = new BaseAttributeKvEntry(attrNewValue, 73L,DataConstants.CLIENT_SCOPE);
         attributesService.save(deviceId, DataConstants.CLIENT_SCOPE, Collections.singletonList(attrNew)).get();
 
-        saved = attributesService.find(deviceId, DataConstants.CLIENT_SCOPE, attrOld.getKey()).get();
+        saved = attributesService.find(deviceId, DataConstants.CLIENT_SCOPE, attrOld.getKey(),0).get();
         Assert.assertEquals(attrNew, saved.get());
     }
 
@@ -81,17 +81,17 @@ public abstract class BaseAttributesServiceTest extends AbstractServiceTest {
         DeviceId deviceId = new DeviceId(UUIDs.timeBased());
 
         KvEntry attrAOldValue = new StringDataEntry("A", "value1");
-        AttributeKvEntry attrAOld = new BaseAttributeKvEntry(attrAOldValue, 42L);
+        AttributeKvEntry attrAOld = new BaseAttributeKvEntry(attrAOldValue, 42L,DataConstants.CLIENT_SCOPE);
         KvEntry attrANewValue = new StringDataEntry("A", "value2");
-        AttributeKvEntry attrANew = new BaseAttributeKvEntry(attrANewValue, 73L);
+        AttributeKvEntry attrANew = new BaseAttributeKvEntry(attrANewValue, 73L,DataConstants.CLIENT_SCOPE);
         KvEntry attrBNewValue = new StringDataEntry("B", "value3");
-        AttributeKvEntry attrBNew = new BaseAttributeKvEntry(attrBNewValue, 73L);
+        AttributeKvEntry attrBNew = new BaseAttributeKvEntry(attrBNewValue, 73L,DataConstants.CLIENT_SCOPE);
 
         attributesService.save(deviceId, DataConstants.CLIENT_SCOPE, Collections.singletonList(attrAOld)).get();
         attributesService.save(deviceId, DataConstants.CLIENT_SCOPE, Collections.singletonList(attrANew)).get();
         attributesService.save(deviceId, DataConstants.CLIENT_SCOPE, Collections.singletonList(attrBNew)).get();
 
-        List<AttributeKvEntry> saved = attributesService.findAll(deviceId, DataConstants.CLIENT_SCOPE).get();
+        List<AttributeKvEntry> saved = attributesService.findAll(deviceId, DataConstants.CLIENT_SCOPE,0).get();
 
         Assert.assertNotNull(saved);
         Assert.assertEquals(2, saved.size());

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbAbstractGetAttributesNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbAbstractGetAttributesNode.java
@@ -77,7 +77,7 @@ public abstract class TbAbstractGetAttributesNode<C extends TbGetAttributesNodeC
         if (CollectionUtils.isEmpty(keys)) {
             return Futures.immediateFuture(null);
         }
-        ListenableFuture<List<AttributeKvEntry>> latest = ctx.getAttributesService().find(entityId, scope, keys);
+        ListenableFuture<List<AttributeKvEntry>> latest = ctx.getAttributesService().find(entityId, scope, keys,0);
         return Futures.transform(latest, l -> {
             l.forEach(r -> {
                 if (r.getValue() != null) {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbEntityGetAttrNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbEntityGetAttrNode.java
@@ -71,7 +71,7 @@ public abstract class TbEntityGetAttrNode<T extends EntityId> implements TbNode 
     }
 
     private ListenableFuture<List<KvEntry>> getAttributesAsync(TbContext ctx, EntityId entityId) {
-        ListenableFuture<List<AttributeKvEntry>> latest = ctx.getAttributesService().find(entityId, SERVER_SCOPE, config.getAttrMapping().keySet());
+        ListenableFuture<List<AttributeKvEntry>> latest = ctx.getAttributesService().find(entityId, SERVER_SCOPE, config.getAttrMapping().keySet(),0);
         return Futures.transform(latest, l ->
                 l.stream().map(i -> (KvEntry) i).collect(Collectors.toList()));
     }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetCustomerAttributeNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetCustomerAttributeNodeTest.java
@@ -106,7 +106,7 @@ public class TbGetCustomerAttributeNodeTest {
         when(userService.findUserByIdAsync(userId)).thenReturn(Futures.immediateFuture(user));
 
         when(ctx.getAttributesService()).thenReturn(attributesService);
-        when(attributesService.find(customerId, SERVER_SCOPE, Collections.singleton("temperature")))
+        when(attributesService.find(customerId, SERVER_SCOPE, Collections.singleton("temperature"),0))
                 .thenThrow(new IllegalStateException("something wrong"));
 
         node.onMsg(ctx, msg);
@@ -131,7 +131,7 @@ public class TbGetCustomerAttributeNodeTest {
         when(userService.findUserByIdAsync(userId)).thenReturn(Futures.immediateFuture(user));
 
         when(ctx.getAttributesService()).thenReturn(attributesService);
-        when(attributesService.find(customerId, SERVER_SCOPE, Collections.singleton("temperature")))
+        when(attributesService.find(customerId, SERVER_SCOPE, Collections.singleton("temperature"),0))
                 .thenReturn(Futures.immediateFailedFuture(new IllegalStateException("something wrong")));
 
         node.onMsg(ctx, msg);
@@ -249,10 +249,10 @@ public class TbGetCustomerAttributeNodeTest {
     }
 
     private void entityAttributeFetched(CustomerId customerId) {
-        List<AttributeKvEntry> attributes = Lists.newArrayList(new BaseAttributeKvEntry(new StringDataEntry("temperature", "high"), 1L));
+        List<AttributeKvEntry> attributes = Lists.newArrayList(new BaseAttributeKvEntry(new StringDataEntry("temperature", "high"), 1L, null));
 
         when(ctx.getAttributesService()).thenReturn(attributesService);
-        when(attributesService.find(customerId, SERVER_SCOPE, Collections.singleton("temperature")))
+        when(attributesService.find(customerId, SERVER_SCOPE, Collections.singleton("temperature"),0))
                 .thenReturn(Futures.immediateFuture(attributes));
 
         node.onMsg(ctx, msg);

--- a/transport/coap/src/test/java/org/thingsboard/server/transport/coap/CoapServerTest.java
+++ b/transport/coap/src/test/java/org/thingsboard/server/transport/coap/CoapServerTest.java
@@ -117,8 +117,8 @@ public class CoapServerTest {
                                 toDeviceMsg = BasicStatusCodeResponse.onSuccess(deviceMsg.getMsgType(), BasicRequest.DEFAULT_REQUEST_ID);
                             } else if (deviceMsg.getMsgType() == SessionMsgType.GET_ATTRIBUTES_REQUEST) {
                                 List<AttributeKvEntry> data = new ArrayList<>();
-                                data.add(new BaseAttributeKvEntry(new StringDataEntry("key1", "value1"), System.currentTimeMillis()));
-                                data.add(new BaseAttributeKvEntry(new LongDataEntry("key2", 42L), System.currentTimeMillis()));
+                                data.add(new BaseAttributeKvEntry(new StringDataEntry("key1", "value1"), System.currentTimeMillis(),null));
+                                data.add(new BaseAttributeKvEntry(new LongDataEntry("key2", 42L), System.currentTimeMillis(),null));
                                 BasicAttributeKVMsg kv = BasicAttributeKVMsg.fromClient(data);
                                 toDeviceMsg = BasicGetAttributesResponse.onSuccess(deviceMsg.getMsgType(), BasicRequest.DEFAULT_REQUEST_ID, kv);
                             }

--- a/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionCtx.java
+++ b/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionCtx.java
@@ -175,7 +175,7 @@ public class GatewaySessionCtx {
                 long ts = System.currentTimeMillis();
                 BasicAttributesUpdateRequest request = new BasicAttributesUpdateRequest(requestId);
                 JsonObject deviceData = deviceEntry.getValue().getAsJsonObject();
-                request.add(JsonConverter.parseValues(deviceData).stream().map(kv -> new BaseAttributeKvEntry(kv, ts)).collect(Collectors.toList()));
+                request.add(JsonConverter.parseValues(deviceData).stream().map(kv -> new BaseAttributeKvEntry(kv, ts,null)).collect(Collectors.toList()));
                 GatewayDeviceSessionCtx deviceSessionCtx = devices.get(deviceName);
                 processor.process(new BasicTransportToDeviceSessionActorMsg(deviceSessionCtx.getDevice(),
                         new BasicAdaptorToSessionActorMsg(deviceSessionCtx, request)));

--- a/ui/src/app/api/alias-controller.js
+++ b/ui/src/app/api/alias-controller.js
@@ -146,6 +146,7 @@ export default class AliasController {
                                     newDatasource.entityId = resolvedEntity.id;
                                     newDatasource.entityType = resolvedEntity.entityType;
                                     newDatasource.entityName = resolvedEntity.name;
+                                    newDatasource.entityDescription = resolvedEntity.entityDescription
                                     newDatasource.name = resolvedEntity.name;
                                     newDatasource.generated = i > 0 ? true : false;
                                     datasources.push(newDatasource);
@@ -167,6 +168,7 @@ export default class AliasController {
                                 datasource.entityType = entity.entityType;
                                 datasource.entityName = entity.name;
                                 datasource.name = entity.name;
+                                datasource.entityDescription = entity.entityDescription;
                                 deferred.resolve([datasource]);
                             } else {
                                 if (aliasInfo.stateEntity) {

--- a/ui/src/app/api/entity.service.js
+++ b/ui/src/app/api/entity.service.js
@@ -329,7 +329,7 @@ function EntityService($http, $q, $filter, $translate, $log, userService, device
     }
 
     function entityToEntityInfo(entity) {
-        return { name: entity.name, entityType: entity.id.entityType, id: entity.id.id };
+        return { name: entity.name, entityType: entity.id.entityType, id: entity.id.id, entityDescription: entity.additionalInfo?entity.additionalInfo.description:"" };
     }
 
     function entityRelationInfoToEntityInfo(entityRelationInfo, direction) {

--- a/ui/src/app/components/datasource-entity.directive.js
+++ b/ui/src/app/components/datasource-entity.directive.js
@@ -171,7 +171,7 @@ function DatasourceEntity($compile, $templateCache, $q, $mdDialog, $window, $doc
             if (scope.maxDataKeys > 0 && ngModelCtrl.$viewValue.dataKeys.length >= scope.maxDataKeys ) {
                 return null;
             } else {
-                return scope.generateDataKey({chip: chip, type: types.dataKeyType.attribute});
+                return scope.generateDataKey({chip: chip.attributeKey, type: types.dataKeyType.attribute});
             }
         };
 

--- a/ui/src/app/components/datasource-entity.tpl.html
+++ b/ui/src/app/components/datasource-entity.tpl.html
@@ -92,7 +92,11 @@
 							md-min-length="0"
 							placeholder="{{'datakey.attributes' | translate }}"
 							md-menu-class="tb-attribute-datakey-autocomplete">
-							<span md-highlight-text="attributeDataKeySearchText" md-highlight-flags="^i">{{item}}</span>
+                            <span ng-show="item.inherited" ng-class="tb-absolute-left"><ng-md-icon size="16" icon="link"></ng-md-icon></span>
+                            <span ng-show="item.scope=='SERVER_SCOPE' && !item.inherited"><ng-md-icon size="16" icon="computer"></ng-md-icon></span>
+                            <span ng-show="item.scope=='SHARED_SCOPE'"><ng-md-icon size="16" icon="share"></ng-md-icon></span>
+                            <span ng-show="item.scope=='CLIENT_SCOPE'"><ng-md-icon size="16" icon="stay_primary_portrait"></ng-md-icon></span>
+							<span md-highlight-text="attributeDataKeySearchText" md-highlight-flags="^i">{{item.attributeKey}}</span>
 						    <md-not-found>
 							  <div class="tb-not-found">
 								  <div class="tb-no-entries" ng-if="!textIsNotEmpty(attributeDataKeySearchText)">

--- a/ui/src/app/components/datasource-func.directive.js
+++ b/ui/src/app/components/datasource-func.directive.js
@@ -124,7 +124,7 @@ function DatasourceFunc($compile, $templateCache, $mdDialog, $window, $document,
             if (scope.maxDataKeys > 0 && ngModelCtrl.$viewValue.dataKeys.length >= scope.maxDataKeys ) {
                 return null;
             } else {
-                return scope.generateDataKey({chip: chip, type: types.dataKeyType.function});
+                return scope.generateDataKey({chip: chip.attributeKey, type: types.dataKeyType.function});
             }
         };
 

--- a/ui/src/app/components/datasource-func.tpl.html
+++ b/ui/src/app/components/datasource-func.tpl.html
@@ -41,7 +41,11 @@
 						md-min-length="0"
 						placeholder="{{ 'datakey.function-types' | translate }}"
 						md-menu-class="tb-func-datakey-autocomplete">
-						<span md-highlight-text="dataKeySearchText" md-highlight-flags="^i">{{item}}</span>
+                        <span ng-show="item.inherited"><ng-md-icon size="16" icon="link"></ng-md-icon></span>
+                        <span ng-show="item.scope=='SERVER_SCOPE' && !item.inherited"><ng-md-icon size="16" icon="computer"></ng-md-icon></span>
+                        <span ng-show="item.scope=='SHARED_SCOPE'"><ng-md-icon size="16" icon="share"></ng-md-icon></span>
+                        <span ng-show="item.scope=='CLIENT_SCOPE'"><ng-md-icon size="16" icon="stay_primary_portrait"></ng-md-icon></span>
+						<span md-highlight-text="dataKeySearchText" md-highlight-flags="^i">{{item.attributeKey}}</span>
 						<md-not-found>
 							<div class="tb-not-found">
 								<div class="tb-no-entries" ng-if="!textIsNotEmpty(dataKeySearchText)">

--- a/ui/src/app/device/device-card.tpl.html
+++ b/ui/src/app/device/device-card.tpl.html
@@ -16,7 +16,8 @@
 
 -->
 <div flex layout="column" style="margin-top: -10px;">
-    <div style="text-transform: uppercase; padding-bottom: 10px;">{{vm.item.type}}</div>
+	<div flex>{{vm.item.additionalInfo.description}}</div>
+    <div flex style="text-transform: uppercase; padding-bottom: 10px;">{{vm.item.type}}</div>
     <div class="tb-small" ng-show="vm.isAssignedToCustomer()">{{'device.assignedToCustomer' | translate}} '{{vm.item.assignedCustomer.title}}'</div>
     <div class="tb-small" ng-show="vm.isPublic()">{{'device.public' | translate}}</div>
 </div>

--- a/ui/src/app/entity/attribute/attribute-table.directive.js
+++ b/ui/src/app/entity/attribute/attribute-table.directive.js
@@ -189,7 +189,7 @@ export default function AttributeTableDirective($compile, $templateCache, $rootS
         });
 
         scope.editAttribute = function($event, attribute) {
-            if (!scope.attributeScope.clientSide) {
+            if (!scope.attributeScope.clientSide && !attribute.inherited) {
                 $event.stopPropagation();
                 $mdEditDialog.show({
                     controller: EditAttributeValueController,

--- a/ui/src/app/entity/attribute/attribute-table.tpl.html
+++ b/ui/src/app/entity/attribute/attribute-table.tpl.html
@@ -139,7 +139,8 @@
                         <td md-cell>{{attribute.key}}</td>
                         <td md-cell class="tb-value-cell" ng-click="editAttribute($event, attribute)">
                             <span>{{attribute.value}}</span>
-                            <span ng-show="!attributeScope.clientSide"><ng-md-icon size="16" icon="edit"></ng-md-icon></span>
+                            <span ng-show="!attributeScope.clientSide && !attribute.inherited"><ng-md-icon size="16" icon="edit"></ng-md-icon></span>
+                            <span ng-show="attribute.inherited"><ng-md-icon size="16" icon="link"></ng-md-icon></span>
                         </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
When an Asset or other device is a parent of a child device, the parent will have Server defined attributes that would be nice for a child to inherit.
This MR allows that,
![server attributes](https://user-images.githubusercontent.com/21164838/41437038-a8f67c62-7077-11e8-82dd-cb83c10a1e9e.PNG) so that when you open a device and view the server attributes you can see the inherited attributes that have been supplied from the parent via the to relation
![relation to](https://user-images.githubusercontent.com/21164838/41437202-f873a5e4-7077-11e8-9b4d-d2068d01dfa5.PNG)

The related attributes and other scope type attribute (Client,Server,Shared,Server Inherited) are now also shown with an idetifier in the auto complete to help identify which are which.
![attribute list](https://user-images.githubusercontent.com/21164838/41437301-2758fa80-7078-11e8-8dc7-86a87671cf30.PNG)

Attributes are inherited from all parents and grand parents etc, up to 10 levels (Restricted for performance reasons and in case there are incestial relations) and a relation can be stopped from being inherited with the inclusion of noinherit in the additional info text area of the relation. 
