### PR TITLE
Fix install_dev_db.sh by using sudo instead of su

### DIFF
--- a/application/src/main/scripts/install/install_dev_db.sh
+++ b/application/src/main/scripts/install/install_dev_db.sh
@@ -30,13 +30,13 @@ export SQL_DATA_FOLDER=${SQL_DATA_FOLDER:-/tmp}
 
 run_user=thingsboard
 
-su -s /bin/sh -c "java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardInstallApplication \
+sudo -u "$run_user" -s /bin/sh -c "java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardInstallApplication \
                     -Dinstall.data_dir=${installDir} \
                     -Dinstall.load_demo=${loadDemo} \
                     -Dspring.jpa.hibernate.ddl-auto=none \
                     -Dinstall.upgrade=false \
                     -Dlogging.config=logback.xml \
-                    org.springframework.boot.loader.PropertiesLauncher" "$run_user"
+                    org.springframework.boot.loader.PropertiesLauncher"
 
 if [ $? -ne 0 ]; then
     echo "ThingsBoard DB installation failed!"


### PR DESCRIPTION
When following instructions on https://thingsboard.io/docs/user-guide/contribution/how-to-contribute/#create-database-schema-and-populate-demo-data, the install script doesn't work when the thingsboard user doens't have a password because su is used instead of sudo.
By using sudo instead of su you can execute the install script without a specified password for the thingsboard user.