### PR TITLE
Cache assets

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -291,6 +291,9 @@ caffeine:
     devices:
       timeToLiveInMinutes: 1440
       maxSize: 100000
+    assets:
+      timeToLiveInMinutes: 1440
+      maxSize: 100000
 
 redis:
   # standalone or cluster

--- a/common/data/src/main/java/org/thingsboard/server/common/data/CacheConstants.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/CacheConstants.java
@@ -19,4 +19,5 @@ public class CacheConstants {
     public static final String DEVICE_CREDENTIALS_CACHE = "deviceCredentials";
     public static final String RELATIONS_CACHE = "relations";
     public static final String DEVICE_CACHE = "devices";
+    public static final String ASSET_CACHE = "assets";
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/asset/AssetService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/asset/AssetService.java
@@ -34,7 +34,7 @@ public interface AssetService {
 
     ListenableFuture<Asset> findAssetByIdAsync(AssetId assetId);
 
-    Optional<Asset> findAssetByTenantIdAndName(TenantId tenantId, String name);
+    Asset findAssetByTenantIdAndName(TenantId tenantId, String name);
 
     Asset saveAsset(Asset asset);
 

--- a/dao/src/test/resources/application-test.properties
+++ b/dao/src/test/resources/application-test.properties
@@ -21,6 +21,9 @@ caffeine.specs.deviceCredentials.maxSize=100000
 caffeine.specs.devices.timeToLiveInMinutes=1440
 caffeine.specs.devices.maxSize=100000
 
+caffeine.specs.assets.timeToLiveInMinutes=1440
+caffeine.specs.assets.maxSize=100000
+
 caching.specs.devices.timeToLiveInMinutes=1440
 caching.specs.devices.maxSize=100000
 


### PR DESCRIPTION
Cache assets when finding them by tenant and name just like it's done when caching of devices.
For this the method signature of findAssetByTenantIdAndName was changed. It now returns an `Asset` or `null` instead of an `Option<Asset>`.
