### PR TITLE
Make RemoteToRuleChainTellNextMsg Serializable

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/ruleChain/RemoteToRuleChainTellNextMsg.java
+++ b/application/src/main/java/org/thingsboard/server/actors/ruleChain/RemoteToRuleChainTellNextMsg.java
@@ -22,12 +22,15 @@ import org.thingsboard.server.common.msg.MsgType;
 import org.thingsboard.server.common.msg.aware.RuleChainAwareMsg;
 import org.thingsboard.server.common.msg.aware.TenantAwareMsg;
 
+import java.io.Serializable;
+
 /**
  * Created by ashvayka on 19.03.18.
  */
 @Data
-final class RemoteToRuleChainTellNextMsg extends RuleNodeToRuleChainTellNextMsg implements TenantAwareMsg, RuleChainAwareMsg {
+final class RemoteToRuleChainTellNextMsg extends RuleNodeToRuleChainTellNextMsg implements TenantAwareMsg, RuleChainAwareMsg, Serializable {
 
+    private static final long serialVersionUID = 2459605482321657447L;
     private final TenantId tenantId;
     private final RuleChainId ruleChainId;
 


### PR DESCRIPTION
The recently add RemoteToRuleChainTellNextMsg isn't Serializable. As a consequence sending this message over the wire fails. This PR fixes that.

```
java.lang.IllegalArgumentException: Failed to serialize object of type: class org.thingsboard.server.actors.ruleChain.RemoteToRuleChainTellNextMsg
	at org.springframework.util.SerializationUtils.serialize(SerializationUtils.java:49) ~[spring-core-4.3.4.RELEASE.jar!/:4.3.4.RELEASE]
	at org.thingsboard.server.service.encoding.ProtoWithJavaSerializationDecodingEncodingService.encode(ProtoWithJavaSerializationDecodingEncodingService.java:50) ~[classes!/:2.1.0-SNAPSHOT]
	at org.thingsboard.server.service.encoding.ProtoWithJavaSerializationDecodingEncodingService.convertToProtoDataMessage(ProtoWithJavaSerializationDecodingEncodingService.java:64) ~[classes!/:2.1.0-SNAPSHOT]
	at org.thingsboard.server.actors.ruleChain.RuleChainActorMessageProcessor.onRemoteTellNext(RuleChainActorMessageProcessor.java:239) ~[classes!/:2.1.0-SNAPSHOT]
	at org.thingsboard.server.actors.ruleChain.RuleChainActorMessageProcessor.onTellNext(RuleChainActorMessageProcessor.java:229) ~[classes!/:2.1.0-SNAPSHOT]
	at org.thingsboard.server.actors.ruleChain.RuleChainActor.process(RuleChainActor.java:53) ~[classes!/:2.1.0-SNAPSHOT]
	at org.thingsboard.server.actors.service.ContextAwareActor.onReceive(ContextAwareActor.java:43) ~[classes!/:2.1.0-SNAPSHOT]

```