### PR TITLE
RuleNodeToRuleChainTellNextMsg is not Serializable

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/ruleChain/RemoteToRuleChainTellNextMsg.java
+++ b/application/src/main/java/org/thingsboard/server/actors/ruleChain/RemoteToRuleChainTellNextMsg.java
@@ -28,7 +28,7 @@ import java.io.Serializable;
  * Created by ashvayka on 19.03.18.
  */
 @Data
-final class RemoteToRuleChainTellNextMsg extends RuleNodeToRuleChainTellNextMsg implements TenantAwareMsg, RuleChainAwareMsg, Serializable {
+final class RemoteToRuleChainTellNextMsg extends RuleNodeToRuleChainTellNextMsg implements TenantAwareMsg, RuleChainAwareMsg {
 
     private static final long serialVersionUID = 2459605482321657447L;
     private final TenantId tenantId;

--- a/application/src/main/java/org/thingsboard/server/actors/ruleChain/RuleNodeToRuleChainTellNextMsg.java
+++ b/application/src/main/java/org/thingsboard/server/actors/ruleChain/RuleNodeToRuleChainTellNextMsg.java
@@ -21,14 +21,16 @@ import org.thingsboard.server.common.msg.MsgType;
 import org.thingsboard.server.common.msg.TbActorMsg;
 import org.thingsboard.server.common.msg.TbMsg;
 
+import java.io.Serializable;
 import java.util.Set;
 
 /**
  * Created by ashvayka on 19.03.18.
  */
 @Data
-class RuleNodeToRuleChainTellNextMsg implements TbActorMsg {
+class RuleNodeToRuleChainTellNextMsg implements TbActorMsg, Serializable {
 
+    private static final long serialVersionUID = 4577026446412871820L;
     private final RuleNodeId originator;
     private final Set<String> relationTypes;
     private final TbMsg msg;


### PR DESCRIPTION
Sending RemoteToRuleChainTellNextMsg over the wire still fails because it's parent's class also must be Serializable.
This is a fixes what https://github.com/thingsboard/thingsboard/pull/949 should have fixed but dodn't entirely.

I noticed that value objects are by default not serializable. I don't know if this is by design, so I just let this one class implement Serializable and leave the others.