### PR TITLE
Hybrid db

### DIFF
--- a/application/src/main/java/org/thingsboard/server/install/ThingsboardInstallService.java
+++ b/application/src/main/java/org/thingsboard/server/install/ThingsboardInstallService.java
@@ -116,7 +116,7 @@ public class ThingsboardInstallService {
 
                 log.info("Installing DataBase schema...");
 
-                databaseSchemaService.createDatabaseSchema();
+                databaseSchemaService.createDatabaseSchema();//TODO
 
                 log.info("Loading system data...");
 

--- a/application/src/main/java/org/thingsboard/server/install/ThingsboardInstallService.java
+++ b/application/src/main/java/org/thingsboard/server/install/ThingsboardInstallService.java
@@ -116,7 +116,7 @@ public class ThingsboardInstallService {
 
                 log.info("Installing DataBase schema...");
 
-                databaseSchemaService.createDatabaseSchema();//TODO
+                databaseSchemaService.createDatabaseSchema();//TODO issue 1005 - create both SQL and C* schemas in hybrid mode
 
                 log.info("Loading system data...");
 

--- a/application/src/main/java/org/thingsboard/server/service/install/CassandraDatabaseSchemaService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/CassandraDatabaseSchemaService.java
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.thingsboard.server.dao.cassandra.CassandraInstallCluster;
-import org.thingsboard.server.dao.util.NoSqlDao;
+import org.thingsboard.server.dao.util.NoSqlAnyDao;
 import org.thingsboard.server.service.install.cql.CQLStatementsParser;
 
 import java.nio.file.Path;
@@ -28,7 +28,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 @Service
-@NoSqlDao
+@NoSqlAnyDao
 @Profile("install")
 @Slf4j
 public class CassandraDatabaseSchemaService implements DatabaseSchemaService {

--- a/application/src/main/java/org/thingsboard/server/service/install/CassandraDatabaseUpgradeService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/CassandraDatabaseUpgradeService.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 import org.thingsboard.server.dao.cassandra.CassandraCluster;
 import org.thingsboard.server.dao.cassandra.CassandraInstallCluster;
 import org.thingsboard.server.dao.dashboard.DashboardService;
-import org.thingsboard.server.dao.util.NoSqlDao;
+import org.thingsboard.server.dao.util.NoSqlAnyDao;
 import org.thingsboard.server.service.install.cql.CQLStatementsParser;
 import org.thingsboard.server.service.install.cql.CassandraDbHelper;
 
@@ -45,7 +45,7 @@ import static org.thingsboard.server.service.install.DatabaseHelper.TENANT_ID;
 import static org.thingsboard.server.service.install.DatabaseHelper.TITLE;
 
 @Service
-@NoSqlDao
+@NoSqlAnyDao
 @Profile("install")
 @Slf4j
 public class CassandraDatabaseUpgradeService implements DatabaseUpgradeService {

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -164,7 +164,8 @@ database:
   entities:
     type: "${DATABASE_TYPE:sql}" # cassandra OR sql
   ts:
-    type: "${DATABASE_TYPE:cassandra}" # cassandra OR sql
+    type: "${DATABASE_TYPE:sql}" # cassandra OR sql (for hybrid mode, only this value should be cassandra)
+
 
 # Cassandra driver configuration parameters
 cassandra:

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -151,6 +151,7 @@ quota:
       # Enable Host API Limits
       enabled: "${QUOTA_TENANT_ENABLED:false}"
       # Array of whitelist tenants
+      # Array of whitelist tenants
       whitelist: "${QUOTA_TENANT_WHITELIST:}"
       # Array of blacklist tenants
       blacklist: "${QUOTA_HOST_BLACKLIST:}"
@@ -160,6 +161,10 @@ quota:
 
 database:
   type: "${DATABASE_TYPE:sql}" # cassandra OR sql
+  entities:
+    type: "${DATABASE_TYPE:sql}" # cassandra OR sql
+  ts:
+    type: "${DATABASE_TYPE:cassandra}" # cassandra OR sql
 
 # Cassandra driver configuration parameters
 cassandra:
@@ -206,7 +211,7 @@ cassandra:
     write_consistency_level: "${CASSANDRA_WRITE_CONSISTENCY_LEVEL:ONE}"
     default_fetch_size: "${CASSANDRA_DEFAULT_FETCH_SIZE:2000}"
     # Specify partitioning size for timestamp key-value storage. Example MINUTES, HOURS, DAYS, MONTHS,INDEFINITE
-    ts_key_value_partitioning: "${TS_KV_PARTITIONING:MONTHS}"
+    ts_key_value_partitioning: "${TS_KV_PARTITIONING:INDEFINITE}"
     ts_key_value_ttl: "${TS_KV_TTL:0}"
     buffer_size: "${CASSANDRA_QUERY_BUFFER_SIZE:200000}"
     concurrent_limit: "${CASSANDRA_QUERY_CONCURRENT_LIMIT:1000}"

--- a/dao/src/main/java/org/thingsboard/server/dao/cassandra/CassandraInstallCluster.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/cassandra/CassandraInstallCluster.java
@@ -17,12 +17,12 @@ package org.thingsboard.server.dao.cassandra;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
-import org.thingsboard.server.dao.util.NoSqlDao;
+import org.thingsboard.server.dao.util.NoSqlAnyDao;
 
 import javax.annotation.PostConstruct;
 
 @Component
-@NoSqlDao
+@NoSqlAnyDao
 @Profile("install")
 public class CassandraInstallCluster extends AbstractCassandraCluster {
 

--- a/dao/src/main/java/org/thingsboard/server/dao/cassandra/CassandraQueryOptions.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/cassandra/CassandraQueryOptions.java
@@ -21,14 +21,14 @@ import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
-import org.thingsboard.server.dao.util.NoSqlDao;
+import org.thingsboard.server.dao.util.NoSqlAnyDao;
 
 import javax.annotation.PostConstruct;
 
 @Component
 @Configuration
 @Data
-@NoSqlDao
+@NoSqlAnyDao
 public class CassandraQueryOptions {
 
     @Value("${cassandra.query.default_fetch_size}")

--- a/dao/src/main/java/org/thingsboard/server/dao/cassandra/CassandraSocketOptions.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/cassandra/CassandraSocketOptions.java
@@ -20,14 +20,14 @@ import lombok.Data;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
-import org.thingsboard.server.dao.util.NoSqlDao;
+import org.thingsboard.server.dao.util.NoSqlAnyDao;
 
 import javax.annotation.PostConstruct;
 
 @Component
 @Configuration
 @Data
-@NoSqlDao
+@NoSqlAnyDao
 public class CassandraSocketOptions {
 
     @Value("${cassandra.socket.connect_timeout}")

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/timeseries/JpaTimeseriesDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/timeseries/JpaTimeseriesDao.java
@@ -42,6 +42,7 @@ import org.thingsboard.server.dao.sql.JpaAbstractDaoListeningExecutorService;
 import org.thingsboard.server.dao.timeseries.TimeseriesDao;
 import org.thingsboard.server.dao.timeseries.TsInsertExecutorType;
 import org.thingsboard.server.dao.util.SqlDao;
+import org.thingsboard.server.dao.util.SqlTsDao;
 
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
@@ -58,7 +59,7 @@ import static org.thingsboard.server.common.data.UUIDConverter.fromTimeUUID;
 
 @Component
 @Slf4j
-@SqlDao
+@SqlTsDao
 public class JpaTimeseriesDao extends JpaAbstractDaoListeningExecutorService implements TimeseriesDao {
 
     @Value("${sql.ts_inserts_executor_type}")

--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDao.java
@@ -47,6 +47,7 @@ import org.thingsboard.server.common.data.kv.TsKvQuery;
 import org.thingsboard.server.dao.model.ModelConstants;
 import org.thingsboard.server.dao.nosql.CassandraAbstractAsyncDao;
 import org.thingsboard.server.dao.util.NoSqlDao;
+import org.thingsboard.server.dao.util.NoSqlTsDao;
 
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
@@ -68,7 +69,7 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
  */
 @Component
 @Slf4j
-@NoSqlDao
+@NoSqlTsDao
 public class CassandraBaseTimeseriesDao extends CassandraAbstractAsyncDao implements TimeseriesDao {
 
     private static final int MIN_AGGREGATION_STEP_MS = 1000;

--- a/dao/src/main/java/org/thingsboard/server/dao/util/BufferedRateLimiter.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/BufferedRateLimiter.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
 @Slf4j
-@NoSqlDao
+@NoSqlAnyDao
 public class BufferedRateLimiter implements AsyncRateLimiter {
 
     private final ListeningExecutorService pool = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(10));

--- a/dao/src/main/java/org/thingsboard/server/dao/util/NoSqlAnyDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/NoSqlAnyDao.java
@@ -13,24 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.dao.cassandra;
+package org.thingsboard.server.dao.util;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import org.thingsboard.server.dao.util.NoSqlAnyDao;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 
-import javax.annotation.PostConstruct;
-
-@Component
-@NoSqlAnyDao
-public class CassandraCluster extends AbstractCassandraCluster {
-
-    @Value("${cassandra.keyspace_name}")
-    private String keyspaceName;
-
-    @PostConstruct
-    public void init() {
-        super.init(keyspaceName);
-    }
-
+@ConditionalOnExpression("'${database.type}'=='cassandra' || '${database.ts.type}'=='cassandra'")
+public @interface NoSqlAnyDao {
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/util/NoSqlTsDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/NoSqlTsDao.java
@@ -13,24 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.dao.cassandra;
+package org.thingsboard.server.dao.util;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import org.thingsboard.server.dao.util.NoSqlAnyDao;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-import javax.annotation.PostConstruct;
-
-@Component
-@NoSqlAnyDao
-public class CassandraCluster extends AbstractCassandraCluster {
-
-    @Value("${cassandra.keyspace_name}")
-    private String keyspaceName;
-
-    @PostConstruct
-    public void init() {
-        super.init(keyspaceName);
-    }
-
+@ConditionalOnProperty(prefix = "database.ts", value = "type", havingValue = "cassandra")
+public @interface NoSqlTsDao {
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/util/SqlTsDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/SqlTsDao.java
@@ -13,24 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.dao.cassandra;
+package org.thingsboard.server.dao.util;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-import org.thingsboard.server.dao.util.NoSqlAnyDao;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-import javax.annotation.PostConstruct;
-
-@Component
-@NoSqlAnyDao
-public class CassandraCluster extends AbstractCassandraCluster {
-
-    @Value("${cassandra.keyspace_name}")
-    private String keyspaceName;
-
-    @PostConstruct
-    public void init() {
-        super.init(keyspaceName);
-    }
-
+@ConditionalOnProperty(prefix = "database.ts", value = "type", havingValue = "sql")
+public @interface SqlTsDao {
 }


### PR DESCRIPTION
issue #1005
add support for activating hybrid db mode using thingsboard.yml parameter database.ts.type=cassandra
add annotations SqlTsDao, NoSqlTsDao (and NoSqlAnyDao for Cassandra infra classes that are needed both in database.type=cassandra and in hybrid mode)
TODO: installation (currently need to manually create cassandra schema for hybrid mode)