### PR TITLE
Add missing break in switch statement of AppActor.

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
@@ -116,6 +116,7 @@ public class AppActor extends RuleChainManagerActor {
                 break;
             case ACTOR_SYSTEM_TO_DEVICE_SESSION_ACTOR_MSG:
                 onToDeviceSessionMsg((BasicActorSystemToDeviceSessionActorMsg) msg);
+                break;
             default:
                 return false;
         }


### PR DESCRIPTION
A break was missing in one of the cases of AppActor's switch statement. As a result the logfiles got an false warning message (Unknown message). 