### PR TITLE
fix bug get shared config for gateway

### DIFF
--- a/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/adaptors/JsonMqttAdaptor.java
+++ b/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/adaptors/JsonMqttAdaptor.java
@@ -183,8 +183,8 @@ public class JsonMqttAdaptor implements MqttTransportAdaptor {
             Integer requestId = Integer.valueOf(topicName.substring(MqttTopics.DEVICE_ATTRIBUTES_REQUEST_TOPIC_PREFIX.length()));
             String payload = inbound.payload().toString(UTF8);
             JsonElement requestBody = new JsonParser().parse(payload);
-            Set<String> clientKeys = toStringSet(requestBody, "clientKeys");
-            Set<String> sharedKeys = toStringSet(requestBody, "sharedKeys");
+            Set<String> clientKeys = toStringSet(requestBody, "client");
+            Set<String> sharedKeys = toStringSet(requestBody, "shared");
             if (clientKeys == null && sharedKeys == null) {
                 return new BasicGetAttributesRequest(requestId);
             } else {


### PR DESCRIPTION
If `remoteConfiguration: true` in gateway config and a extension config in thingsboard backend is pressent when gateway service starts it will request the shard config form the backend. This always fails because the request message gets not correctly parsed. The json entry key is `shared` and not `sharedKeys`.