### PR TITLE
issue-1248: Correct mispelled package.json dependecy (flot.curvedlines)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,7 @@
     "compass-sass-mixins": "^0.12.7",
     "event-source-polyfill": "0.0.9",
     "flot": "git://github.com/thingsboard/flot.git#0.9-work",
-    "flot-curvedlines": "git://github.com/MichaelZinsmaier/CurvedLines.git#master",
+    "flot.curvedlines": "git://github.com/MichaelZinsmaier/CurvedLines.git#master",
     "font-awesome": "^4.6.3",
     "javascript-detect-element-resize": "^0.5.3",
     "jquery": "^3.1.0",


### PR DESCRIPTION
Correct mispelled **flot.curvedlines** (was flow-curvedlines) dependency on ui/package.json

Package name is [flot.curvedlines](https://github.com/MichaelZinsmaier/CurvedLines/blob/master/package.json#L2)  (with a dot)

Resolves https://github.com/thingsboard/thingsboard/issues/1248

Literally a single character MR :smile: 

Before this, when executing `npm run build`, it throws this error:

```
ERROR in ./src/app/widget/lib/flot-widget.js

/home/gmatheu/Documentos/ascentio/ascentio-tech/thingsboard/ui/src/app/widget/lib/flot-widget.js
  26:8  error  Unable to resolve path to module 'flot.curvedlines/curvedLines'  import/no-unresolved

✖ 1 problem (1 error, 0 warnings)


ERROR in ./src/app/widget/lib/flot-widget.js
Module not found: Error: Cannot resolve module 'flot.curvedlines/curvedLines' in /home/gmatheu/Documentos/ascentio/ascentio-tech/thingsboard/ui/src/app/widget/lib
 @ ./src/app/widget/lib/flot-widget.js 50:0-39

```