### PR TITLE
Fix sql missing primary keys

### DIFF
--- a/dao/src/main/resources/sql/schema-entities.sql
+++ b/dao/src/main/resources/sql/schema-entities.sql
@@ -72,7 +72,7 @@ CREATE TABLE IF NOT EXISTS attribute_kv (
   long_v bigint,
   dbl_v double precision,
   last_update_ts bigint,
-  CONSTRAINT attribute_kv_unq_key UNIQUE (entity_type, entity_id, attribute_type, attribute_key)
+  CONSTRAINT attribute_kv_pkey PRIMARY KEY (entity_type, entity_id, attribute_type, attribute_key)
 );
 
 CREATE TABLE IF NOT EXISTS component_descriptor (
@@ -148,7 +148,7 @@ CREATE TABLE IF NOT EXISTS relation (
     relation_type_group varchar(255),
     relation_type varchar(255),
     additional_info varchar,
-    CONSTRAINT relation_unq_key UNIQUE (from_id, from_type, relation_type_group, relation_type, to_id, to_type)
+    CONSTRAINT relation_pkey PRIMARY KEY (from_id, from_type, relation_type_group, relation_type, to_id, to_type)
 );
 
 CREATE TABLE IF NOT EXISTS tb_user (

--- a/dao/src/main/resources/sql/schema-ts.sql
+++ b/dao/src/main/resources/sql/schema-ts.sql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS ts_kv (
     str_v varchar(10000000),
     long_v bigint,
     dbl_v double precision,
-    CONSTRAINT ts_kv_unq_key UNIQUE (entity_type, entity_id, key, ts)
+    CONSTRAINT ts_kv_pkey PRIMARY KEY (entity_type, entity_id, key, ts)
 );
 
 CREATE TABLE IF NOT EXISTS ts_kv_latest (
@@ -35,5 +35,5 @@ CREATE TABLE IF NOT EXISTS ts_kv_latest (
     str_v varchar(10000000),
     long_v bigint,
     dbl_v double precision,
-    CONSTRAINT ts_kv_latest_unq_key UNIQUE (entity_type, entity_id, key)
+    CONSTRAINT ts_kv_latest_pkey PRIMARY KEY (entity_type, entity_id, key)
 );


### PR DESCRIPTION
This pull request changes the unique indexes of the four tables without primary keys into primary keys.

Reason: Many database tools like Entity Framework Core require a primary key to be present for each table in order to generate a database context and all entities.

I have tested that the database is fully working by applying this script to an existing schema:

```
ALTER TABLE relation DROP CONSTRAINT relation_unq_key;
ALTER TABLE relation ADD CONSTRAINT relation_pkey PRIMARY KEY (from_id, from_type, relation_type_group, relation_type, to_id, to_type);

ALTER TABLE attribute_kv DROP CONSTRAINT attribute_kv_unq_key;
ALTER TABLE attribute_kv ADD CONSTRAINT attribute_kv_pkey PRIMARY KEY (entity_type, entity_id, attribute_type, attribute_key);

ALTER TABLE ts_kv DROP CONSTRAINT ts_kv_unq_key;
ALTER TABLE ts_kv ADD CONSTRAINT ts_kv_pkey PRIMARY KEY (entity_type, entity_id, key, ts);

ALTER TABLE ts_kv_latest DROP CONSTRAINT ts_kv_latest_unq_key;
ALTER TABLE ts_kv_latest ADD CONSTRAINT ts_kv_latest_pkey PRIMARY KEY (entity_type, entity_id, key);
```