### PR TITLE
Add ability to disable map updates after zoom-in PROD-60 task

### DIFF
--- a/ui/src/app/api/subscription.js
+++ b/ui/src/app/api/subscription.js
@@ -648,6 +648,12 @@ export default class Subscription {
     }
 
     dataUpdated(sourceData, datasourceIndex, dataKeyIndex, apply) {
+        for (var x = 0; x < this.datasourceListeners.length; x++) {
+            this.datasources[x].dataReceived = this.datasources[x].dataReceived === true;
+            if (this.datasourceListeners[x].datasourceIndex === datasourceIndex && sourceData.data.length > 0) {
+                this.datasources[x].dataReceived = true;
+            }
+        }
         this.notifyDataLoaded();
         var update = true;
         var currentData;

--- a/ui/src/app/widget/lib/map-widget2.js
+++ b/ui/src/app/widget/lib/map-widget2.js
@@ -60,7 +60,8 @@ export default class TbMapWidgetV2 {
 
         var minZoomLevel = this.drawRoutes ? 18 : 15;
 
-        this.initBounds = true;
+
+
 
         var initCallback = function() {
             tbMap.update();
@@ -89,6 +90,9 @@ export default class TbMapWidgetV2 {
         } else if (mapProvider === 'tencent-map') {
             this.map = new TbTencentMap($element,this.utils, initCallback, this.defaultZoomLevel, this.dontFitMapBounds, minZoomLevel, settings.tmApiKey, settings.tmDefaultMapType);
         }
+
+
+        tbMap.initBounds = true;
     }
 
     setCallbacks(callbacks) {
@@ -444,6 +448,7 @@ export default class TbMapWidgetV2 {
         }
 
         function updateLocations(data, datasources) {
+
             var locationsChanged = false;
             var bounds = tbMap.map.createBounds();
             var dataMap = toLabelValueMap(data, datasources);
@@ -457,8 +462,11 @@ export default class TbMapWidgetV2 {
                 }
             }
              if (locationsChanged && tbMap.initBounds) {
-                 tbMap.map.fitBounds(bounds);
-                 tbMap.initBounds = false;
+                tbMap.initBounds = !datasources.every(
+                    function (ds) {
+                        return ds.dataReceived === true;
+                    });
+                tbMap.map.fitBounds(bounds);
              }
         }
 
@@ -480,7 +488,6 @@ export default class TbMapWidgetV2 {
             content = fillPattern(settings.tooltipPattern, settings.tooltipReplaceInfo, data);
             return fillPatternWithActions(content, 'onTooltipAction', tooltip.markerArgs);
         }
-
         if (this.map && this.map.inited() && this.subscription) {
             if (this.subscription.data) {
                 if (!this.locations) {

--- a/ui/src/app/widget/lib/map-widget2.js
+++ b/ui/src/app/widget/lib/map-widget2.js
@@ -60,6 +60,8 @@ export default class TbMapWidgetV2 {
 
         var minZoomLevel = this.drawRoutes ? 18 : 15;
 
+        this.initBounds = true;
+
         var initCallback = function() {
             tbMap.update();
             tbMap.resize();
@@ -454,9 +456,10 @@ export default class TbMapWidgetV2 {
                     tbMap.map.extendBoundsWithMarker(bounds, location.marker);
                 }
             }
-            if (locationsChanged) {
-                tbMap.map.fitBounds(bounds);
-            }
+             if (locationsChanged && tbMap.initBounds) {
+                 tbMap.map.fitBounds(bounds);
+                 tbMap.initBounds = false;
+             }
         }
 
         function createTooltipContent(tooltip, data, datasources) {


### PR DESCRIPTION
Added _dataReceived_ attribute to data source to indicate that data was received at least once.
Added _initBounds_ attribute to map widget which indicates ability remove auto focus and zoom on current map.
Added check/change condition for _initBounds_ attribute that depends on _dataReceived_ attribute value.