### PR TITLE
Use a fast serialization library like FST for serialization of TbActo…

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -42,6 +42,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>de.ruedigermoeller</groupId>
+            <artifactId>fst</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
             <version>${netty.version}</version>
@@ -179,6 +183,10 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
@@ -528,6 +536,16 @@
                 </configuration>
                 <executions>
                     <execution>
+                        <id>boot</id>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                        <!--<configuration>-->
+                            <!--<classifier>axians-custom</classifier>-->
+                        <!--</configuration>-->
+                    </execution>
+                    <execution>
+                        <id>custom</id>
                         <goals>
                             <goal>repackage</goal>
                         </goals>

--- a/application/src/main/java/org/thingsboard/server/service/encoding/ProtoWithFSTService.java
+++ b/application/src/main/java/org/thingsboard/server/service/encoding/ProtoWithFSTService.java
@@ -17,8 +17,8 @@ package org.thingsboard.server.service.encoding;
 
 import com.google.protobuf.ByteString;
 import lombok.extern.slf4j.Slf4j;
+import org.nustaq.serialization.FSTConfiguration;
 import org.springframework.stereotype.Service;
-import org.springframework.util.SerializationUtils;
 import org.thingsboard.server.common.msg.TbActorMsg;
 import org.thingsboard.server.common.msg.cluster.ServerAddress;
 import org.thingsboard.server.gen.cluster.ClusterAPIProtos;
@@ -30,13 +30,14 @@ import static org.thingsboard.server.gen.cluster.ClusterAPIProtos.MessageType.CL
 
 @Slf4j
 @Service
-public class ProtoWithJavaSerializationDecodingEncodingService implements DataDecodingEncodingService {
+public class ProtoWithFSTService implements DataDecodingEncodingService {
 
 
+    private final FSTConfiguration config = FSTConfiguration.createDefaultConfiguration();
     @Override
     public Optional<TbActorMsg> decode(byte[] byteArray) {
         try {
-            TbActorMsg msg = (TbActorMsg) SerializationUtils.deserialize(byteArray);
+            TbActorMsg msg = (TbActorMsg) config.asObject(byteArray);
             return Optional.of(msg);
 
         } catch (IllegalArgumentException e) {
@@ -47,7 +48,7 @@ public class ProtoWithJavaSerializationDecodingEncodingService implements DataDe
 
     @Override
     public byte[] encode(TbActorMsg msq) {
-        return SerializationUtils.serialize(msq);
+        return config.asByteArray(msq);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <delight-nashorn-sandbox.version>0.1.14</delight-nashorn-sandbox.version>
         <kafka.version>2.0.0</kafka.version>
         <bucket4j.version>4.1.1</bucket4j.version>
+        <fst.version>2.57</fst.version>
     </properties>
 
     <modules>
@@ -794,6 +795,11 @@
                 <groupId>com.github.vladimir-bukhtoyarov</groupId>
                 <artifactId>bucket4j-core</artifactId>
                 <version>${bucket4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.ruedigermoeller</groupId>
+                <artifactId>fst</artifactId>
+                <version>${fst.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.springfox.ui</groupId>


### PR DESCRIPTION
Use a fast serialization library like FST for serialization of TbActorMsg instead of the default java serialization because java serialization is notoriously slow.

This should improve throughput when serialization/deserialization is the bottleneck.

See https://github.com/RuedigerMoeller/fast-serialization