### PR TITLE
fix regEx

### DIFF
--- a/ui/webpack.config.prod.js
+++ b/ui/webpack.config.prod.js
@@ -96,7 +96,7 @@ module.exports = {
         new CompressionPlugin({
             asset: "[path].gz[query]",
             algorithm: "gzip",
-            test: /\.js$|\.css$|\.svg$|\.ttf$|\.woff$|\.woff2|\.eot$\.json$/,
+            test: /\.js$|\.css$|\.svg$|\.ttf$|\.woff$|\.woff2$|\.eot$|\.json$/,
             threshold: 10240,
             minRatio: 0.8
         }),


### PR DESCRIPTION
I noticed a regEx missing an `|`, which leads to `.eot` and `.json` not being properly recognized.

(Full disclosure: I noticed using the automatic code analysis tool LGTM which my company works for: [link to alert](https://lgtm.com/projects/g/thingsboard/thingsboard/snapshot/4ad077b5058ff5a3eb4bf05d8b84489d5dab8f75/files/ui/webpack.config.prod.js#x75d982e4c4aea7a0:1))