### PR TITLE
Add full Canadian postal code validation.

### DIFF
--- a/ui/src/app/components/contact.directive.js
+++ b/ui/src/app/components/contact.directive.js
@@ -283,7 +283,7 @@ function Contact($compile, $templateCache) {
         "Austria": "[0-9]{4}",
         "Belgium": "[0-9]{4}",
         "Brazil": "[0-9]{5}[\\-]?[0-9]{3}",
-        "Canada": "[A-Za-z][0-9][A-Za-z] [0-9][A-Za-z][0-9]",
+        "Canada": "^(?!.*[DFIOQU])[A-VXY][0-9][A-Z][ -]?[0-9][A-Z][0-9]$",
         "Denmark": "[0-9]{3,4}",
         "Faroe Islands": "[0-9]{3,4}",
         "Netherlands": "[1-9][0-9]{3}\\s?[a-zA-Z]{2}",


### PR DESCRIPTION
Please review. Note the upper case change, if necessary lower case can be added back but generally upper case is used in Canadian postal codes. 