### PR TITLE
Fix postgres deployment on GKE

### DIFF
--- a/k8s/postgres.yml
+++ b/k8s/postgres.yml
@@ -55,6 +55,8 @@ spec:
         env:
         - name: POSTGRES_DB
           value: "thingsboard"
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         volumeMounts:
           - mountPath: /var/lib/postgresql/data
             name: postgres-data


### PR DESCRIPTION
When creating postgres deployment on GKE Postgres complains about data folder being mounted directly on root of the PV claim.

```
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.utf8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

initdb: directory "/var/lib/postgresql/data" exists but is not empty
It contains a lost+found directory, perhaps due to it being a mount point.
Using a mount point directly as the data directory is not recommended.
Create a subdirectory under the mount point.
```

A simple solution is to force Postgres to use a sub folder using PGDATA env variable.