### PR TITLE
Improvement float directory: fix autoScale and delete not support param

### DIFF
--- a/ui/src/app/widget/lib/flot-widget.js
+++ b/ui/src/app/widget/lib/flot-widget.js
@@ -535,7 +535,11 @@ export default class TbFlot {
         yaxis.tickUnits = units;
         yaxis.tickDecimals = tickDecimals;
         yaxis.tickSize = tickSize;
-        yaxis.alignTicksWithAxis = position == "right" ? 1 : null;
+        if (position === "right" && tickSize === null) {
+            yaxis.alignTicksWithAxis = 1;
+        } else {
+            yaxis.alignTicksWithAxis = null;
+        }
         yaxis.position = position;
 
         yaxis.keysInfo = [];
@@ -938,11 +942,6 @@ export default class TbFlot {
                     "type": "string",
                     "default": null
                 },
-                "titleAngle": {
-                    "title": "Axis title's angle in degrees",
-                    "type": "number",
-                    "default": 0
-                },
                 "color": {
                     "title": "Ticks color",
                     "type": "string",
@@ -974,11 +973,6 @@ export default class TbFlot {
                     "title": "Axis title",
                     "type": "string",
                     "default": null
-                },
-                "titleAngle": {
-                    "title": "Axis title's angle in degrees",
-                    "type": "number",
-                    "default": 0
                 },
                 "color": {
                     "title": "Ticks color",
@@ -1048,7 +1042,6 @@ export default class TbFlot {
             "items": [
                 "xaxis.showLabels",
                 "xaxis.title",
-                "xaxis.titleAngle",
                 {
                     "key": "xaxis.color",
                     "type": "color"
@@ -1064,7 +1057,6 @@ export default class TbFlot {
                 "yaxis.tickSize",
                 "yaxis.showLabels",
                 "yaxis.title",
-                "yaxis.titleAngle",
                 {
                     "key": "yaxis.color",
                     "type": "color"


### PR DESCRIPTION
Delete param "Axis title's angle" because it does not work on ThingsBoard and even not supported in the current version of float charts.
Fix displaying yAxis in charts, when option "Axis position" is set to "right" and the value of  "Axis step size between ticks" option is set up.  In that case, yAxis ignored option "Axis step size between ticks" but the autoscaling. 