### PR TITLE
Fix ${entityName} resolution when using a state entity parameter name

### DIFF
--- a/ui/src/app/components/widget/widget.controller.js
+++ b/ui/src/app/components/widget/widget.controller.js
@@ -455,6 +455,7 @@ export default function WidgetController($scope, $state, $timeout, $window, $ele
                 if (!targetEntityParams) {
                     targetEntityParams = {};
                     params[targetEntityParamName] = targetEntityParams;
+					params.targetEntityParamName = targetEntityParamName;
                 }
             } else {
                 targetEntityParams = params;

--- a/ui/src/app/dashboard/states/entity-state-controller.js
+++ b/ui/src/app/dashboard/states/entity-state-controller.js
@@ -179,6 +179,9 @@ export default function EntityStateController($scope, $timeout, $location, $stat
 
     function resolveEntity(params) {
         var deferred = $q.defer();
+        if (params && params.targetEntityParamName) {
+            params = params[params.targetEntityParamName];
+        }
         if (params && params.entityId && params.entityId.id && params.entityId.entityType) {
             if (params.entityName && params.entityName.length) {
                 deferred.resolve(params.entityName);


### PR DESCRIPTION
Using ${entityName} in dashboard state name allows entity name resolution using resolveEntity() function. 
This is done using the following object:

```
{
  entityId: {
    id: "767b5ca0-878f-11e9-bc60-e900a1e32051", 
    entityType: "ASSET"}
  entityName: "Current name"
}
```
However, if a state entity parameter name (i.e. "parameterName") is defined when opening a new dashboard state, the previous object is modified as:

```
{
  parameterName: {
    entityId: {
      id: "767b5ca0-878f-11e9-bc60-e900a1e32051", 
      entityType: "ASSET"}
    entityName: "Current name"
  }
}
```

In this way, resolveEntity() cannot access entityName key anymore, and ${entityName} results undefined.

This fix add a further key (**targetEntityParamName**) to point out a state entity parameter name is used, so entityName can be still resolved.

```
{
  targetEntityParamName: "parameterName",
  parameterName: {
    entityId: {
      id: "767b5ca0-878f-11e9-bc60-e900a1e32051", 
      entityType: "ASSET"}
    entityName: "Current name"
  }
}
```