### PR TITLE
Fix 'md-circular-progress' with no resolved entities

### DIFF
--- a/ui/src/app/api/subscription.js
+++ b/ui/src/app/api/subscription.js
@@ -292,6 +292,7 @@ export default class Subscription {
                         deferred.resolve();
                     },
                     function fail() {
+                        subscription.notifyDataLoaded();
                         deferred.reject();
                     }
                 );


### PR DESCRIPTION
Widgets HTML template has a 'md-circular-progress' element that remains active until its subscription returns a list of resolved entities. However, it this list is empty, no one disables the progress indicator, which runs to infinity. This fix invokes the 'notifyDataLoaded' callback even if there are no resolved entities, without however reconfiguring widget data.