### PR TITLE
Add the possibility to select timewindow source even for individual parameters separately

### DIFF
--- a/ui/src/app/api/subscription.js
+++ b/ui/src/app/api/subscription.js
@@ -85,7 +85,34 @@ export default class Subscription {
 
             if (this.useDashboardTimewindow) {
                 this.timeWindowConfig = angular.copy(options.dashboardTimewindow);
-            } else {
+            } else if (angular.isDefined(options.timeWindowConfig)) {
+                var dashboardAggInterval = null;
+                if (options.timeWindowConfig.useDashboardAggregation) {
+                    options.timeWindowConfig.aggregation = angular.copy(options.dashboardTimewindow.aggregation);
+                }
+                if (options.timeWindowConfig.useDashboardInterval) {
+                    dashboardAggInterval = angular.isDefined(options.timeWindowConfig.realtime) ?
+                            options.timeWindowConfig.realtime.interval : options.timeWindowConfig.history.interval;
+                    if (angular.isDefined(options.dashboardTimewindow.realtime)) {
+                        options.timeWindowConfig.realtime = angular.copy(options.dashboardTimewindow.realtime);
+                        delete options.timeWindowConfig.history;
+                    }
+                    else if (angular.isDefined(options.dashboardTimewindow.history)) {
+                        options.timeWindowConfig.history = angular.copy(options.dashboardTimewindow.history);
+                        delete options.timeWindowConfig.realtime;
+                    }
+                }
+                if (options.timeWindowConfig.useDashboardAggInterval) {
+                    dashboardAggInterval = angular.isDefined(options.dashboardTimewindow.realtime) ?
+                            options.dashboardTimewindow.realtime.interval : options.dashboardTimewindow.history.interval;
+                }
+                if (dashboardAggInterval) {
+                    if (angular.isDefined(options.timeWindowConfig.realtime)) {
+                        options.timeWindowConfig.realtime.interval = dashboardAggInterval;
+                    } else if (angular.isDefined(options.timeWindowConfig.history)) {
+                        options.timeWindowConfig.history.interval = dashboardAggInterval;
+                    }
+                }
                 this.timeWindowConfig = angular.copy(options.timeWindowConfig);
             }
 
@@ -127,7 +154,34 @@ export default class Subscription {
             this.stateData = options.stateData;
             if (this.useDashboardTimewindow) {
                 this.timeWindowConfig = angular.copy(options.dashboardTimewindow);
-            } else {
+            } else if (angular.isDefined(options.timeWindowConfig)) {
+                dashboardAggInterval = null;
+                if (options.timeWindowConfig.useDashboardAggregation) {
+                    options.timeWindowConfig.aggregation = angular.copy(options.dashboardTimewindow.aggregation);
+                }
+                if (options.timeWindowConfig.useDashboardInterval) {
+                    dashboardAggInterval = angular.isDefined(options.timeWindowConfig.realtime) ?
+                            options.timeWindowConfig.realtime.interval : options.timeWindowConfig.history.interval;
+                    if (angular.isDefined(options.dashboardTimewindow.realtime)) {
+                        options.timeWindowConfig.realtime = angular.copy(options.dashboardTimewindow.realtime);
+                        delete options.timeWindowConfig.history;
+                    }
+                    else if (angular.isDefined(options.dashboardTimewindow.history)) {
+                        options.timeWindowConfig.history = angular.copy(options.dashboardTimewindow.history);
+                        delete options.timeWindowConfig.realtime;
+                    }
+                }
+                if (options.timeWindowConfig.useDashboardAggInterval) {
+                    dashboardAggInterval = angular.isDefined(options.dashboardTimewindow.realtime) ?
+                            options.dashboardTimewindow.realtime.interval : options.dashboardTimewindow.history.interval;
+                }
+                if (dashboardAggInterval) {
+                    if (angular.isDefined(options.timeWindowConfig.realtime)) {
+                        options.timeWindowConfig.realtime.interval = dashboardAggInterval;
+                    } else if (angular.isDefined(options.timeWindowConfig.history)) {
+                        options.timeWindowConfig.history.interval = dashboardAggInterval;
+                    }
+                }
                 this.timeWindowConfig = angular.copy(options.timeWindowConfig);
             }
 
@@ -371,8 +425,47 @@ export default class Subscription {
                     }
                 });
                 this.registrations.push(registration);
+            } else if (this.timeWindowConfig.useDashboardAggregation || this.timeWindowConfig.useDashboardAggInterval ||
+                    this.timeWindowConfig.useDashboardInterval) {
+                registration = this.ctx.$scope.$on('dashboardTimewindowChanged', function (event, newDashboardTimewindow) {
+                    subscription.updateFromDashboardTimewindow(subscription, newDashboardTimewindow);
+                });
+                this.registrations.push(registration);
+                this.startWatchingTimewindow();
             } else {
                 this.startWatchingTimewindow();
+            }
+        }
+    }
+
+    updateFromDashboardTimewindow(subscription, newDashboardTimewindow) {
+        if (newDashboardTimewindow) {
+            var prevTimewindow = angular.isDefined(subscription.timeWindowConfig.realtime) ?
+                    angular.copy(subscription.timeWindowConfig.realtime) : angular.copy(subscription.timeWindowConfig.history);
+            var newTimewindow = angular.isDefined(newDashboardTimewindow.realtime) ?
+                    angular.copy(newDashboardTimewindow.realtime) : angular.copy(newDashboardTimewindow.history);
+            var dashboardAggInterval = prevTimewindow.interval;
+            if (subscription.timeWindowConfig.useDashboardAggregation) {
+                subscription.timeWindowConfig.aggregation = angular.copy(newDashboardTimewindow.aggregation);
+            }
+            if (subscription.timeWindowConfig.useDashboardInterval) {
+                if (angular.isDefined(newDashboardTimewindow.realtime)) {
+                    subscription.timeWindowConfig.realtime = angular.copy(newDashboardTimewindow.realtime);
+                    delete subscription.timeWindowConfig.history;
+                }
+                else if (angular.isDefined(newDashboardTimewindow.history)) {
+                    subscription.timeWindowConfig.history = angular.copy(newDashboardTimewindow.history);
+                    delete subscription.timeWindowConfig.realtime;
+                }
+            }
+            if (subscription.timeWindowConfig.useDashboardAggInterval) {
+                dashboardAggInterval = newTimewindow.interval;
+            }
+
+            if (angular.isDefined(subscription.timeWindowConfig.realtime)) {
+                subscription.timeWindowConfig.realtime.interval = dashboardAggInterval;
+            } else if (angular.isDefined(subscription.timeWindowConfig.history)) {
+                subscription.timeWindowConfig.history.interval = dashboardAggInterval;
             }
         }
     }
@@ -592,6 +685,33 @@ export default class Subscription {
     }
 
     updateTimewindowConfig(newTimewindow) {
+        var dashboardAggInterval = null;
+        if (this.timeWindowConfig.useDashboardAggregation) {
+            newTimewindow.aggregation = angular.copy(this.timeWindowConfig.aggregation);
+        }
+        if (this.timeWindowConfig.useDashboardInterval) {
+            dashboardAggInterval = angular.isDefined(this.timeWindowConfig.realtime) ?
+                    this.timeWindowConfig.realtime.interval : this.timeWindowConfig.history.interval;
+            if (angular.isDefined(this.timeWindowConfig.realtime)) {
+                newTimewindow.realtime = angular.copy(this.timeWindowConfig.realtime);
+                delete newTimewindow.history;
+            }
+            else if (angular.isDefined(this.timeWindowConfig.history)) {
+                newTimewindow.history = angular.copy(this.timeWindowConfig.history);
+                delete newTimewindow.realtime;
+            }
+        }
+        if (this.timeWindowConfig.useDashboardAggInterval) {
+            dashboardAggInterval = angular.isDefined(this.timeWindowConfig.realtime) ?
+                    this.timeWindowConfig.realtime.interval : this.timeWindowConfig.history.interval;
+        }
+        if (dashboardAggInterval) {
+            if (angular.isDefined(newTimewindow.realtime)) {
+                newTimewindow.realtime.interval = dashboardAggInterval;
+            } else if (angular.isDefined(newTimewindow.history)) {
+                newTimewindow.history.interval = dashboardAggInterval;
+            }
+        }
         this.timeWindowConfig = newTimewindow;
     }
 

--- a/ui/src/app/api/time.service.js
+++ b/ui/src/app/api/time.service.js
@@ -283,6 +283,9 @@ function TimeService($translate, $http, $q, types) {
 
 
         var historyTimewindow = {
+            useDashboardInterval: timewindow.useDashboardInterval || false,
+            useDashboardAggregation: timewindow.useDashboardAggregation || false,
+            useDashboardAggInterval: timewindow.useDashboardAggInterval || false,
             history: {
                 fixedTimewindow: {
                     startTimeMs: startTimeMs,

--- a/ui/src/app/api/time.service.js
+++ b/ui/src/app/api/time.service.js
@@ -238,6 +238,9 @@ function TimeService($translate, $http, $q, types) {
             hideInterval: false,
             hideAggregation: false,
             hideAggInterval: false,
+            useDashboardInterval: false,
+            useDashboardAggregation: false,
+            useDashboardAggInterval: false,
             realtime: {
                 interval: SECOND,
                 timewindowMs: MINUTE // 1 min by default

--- a/ui/src/app/components/timeinterval.directive.js
+++ b/ui/src/app/components/timeinterval.directive.js
@@ -233,6 +233,8 @@ function Timeinterval($compile, $templateCache, timeService) {
             max: '=?',
             predefinedName: '=?',
             hideFlag: '=?',
+            fromDashboardFlag: '=?',
+            isToolbar: '=?',
             isEdit: '=?'
         },
         link: linker

--- a/ui/src/app/components/timeinterval.tpl.html
+++ b/ui/src/app/components/timeinterval.tpl.html
@@ -16,9 +16,14 @@
 
 -->
 <section layout="row">
-	<section layout="column" layout-align=" none" ng-show="isEdit">
+	<section layout="column" layout-align="none center" ng-show="isEdit" style="padding-right: 10px;">
 		<label class="tb-small advanced-label" translate>timewindow.hide</label>
 		<md-checkbox aria-label="{{ 'timewindow.hide' | translate }}" ng-model="hideFlag">
+		</md-checkbox>
+	</section>
+	<section layout="column" layout-align="none center" ng-show="isEdit && !isToolbar" style="padding-right: 10px;">
+		<label class="tb-small advanced-label" translate>timewindow.from-dashboard</label>
+		<md-checkbox aria-label="{{ 'timewindow.from-dashboard' | translate }}" ng-model="fromDashboardFlag">
 		</md-checkbox>
 	</section>
 	<section layout="column" flex ng-show="advanced && (isEdit || !hideFlag)">
@@ -26,26 +31,26 @@
 		<section layout="row" layout-align="start start" flex>
 			<md-input-container>
 				 <label translate>timeinterval.days</label>
-				 <input type="number" ng-model="days" step="1" aria-label="{{ 'timeinterval.days' | translate }}">
+				 <input ng-disabled="hideFlag || fromDashboardFlag" type="number" ng-model="days" step="1" aria-label="{{ 'timeinterval.days' | translate }}">
 			</md-input-container>
 			<md-input-container>
 				 <label translate>timeinterval.hours</label>
-				 <input ng-disabled="hideFlag" type="number" ng-model="hours" step="1" aria-label="{{ 'timeinterval.hours' | translate }}">
+				 <input ng-disabled="hideFlag || fromDashboardFlag" type="number" ng-model="hours" step="1" aria-label="{{ 'timeinterval.hours' | translate }}">
 			</md-input-container>
 			<md-input-container>
 				 <label translate>timeinterval.minutes</label>
-				 <input type="number" ng-model="mins" step="1" aria-label="{{ 'timeinterval.minutes' | translate }}">
+				 <input ng-disabled="hideFlag || fromDashboardFlag" type="number" ng-model="mins" step="1" aria-label="{{ 'timeinterval.minutes' | translate }}">
 			</md-input-container>
 			<md-input-container>
 				 <label translate>timeinterval.seconds</label>
-				 <input ng-disabled="hideFlag" type="number" ng-model="secs" step="1" aria-label="{{ 'timeinterval.seconds' | translate }}">
+				 <input ng-disabled="hideFlag || fromDashboardFlag" type="number" ng-model="secs" step="1" aria-label="{{ 'timeinterval.seconds' | translate }}">
 			</md-input-container>
 		</section>
 	</section>
 	<section layout="row" flex ng-show="!advanced && (isEdit || !hideFlag)">
 		<md-input-container flex>
 			<label translate>{{ predefinedName }}</label>
-			<md-select ng-disabled="hideFlag" ng-model="intervalMs" style="min-width: 150px;" aria-label="predefined-interval">
+			<md-select ng-disabled="hideFlag || fromDashboardFlag" ng-model="intervalMs" style="min-width: 150px;" aria-label="predefined-interval">
 				<md-option ng-repeat="interval in intervals" ng-value="interval.value">
 					{{interval.name}}
 				</md-option>
@@ -54,7 +59,7 @@
 	</section>
 	<section layout="column" layout-align="center center" ng-show="(isEdit || !hideFlag)">
 		<label class="tb-small advanced-label" translate>timeinterval.advanced</label>
-		<md-switch ng-disabled="hideFlag" class="advanced-switch" ng-model="advanced" aria-label="predefined-switcher">
+		<md-switch ng-disabled="hideFlag || fromDashboardFlag" class="advanced-switch" ng-model="advanced" aria-label="predefined-switcher">
 		</md-switch>
 	</section>
 </section>

--- a/ui/src/app/components/timewindow-panel.controller.js
+++ b/ui/src/app/components/timewindow-panel.controller.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /*@ngInject*/
-export default function TimewindowPanelController(mdPanelRef, $scope, timeService, types, timewindow, historyOnly, aggregation, isEdit, onTimewindowUpdate) {
+export default function TimewindowPanelController(mdPanelRef, $scope, timeService, types, timewindow, historyOnly, aggregation, isEdit, isToolbar, onTimewindowUpdate) {
 
     var vm = this;
 
@@ -34,6 +34,7 @@ export default function TimewindowPanelController(mdPanelRef, $scope, timeServic
     vm.minDatapointsLimit = minDatapointsLimit;
     vm.maxDatapointsLimit = maxDatapointsLimit;
     vm.isEdit = isEdit;
+    vm.isToolbar = isToolbar;
 
     if (vm.historyOnly) {
         vm.timewindow.selectedTab = 1;

--- a/ui/src/app/components/timewindow-panel.tpl.html
+++ b/ui/src/app/components/timewindow-panel.tpl.html
@@ -19,26 +19,37 @@
 	<fieldset ng-disabled="$root.loading">
 		<md-content style="height: 100%" flex layout="column">
 			<section layout="column">
-				<md-tabs ng-class="{'tb-headless': vm.historyOnly}" md-dynamic-height md-selected="vm.timewindow.selectedTab" md-border-bottom>
+				<md-tabs ng-class="{'tb-headless': vm.historyOnly}" md-dynamic-height md-selected="vm.timewindow.selectedTab" md-border-bottom
+						 ng-hide="!vm.isEdit && (vm.timewindow.hideInterval || vm.timewindow.useDashboardInterval)">
 					<md-tab label="{{ 'timewindow.realtime' | translate }}">
 						<md-content class="md-padding" layout="column">
-							<tb-timeinterval hide-flag="vm.timewindow.hideInterval" predefined-name="'timewindow.last'"
-								is-edit="vm.isEdit" ng-required="vm.timewindow.selectedTab === 0"
+							<tb-timeinterval hide-flag="vm.timewindow.hideInterval" from-dashboard-flag="vm.timewindow.useDashboardInterval"
+								is-toolbar="vm.isToolbar" predefined-name="'timewindow.last'" is-edit="vm.isEdit" ng-required="vm.timewindow.selectedTab === 0"
 								ng-model="vm.timewindow.realtime.timewindowMs" style="padding-top: 8px;"></tb-timeinterval>
 						</md-content>
 					</md-tab>
 					<md-tab label="{{ 'timewindow.history' | translate }}">
 						<section layout="row">
-							<section layout="column" class="md-padding" style="padding-top: 8px;">
-								<label ng-if="vm.isEdit" class="tb-small advanced-label" translate>timewindow.hide</label>
-								<md-checkbox ng-if="vm.isEdit" aria-label="{{ 'timewindow.hide' | translate }}"
-											 ng-model="vm.timewindow.hideInterval">
+							<section layout="column" class="md-padding" layout-align="none center" ng-show="vm.isEdit"
+										 style="padding-right: 10px; padding-top: 8px;">
+								<label class="tb-small advanced-label" translate>timewindow.hide</label>
+								<md-checkbox aria-label="{{ 'timewindow.hide' | translate }}"
+												 ng-model="vm.timewindow.hideInterval" >
 								</md-checkbox>
 							</section>
-							<section layout="column" flex ng-show="vm.isEdit || !vm.timewindow.hideInterval">
+							<section layout="column" layout-align="none center" ng-show="vm.isEdit && !vm.isToolbar"
+										 style="padding-right: 10px; padding-top: 8px;">
+								<label class="tb-small advanced-label" translate>timewindow.from-dashboard</label>
+								<md-checkbox aria-label="{{ 'timewindow.from-dashboard' | translate }}"
+												 ng-model="vm.timewindow.useDashboardInterval">
+								</md-checkbox>
+							</section>
+							<section layout="column" flex>
 								<md-content class="md-padding" layout="column" style="padding-top: 8px;">
-									<md-radio-group ng-disabled="vm.timewindow.hideInterval" ng-model="vm.timewindow.history.historyType" class="md-primary">
-										<md-radio-button ng-value=0 aria-label="{{ 'timewindow.last' | translate }}" class="md-primary md-align-top-left md-radio-interactive">
+									<md-radio-group ng-disabled="vm.timewindow.hideInterval || vm.timewindow.useDashboardInterval" 
+														ng-model="vm.timewindow.history.historyType" class="md-primary">
+										<md-radio-button ng-value=0 aria-label="{{ 'timewindow.last' | translate }}" 
+															 class="md-primary md-align-top-left md-radio-interactive">
 											<section layout="column">
 												<tb-timeinterval predefined-name="'timewindow.last'"
 													ng-required="vm.timewindow.selectedTab === 1 && vm.timewindow.history.historyType === 0"
@@ -46,7 +57,8 @@
 													ng-model="vm.timewindow.history.timewindowMs" style="padding-top: 8px;"></tb-timeinterval>
 											</section>
 										</md-radio-button>
-										<md-radio-button ng-value=1 aria-label="{{ 'timewindow.time-period' | translate }}" class="md-primary md-align-top-left md-radio-interactive">
+										<md-radio-button ng-value=1 aria-label="{{ 'timewindow.time-period' | translate }}"
+															 class="md-primary md-align-top-left md-radio-interactive">
 											<section layout="column">
 												<span translate>timewindow.time-period</span>
 												<tb-datetime-period
@@ -61,18 +73,26 @@
 						</section>
 					</md-tab>
 				</md-tabs>
-				<md-content ng-if="vm.aggregation" class="md-padding" layout="column">
+				<md-content ng-if="vm.aggregation" class="md-padding" layout="column"
+							ng-style="(vm.timewindow.hideInterval || vm.timewindow.useDashboardInterval) ? {'padding-top':'8px'} : {}">
 					<section layout="row">
-						<section layout="column" style="padding-top: 5px;" ng-show="vm.isEdit">
+						<section layout="column" layout-align="none center" ng-show="vm.isEdit" style="padding-right: 10px; padding-top: 5px;">
 							<label class="tb-small advanced-label" translate>timewindow.hide</label>
 							<md-checkbox aria-label="{{ 'timewindow.hide' | translate }}"
-										 ng-model="vm.timewindow.hideAggregation">
+										 ng-model="vm.timewindow.hideAggregation" >
+							</md-checkbox>
+						</section>
+						<section layout="column" layout-align="none center" ng-show="vm.isEdit && !vm.isToolbar" style="padding-right: 10px; padding-top: 5px;">
+							<label class="tb-small advanced-label" translate>timewindow.from-dashboard</label>
+							<md-checkbox aria-label="{{ 'timewindow.from-dashboard' | translate }}"
+										 ng-model="vm.timewindow.useDashboardAggregation">
 							</md-checkbox>
 						</section>
 						<section layout="column" flex ng-show="vm.isEdit || !vm.timewindow.hideAggregation">
 							<md-input-container>
 								<label translate>aggregation.function</label>
-								<md-select ng-disabled="vm.timewindow.hideAggregation" ng-model="vm.timewindow.aggregation.type" style="min-width: 150px;">
+								<md-select ng-disabled="vm.timewindow.hideAggregation || vm.timewindow.useDashboardAggregation"
+										   ng-model="vm.timewindow.aggregation.type" style="min-width: 150px;">
 									<md-option ng-repeat="type in vm.aggregationTypes" ng-value="type.value">
 										{{type.name | translate}}
 									</md-option>
@@ -80,34 +100,35 @@
 							</md-input-container>
 						</section>
 					</section>
-					<section layout="row" ng-show="vm.showLimit()">
-						<section layout="column" style="padding-top: 5px;" ng-show="vm.showLimit() && vm.isEdit">
+					<section layout="row" flex ng-show="vm.showLimit()">
+						<section layout="column" layout-align="none center" ng-show="vm.isEdit" style="padding-right: 95px; padding-top: 5px;">
 							<label class="tb-small advanced-label" translate>timewindow.hide</label>
 							<md-checkbox aria-label="{{ 'timewindow.hide' | translate }}"
 										 ng-model="vm.timewindow.hideAggInterval" >
 							</md-checkbox>
 						</section>
-						<section layout="column" flex ng-show="vm.isEdit || !vm.timewindow.hideAggInterval">
-							<md-slider-container>
-								<span translate>aggregation.limit</span>
-								<md-slider flex min="{{vm.minDatapointsLimit()}}" max="{{vm.maxDatapointsLimit()}}" step="1"
-										   ng-disabled="vm.timewindow.hideAggInterval" ng-model="vm.timewindow.aggregation.limit" aria-label="limit" id="limit-slider">
-								</md-slider>
-								<md-input-container style="max-width: 80px;">
-									<input flex type="number" step="1" ng-disabled="vm.timewindow.hideAggInterval"
-										   min="{{vm.minDatapointsLimit()}}" max="{{vm.maxDatapointsLimit()}}"
-										   ng-model="vm.timewindow.aggregation.limit" aria-label="limit" aria-controls="limit-slider">
-								</md-input-container>
-							</md-slider-container>
-						</section>
+						<md-slider-container ng-show="vm.isEdit || !vm.timewindow.hideAggInterval">
+							<span translate>aggregation.limit</span>
+							<md-slider flex min="{{vm.minDatapointsLimit()}}" max="{{vm.maxDatapointsLimit()}}" step="1"
+									   ng-disabled="vm.timewindow.hideAggInterval"
+									   ng-model="vm.timewindow.aggregation.limit" aria-label="limit" id="limit-slider">
+							</md-slider>
+							<md-input-container style="max-width: 80px;">
+								<input flex type="number" step="1" ng-disabled="vm.timewindow.hideAggInterval"
+									   min="{{vm.minDatapointsLimit()}}" max="{{vm.maxDatapointsLimit()}}"
+									   ng-model="vm.timewindow.aggregation.limit" aria-label="limit" aria-controls="limit-slider">
+							</md-input-container>
+						</md-slider-container>
 					</section>
-					<tb-timeinterval ng-if="vm.showRealtimeAggInterval()" min="vm.minRealtimeAggInterval()"
+					<tb-timeinterval ng-if="vm.showRealtimeAggInterval()" min="vm.minRealtimeAggInterval()" is-toolbar="vm.isToolbar"
 									 max="vm.maxRealtimeAggInterval()" ng-model="vm.timewindow.realtime.interval" is-edit="vm.isEdit"
-									 hide-flag="vm.timewindow.hideAggInterval" predefined-name="'aggregation.group-interval'">
+									 hide-flag="vm.timewindow.hideAggInterval" from-dashboard-flag="vm.timewindow.useDashboardAggInterval"
+									 predefined-name="'aggregation.group-interval'">
 					</tb-timeinterval>
-					<tb-timeinterval ng-if="vm.showHistoryAggInterval()" min="vm.minHistoryAggInterval()"
+					<tb-timeinterval ng-if="vm.showHistoryAggInterval()" min="vm.minHistoryAggInterval()" is-toolbar="vm.isToolbar"
 									 max="vm.maxHistoryAggInterval()" ng-model="vm.timewindow.history.interval" is-edit="vm.isEdit"
-									 hide-flag="vm.timewindow.hideAggInterval" predefined-name="'aggregation.group-interval'">
+									 hide-flag="vm.timewindow.hideAggInterval" from-dashboard-flag="vm.timewindow.useDashboardAggInterval"
+									 predefined-name="'aggregation.group-interval'">
 					</tb-timeinterval>
 				</md-content>
 			</section>

--- a/ui/src/app/components/timewindow.directive.js
+++ b/ui/src/app/components/timewindow.directive.js
@@ -46,6 +46,9 @@ function Timewindow($compile, $templateCache, $filter, $mdPanel, $document, $mdM
          *    hideInterval: false,
          *    hideAggregation: false,
          *    hideAggInterval: false,
+         *    useDashboardInterval: false,
+         *    useDashboardAggregation: false,
+         *    useDashboardAggInterval: false,
          * 	  realtime: {
          * 	        interval: 0,
          * 			timewindowMs: 0
@@ -142,6 +145,7 @@ function Timewindow($compile, $templateCache, $filter, $mdPanel, $document, $mdM
                     'historyOnly': scope.historyOnly,
                     'aggregation': scope.aggregation,                    
                     'isEdit': scope.isEdit,
+                    'isToolbar': scope.isToolbar,
                     'onTimewindowUpdate': function (timewindow) {
                         scope.model = timewindow;
                         scope.updateView();
@@ -186,6 +190,9 @@ function Timewindow($compile, $templateCache, $filter, $mdPanel, $document, $mdM
             value.hideInterval = model.hideInterval;
             value.hideAggregation = model.hideAggregation;
             value.hideAggInterval = model.hideAggInterval;
+            value.useDashboardInterval = model.useDashboardInterval;
+            value.useDashboardAggregation = model.useDashboardAggregation;
+            value.useDashboardAggInterval = model.useDashboardAggInterval;
             ngModelCtrl.$setViewValue(value);
             scope.updateDisplayValue();
         }
@@ -242,6 +249,9 @@ function Timewindow($compile, $templateCache, $filter, $mdPanel, $document, $mdM
                 model.hideInterval = value.hideInterval;
                 model.hideAggregation = value.hideAggregation;
                 model.hideAggInterval = value.hideAggInterval;
+                model.useDashboardInterval = value.useDashboardInterval;
+                model.useDashboardAggregation = value.useDashboardAggregation;
+                model.useDashboardAggInterval = value.useDashboardAggInterval;
             }
             scope.updateDisplayValue();
         };

--- a/ui/src/app/components/timewindow.tpl.html
+++ b/ui/src/app/components/timewindow.tpl.html
@@ -15,14 +15,17 @@
     limitations under the License.
 
 -->
-<section class="tb-timewindow" layout='row' layout-align="start center">
+<section class="tb-timewindow" layout='row' layout-align="start center"
+         ng-hide="!isEdit && (model.hideInterval || model.useDashboardInterval) &&
+                  (model.hideAggInterval || model.useDashboardAggInterval) &&
+                  (model.hideAggregation || model.useDashboardAggregation)">
     <md-button ng-if="direction === 'left'" ng-disabled="disabled" class="md-icon-button tb-md-32" aria-label="{{ 'timewindow.edit' | translate }}" ng-click="openEditMode($event)">
         <md-tooltip md-direction="{{tooltipDirection}}">
             {{ 'timewindow.edit' | translate }}
         </md-tooltip>
         <ng-md-icon aria-label="{{ 'timewindow.date-range' | translate }}" icon="query_builder"></ng-md-icon>
     </md-button>
-    <span ng-hide="hideLabel()" ng-click="openEditMode($event)">
+    <span ng-hide="hideLabel() || model.useDashboardInterval" ng-click="openEditMode($event)">
         <md-tooltip md-direction="{{tooltipDirection}}">
             {{ 'timewindow.edit' | translate }}
         </md-tooltip>

--- a/ui/src/app/locale/locale.constant-en_US.json
+++ b/ui/src/app/locale/locale.constant-en_US.json
@@ -1413,7 +1413,8 @@
         "date-range": "Date range",
         "last": "Last",
         "time-period": "Time period",
-        "hide": "Hide"
+        "hide": "Hide",
+        "from-dashboard": "From dashboard"
     },
     "user": {
         "user": "User",

--- a/ui/src/app/locale/locale.constant-es_ES.json
+++ b/ui/src/app/locale/locale.constant-es_ES.json
@@ -1412,7 +1412,8 @@
         "date-range": "Rango de fecha",
         "last": "Último(s)",
         "time-period": "Período de tiempo",
-        "hide": "Ocultar"
+        "hide": "Ocultar",
+        "from-dashboard": "Desde ed panel"
     },
     "user": {
         "user": "Usuario",

--- a/ui/src/app/locale/locale.constant-fr_FR.json
+++ b/ui/src/app/locale/locale.constant-fr_FR.json
@@ -1265,7 +1265,8 @@
         "realtime": "Temps réel",
         "seconds": "{seconds, plural, 0 {second} 1 {1 second} other {# seconds}}",
         "time-period": "Période",
-        "hide": "Masquer"
+        "hide": "Masquer",
+        "from-dashboard": "Du tableau de bord"
     },
     "user": {
         "activation-email-sent-message": "L'e-mail d'activation a été envoyé avec succès!",

--- a/ui/src/app/locale/locale.constant-it_IT.json
+++ b/ui/src/app/locale/locale.constant-it_IT.json
@@ -1354,7 +1354,8 @@
         "date-range": "Intervallo date",
         "last": "Ultimo",
         "time-period": "Intervallo temporale",
-        "hide": "Nascondi"
+        "hide": "Nascondi",
+        "from-dashboard": "Da dashboard"
     },
     "user": {
         "user": "Utente",


### PR DESCRIPTION
Currently the subscription parameters of a widget are taken either from the widget timewindow or from the general one of dashboard. It should be possible to create a mixed subscription, in which some parameters are selected locally (in the widget's timewindow), while others are taken from the global one.