### PR TITLE
Update dashboard state after 'entityAliasesChanged' event

### DIFF
--- a/ui/src/app/api/entity.service.js
+++ b/ui/src/app/api/entity.service.js
@@ -413,7 +413,15 @@ function EntityService($http, $q, $filter, $translate, $log, userService, device
                 aliasInfo.resolvedEntities = result.entities;
                 aliasInfo.currentEntity = null;
                 if (aliasInfo.resolvedEntities.length) {
-                    aliasInfo.currentEntity = aliasInfo.resolvedEntities[0];
+                    var defaultEntity;
+                    if (!filter.resolveMultiple) {
+                        if (stateParams && stateParams.targetEntityParamName === entityAlias.alias) {
+                            defaultEntity = $filter('filter')(aliasInfo.resolvedEntities, {id: stateParams[entityAlias.alias].entityId.id});
+                        } else if (filter.defaultEntity) {
+                            defaultEntity = $filter('filter')(aliasInfo.resolvedEntities, {id: filter.defaultEntity.id});
+                        }
+                    }
+                    aliasInfo.currentEntity = defaultEntity ? defaultEntity[0] : aliasInfo.resolvedEntities[0];
                 }
                 deferred.resolve(aliasInfo);
             },

--- a/ui/src/app/components/widget/widget.controller.js
+++ b/ui/src/app/components/widget/widget.controller.js
@@ -769,6 +769,18 @@ export default function WidgetController($scope, $state, $timeout, $window, $ocL
 
         $scope.$on('entityAliasesChanged', function (event, aliasIds) {
             var subscriptionChanged = false;
+            var selectedAlias = widgetContext.aliasController.getInstantAliasInfo(aliasIds);
+
+            if (selectedAlias) {
+                var params = {};
+                var entityId = {
+                    entityType : selectedAlias.currentEntity.entityType,
+                    id: selectedAlias.currentEntity.id
+                };
+                updateEntityParams(params, selectedAlias.alias, entityId, selectedAlias.currentEntity.name);
+                widgetContext.stateController.updateState(null, params, null);
+            }
+
             for (var id in widgetContext.subscriptions) {
                 var subscription = widgetContext.subscriptions[id];
                 subscriptionChanged = subscriptionChanged || subscription.onAliasesChanged(aliasIds);

--- a/ui/src/app/entity/entity-filter.directive.js
+++ b/ui/src/app/entity/entity-filter.directive.js
@@ -63,14 +63,17 @@ export default function EntityFilterDirective($compile, $templateCache, $q, $doc
                     break;
                 case types.aliasFilterType.assetType.value:
                     filter.assetType = null;
+                    filter.defaultEntity = null;
                     filter.assetNameFilter = '';
                     break;
                 case types.aliasFilterType.deviceType.value:
                     filter.deviceType = null;
+                    filter.defaultEntity = null;
                     filter.deviceNameFilter = '';
                     break;
                 case types.aliasFilterType.entityViewType.value:
                     filter.entityViewType = null;
+                    filter.defaultEntity = null;
                     filter.entityViewNameFilter = '';
                     break;
                 case types.aliasFilterType.relationsQuery.value:

--- a/ui/src/app/entity/entity-filter.tpl.html
+++ b/ui/src/app/entity/entity-filter.tpl.html
@@ -91,6 +91,15 @@
                 ng-model="filter.assetType"
                 entity-type="types.entityType.asset">
         </tb-entity-subtype-autocomplete>
+        <div flex layout="column" ng-if="!filter.resolveMultiple">
+            <label class="tb-small">{{ 'alias.default-entity' | translate }}</label>
+            <tb-entity-select flex
+                              the-form="theForm"
+                              tb-required="false"
+                              allowed-entity-types="[types.entityType.asset]"
+                              ng-model="filter.defaultEntity">
+            </tb-entity-select>
+        </div>
         <md-input-container class="md-block">
             <label translate>asset.name-starts-with</label>
             <input name="assetNameFilter"
@@ -105,6 +114,15 @@
                 ng-model="filter.deviceType"
                 entity-type="types.entityType.device">
         </tb-entity-subtype-autocomplete>
+        <div flex layout="column" ng-if="!filter.resolveMultiple">
+            <label class="tb-small">{{ 'alias.default-entity' | translate }}</label>
+            <tb-entity-select flex
+                              the-form="theForm"
+                              tb-required="false"
+                              allowed-entity-types="[types.entityType.device]"
+                              ng-model="filter.defaultEntity">
+            </tb-entity-select>
+        </div>
         <md-input-container class="md-block">
             <label translate>device.name-starts-with</label>
             <input name="deviceNameFilter"
@@ -119,6 +137,15 @@
                 ng-model="filter.entityViewType"
                 entity-type="types.entityType.entityView">
         </tb-entity-subtype-autocomplete>
+        <div flex layout="column" ng-if="!filter.resolveMultiple">
+            <label class="tb-small">{{ 'alias.default-entity' | translate }}</label>
+            <tb-entity-select flex
+                              the-form="theForm"
+                              tb-required="false"
+                              allowed-entity-types="[types.entityType.entityView]"
+                              ng-model="filter.defaultEntity">
+            </tb-entity-select>
+        </div>
         <md-input-container class="md-block">
             <label translate>entity-view.name-starts-with</label>
             <input name="entityViewNameFilter"

--- a/ui/src/app/locale/locale.constant-de_DE.json
+++ b/ui/src/app/locale/locale.constant-de_DE.json
@@ -184,7 +184,8 @@
     "unlimited-level": "Unbegrenzte Ebenen",
     "state-entity": "Dashboard Status Entität",
     "all-entities": "Alle Entitäten",
-    "any-relation": "Jede Beziehung"
+    "any-relation": "Jede Beziehung",
+    "default-entity": "Standard Entität"
   },
   "asset": {
     "asset": "Objekt",

--- a/ui/src/app/locale/locale.constant-en_US.json
+++ b/ui/src/app/locale/locale.constant-en_US.json
@@ -207,7 +207,8 @@
         "unlimited-level": "Unlimited level",
         "state-entity": "Dashboard state entity",
         "all-entities": "All entities",
-        "any-relation": "any"
+        "any-relation": "any",
+        "default-entity": "Default entity"
     },
     "asset": {
         "asset": "Asset",

--- a/ui/src/app/locale/locale.constant-es_ES.json
+++ b/ui/src/app/locale/locale.constant-es_ES.json
@@ -201,7 +201,8 @@
         "unlimited-level": "Nivel ilimitado",
         "state-entity": "Entidad del panel de estados",
         "all-entities": "Todas las entidades",
-        "any-relation": "alguna"
+        "any-relation": "alguna",
+        "default-entity": "Entidad predeterminada"
     },
     "asset": {
         "asset": "Activo",

--- a/ui/src/app/locale/locale.constant-fr_FR.json
+++ b/ui/src/app/locale/locale.constant-fr_FR.json
@@ -186,7 +186,8 @@
         "root-state-entity": "Utiliser l'entité d'état du tableau de bord en tant que racine",
         "state-entity": "Entité d'état du tableau de bord",
         "state-entity-parameter-name": "Nom du paramétre d'entité d'état",
-        "unlimited-level": "niveau illimité"
+        "unlimited-level": "niveau illimité",
+        "default-entity": "Entité par défaut"
     },
     "asset": {
         "add": "Ajouter un actif",

--- a/ui/src/app/locale/locale.constant-it_IT.json
+++ b/ui/src/app/locale/locale.constant-it_IT.json
@@ -185,7 +185,8 @@
         "unlimited-level": "Illimitato",
         "state-entity": "Entità di stato della dashboard",
         "all-entities": "Tutte le entità",
-        "any-relation": "qualsiasi"
+        "any-relation": "qualsiasi",
+        "default-entity": "Entità predefinita"
     },
     "asset": {
         "asset": "Asset",


### PR DESCRIPTION
Currently, aliases entity selection menu contains all aliases that are resolved as a list but not as multiple entities. When an entity is selected from this menu, dashboard state must be updated in order to update all widgets and other aliases that depends on that one.