### PR TITLE
Fixed spelling of german word Standard

### DIFF
--- a/ui/src/app/locale/locale.constant-de_DE.json
+++ b/ui/src/app/locale/locale.constant-de_DE.json
@@ -200,7 +200,7 @@
     "root-entity": "Wurzelentität",
     "state-entity-parameter-name": "Parameter-Name der Statusentität",
     "default-state-entity": "Standard Statusentität",
-    "default-entity-parameter-name": "Standartmäßig",
+    "default-entity-parameter-name": "Standardmäßig",
     "max-relation-level": "Maximale Beziehungstiefe",
     "unlimited-level": "Unbegrenzte Ebenen",
     "state-entity": "Dashboard Status Entität",


### PR DESCRIPTION
Its just a small typo.