### PR TITLE
Add some datakey settings to edit legend appearance for flot widget

### DIFF
--- a/ui/src/app/api/subscription.js
+++ b/ui/src/app/api/subscription.js
@@ -316,7 +316,8 @@ export default class Subscription {
             var datasource = this.datasources[i];
             for (var a = 0; a < datasource.dataKeys.length; a++) {
                 var dataKey = datasource.dataKeys[a];
-                dataKey.hidden = false;
+                dataKey.hidden = dataKey.settings.hideDataByDefault ? true : false;
+                dataKey.inLegend = dataKey.settings.removeFromLegend ? false : true;
                 dataKey.pattern = angular.copy(dataKey.label);
                 var datasourceData = {
                     datasource: datasource,

--- a/ui/src/app/components/legend.directive.js
+++ b/ui/src/app/components/legend.directive.js
@@ -46,7 +46,9 @@ function Legend($compile, $templateCache, types) {
         scope.isRowDirection = scope.legendConfig.direction === types.direction.row.value;
 
         scope.toggleHideData = function(index) {
-            scope.legendData.keys[index].dataKey.hidden = !scope.legendData.keys[index].dataKey.hidden;
+            if (!scope.legendData.keys[index].dataKey.settings.disableDataHiding) {
+                scope.legendData.keys[index].dataKey.hidden = !scope.legendData.keys[index].dataKey.hidden;
+            }
         }
 
         $compile(element.contents())(scope);

--- a/ui/src/app/components/legend.tpl.html
+++ b/ui/src/app/components/legend.tpl.html
@@ -27,7 +27,8 @@
         </tr>
     </thead>
     <tbody>
-        <tr class="tb-legend-keys" ng-repeat="legendKey in legendData.keys" ng-if="!isRowDirection">
+        <tr class="tb-legend-keys" ng-repeat="legendKey in legendData.keys"
+            ng-if="!isRowDirection && legendData.keys[legendKey.dataIndex].dataKey.inLegend">
             <td><span class="tb-legend-line"  ng-style="{backgroundColor: legendKey.dataKey.color}"></span></td>
             <td class="tb-legend-label"
                 ng-click="toggleHideData(legendKey.dataIndex)"
@@ -41,7 +42,7 @@
         </tr>
         <tr class="tb-legend-keys" ng-class="{ 'tb-row-direction': !displayHeader() }" ng-if="isRowDirection">
             <td></td>
-            <td ng-repeat="legendKey in legendData.keys">
+            <td ng-repeat="legendKey in legendData.keys" ng-if="legendData.keys[legendKey.dataIndex].dataKey.inLegend">
                 <span class="tb-legend-line" ng-style="{backgroundColor: legendKey.dataKey.color}"></span>
                 <span class="tb-legend-label"
                       ng-click="toggleHideData(legendKey.dataIndex)"
@@ -52,19 +53,31 @@
         </tr>
         <tr class="tb-legend-keys" ng-if="isRowDirection && legendConfig.showMin === true">
             <td class="tb-legend-type">{{ 'legend.min' | translate }}</td>
-            <td class="tb-legend-value" ng-repeat="legendKey in legendData.keys">{{ legendData.data[legendKey.dataIndex].min }}</td>
+            <td class="tb-legend-value" ng-repeat="legendKey in legendData.keys"
+                ng-if="legendData.keys[legendKey.dataIndex].dataKey.inLegend">
+                {{ legendData.data[legendKey.dataIndex].min }}
+            </td>
         </tr>
         <tr class="tb-legend-keys" ng-if="isRowDirection && legendConfig.showMax === true">
             <td class="tb-legend-type">{{ 'legend.max' | translate }}</td>
-            <td class="tb-legend-value" ng-repeat="legendKey in legendData.keys">{{ legendData.data[legendKey.dataIndex].max }}</td>
+            <td class="tb-legend-value" ng-repeat="legendKey in legendData.keys"
+                ng-if="legendData.keys[legendKey.dataIndex].dataKey.inLegend">
+                {{ legendData.data[legendKey.dataIndex].max }}
+            </td>
         </tr>
         <tr class="tb-legend-keys" ng-if="isRowDirection && legendConfig.showAvg === true">
             <td class="tb-legend-type">{{ 'legend.avg' | translate }}</td>
-            <td class="tb-legend-value" ng-repeat="legendKey in legendData.keys">{{ legendData.data[legendKey.dataIndex].avg }}</td>
+            <td class="tb-legend-value" ng-repeat="legendKey in legendData.keys"
+                ng-if="legendData.keys[legendKey.dataIndex].dataKey.inLegend">
+                {{ legendData.data[legendKey.dataIndex].avg }}
+            </td>
         </tr>
         <tr class="tb-legend-keys" ng-if="isRowDirection && legendConfig.showTotal === true">
             <td class="tb-legend-type">{{ 'legend.total' | translate }}</td>
-            <td class="tb-legend-value" ng-repeat="legendKey in legendData.keys">{{ legendData.data[legendKey.dataIndex].total }}</td>
+            <td class="tb-legend-value" ng-repeat="legendKey in legendData.keys"
+                ng-if="legendData.keys[legendKey.dataIndex].dataKey.inLegend">
+                {{ legendData.data[legendKey.dataIndex].total }}
+            </td>
         </tr>
     </tbody>
 </table>

--- a/ui/src/app/widget/lib/flot-widget.js
+++ b/ui/src/app/widget/lib/flot-widget.js
@@ -1083,7 +1083,35 @@ export default class TbFlot {
     }
 
     static get pieDatakeySettingsSchema() {
-        return {}
+        return {
+            "schema": {
+                "type": "object",
+                "title": "DataKeySettings",
+                "properties": {
+                    "hideDataByDefault": {
+                        "title": "Data is hidden by default",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "disableDataHiding": {
+                        "title": "Disable data hiding",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "removeFromLegend": {
+                        "title": "Remove datakey from legend",
+                        "type": "boolean",
+                        "default": false
+                    }
+                },
+                "required": []
+            },
+            "form": [
+                "hideDataByDefault",
+                "disableDataHiding",
+                "removeFromLegend"
+            ]
+        };
     }
 
     static datakeySettingsSchema(defaultShowLines) {
@@ -1092,6 +1120,21 @@ export default class TbFlot {
                 "type": "object",
                 "title": "DataKeySettings",
                 "properties": {
+                    "hideDataByDefault": {
+                        "title": "Data is hidden by default",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "disableDataHiding": {
+                        "title": "Disable data hiding",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "removeFromLegend": {
+                        "title": "Remove datakey from legend",
+                        "type": "boolean",
+                        "default": false
+                    },
                     "showLines": {
                         "title": "Show lines",
                         "type": "boolean",
@@ -1161,6 +1204,9 @@ export default class TbFlot {
                 "required": ["showLines", "fillLines", "showPoints"]
             },
             "form": [
+                "hideDataByDefault",
+                "disableDataHiding",
+                "removeFromLegend",
                 "showLines",
                 "fillLines",
                 "showPoints",


### PR DESCRIPTION
Add some options to datakey settings schema to edit legend appearance. In 'line' and 'pie' flot widget it's now possible to:
 - hide a datakey by default
 - disable data hiding by click 
 - remove a datakey from legend