### PR TITLE
added delete alarm api to alarm ui service

### DIFF
--- a/ui/src/app/api/alarm.service.js
+++ b/ui/src/app/api/alarm.service.js
@@ -47,6 +47,7 @@ function AlarmService($http, $q, $interval, $filter, $timeout, utils, types) {
         saveAlarm: saveAlarm,
         ackAlarm: ackAlarm,
         clearAlarm: clearAlarm,
+        deleteAlarm: deleteAlarm,
         getAlarms: getAlarms,
         getHighestAlarmSeverity: getHighestAlarmSeverity,
         pollAlarms: pollAlarms,
@@ -125,6 +126,21 @@ function AlarmService($http, $q, $interval, $filter, $timeout, utils, types) {
         }
         config = Object.assign(config, { ignoreErrors: ignoreErrors });
         $http.post(url, null, config).then(function success(response) {
+            deferred.resolve(response.data);
+        }, function fail() {
+            deferred.reject();
+        });
+        return deferred.promise;
+    }
+
+    function deleteAlarm(alarmId, ignoreErrors, config) {
+        var deferred = $q.defer();
+        var url = '/api/alarm/' + alarmId;
+        if (!config) {
+            config = {};
+        }
+        config = Object.assign(config, { ignoreErrors: ignoreErrors });
+        $http.delete(url, config).then(function success(response) {
             deferred.resolve(response.data);
         }, function fail() {
             deferred.reject();


### PR DESCRIPTION
Issue: https://github.com/thingsboard/thingsboard/issues/1261

The delete alarm api wasn't added to the alarm.service.js.

Can be used in alarm widget like this:
```
var $injector = widgetContext.$scope.$injector;
var alarmService = $injector.get('alarmService');
alarmService.deleteAlarm(additionalParams.alarm.id.id);
```