### PR TITLE
Fix timewindow parameters when zooming flot widget chart

### DIFF
--- a/ui/src/app/api/time.service.js
+++ b/ui/src/app/api/time.service.js
@@ -280,6 +280,9 @@ function TimeService($translate, $http, $q, types) {
 
 
         var historyTimewindow = {
+            hideInterval: timewindow.hideInterval || false,
+            hideAggregation: timewindow.hideAggregation || false,
+            hideAggInterval: timewindow.hideAggInterval || false,
             history: {
                 fixedTimewindow: {
                     startTimeMs: startTimeMs,


### PR DESCRIPTION
This resolves the issue described in https://github.com/thingsboard/thingsboard/issues/2268