### PR TITLE
Add possibility to select a preferred entity for alias not resolved as multiple entities

### DIFF
--- a/ui/src/app/api/entity.service.js
+++ b/ui/src/app/api/entity.service.js
@@ -414,6 +414,15 @@ function EntityService($http, $q, $filter, $translate, $log, userService, device
                 aliasInfo.currentEntity = null;
                 if (aliasInfo.resolvedEntities.length) {
                     aliasInfo.currentEntity = aliasInfo.resolvedEntities[0];
+                    var defaultEntity = [];
+                    if (!filter.resolveMultiple) {
+                        if (stateParams && stateParams.targetEntityParamName === entityAlias.alias) {
+                            defaultEntity = $filter('filter')(aliasInfo.resolvedEntities, {id: stateParams[entityAlias.alias].entityId.id});
+                        } else if (filter.defaultEntity) {
+                            defaultEntity = $filter('filter')(aliasInfo.resolvedEntities, {id: filter.defaultEntity.id});
+                        }
+                    }
+                    aliasInfo.currentEntity = defaultEntity.length ? defaultEntity[0] : aliasInfo.resolvedEntities[0];        
                 }
                 deferred.resolve(aliasInfo);
             },

--- a/ui/src/app/entity/entity-filter.directive.js
+++ b/ui/src/app/entity/entity-filter.directive.js
@@ -63,14 +63,17 @@ export default function EntityFilterDirective($compile, $templateCache, $q, $doc
                     break;
                 case types.aliasFilterType.assetType.value:
                     filter.assetType = null;
+                    filter.defaultEntity = null;
                     filter.assetNameFilter = '';
                     break;
                 case types.aliasFilterType.deviceType.value:
                     filter.deviceType = null;
+                    filter.defaultEntity = null;
                     filter.deviceNameFilter = '';
                     break;
                 case types.aliasFilterType.entityViewType.value:
                     filter.entityViewType = null;
+                    filter.defaultEntity = null;
                     filter.entityViewNameFilter = '';
                     break;
                 case types.aliasFilterType.relationsQuery.value:

--- a/ui/src/app/entity/entity-filter.tpl.html
+++ b/ui/src/app/entity/entity-filter.tpl.html
@@ -91,6 +91,15 @@
                 ng-model="filter.assetType"
                 entity-type="types.entityType.asset">
         </tb-entity-subtype-autocomplete>
+        <div flex layout="column" ng-if="!filter.resolveMultiple">
+            <label class="tb-small">{{ 'alias.default-entity' | translate }}</label>
+            <tb-entity-select flex
+                              the-form="theForm"
+                              tb-required="false"
+                              allowed-entity-types="[types.entityType.asset]"
+                              ng-model="filter.defaultEntity">
+            </tb-entity-select>
+        </div>
         <md-input-container class="md-block">
             <label translate>asset.name-starts-with</label>
             <input name="assetNameFilter"
@@ -105,6 +114,15 @@
                 ng-model="filter.deviceType"
                 entity-type="types.entityType.device">
         </tb-entity-subtype-autocomplete>
+        <div flex layout="column" ng-if="!filter.resolveMultiple">
+            <label class="tb-small">{{ 'alias.default-entity' | translate }}</label>
+            <tb-entity-select flex
+                              the-form="theForm"
+                              tb-required="false"
+                              allowed-entity-types="[types.entityType.device]"
+                              ng-model="filter.defaultEntity">
+            </tb-entity-select>
+        </div>
         <md-input-container class="md-block">
             <label translate>device.name-starts-with</label>
             <input name="deviceNameFilter"
@@ -119,6 +137,15 @@
                 ng-model="filter.entityViewType"
                 entity-type="types.entityType.entityView">
         </tb-entity-subtype-autocomplete>
+        <div flex layout="column" ng-if="!filter.resolveMultiple">
+            <label class="tb-small">{{ 'alias.default-entity' | translate }}</label>
+            <tb-entity-select flex
+                              the-form="theForm"
+                              tb-required="false"
+                              allowed-entity-types="[types.entityType.entityView]"
+                              ng-model="filter.defaultEntity">
+            </tb-entity-select>
+        </div>
         <md-input-container class="md-block">
             <label translate>entity-view.name-starts-with</label>
             <input name="entityViewNameFilter"

--- a/ui/src/app/locale/locale.constant-de_DE.json
+++ b/ui/src/app/locale/locale.constant-de_DE.json
@@ -205,7 +205,8 @@
     "unlimited-level": "Unbegrenzte Ebenen",
     "state-entity": "Dashboard Status Entität",
     "all-entities": "Alle Entitäten",
-    "any-relation": "Jede Beziehung"
+    "any-relation": "Jede Beziehung",
+    "default-entity": "Standard Entität"
   },
   "asset": {
     "asset": "Objekt",

--- a/ui/src/app/locale/locale.constant-en_US.json
+++ b/ui/src/app/locale/locale.constant-en_US.json
@@ -213,7 +213,8 @@
         "unlimited-level": "Unlimited level",
         "state-entity": "Dashboard state entity",
         "all-entities": "All entities",
-        "any-relation": "any"
+        "any-relation": "any",
+        "default-entity": "Default entity"
     },
     "asset": {
         "asset": "Asset",

--- a/ui/src/app/locale/locale.constant-es_ES.json
+++ b/ui/src/app/locale/locale.constant-es_ES.json
@@ -207,7 +207,8 @@
         "unlimited-level": "Nivel ilimitado",
         "state-entity": "Entidad del panel de estados",
         "all-entities": "Todas las entidades",
-        "any-relation": "alguna"
+        "any-relation": "alguna",
+        "default-entity": "Entidad predeterminada"
     },
     "asset": {
         "asset": "Activo",

--- a/ui/src/app/locale/locale.constant-fr_FR.json
+++ b/ui/src/app/locale/locale.constant-fr_FR.json
@@ -207,7 +207,8 @@
         "root-state-entity": "Utiliser l'entité d'état du tableau de bord en tant que racine",
         "state-entity": "Entité d'état du tableau de bord",
         "state-entity-parameter-name": "Nom du paramétre d'entité d'état",
-        "unlimited-level": "niveau illimité"
+        "unlimited-level": "niveau illimité",
+        "default-entity": "Entité par défaut"
     },
     "asset": {
         "add": "Ajouter un actif",

--- a/ui/src/app/locale/locale.constant-it_IT.json
+++ b/ui/src/app/locale/locale.constant-it_IT.json
@@ -206,7 +206,8 @@
         "unlimited-level": "Illimitato",
         "state-entity": "Entità di stato della dashboard",
         "all-entities": "Tutte le entità",
-        "any-relation": "qualsiasi"
+        "any-relation": "qualsiasi",
+        "default-entity": "Entità predefinita"
     },
     "asset": {
         "asset": "Asset",


### PR DESCRIPTION
By default, when an alias returns a list of entities and is not resolved as multiple entities, its current entity is set to the first element of this list. With this feature, it's possible to select a default entity instead of the first one found.