### PR TITLE
Add a further alias filter type using a custom function

### DIFF
--- a/ui/src/app/api/entity.service.js
+++ b/ui/src/app/api/entity.service.js
@@ -680,6 +680,26 @@ function EntityService($http, $q, $filter, $translate, $log, userService, device
                     deferred.resolve(result);
                 }
                 break;
+            case types.aliasFilterType.entitiesCustomSearchFunction.value:
+                var entitiesSearchFunction = new Function("filter", filter.entitiesCustomSearchFunction);
+                if (entitiesSearchFunction) {
+                    entitiesSearchFunction(filter).then(
+                        function success(entities) {
+                            if (entities && entities.length || !failOnEmpty) {
+                                result.entities = entitiesToEntitiesInfo(entities);
+                                deferred.resolve(result);
+                            } else {
+                                deferred.reject();
+                            }
+                        },
+                        function fail() {
+                            deferred.reject();
+                        }
+                    );
+                } else {
+                    deferred.reject();
+                }
+                break;
         }
         return deferred.promise;
     }
@@ -729,6 +749,8 @@ function EntityService($http, $q, $filter, $translate, $log, userService, device
                     return entityTypes.indexOf(types.entityType.device)  > -1 ? true : false;
                 case types.aliasFilterType.entityViewSearchQuery.value:
                     return entityTypes.indexOf(types.entityType.entityView)  > -1 ? true : false;
+                case types.aliasFilterType.entitiesCustomSearchFunction.value:
+                    return entityTypes.indexOf(filter.entityType) > -1 ? true : false;
             }
         }
         return false;
@@ -758,6 +780,8 @@ function EntityService($http, $q, $filter, $translate, $log, userService, device
                 return entityType === types.entityType.device;
             case types.aliasFilterType.entityViewSearchQuery.value:
                 return entityType === types.entityType.entityView;
+            case types.aliasFilterType.entitiesCustomSearchFunction.value:
+                return true;
         }
         return false;
     }

--- a/ui/src/app/common/types.constant.js
+++ b/ui/src/app/common/types.constant.js
@@ -284,6 +284,10 @@ export default angular.module('thingsboard.types', [])
                 entityViewSearchQuery: {
                     value: 'entityViewSearchQuery',
                     name: 'alias.filter-type-entity-view-search-query'
+                },
+                entitiesCustomSearchFunction: {
+                    value: 'entitiesCustomSearchFunction',
+                    name: "alias.filter-type-entities-custom-search-function"
                 }
             },
             direction: {

--- a/ui/src/app/entity/entity-filter-view.directive.js
+++ b/ui/src/app/entity/entity-filter-view.directive.js
@@ -197,6 +197,9 @@ export default function EntityFilterViewDirective($compile, $templateCache, $q, 
                             );
                         }
                         break;
+                    case types.aliasFilterType.entitiesCustomSearchFunction.value:
+                        scope.filterDisplayValue = $translate.instant('alias.filter-type-entities-custom-search-function-description');
+                        break;
                     default:
                         scope.filterDisplayValue = scope.filter.type;
                         break;

--- a/ui/src/app/entity/entity-filter.directive.js
+++ b/ui/src/app/entity/entity-filter.directive.js
@@ -96,6 +96,21 @@ export default function EntityFilterDirective($compile, $templateCache, $q, $doc
                         filter.entityViewTypes = [];
                     }
                     break;
+                case types.aliasFilterType.entitiesCustomSearchFunction.value:
+                    filter.rootStateEntity = false;
+                    filter.stateEntityParamName = null;
+                    filter.defaultStateEntity = null;
+                    filter.entitiesCustomSearchFunction = '/*\n\n// Function should return a promise. When it is resolved,'
+                        + ' an array containing a\n// list of entities is returned.\n\n// The following example code '
+                        + 'returns two ASSETs specified in entitiesList array.\n\nvar $injector = angular.element('
+                        + 'document.body).injector();\nvar $q = $injector.get("$q");\nvar entityService = $injector.get'
+                        + '("entityService");\nvar deferred = $q.defer();\n\nvar entitiesList = ["d037e950-f410-11e9'
+                        + '-b866-87183a2233fa","977d7100-f412-11e9-b866-87183a2233fa"];\n\nentityService.getEntities'
+                        + '("ASSET", entitiesList, {ignoreLoading: true}).then(\n\tfunction success(entities) {\n\t\t'
+                        + 'if (entities && entities.length) {\n\t\t\tdeferred.resolve(entities);\n\t\t} else {\n\t\t\t'
+                        + 'deferred.reject();\n\t\t}\n\t},\n\tfunction fail() {\n\t\tdeferred.reject();\n\t}\n);\n\n'
+                        + 'return deferred.promise;\n\n*/';
+                    break;
             }
             scope.filter = filter;
         }

--- a/ui/src/app/entity/entity-filter.tpl.html
+++ b/ui/src/app/entity/entity-filter.tpl.html
@@ -394,4 +394,40 @@
                 ng-model="filter.entityViewTypes">
         </tb-entity-subtype-list>
     </section>
+    <section layout="column" ng-if="filter.type == types.aliasFilterType.entitiesCustomSearchFunction.value" id="customEntitiesSearchFunction">
+        <label class="tb-small">{{ 'alias.root-entity' | translate }}</label>
+        <section class="tb-root-state-entity-switch" layout="row" layout-align="start center" style="padding-left: 0px;">
+            <md-switch class="root-state-entity-switch" ng-model="filter.rootStateEntity"
+                       aria-label="{{ 'alias.root-state-entity' | translate }}">
+            </md-switch>
+            <label class="tb-small root-state-entity-label" translate>alias.root-state-entity</label>
+        </section>
+        <div flex layout="row" ng-if="filter.rootStateEntity">
+            <md-input-container class="md-block" style="margin-top: 32px;">
+                <label translate>alias.state-entity-parameter-name</label>
+                <input name="stateEntityParamName"
+                       placeholder="{{ 'alias.default-entity-parameter-name' | translate }}"
+                       ng-model="filter.stateEntityParamName"
+                       aria-label="{{ 'alias.state-entity-parameter-name' | translate }}">
+            </md-input-container>
+            <div flex layout="column">
+                <label class="tb-small">{{ 'alias.default-state-entity' | translate }}</label>
+                <tb-entity-select flex
+                                  the-form="theForm"
+                                  tb-required="false"
+                                  use-alias-entity-types="true"
+                                  ng-model="filter.defaultStateEntity">
+                </tb-entity-select>
+            </div>
+        </div>
+        <tb-entity-type-select
+            ng-model="filter.entityType"
+            the-form="theForm"
+            allowed-entity-types="allowedEntityTypes">
+        </tb-entity-type-select>
+        <tb-js-func ng-model="filter.entitiesCustomSearchFunction"
+                    function-args="{{ ['filter'] }}"
+                    validation-args="{{ [] }}">
+        </tb-js-func>
+    </section>
 </div>

--- a/ui/src/app/locale/locale.constant-en_US.json
+++ b/ui/src/app/locale/locale.constant-en_US.json
@@ -198,6 +198,8 @@
         "filter-type-device-search-query-description": "Devices with types {{deviceTypes}} that have {{relationType}} relation {{direction}} {{rootEntity}}",
         "filter-type-entity-view-search-query": "Entity view search query",
         "filter-type-entity-view-search-query-description": "Entity views with types {{entityViewTypes}} that have {{relationType}} relation {{direction}} {{rootEntity}}",
+        "filter-type-entities-custom-search-function": "Entities custom search function",
+        "filter-type-entities-custom-search-function-description": "Entities custom search function",
         "entity-filter": "Entity filter",
         "resolve-multiple": "Resolve as multiple entities",
         "filter-type": "Filter type",

--- a/ui/src/app/locale/locale.constant-es_ES.json
+++ b/ui/src/app/locale/locale.constant-es_ES.json
@@ -192,6 +192,8 @@
         "filter-type-device-search-query-description": "Dispositivos con tipos {{deviceTypes}} que tienen {{relationType}} relación {{direction}} {{rootEntity}}",
         "filter-type-entity-view-search-query": "Consultar vista de entidad",
         "filter-type-entity-view-search-query-description": "Las vista de entidad de tipo {{entityViewTypes}} que tienen {{relationType}} relación {{direction}} {{rootEntity}}",
+        "filter-type-entities-custom-search-function": "Función de búsqueda personalizada de entidades",
+        "filter-type-entities-custom-search-function-description": "Función de búsqueda personalizada de entidades",
         "entity-filter": "Filtro de entidad",
         "resolve-multiple": "Resolver como entidades múltiples",
         "filter-type": "Tipo de filtro",

--- a/ui/src/app/locale/locale.constant-fr_FR.json
+++ b/ui/src/app/locale/locale.constant-fr_FR.json
@@ -198,6 +198,8 @@
         "filter-type-single-entity": "Entité unique",
         "filter-type-state-entity": "Entité de l'état du tableau de bord",
         "filter-type-state-entity-description": "Entité extraite des paramétres d'état du tableau de bord",
+        "filter-type-entities-custom-search-function": "Fonction de recherche personnalisée d'entités",
+        "filter-type-entities-custom-search-function-description": "Fonction de recherche personnalisée d'entités",
         "max-relation-level": "Niveau de relation maximum",
         "name": "Nom de l'alias",
         "name-required": "Le nom d'alias est requis",

--- a/ui/src/app/locale/locale.constant-it_IT.json
+++ b/ui/src/app/locale/locale.constant-it_IT.json
@@ -191,6 +191,8 @@
         "filter-type-device-search-query-description": "Dispositivi di tipo {{deviceTypes}} che hanno una relazione {{relationType}} {{direction}} {{rootEntity}}",
         "filter-type-entity-view-search-query": "Query ricerca Vista entità",
         "filter-type-entity-view-search-query-description": "Viste entità di tipo {{entityViewTypes}} che hanno una relazione {{relationType}} {{direction}} {{rootEntity}}",
+        "filter-type-entities-custom-search-function": "Funzione personalizzata di ricerca entità",
+        "filter-type-entities-custom-search-function-description": "Funzione personalizzata di ricerca entità",
         "entity-filter": "Filtro entità",
         "resolve-multiple": "Risolvi come entità multiple",
         "filter-type": "Tipo di filtro",


### PR DESCRIPTION
With this feature there's the possibility of writing a custom function which, using the Promise mechanism, returns a list of entities that could not be obtained by using standard filters.

For example, the following function returns two ASSETs whose ids are contained in the entitiesList array

```javascript
var $injector = angular.element(document.body).injector();
var $q = $injector.get("$q");
var entityService = $injector.get("entityService");
var deferred = $q.defer();

var entitiesList = ["d037e950-f410-11e9-b866-87183a2233fa","977d7100-f412-11e9-b866-87183a2233fa"];

entityService.getEntities("ASSET", entitiesList, {ignoreLoading: true}).then(
    function success(entities) {
        if (entities && entities.length) {
            deferred.resolve(entities); 
        } else {
            deferred.reject();
        }
    },
    function fail() {
        deferred.reject();
    }
);
return deferred.promise;
```