### PR TITLE
Add pre/post functions in widget editor to be called before/after onInit and onDataUpdated

### DIFF
--- a/ui/src/app/components/widget/widget-config.directive.js
+++ b/ui/src/app/components/widget/widget-config.directive.js
@@ -183,6 +183,18 @@ function WidgetConfig($compile, $templateCache, $rootScope, $translate, $timeout
                             scope.alarmSource.value = null;
                         }
                     }
+                    scope.useOnInitPre = angular.isDefined(config.useOnInitPre) ? config.useOnInitPre : false;
+                    scope.useOnInitPost = angular.isDefined(config.useOnInitPost) ? config.useOnInitPost : false;
+                    scope.useOnDataUpdatedPre = angular.isDefined(config.useOnDataUpdatedPre) ? config.useOnDataUpdatedPre : false;
+                    scope.useOnDataUpdatedPost = angular.isDefined(config.useOnDataUpdatedPost) ? config.useOnDataUpdatedPost : false;
+                    scope.onInitPreFunction = angular.isDefined(config.onInitPreFunction) ? config.onInitPreFunction :
+                        '/*\n// If you want to override default onInit(), this function should end with:'
+                        + '\nreturn "skip-default";\n*/';
+                    scope.onInitPostFunction = angular.isDefined(config.onInitPostFunction) ? config.onInitPostFunction : '';                    
+                    scope.onDataUpdatedPreFunction = angular.isDefined(config.onDataUpdatedPreFunction) ? config.onDataUpdatedPreFunction :
+                        '/*\n// If you want to override default onDataUpdated(), this function should end with:'
+                        + '\nreturn "skip-default";\n*/';
+                    scope.onDataUpdatedPostFunction = angular.isDefined(config.onDataUpdatedPostFunction) ? config.onDataUpdatedPostFunction : '';
 
                     scope.settings = config.settings;
 
@@ -247,7 +259,8 @@ function WidgetConfig($compile, $templateCache, $rootScope, $translate, $timeout
 
         scope.$watch('title + showTitleIcon + titleIcon + iconColor + iconSize + titleTooltip + showTitle + dropShadow + enableFullscreen + backgroundColor + ' +
             'color + padding + margin + widgetStyle + titleStyle + mobileOrder + mobileHeight + units + decimals + useDashboardTimewindow + ' +
-            'displayTimewindow + alarmSearchStatus + alarmsPollingInterval + alarmsMaxCountLoad + alarmsFetchSize + showLegend', function () {
+            'displayTimewindow + alarmSearchStatus + alarmsPollingInterval + showLegend + useOnInitPre + useOnInitPost + useOnDataUpdatedPre + useOnDataUpdatedPost + ' +
+            'onInitPreFunction + onInitPostFunction + onDataUpdatedPreFunction + onDataUpdatedPostFunction', function () {
             if (ngModelCtrl.$viewValue) {
                 var value = ngModelCtrl.$viewValue;
                 if (value.config) {
@@ -284,6 +297,14 @@ function WidgetConfig($compile, $templateCache, $rootScope, $translate, $timeout
                     config.alarmsMaxCountLoad = scope.alarmsMaxCountLoad;
                     config.alarmsFetchSize = scope.alarmsFetchSize;
                     config.showLegend = scope.showLegend;
+                    config.useOnInitPre = scope.useOnInitPre;
+                    config.useOnInitPost = scope.useOnInitPost;
+                    config.useOnDataUpdatedPre = scope.useOnDataUpdatedPre;
+                    config.useOnDataUpdatedPost = scope.useOnDataUpdatedPost;
+                    config.onInitPreFunction = scope.onInitPreFunction;
+                    config.onInitPostFunction = scope.onInitPostFunction;
+                    config.onDataUpdatedPreFunction = scope.onDataUpdatedPreFunction;
+                    config.onDataUpdatedPostFunction = scope.onDataUpdatedPostFunction;
                 }
                 if (value.layout) {
                     var layout = value.layout;

--- a/ui/src/app/components/widget/widget-config.tpl.html
+++ b/ui/src/app/components/widget/widget-config.tpl.html
@@ -351,6 +351,46 @@
             </ng-form>
         </md-content>
     </md-tab>
+    <md-tab label="{{ 'widget-config.custom-functions' | translate }}">
+        <md-content class="md-padding" layout="column">
+            <md-checkbox aria-label="{{ 'widget-config.use-on-init-pre' | translate }}"
+                         ng-model="useOnInitPre">{{ 'widget-config.use-on-init-pre' | translate }}
+            </md-checkbox>
+            <tb-js-func ng-show="useOnInitPre"
+                        ng-model="onInitPreFunction"
+                        function-name="{{'onInitPre'}}"
+                        function-args="{{ ['ctx'] }}"
+                        validation-args="{{ [] }}">
+            </tb-js-func>
+            <md-checkbox aria-label="{{ 'widget-config.use-on-init-post' | translate }}"
+                         ng-model="useOnInitPost">{{ 'widget-config.use-on-init-post' | translate }}
+            </md-checkbox>
+            <tb-js-func ng-show="useOnInitPost"
+                        ng-model="onInitPostFunction"
+                        function-name="{{'onInitPost'}}"
+                        function-args="{{ ['ctx'] }}"
+                        validation-args="{{ [] }}">
+            </tb-js-func>
+            <md-checkbox aria-label="{{ 'widget-config.use-on-data-updated-pre' | translate }}"
+                         ng-model="useOnDataUpdatedPre">{{ 'widget-config.use-on-data-updated-pre' | translate }}
+            </md-checkbox>
+            <tb-js-func ng-show="useOnDataUpdatedPre"
+                        ng-model="onDataUpdatedPreFunction"
+                        function-name="{{'onDataUpdatedPre'}}"
+                        function-args="{{ ['ctx'] }}"
+                        validation-args="{{ [] }}">
+            </tb-js-func>
+            <md-checkbox aria-label="{{ 'widget-config.use-on-data-updated-post' | translate }}"
+                         ng-model="useOnDataUpdatedPost">{{ 'widget-config.use-on-data-updated-post' | translate }}
+            </md-checkbox>
+            <tb-js-func ng-show="useOnDataUpdatedPost"
+                        ng-model="onDataUpdatedPostFunction"
+                        function-name="{{'onDataUpdatedPost'}}"
+                        function-args="{{ ['ctx'] }}"
+                        validation-args="{{ [] }}">
+            </tb-js-func>
+        </md-content>
+    </md-tab>
     <md-tab label="{{ 'widget-config.actions' | translate }}">
         <md-content class="md-padding" layout="column">
             <tb-manage-widget-actions

--- a/ui/src/app/components/widget/widget.controller.js
+++ b/ui/src/app/components/widget/widget.controller.js
@@ -209,6 +209,31 @@ export default function WidgetController($scope, $state, $timeout, $window, $ocL
         widgetTypeInstance.onDestroy = function() {};
     }
 
+    if (widgetTypeInstance.ctx.widgetConfig.useOnInitPre &&
+            widgetContext.widgetConfig.onInitPreFunction && widgetContext.widgetConfig.onInitPreFunction.length) {
+        widgetTypeInstance.ctx.onInitPre = new Function("ctx", widgetContext.widgetConfig.onInitPreFunction);
+    } else {
+        widgetTypeInstance.ctx.onInitPre = function() {};
+    }
+    if (widgetTypeInstance.ctx.widgetConfig.useOnInitPost &&
+            widgetContext.widgetConfig.onInitPostFunction && widgetContext.widgetConfig.onInitPostFunction.length) {
+        widgetTypeInstance.ctx.onInitPost = new Function("ctx", widgetContext.widgetConfig.onInitPostFunction);
+    } else {
+        widgetTypeInstance.ctx.onInitPost = function() {};
+    }
+    if (widgetTypeInstance.ctx.widgetConfig.useOnDataUpdatedPre &&
+            widgetContext.widgetConfig.onDataUpdatedPreFunction && widgetContext.widgetConfig.onDataUpdatedPreFunction.length) {
+        widgetTypeInstance.ctx.onDataUpdatedPre = new Function("ctx", widgetContext.widgetConfig.onDataUpdatedPreFunction);
+    } else {
+        widgetTypeInstance.ctx.onDataUpdatedPre = function() {};
+    }
+    if (widgetTypeInstance.ctx.widgetConfig.useOnDataUpdatedPost &&
+            widgetContext.widgetConfig.onDataUpdatedPostFunction && widgetContext.widgetConfig.onDataUpdatedPostFunction.length) {
+        widgetTypeInstance.ctx.onDataUpdatedPost = new Function("ctx", widgetContext.widgetConfig.onDataUpdatedPostFunction);
+    } else {
+        widgetTypeInstance.ctx.onDataUpdatedPost = function() {};
+    }
+
     //TODO: widgets visibility
 
     //var bounds = {top: 0, left: 0, bottom: 0, right: 0};
@@ -314,7 +339,10 @@ export default function WidgetController($scope, $state, $timeout, $window, $ocL
         options.callbacks = {
             onDataUpdated: function() {
                 if (displayWidgetInstance()) {
-                    widgetTypeInstance.onDataUpdated();
+                    if (widgetTypeInstance.ctx.onDataUpdatedPre(widgetTypeInstance.ctx) != 'skip-default') {
+                        widgetTypeInstance.onDataUpdated();
+                    }
+                    widgetTypeInstance.ctx.onDataUpdatedPost(widgetTypeInstance.ctx);
                 }
             },
             onDataUpdateError: function(subscription, e) {
@@ -863,7 +891,10 @@ export default function WidgetController($scope, $state, $timeout, $window, $ocL
             widgetContext.inited = true;
             try {
                 if (displayWidgetInstance()) {
-                    widgetTypeInstance.onInit();
+                    if (widgetTypeInstance.ctx.onInitPre(widgetTypeInstance.ctx) != 'skip-default') {
+                        widgetTypeInstance.onInit();
+                    }
+                    widgetTypeInstance.ctx.onInitPost(widgetTypeInstance.ctx);
                 } else {
                     $scope.loadingData = false;
                 }

--- a/ui/src/app/locale/locale.constant-en_US.json
+++ b/ui/src/app/locale/locale.constant-en_US.json
@@ -1661,7 +1661,12 @@
         "delete-action-text": "Are you sure you want delete widget action with name '{{actionName}}'?",
         "display-icon": "Display title icon",
         "icon-color": "Icon color",
-        "icon-size": "Icon size"
+        "icon-size": "Icon size",
+        "custom-functions": "Custom functions",
+        "use-on-init-pre": "Execute a function before onInit() call",
+        "use-on-init-post": "Execute a function after onInit() call",
+        "use-on-data-updated-pre": "Execute a function before onDataUpdated() call",
+        "use-on-data-updated-post": "Execute a function after onDataUpdated() call"
     },
     "widget-type": {
         "import": "Import widget type",

--- a/ui/src/app/locale/locale.constant-es_ES.json
+++ b/ui/src/app/locale/locale.constant-es_ES.json
@@ -1645,7 +1645,12 @@
         "delete-action-text": "¿Está seguro de que desea eliminar la acción del widget con nombre '{{actionName}}'?",
         "display-icon": "Mostrar icono del título",
         "icon-color": "Color del icono",
-        "icon-size": "Tamaño del icono"
+        "icon-size": "Tamaño del icono",
+        "custom-functions": "Funciones personalizadas",
+        "use-on-init-pre": "Ejecutar una función antes de la onInit()",
+        "use-on-init-post": "Ejecutar una función después de la onInit()",
+        "use-on-data-updated-pre": "Ejecutar una función antes de la onDataUpdated()",
+        "use-on-init-post": "Ejecutar una función después de la onDataUpdated()"
     },
     "widget-type": {
         "import": "Importar tipo de widget",

--- a/ui/src/app/locale/locale.constant-fr_FR.json
+++ b/ui/src/app/locale/locale.constant-fr_FR.json
@@ -1609,7 +1609,12 @@
         "widget-style": "Style du widget",
         "display-icon": "Afficher l'icône du titre",
         "icon-color": "Couleur de l'icône",
-        "icon-size": "Taille de l'icône"
+        "icon-size": "Taille de l'icône",
+        "custom-functions": "Fonctions personnalisées",
+        "use-on-init-pre": "Exécuter une fonction avant la onInit()",
+        "use-on-init-post": "Exécuter une fonction après la onInit()",
+        "use-on-data-updated-pre": "Exécuter une fonction avant la onDataUpdated()",
+        "use-on-data-updated-post": "Exécuter une fonction après la onDataUpdated()"
     },
     "widget-type": {
         "create-new-widget-type": "Créer un nouveau type de widget",

--- a/ui/src/app/locale/locale.constant-it_IT.json
+++ b/ui/src/app/locale/locale.constant-it_IT.json
@@ -1586,7 +1586,12 @@
         "delete-action-text": "Sei sicuro di voler cancellare l'azione del widget '{{actionName}}'?",
         "display-icon": "Mostra icona titolo",
         "icon-color": "Colore dell'icona",
-        "icon-size": "Dimensione dell'icona"
+        "icon-size": "Dimensione dell'icona",
+        "custom-functions": "Funzioni personalizzate",
+        "use-on-init-pre": "Esegui una funzione prima della onInit()",
+        "use-on-init-post": "Esegui una funzione dopo la onInit()",
+        "use-on-data-updated-pre": "Esegui una funzione prima della onDataUpdated()",
+        "use-on-data-updated-post": "Esegui una funzione dopo la onDataUpdated()"
     },
     "widget-type": {
         "import": "Importa un tipo di widget",


### PR DESCRIPTION
With this feature it's possible to write different custom functions in widget editor that will be called before (pre) or after (post) standard `onInit` and `onDataUpdated`. This can be useful, for example, if some data should be edited before calling the original `onDataUpdated`, or if after the original `onInit` an HTTP GET should be called to obtain a value usable in widget context. Furthermore, it's possibile to override original onInit and onDataUpdated if the 'pre' functions return **skip-default** string.