### PR TITLE
Update Dockerfile

### DIFF
--- a/msa/tb/docker-cassandra/Dockerfile
+++ b/msa/tb/docker-cassandra/Dockerfile
@@ -19,7 +19,7 @@ FROM thingsboard/openjdk8
 RUN apt-get update
 RUN apt-get install -y curl nmap procps
 RUN echo 'deb http://www.apache.org/dist/cassandra/debian 311x main' | tee --append /etc/apt/sources.list.d/cassandra.list > /dev/null
-RUN curl -L https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN curl -L https://downloads.apache.org/cassandra/KEYS | apt-key add -
 RUN apt-get update
 RUN apt-get install -y cassandra cassandra-tools
 RUN update-rc.d cassandra disable


### PR DESCRIPTION
The Cassandra KEYS document moved.
Thingsboard build has been failing if you download it using the curl.