### PR TITLE
Fix MQTT inactivity disconnects

### DIFF
--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -138,12 +138,24 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                 break;
             case PUBLISH:
                 processPublish(ctx, (MqttPublishMessage) msg);
+                transportService.reportActivity(sessionInfo);
+                if (gatewaySessionHandler != null) {
+                    gatewaySessionHandler.reportActivity();
+                }
                 break;
             case SUBSCRIBE:
                 processSubscribe(ctx, (MqttSubscribeMessage) msg);
+                transportService.reportActivity(sessionInfo);
+                if (gatewaySessionHandler != null) {
+                    gatewaySessionHandler.reportActivity();
+                }
                 break;
             case UNSUBSCRIBE:
                 processUnsubscribe(ctx, (MqttUnsubscribeMessage) msg);
+                transportService.reportActivity(sessionInfo);
+                if (gatewaySessionHandler != null) {
+                    gatewaySessionHandler.reportActivity();
+                }
                 break;
             case PINGREQ:
                 if (checkConnected(ctx, msg)) {


### PR DESCRIPTION
#2500 

MQTT clients don't send PINGREQ messages if they've recently sent [UN]SUBSCRIBE/PUBLISH messages.  The MQTT server last activity timestamp is currently only updated in response to PINGREQ messages.  This causes the server to disconnect any clients that regularly send PUBLISH messages since they don't send PINGREQ. 

This change adds reportActivity calls in response to PUBLISH, SUBSCRIBE and UNSUBSCRIBE in addition to PINGREQ.