### PR TITLE
fix bug: Sending a subscription message multiple times causes the client to interrupt

### DIFF
--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/RetransmissionHandler.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/RetransmissionHandler.java
@@ -44,7 +44,8 @@ final class RetransmissionHandler<T extends MqttMessage> {
     private void startTimer(EventLoop eventLoop){
         this.timer = eventLoop.schedule(() -> {
             this.timeout += 5;
-            MqttFixedHeader fixedHeader = new MqttFixedHeader(this.originalMessage.fixedHeader().messageType(), true, this.originalMessage.fixedHeader().qosLevel(), this.originalMessage.fixedHeader().isRetain(), this.originalMessage.fixedHeader().remainingLength());
+            boolean isDup = this.originalMessage.fixedHeader().messageType() == MqttMessageType.PUBLISH ? true : this.originalMessage.fixedHeader().isDup();
+            MqttFixedHeader fixedHeader = new MqttFixedHeader(this.originalMessage.fixedHeader().messageType(), isDup, this.originalMessage.fixedHeader().qosLevel(), this.originalMessage.fixedHeader().isRetain(), this.originalMessage.fixedHeader().remainingLength());
             handler.accept(fixedHeader, originalMessage);
             startTimer(eventLoop);
         }, timeout, TimeUnit.SECONDS);


### PR DESCRIPTION
In the mqtt 3.1 protocol or mqtt 3.1.1 protocol, except for messages of type pubish, the isDup of other messages must be zero，Sending a subscription message multiple times causes the client to reconnect，therefore, resending the subscription message with isDup true will cause the server to think that the message is abnormal, thus interrupting the connection with the client