### PR TITLE
Add a new widget action to go back to previous dashboard state

### DIFF
--- a/ui/src/app/common/types.constant.js
+++ b/ui/src/app/common/types.constant.js
@@ -963,6 +963,10 @@ export default angular.module('thingsboard.types', [])
                     name: 'widget-action.open-dashboard-state',
                     value: 'openDashboardState'
                 },
+                previousDashboardState: {
+                    name: 'widget-action.previous-dashboard-state',
+                    value: 'previousDashboardState'
+                },
                 updateDashboardState: {
                     name: 'widget-action.update-dashboard-state',
                     value: 'updateDashboardState'

--- a/ui/src/app/components/widget/widget.controller.js
+++ b/ui/src/app/components/widget/widget.controller.js
@@ -500,6 +500,7 @@ export default function WidgetController($scope, $state, $timeout, $window, $ocL
         switch (type) {
             case types.widgetActionTypes.openDashboardState.value:
             case types.widgetActionTypes.updateDashboardState.value:
+            case types.widgetActionTypes.previousDashboardState.value:
                 var targetDashboardStateId = descriptor.targetDashboardStateId;
                 var params = angular.copy(widgetContext.stateController.getStateParams());
                 if (!params) {
@@ -508,6 +509,8 @@ export default function WidgetController($scope, $state, $timeout, $window, $ocL
                 updateEntityParams(params, targetEntityParamName, targetEntityId, entityName, entityLabel);
                 if (type == types.widgetActionTypes.openDashboardState.value) {
                     widgetContext.stateController.openState(targetDashboardStateId, params, descriptor.openRightLayout);
+                } else if (type == types.widgetActionTypes.previousDashboardState.value) {
+                    widgetContext.stateController.previousState(params);
                 } else {
                     widgetContext.stateController.updateState(targetDashboardStateId, params, descriptor.openRightLayout);
                 }

--- a/ui/src/app/dashboard/states/entity-state-controller.js
+++ b/ui/src/app/dashboard/states/entity-state-controller.js
@@ -26,6 +26,7 @@ export default function EntityStateController($scope, $timeout, $location, $stat
     vm.skipStateChange = false;
 
     vm.openState = openState;
+    vm.previousState = previousState;
     vm.updateState = updateState;
     vm.resetState = resetState;
     vm.getStateObject = getStateObject;
@@ -53,6 +54,22 @@ export default function EntityStateController($scope, $timeout, $location, $stat
                     vm.stateObject.push(newState);
                     vm.selectedStateIndex = vm.stateObject.length-1;
                     gotoState(vm.stateObject[vm.stateObject.length-1].id, true, openRightLayout);
+                    vm.skipStateChange = true;
+                }
+            );
+        }
+    }
+
+    function previousState(params) {
+        if (vm.states) {
+            resolveEntity(params).then(
+                function success(entityName) {
+                    params.entityName = entityName;
+                    //remove current state
+                    vm.stateObject.pop();
+                    vm.previousStateIndex = vm.stateObject.length-1;
+                    vm.stateObject[vm.previousStateIndex].params = params;
+                    gotoState(vm.stateObject[vm.previousStateIndex].id, true);
                     vm.skipStateChange = true;
                 }
             );

--- a/ui/src/app/dashboard/states/states-component.directive.js
+++ b/ui/src/app/dashboard/states/states-component.directive.js
@@ -34,6 +34,12 @@ export default function StatesComponent($compile, $templateCache, $controller, s
                 }
             }
 
+            stateController.previousState = function(params) {
+                if (scope.statesController) {
+                    scope.statesController.previousState(params);
+                }
+            }
+
             stateController.updateState = function(id, params, openRightLayout) {
                 if (scope.statesController) {
                     scope.statesController.updateState(id, params, openRightLayout);

--- a/ui/src/app/locale/locale.constant-en_US.json
+++ b/ui/src/app/locale/locale.constant-en_US.json
@@ -1683,6 +1683,7 @@
     "widget-action": {
         "header-button": "Widget header button",
         "open-dashboard-state": "Navigate to new dashboard state",
+        "previous-dashboard-state": "Back to previous dashboard state",
         "update-dashboard-state": "Update current dashboard state",
         "open-dashboard": "Navigate to other dashboard",
         "custom": "Custom action",

--- a/ui/src/app/locale/locale.constant-es_ES.json
+++ b/ui/src/app/locale/locale.constant-es_ES.json
@@ -1559,6 +1559,7 @@
     "widget-action": {
         "header-button": "Botón del encabezado del widget",
         "open-dashboard-state": "Navegar a nuevo estado del panel",
+        "previous-dashboard-state": "Volver al anterior estado del panel",
         "update-dashboard-state": "Actualizar estado vigente del panel",
         "open-dashboard": "Navegar a otro panel",
         "custom": "Acción personalizada",

--- a/ui/src/app/locale/locale.constant-it_IT.json
+++ b/ui/src/app/locale/locale.constant-it_IT.json
@@ -1500,16 +1500,17 @@
         "export": "Esporta widget"
     },
     "widget-action": {
-        "header-button": "Widget header button",
-        "open-dashboard-state": "Navigate to new dashboard state",
-        "update-dashboard-state": "Update current dashboard state",
-        "open-dashboard": "Navigate to other dashboard",
-        "custom": "Custom action",
-        "target-dashboard-state": "Target dashboard state",
-        "target-dashboard-state-required": "Target dashboard state is required",
-        "set-entity-from-widget": "Set entity from widget",
-        "target-dashboard": "Target dashboard",
-        "open-right-layout": "Open right dashboard layout (mobile view)"
+        "header-button": "Pulsante header widget",
+        "open-dashboard-state": "Vai ad un nuovo stato della dashboard",
+        "previous-dashboard-state": "Torna allo stato precedente della dashboard",
+        "update-dashboard-state": "Aggiorna lo stato corrente della dashboard",
+        "open-dashboard": "Vai a una nuova dashboard",
+        "custom": "Azione personalizzata",
+        "target-dashboard-state": "Stato della dashboard di destinazione",
+        "target-dashboard-state-required": "Lo stato della dashboard di destinazione è obbligatorio",
+        "set-entity-from-widget": "Assegna l'entità dal widget",
+        "target-dashboard": "Dashboard di destinazione",
+        "open-right-layout": "Apri layout destro di dashboard (mobile view)"
     },
     "widgets-bundle": {
         "current": "Bundle corrente",


### PR DESCRIPTION
In widget editor, section 'actions', it should be possible to select an action to return to previous dashboard state, alongside a new state or a new dashboard.