### PR TITLE
Add the possibility to select timewindow source even for individual parameters separately

### DIFF
--- a/ui/src/app/api/subscription.js
+++ b/ui/src/app/api/subscription.js
@@ -89,7 +89,44 @@ export default class Subscription {
 
             if (this.useDashboardTimewindow) {
                 this.timeWindowConfig = angular.copy(options.dashboardTimewindow);
-            } else {
+            } else if (angular.isDefined(options.timeWindowConfig)) {
+                var dashboardAggInterval = null,
+                    newAggRatio = null;
+                if (options.timeWindowConfig.useDashboardAggregation) {
+                    newAggRatio = options.timeWindowConfig.aggregation.ratio;
+                    options.timeWindowConfig.aggregation = angular.copy(options.dashboardTimewindow.aggregation);
+                }
+                if (options.timeWindowConfig.useDashboardInterval) {
+                    dashboardAggInterval = angular.isDefined(options.timeWindowConfig.realtime) ?
+                            options.timeWindowConfig.realtime.interval : options.timeWindowConfig.history.interval;
+                    if (angular.isDefined(options.dashboardTimewindow.realtime)) {
+                        options.timeWindowConfig.realtime = angular.copy(options.dashboardTimewindow.realtime);
+                        delete options.timeWindowConfig.history;
+                    }
+                    else if (angular.isDefined(options.dashboardTimewindow.history)) {
+                        options.timeWindowConfig.history = angular.copy(options.dashboardTimewindow.history);
+                        delete options.timeWindowConfig.realtime;
+                    }
+                }
+                if (options.timeWindowConfig.useDashboardAggInterval) {
+                    options.timeWindowConfig.useTimeRatio = options.dashboardTimewindow.useTimeRatio;
+                    if (options.timeWindowConfig.useTimeRatio) {
+                        newAggRatio = options.dashboardTimewindow.aggregation.ratio;
+                    } else {
+                        dashboardAggInterval = angular.isDefined(options.dashboardTimewindow.realtime) ?
+                                options.dashboardTimewindow.realtime.interval : options.dashboardTimewindow.history.interval;
+                    }
+                }
+                if (newAggRatio) {
+                    options.timeWindowConfig.aggregation.ratio = newAggRatio;
+                }
+                if (dashboardAggInterval) {
+                    if (angular.isDefined(options.timeWindowConfig.realtime)) {
+                        options.timeWindowConfig.realtime.interval = dashboardAggInterval;
+                    } else if (angular.isDefined(options.timeWindowConfig.history)) {
+                        options.timeWindowConfig.history.interval = dashboardAggInterval;
+                    }
+                }
                 this.timeWindowConfig = angular.copy(options.timeWindowConfig);
             }
 
@@ -131,7 +168,44 @@ export default class Subscription {
             this.stateData = options.stateData;
             if (this.useDashboardTimewindow) {
                 this.timeWindowConfig = angular.copy(options.dashboardTimewindow);
-            } else {
+            } else if (angular.isDefined(options.timeWindowConfig)) {
+                dashboardAggInterval = null;
+                newAggRatio = null;
+                if (options.timeWindowConfig.useDashboardAggregation) {
+                    newAggRatio = options.timeWindowConfig.aggregation.ratio;
+                    options.timeWindowConfig.aggregation = angular.copy(options.dashboardTimewindow.aggregation);
+                }
+                if (options.timeWindowConfig.useDashboardInterval) {
+                    dashboardAggInterval = angular.isDefined(options.timeWindowConfig.realtime) ?
+                            options.timeWindowConfig.realtime.interval : options.timeWindowConfig.history.interval;
+                    if (angular.isDefined(options.dashboardTimewindow.realtime)) {
+                        options.timeWindowConfig.realtime = angular.copy(options.dashboardTimewindow.realtime);
+                        delete options.timeWindowConfig.history;
+                    }
+                    else if (angular.isDefined(options.dashboardTimewindow.history)) {
+                        options.timeWindowConfig.history = angular.copy(options.dashboardTimewindow.history);
+                        delete options.timeWindowConfig.realtime;
+                    }
+                }
+                if (options.timeWindowConfig.useDashboardAggInterval) {
+                    options.timeWindowConfig.useTimeRatio = options.dashboardTimewindow.useTimeRatio;
+                    if (options.timeWindowConfig.useTimeRatio) {
+                        newAggRatio = options.dashboardTimewindow.aggregation.ratio;
+                    } else {
+                        dashboardAggInterval = angular.isDefined(options.dashboardTimewindow.realtime) ?
+                                options.dashboardTimewindow.realtime.interval : options.dashboardTimewindow.history.interval;
+                    }
+                }
+                if (newAggRatio) {
+                    options.timeWindowConfig.aggregation.ratio = newAggRatio;
+                }
+                if (dashboardAggInterval) {
+                    if (angular.isDefined(options.timeWindowConfig.realtime)) {
+                        options.timeWindowConfig.realtime.interval = dashboardAggInterval;
+                    } else if (angular.isDefined(options.timeWindowConfig.history)) {
+                        options.timeWindowConfig.history.interval = dashboardAggInterval;
+                    }
+                }
                 this.timeWindowConfig = angular.copy(options.timeWindowConfig);
             }
 
@@ -443,8 +517,53 @@ export default class Subscription {
                     }
                 });
                 this.registrations.push(registration);
+            } else if (this.timeWindowConfig.useDashboardAggregation || this.timeWindowConfig.useDashboardAggInterval ||
+                    this.timeWindowConfig.useDashboardInterval) {
+                registration = this.ctx.$scope.$on('dashboardTimewindowChanged', function (event, newDashboardTimewindow) {
+                    subscription.updateFromDashboardTimewindow(subscription, newDashboardTimewindow);
+                });
+                this.registrations.push(registration);
+                this.startWatchingTimewindow();
             } else {
                 this.startWatchingTimewindow();
+            }
+        }
+    }
+
+    updateFromDashboardTimewindow(subscription, newDashboardTimewindow) {
+        if (newDashboardTimewindow) {
+            var prevTimewindow = angular.isDefined(subscription.timeWindowConfig.realtime) ?
+                    angular.copy(subscription.timeWindowConfig.realtime) : angular.copy(subscription.timeWindowConfig.history);
+            var newTimewindow = angular.isDefined(newDashboardTimewindow.realtime) ?
+                    angular.copy(newDashboardTimewindow.realtime) : angular.copy(newDashboardTimewindow.history);
+            var dashboardAggInterval = prevTimewindow.interval,
+                newAggRatio = subscription.timeWindowConfig.aggregation.ratio;
+            if (subscription.timeWindowConfig.useDashboardAggregation) {
+                subscription.timeWindowConfig.aggregation = angular.copy(newDashboardTimewindow.aggregation);
+            }
+            if (subscription.timeWindowConfig.useDashboardInterval) {
+                if (angular.isDefined(newDashboardTimewindow.realtime)) {
+                    subscription.timeWindowConfig.realtime = angular.copy(newDashboardTimewindow.realtime);
+                    delete subscription.timeWindowConfig.history;
+                }
+                else if (angular.isDefined(newDashboardTimewindow.history)) {
+                    subscription.timeWindowConfig.history = angular.copy(newDashboardTimewindow.history);
+                    delete subscription.timeWindowConfig.realtime;
+                }
+            }
+            if (subscription.timeWindowConfig.useDashboardAggInterval) {
+                subscription.timeWindowConfig.useTimeRatio = newDashboardTimewindow.useTimeRatio;
+                if (subscription.timeWindowConfig.useTimeRatio) {
+                    newAggRatio = newDashboardTimewindow.aggregation.ratio;
+                } else {
+                    dashboardAggInterval = newTimewindow.interval;
+                }
+            }
+            subscription.timeWindowConfig.aggregation.ratio = newAggRatio;
+            if (angular.isDefined(subscription.timeWindowConfig.realtime)) {
+                subscription.timeWindowConfig.realtime.interval = dashboardAggInterval;
+            } else if (angular.isDefined(subscription.timeWindowConfig.history)) {
+                subscription.timeWindowConfig.history.interval = dashboardAggInterval;
             }
         }
     }
@@ -664,6 +783,43 @@ export default class Subscription {
     }
 
     updateTimewindowConfig(newTimewindow) {
+        var dashboardAggInterval = null,
+            newAggRatio = null;
+        if (this.timeWindowConfig.useDashboardAggregation) {
+            newAggRatio = newTimewindow.aggregation.ratio;
+            newTimewindow.aggregation = angular.copy(this.timeWindowConfig.aggregation);
+        }
+        if (this.timeWindowConfig.useDashboardInterval) {
+            dashboardAggInterval = angular.isDefined(newTimewindow.realtime) ?
+                    newTimewindow.realtime.interval : newTimewindow.history.interval;
+            if (angular.isDefined(this.timeWindowConfig.realtime)) {
+                newTimewindow.realtime = angular.copy(this.timeWindowConfig.realtime);
+                delete newTimewindow.history;
+            }
+            else if (angular.isDefined(this.timeWindowConfig.history)) {
+                newTimewindow.history = angular.copy(this.timeWindowConfig.history);
+                delete newTimewindow.realtime;
+            }
+        }
+        if (this.timeWindowConfig.useDashboardAggInterval) {
+            newTimewindow.useTimeRatio = this.timeWindowConfig.useTimeRatio;
+            if (this.timeWindowConfig.useTimeRatio) {
+                newAggRatio = this.timeWindowConfig.aggregation.ratio;
+            } else {
+                dashboardAggInterval = angular.isDefined(this.timeWindowConfig.realtime) ?
+                        this.timeWindowConfig.realtime.interval : this.timeWindowConfig.history.interval;
+            }
+        }
+        if (newAggRatio) {
+            newTimewindow.aggregation.ratio = newAggRatio;
+        }
+        if (dashboardAggInterval) {
+            if (angular.isDefined(newTimewindow.realtime)) {
+                newTimewindow.realtime.interval = dashboardAggInterval;
+            } else if (angular.isDefined(newTimewindow.history)) {
+                newTimewindow.history.interval = dashboardAggInterval;
+            }
+        }
         this.timeWindowConfig = newTimewindow;
     }
 

--- a/ui/src/app/components/timeinterval.directive.js
+++ b/ui/src/app/components/timeinterval.directive.js
@@ -233,6 +233,8 @@ function Timeinterval($compile, $templateCache, timeService) {
             max: '=?',
             predefinedName: '=?',
             hideFlag: '=?',
+            fromDashboardFlag: '=?',
+            isToolbar: '=?',
             isEdit: '=?'
         },
         link: linker

--- a/ui/src/app/components/timeinterval.tpl.html
+++ b/ui/src/app/components/timeinterval.tpl.html
@@ -16,9 +16,14 @@
 
 -->
 <section layout="row">
-	<section layout="column" layout-align=" none" ng-show="isEdit">
+	<section layout="column" layout-align="none center" ng-show="isEdit" style="padding-right: 10px;">
 		<label class="tb-small advanced-label" translate>timewindow.hide</label>
 		<md-checkbox aria-label="{{ 'timewindow.hide' | translate }}" ng-model="hideFlag">
+		</md-checkbox>
+	</section>
+	<section layout="column" layout-align="none center" ng-show="isEdit && !isToolbar" style="padding-right: 10px;">
+		<label class="tb-small advanced-label" translate>timewindow.from-dashboard</label>
+		<md-checkbox aria-label="{{ 'timewindow.from-dashboard' | translate }}" ng-model="fromDashboardFlag">
 		</md-checkbox>
 	</section>
 	<section layout="column" flex ng-show="advanced && (isEdit || !hideFlag)">
@@ -26,26 +31,26 @@
 		<section layout="row" layout-align="start start" flex>
 			<md-input-container>
 				 <label translate>timeinterval.days</label>
-				 <input type="number" ng-model="days" step="1" aria-label="{{ 'timeinterval.days' | translate }}">
+				 <input ng-disabled="hideFlag || fromDashboardFlag" type="number" ng-model="days" step="1" aria-label="{{ 'timeinterval.days' | translate }}">
 			</md-input-container>
 			<md-input-container>
 				 <label translate>timeinterval.hours</label>
-				 <input ng-disabled="hideFlag" type="number" ng-model="hours" step="1" aria-label="{{ 'timeinterval.hours' | translate }}">
+				 <input ng-disabled="hideFlag || fromDashboardFlag" type="number" ng-model="hours" step="1" aria-label="{{ 'timeinterval.hours' | translate }}">
 			</md-input-container>
 			<md-input-container>
 				 <label translate>timeinterval.minutes</label>
-				 <input type="number" ng-model="mins" step="1" aria-label="{{ 'timeinterval.minutes' | translate }}">
+				 <input ng-disabled="hideFlag || fromDashboardFlag" type="number" ng-model="mins" step="1" aria-label="{{ 'timeinterval.minutes' | translate }}">
 			</md-input-container>
 			<md-input-container>
 				 <label translate>timeinterval.seconds</label>
-				 <input ng-disabled="hideFlag" type="number" ng-model="secs" step="1" aria-label="{{ 'timeinterval.seconds' | translate }}">
+				 <input ng-disabled="hideFlag || fromDashboardFlag" type="number" ng-model="secs" step="1" aria-label="{{ 'timeinterval.seconds' | translate }}">
 			</md-input-container>
 		</section>
 	</section>
 	<section layout="row" flex ng-show="!advanced && (isEdit || !hideFlag)">
 		<md-input-container flex>
 			<label translate>{{ predefinedName }}</label>
-			<md-select ng-disabled="hideFlag" ng-model="intervalMs" style="min-width: 150px;" aria-label="predefined-interval">
+			<md-select ng-disabled="hideFlag || fromDashboardFlag" ng-model="intervalMs" style="min-width: 150px;" aria-label="predefined-interval">
 				<md-option ng-repeat="interval in intervals" ng-value="interval.value">
 					{{interval.name}}
 				</md-option>
@@ -54,7 +59,7 @@
 	</section>
 	<section layout="column" layout-align="center center" ng-show="(isEdit || !hideFlag)">
 		<label class="tb-small advanced-label" translate>timeinterval.advanced</label>
-		<md-switch ng-disabled="hideFlag" class="advanced-switch" ng-model="advanced" aria-label="predefined-switcher">
+		<md-switch ng-disabled="hideFlag || fromDashboardFlag" class="advanced-switch" ng-model="advanced" aria-label="predefined-switcher">
 		</md-switch>
 	</section>
 </section>

--- a/ui/src/app/components/timeratio.directive.js
+++ b/ui/src/app/components/timeratio.directive.js
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2016-2020 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import './timeratio.scss';
+
+/* eslint-disable import/no-unresolved, import/default */
+
+import timeratioTemplate from './timeratio.tpl.html';
+
+/* eslint-enable import/no-unresolved, import/default */
+
+export default angular.module('thingsboard.directives.timeratio', [])
+    .directive('tbTimeratio', Timeratio)
+    .name;
+
+/*@ngInject*/
+function Timeratio($compile, $templateCache, timeService) {
+
+    var linker = function (scope, element, attrs, ngModelCtrl) {
+
+        var template = $templateCache.get(timeratioTemplate);
+        element.html(template);
+
+        scope.boundRatio = function() {
+            var min = timeService.getMinDatapointsLimit();
+            var max = timeService.getMaxDatapointsLimit();
+            if (scope.rendered) {
+                var newTimeRatio = ngModelCtrl.$viewValue;
+                if (newTimeRatio < min) {
+                    newTimeRatio = min;
+                } else if (newTimeRatio > max) {
+                    newTimeRatio = max;
+                }
+                if (newTimeRatio !== ngModelCtrl.$viewValue) {
+                    scope.updateView();
+                }
+            }
+        }
+
+        scope.setTimeRatio = function (timeRatio) {
+            scope.timeRatio = timeRatio;
+        }
+
+        ngModelCtrl.$render = function () {
+            var timeRatio = ngModelCtrl.$viewValue;
+            scope.setTimeRatio(timeRatio);
+            scope.rendered = true;
+        }
+
+        scope.updateView = function () {
+            if (!scope.rendered) {
+                return;
+            }
+            var value = null;
+            var timeRatio = scope.timeRatio;
+            if (!isNaN(timeRatio) && timeRatio > 0) {
+                value = timeRatio;
+                ngModelCtrl.$setValidity('tb-timeratio', true);
+            } else {
+                ngModelCtrl.$setValidity('tb-timeratio', !scope.required);
+            }
+            ngModelCtrl.$setViewValue(value);
+            scope.boundRatio();
+        }
+
+        scope.$watch('required', function (newRequired, prevRequired) {
+            if (angular.isDefined(newRequired) && newRequired !== prevRequired) {
+                scope.updateView();
+            }
+        });
+
+        scope.$watch('min', function (newMin, prevMin) {
+            if (angular.isDefined(newMin) && newMin !== prevMin) {
+                scope.updateView();
+            }
+        });
+
+        scope.$watch('max', function (newMax, prevMax) {
+            if (angular.isDefined(newMax) && newMax !== prevMax) {
+                scope.updateView();
+            }
+        });
+
+        scope.$watch('timeRatio', function (newTimeRatio, prevTimeRatio) {
+            if (angular.isDefined(newTimeRatio) && newTimeRatio !== prevTimeRatio) {
+                scope.updateView();
+            }
+        });
+
+        scope.boundRatio();
+
+        $compile(element.contents())(scope);
+
+    }
+
+    return {
+        restrict: "E",
+        require: "^ngModel",
+        scope: {
+            required: '=ngRequired',
+            min: '=?',
+            max: '=?',
+            predefinedName: '=?',
+            hideFlag: '=?',
+            fromDashboardFlag: '=?',
+            isToolbar: '=?',
+            isEdit: '=?',
+            form: '=?'
+        },
+        link: linker
+    };
+}

--- a/ui/src/app/components/timeratio.scss
+++ b/ui/src/app/components/timeratio.scss
@@ -1,0 +1,44 @@
+/**
+ * Copyright © 2016-2020 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+tb-timeratio {
+  min-width: 355px;
+
+  md-input-container {
+    margin-bottom: 0;
+
+    .md-errors-spacer {
+      min-height: 0;
+    }
+  }
+
+  mdp-date-picker {
+    .md-input {
+      width: 150px;
+    }
+  }
+
+  .md-input {
+    width: 70px !important;
+  }
+
+  .advanced-switch {
+    margin-top: 0;
+  }
+
+  .advanced-label {
+    margin: 5px 0;
+  }
+}

--- a/ui/src/app/components/timeratio.tpl.html
+++ b/ui/src/app/components/timeratio.tpl.html
@@ -1,0 +1,40 @@
+<!--
+
+    Copyright © 2016-2020 The Thingsboard Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<section layout="row" flex>
+	<section layout="column" layout-align="none center" ng-show="isEdit" style="padding-right: 10px;">
+		<label class="tb-small advanced-label" translate>timewindow.hide</label>
+		<md-checkbox aria-label="{{ 'timewindow.hide' | translate }}" ng-model="hideFlag">
+		</md-checkbox>
+	</section>
+	<section layout="column" layout-align="none center" ng-show="isEdit && !isToolbar" style="padding-right: 10px;">
+		<label class="tb-small advanced-label" translate>timewindow.from-dashboard</label>
+		<md-checkbox aria-label="{{ 'timewindow.from-dashboard' | translate }}" ng-model="fromDashboardFlag">
+		</md-checkbox>
+	</section>
+	<section layout="column" flex ng-show="isEdit || !hideFlag">
+		<md-input-container flex>
+			<label translate>{{ predefinedName }}</label>
+			<input type="number" step="1" ng-disabled="hideFlag || fromDashboardFlag"
+				   ng-min="min" ng-max="max" ng-model="timeRatio" aria-label="predefined-interval" aria-controls="limit-slider">
+			<div ng-messages="form.$error">
+				<div ng-message="min">Value must be greater than {{min}}</div>
+				<div ng-message="max">Value must be lower than {{max}}</div>
+			</div>
+		</md-input-container>
+	</section>
+</section>

--- a/ui/src/app/components/timewindow-panel.controller.js
+++ b/ui/src/app/components/timewindow-panel.controller.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /*@ngInject*/
-export default function TimewindowPanelController(mdPanelRef, $scope, timeService, types, timewindow, historyOnly, aggregation, isEdit, onTimewindowUpdate) {
+export default function TimewindowPanelController(mdPanelRef, $scope, timeService, types, timewindow, historyOnly, aggregation, isEdit, isToolbar, onTimewindowUpdate) {
 
     var vm = this;
 
@@ -32,8 +32,11 @@ export default function TimewindowPanelController(mdPanelRef, $scope, timeServic
     vm.minHistoryAggInterval = minHistoryAggInterval;
     vm.maxHistoryAggInterval = maxHistoryAggInterval;
     vm.minDatapointsLimit = minDatapointsLimit;
-    vm.maxDatapointsLimit = maxDatapointsLimit;
+    vm.maxDatapointsLimit = maxDatapointsLimit;    
+    vm.minTimeRatioLimit = minTimeRatioLimit;
+    vm.maxTimeRatioLimit = maxTimeRatioLimit;
     vm.isEdit = isEdit;
+    vm.isToolbar = isToolbar;
 
     if (vm.historyOnly) {
         vm.timewindow.selectedTab = 1;
@@ -95,6 +98,14 @@ export default function TimewindowPanelController(mdPanelRef, $scope, timeServic
 
     function maxDatapointsLimit () {
         return timeService.getMaxDatapointsLimit();
+    }
+
+    function minTimeRatioLimit () {
+        return timeService.getMinTimeRatioLimit();
+    }
+
+    function maxTimeRatioLimit () {
+        return timeService.getMaxTimeRatioLimit();
     }
 
     function currentHistoryTimewindow() {

--- a/ui/src/app/components/timewindow-panel.tpl.html
+++ b/ui/src/app/components/timewindow-panel.tpl.html
@@ -19,60 +19,80 @@
 	<fieldset ng-disabled="$root.loading">
 		<md-content style="height: 100%" flex layout="column">
 			<section layout="column">
-				<md-tabs ng-class="{'tb-headless': vm.historyOnly}" md-dynamic-height md-selected="vm.timewindow.selectedTab" md-border-bottom>
+				<md-tabs ng-class="{'tb-headless': vm.historyOnly}" md-dynamic-height md-selected="vm.timewindow.selectedTab" md-border-bottom
+						 ng-hide="!vm.isEdit && (vm.timewindow.hideInterval || vm.timewindow.useDashboardInterval)">
 					<md-tab label="{{ 'timewindow.realtime' | translate }}">
 						<md-content class="md-padding" layout="column">
-							<tb-timeinterval hide-flag="vm.timewindow.hideInterval" predefined-name="'timewindow.last'"
-								is-edit="vm.isEdit" ng-required="vm.timewindow.selectedTab === 0"
+							<tb-timeinterval hide-flag="vm.timewindow.hideInterval" from-dashboard-flag="vm.timewindow.useDashboardInterval"
+								is-toolbar="vm.isToolbar" predefined-name="'timewindow.last'" is-edit="vm.isEdit" ng-required="vm.timewindow.selectedTab === 0"
 								ng-model="vm.timewindow.realtime.timewindowMs" style="padding-top: 8px;"></tb-timeinterval>
 						</md-content>
 					</md-tab>
 					<md-tab label="{{ 'timewindow.history' | translate }}">
-						<section layout="row">
-							<section layout="column" class="md-padding" style="padding-top: 8px;">
-								<label ng-if="vm.isEdit" class="tb-small advanced-label" translate>timewindow.hide</label>
-								<md-checkbox ng-if="vm.isEdit" aria-label="{{ 'timewindow.hide' | translate }}"
-											 ng-model="vm.timewindow.hideInterval">
-								</md-checkbox>
+							<section layout="row">
+								<section layout="column" class="md-padding" layout-align="none center" ng-show="vm.isEdit"
+										 style="padding-right: 10px; padding-top: 8px;">
+									<label class="tb-small advanced-label" translate>timewindow.hide</label>
+									<md-checkbox aria-label="{{ 'timewindow.hide' | translate }}"
+												 ng-model="vm.timewindow.hideInterval" >
+									</md-checkbox>
+								</section>
+								<section layout="column" layout-align="none center" ng-show="vm.isEdit && !vm.isToolbar"
+										 style="padding-right: 10px; padding-top: 8px;">
+									<label class="tb-small advanced-label" translate>timewindow.from-dashboard</label>
+									<md-checkbox aria-label="{{ 'timewindow.from-dashboard' | translate }}"
+												 ng-model="vm.timewindow.useDashboardInterval">
+									</md-checkbox>
+								</section>
+								<section layout="column" flex>
+									<md-content class="md-padding" layout="column" style="padding-top: 8px;">
+										<md-radio-group ng-disabled="vm.timewindow.hideInterval || vm.timewindow.useDashboardInterval"
+														ng-model="vm.timewindow.history.historyType" class="md-primary">
+											<md-radio-button ng-value=0 aria-label="{{ 'timewindow.last' | translate }}"
+															 class="md-primary md-align-top-left md-radio-interactive">
+												<section layout="column">
+													<tb-timeinterval predefined-name="'timewindow.last'"
+														ng-required="vm.timewindow.selectedTab === 1 && vm.timewindow.history.historyType === 0"
+														ng-show="vm.timewindow.history.historyType === 0"
+														ng-model="vm.timewindow.history.timewindowMs" style="padding-top: 8px;"></tb-timeinterval>
+												</section>
+											</md-radio-button>
+											<md-radio-button ng-value=1 aria-label="{{ 'timewindow.time-period' | translate }}"
+															 class="md-primary md-align-top-left md-radio-interactive">
+												<section layout="column">
+													<span translate>timewindow.time-period</span>
+													<tb-datetime-period
+															ng-required="vm.timewindow.selectedTab === 1 && vm.timewindow.history.historyType === 1"
+															ng-show="vm.timewindow.history.historyType === 1"
+															ng-model="vm.timewindow.history.fixedTimewindow" style="padding-top: 8px;"></tb-datetime-period>
+												</section>
+											</md-radio-button>
+										</md-radio-group>
+									</md-content>
+								</section>
 							</section>
-							<section layout="column" flex ng-show="vm.isEdit || !vm.timewindow.hideInterval">
-								<md-content class="md-padding" layout="column" style="padding-top: 8px;">
-									<md-radio-group ng-disabled="vm.timewindow.hideInterval" ng-model="vm.timewindow.history.historyType" class="md-primary">
-										<md-radio-button ng-value=0 aria-label="{{ 'timewindow.last' | translate }}" class="md-primary md-align-top-left md-radio-interactive">
-											<section layout="column">
-												<tb-timeinterval predefined-name="'timewindow.last'"
-													ng-required="vm.timewindow.selectedTab === 1 && vm.timewindow.history.historyType === 0"
-													ng-show="vm.timewindow.history.historyType === 0"
-													ng-model="vm.timewindow.history.timewindowMs" style="padding-top: 8px;"></tb-timeinterval>
-											</section>
-										</md-radio-button>
-										<md-radio-button ng-value=1 aria-label="{{ 'timewindow.time-period' | translate }}" class="md-primary md-align-top-left md-radio-interactive">
-											<section layout="column">
-												<span translate>timewindow.time-period</span>
-												<tb-datetime-period
-														ng-required="vm.timewindow.selectedTab === 1 && vm.timewindow.history.historyType === 1"
-														ng-show="vm.timewindow.history.historyType === 1"
-														ng-model="vm.timewindow.history.fixedTimewindow" style="padding-top: 8px;"></tb-datetime-period>
-											</section>
-										</md-radio-button>
-									</md-radio-group>
-								</md-content>
-							</section>
-						</section>
 					</md-tab>
 				</md-tabs>
-				<md-content ng-if="vm.aggregation" class="md-padding" layout="column">
+				<md-content ng-if="vm.aggregation" class="md-padding" layout="column"
+							ng-style="(vm.timewindow.hideInterval || vm.timewindow.useDashboardInterval) ? {'padding-top':'8px'} : {}">
 					<section layout="row">
-						<section layout="column" style="padding-top: 5px;" ng-show="vm.isEdit">
+						<section layout="column" layout-align="none center" ng-show="vm.isEdit" style="padding-right: 10px; padding-top: 5px;">
 							<label class="tb-small advanced-label" translate>timewindow.hide</label>
 							<md-checkbox aria-label="{{ 'timewindow.hide' | translate }}"
-										 ng-model="vm.timewindow.hideAggregation">
+										 ng-model="vm.timewindow.hideAggregation" >
 							</md-checkbox>
 						</section>
-						<section layout="column" flex ng-show="vm.isEdit || !vm.timewindow.hideAggregation">
+						<section layout="column" layout-align="none center" ng-show="vm.isEdit && !vm.isToolbar" style="padding-right: 10px; padding-top: 5px;">
+							<label class="tb-small advanced-label" translate>timewindow.from-dashboard</label>
+							<md-checkbox aria-label="{{ 'timewindow.from-dashboard' | translate }}"
+										 ng-model="vm.timewindow.useDashboardAggregation">
+							</md-checkbox>
+						</section>
+						<section layout="column" flex ng-show="vm.isEdit || (!vm.timewindow.hideAggregation && !vm.timewindow.useDashboardAggregation)">
 							<md-input-container>
 								<label translate>aggregation.function</label>
-								<md-select ng-disabled="vm.timewindow.hideAggregation" ng-model="vm.timewindow.aggregation.type" style="min-width: 150px;">
+								<md-select ng-disabled="vm.timewindow.hideAggregation || vm.timewindow.useDashboardAggregation"
+										   ng-model="vm.timewindow.aggregation.type" style="min-width: 150px;">
 									<md-option ng-repeat="type in vm.aggregationTypes" ng-value="type.value">
 										{{type.name | translate}}
 									</md-option>
@@ -80,35 +100,53 @@
 							</md-input-container>
 						</section>
 					</section>
-					<section layout="row" ng-show="vm.showLimit()">
-						<section layout="column" style="padding-top: 5px;" ng-show="vm.showLimit() && vm.isEdit">
+					<section layout="row" flex ng-show="vm.showLimit()">
+						<section layout="column" layout-align="none center" ng-show="vm.isEdit" style="padding-right: 95px; padding-top: 5px;">
 							<label class="tb-small advanced-label" translate>timewindow.hide</label>
 							<md-checkbox aria-label="{{ 'timewindow.hide' | translate }}"
 										 ng-model="vm.timewindow.hideAggInterval" >
 							</md-checkbox>
 						</section>
-						<section layout="column" flex ng-show="vm.isEdit || !vm.timewindow.hideAggInterval">
-							<md-slider-container>
-								<span translate>aggregation.limit</span>
-								<md-slider flex min="{{vm.minDatapointsLimit()}}" max="{{vm.maxDatapointsLimit()}}" step="1"
-										   ng-disabled="vm.timewindow.hideAggInterval" ng-model="vm.timewindow.aggregation.limit" aria-label="limit" id="limit-slider">
-								</md-slider>
-								<md-input-container style="max-width: 80px;">
-									<input flex type="number" step="1" ng-disabled="vm.timewindow.hideAggInterval"
-										   min="{{vm.minDatapointsLimit()}}" max="{{vm.maxDatapointsLimit()}}"
-										   ng-model="vm.timewindow.aggregation.limit" aria-label="limit" aria-controls="limit-slider">
-								</md-input-container>
-							</md-slider-container>
-						</section>
+						<md-slider-container ng-show="vm.isEdit || !vm.timewindow.hideAggInterval">
+							<span translate>aggregation.limit</span>
+							<md-slider flex min="{{vm.minDatapointsLimit()}}" max="{{vm.maxDatapointsLimit()}}" step="1"
+									   ng-disabled="vm.timewindow.hideAggInterval"
+									   ng-model="vm.timewindow.aggregation.limit" aria-label="limit" id="limit-slider">
+							</md-slider>
+							<md-input-container style="max-width: 80px;">
+								<input flex type="number" step="1" ng-disabled="vm.timewindow.hideAggInterval"
+									   min="{{vm.minDatapointsLimit()}}" max="{{vm.maxDatapointsLimit()}}"
+									   ng-model="vm.timewindow.aggregation.limit" aria-label="limit" aria-controls="limit-slider">
+							</md-input-container>
+						</md-slider-container>
 					</section>
-					<tb-timeinterval ng-if="vm.showRealtimeAggInterval()" min="vm.minRealtimeAggInterval()"
-									 max="vm.maxRealtimeAggInterval()" ng-model="vm.timewindow.realtime.interval" is-edit="vm.isEdit"
-									 hide-flag="vm.timewindow.hideAggInterval" predefined-name="'aggregation.group-interval'">
-					</tb-timeinterval>
-					<tb-timeinterval ng-if="vm.showHistoryAggInterval()" min="vm.minHistoryAggInterval()"
-									 max="vm.maxHistoryAggInterval()" ng-model="vm.timewindow.history.interval" is-edit="vm.isEdit"
-									 hide-flag="vm.timewindow.hideAggInterval" predefined-name="'aggregation.group-interval'">
-					</tb-timeinterval>
+					<section flex ng-show="!vm.showLimit() && (vm.isEdit || !vm.timewindow.hideAggInterval)" >
+						<label class="tb-small advanced-label" ng-if="vm.isEdit" translate>aggregation.group-type</label>
+						<md-radio-group layout="row" flex ng-if="vm.isEdit" ng-model="vm.timewindow.useTimeRatio" class="md-primary"
+										style="margin-top:10px;margin-bottom:10px;">
+							<md-radio-button ng-value="false" class="md-primary">
+								<span translate>aggregation.interval</span>
+							</md-radio-button>
+							<md-radio-button ng-value="true" class="md-primary">
+								<span translate>aggregation.ratio</span>
+							</md-radio-button>
+						</md-radio-group>
+						<tb-timeinterval ng-if="vm.showRealtimeAggInterval() && !vm.timewindow.useTimeRatio" min="vm.minRealtimeAggInterval()"
+										 max="vm.maxRealtimeAggInterval()" ng-model="vm.timewindow.realtime.interval" is-edit="vm.isEdit"
+										 hide-flag="vm.timewindow.hideAggInterval" from-dashboard-flag="vm.timewindow.useDashboardAggInterval"
+										 is-toolbar="vm.isToolbar" predefined-name="'aggregation.group-interval'">
+						</tb-timeinterval>
+						<tb-timeinterval ng-if="vm.showHistoryAggInterval() && !vm.timewindow.useTimeRatio" min="vm.minHistoryAggInterval()"
+										 max="vm.maxHistoryAggInterval()" ng-model="vm.timewindow.history.interval" is-edit="vm.isEdit"
+										 hide-flag="vm.timewindow.hideAggInterval" from-dashboard-flag="vm.timewindow.useDashboardAggInterval"
+										 is-toolbar="vm.isToolbar" predefined-name="'aggregation.group-interval'">
+						</tb-timeinterval>
+						<tb-timeratio ng-if="vm.timewindow.useTimeRatio" min="vm.minTimeRatioLimit()" max="vm.maxTimeRatioLimit()"
+									  ng-model="vm.timewindow.aggregation.ratio" is-edit="vm.isEdit" hide-flag="vm.timewindow.hideAggInterval"
+									  from-dashboard-flag="vm.timewindow.useDashboardAggInterval" is-toolbar="vm.isToolbar"
+									  predefined-name="'aggregation.values'" form="theForm">
+						</tb-timeratio>
+					</section>
 				</md-content>
 			</section>
 			<span flex></span>

--- a/ui/src/app/components/timewindow.directive.js
+++ b/ui/src/app/components/timewindow.directive.js
@@ -17,6 +17,7 @@ import './timewindow.scss';
 
 import $ from 'jquery';
 import thingsboardTimeinterval from './timeinterval.directive';
+import thingsboardTimeratio from './timeratio.directive';
 import thingsboardDatetimePeriod from './datetime-period.directive';
 
 /* eslint-disable import/no-unresolved, import/default */
@@ -29,7 +30,7 @@ import timewindowPanelTemplate from './timewindow-panel.tpl.html';
 
 import TimewindowPanelController from './timewindow-panel.controller';
 
-export default angular.module('thingsboard.directives.timewindow', [thingsboardTimeinterval, thingsboardDatetimePeriod])
+export default angular.module('thingsboard.directives.timewindow', [thingsboardTimeinterval, thingsboardTimeratio, thingsboardDatetimePeriod])
     .controller('TimewindowPanelController', TimewindowPanelController)
     .directive('tbTimewindow', Timewindow)
     .filter('milliSecondsToTimeString', MillisecondsToTimeString)
@@ -46,6 +47,10 @@ function Timewindow($compile, $templateCache, $filter, $mdPanel, $document, $mdM
          *    hideInterval: false,
          *    hideAggregation: false,
          *    hideAggInterval: false,
+         *    useDashboardInterval: false,
+         *    useDashboardAggregation: false,
+         *    useDashboardAggInterval: false,
+         *    useTimeRatio: false,
          * 	  realtime: {
          * 	        interval: 0,
          * 			timewindowMs: 0
@@ -60,7 +65,8 @@ function Timewindow($compile, $templateCache, $filter, $mdPanel, $document, $mdM
          * 	  },
          * 	  aggregation: {
          * 	        type: types.aggregation.avg.value,
-         * 	        limit: 200
+         * 	        limit: 200,
+         *          ratio: 1
          * 	  }
          * }
          */
@@ -142,6 +148,7 @@ function Timewindow($compile, $templateCache, $filter, $mdPanel, $document, $mdM
                     'historyOnly': scope.historyOnly,
                     'aggregation': scope.aggregation,                    
                     'isEdit': scope.isEdit,
+                    'isToolbar': scope.isToolbar,
                     'onTimewindowUpdate': function (timewindow) {
                         scope.model = timewindow;
                         scope.updateView();
@@ -181,11 +188,16 @@ function Timewindow($compile, $templateCache, $filter, $mdPanel, $document, $mdM
             }
             value.aggregation = {
                 type: model.aggregation.type,
-                limit: model.aggregation.limit
+                limit: model.aggregation.limit,
+                ratio: model.aggregation.ratio
             };            
             value.hideInterval = model.hideInterval;
             value.hideAggregation = model.hideAggregation;
             value.hideAggInterval = model.hideAggInterval;
+            value.useDashboardInterval = model.useDashboardInterval;
+            value.useDashboardAggregation = model.useDashboardAggregation;
+            value.useDashboardAggInterval = model.useDashboardAggInterval;
+            value.useTimeRatio = model.useTimeRatio;
             ngModelCtrl.$setViewValue(value);
             scope.updateDisplayValue();
         }
@@ -242,10 +254,15 @@ function Timewindow($compile, $templateCache, $filter, $mdPanel, $document, $mdM
                         model.aggregation.type = value.aggregation.type;
                     }
                     model.aggregation.limit = value.aggregation.limit || Math.floor(timeService.getMaxDatapointsLimit() / 2);
+                    model.aggregation.ratio = value.aggregation.ratio || timeService.getMinTimeRatioLimit();
                 }
                 model.hideInterval = value.hideInterval;
                 model.hideAggregation = value.hideAggregation;
                 model.hideAggInterval = value.hideAggInterval;
+                model.useDashboardInterval = value.useDashboardInterval;
+                model.useDashboardAggregation = value.useDashboardAggregation;
+                model.useDashboardAggInterval = value.useDashboardAggInterval;
+                model.useTimeRatio = value.useTimeRatio;
             }
             scope.timewindowDisabled = isTimewindowDisabled();
             scope.updateDisplayValue();

--- a/ui/src/app/components/timewindow.tpl.html
+++ b/ui/src/app/components/timewindow.tpl.html
@@ -15,23 +15,29 @@
     limitations under the License.
 
 -->
-<section class="tb-timewindow" layout='row' layout-align="start center">
+<section class="tb-timewindow" layout='row' layout-align="start center"
+         ng-hide="!isEdit && (model.hideInterval || model.useDashboardInterval) &&
+                  (model.hideAggInterval || model.useDashboardAggInterval) &&
+                  (model.hideAggregation || model.useDashboardAggregation)">
     <md-button ng-if="direction === 'left'" ng-disabled="timewindowDisabled" class="md-icon-button tb-md-32" aria-label="{{ 'timewindow.edit' | translate }}" ng-click="openEditMode($event)">
         <md-tooltip md-direction="{{tooltipDirection}}">
-            {{ 'timewindow.edit' | translate }}
+            {{ ((model.hideInterval || model.useDashboardInterval) && !model.hideAggregation) ? 'timewindow.edit-aggregation' : 'timewindow.edit' | translate }}
         </md-tooltip>
-        <ng-md-icon aria-label="{{ 'timewindow.date-range' | translate }}" icon="query_builder"></ng-md-icon>
+        <ng-md-icon aria-label="{{ 'timewindow.date-range' | translate }}" icon="{{ ((model.hideInterval || model.useDashboardInterval) && !model.hideAggregation) ? 'functions' : 'query_builder' }}"></ng-md-icon>
     </md-button>
-    <span ng-hide="hideLabel()" ng-click="openEditMode($event)">
+    <span ng-hide="hideLabel() || 
+                  ((model.hideInterval || model.useDashboardInterval) && 
+                   (model.hideAggregation || model.useDashboardAggregation))"
+                  ng-click="openEditMode($event)">
         <md-tooltip md-direction="{{tooltipDirection}}">
-            {{ 'timewindow.edit' | translate }}
+            {{ ((model.hideInterval || model.useDashboardInterval) && !model.hideAggregation) ? 'timewindow.edit-aggregation' : 'timewindow.edit' | translate }}
         </md-tooltip>
         {{model.displayValue}}
     </span>
     <md-button ng-if="direction === 'right'" ng-disabled="timewindowDisabled" class="md-icon-button tb-md-32" aria-label="{{ 'timewindow.edit' | translate }}" ng-click="openEditMode($event)">
         <md-tooltip md-direction="{{tooltipDirection}}">
-            {{ 'timewindow.edit' | translate }}
+            {{ ((model.hideInterval || model.useDashboardInterval) && !model.hideAggregation) ? 'timewindow.edit-aggregation' : 'timewindow.edit' | translate }}
         </md-tooltip>
-        <ng-md-icon aria-label="{{ 'timewindow.date-range' | translate }}" icon="query_builder"></ng-md-icon>
+        <ng-md-icon aria-label="{{ 'timewindow.date-range' | translate }}" icon="{{ ((model.hideInterval || model.useDashboardInterval) && !model.hideAggregation) ? 'functions' : 'query_builder' }}"></ng-md-icon>
     </md-button>
 </section>

--- a/ui/src/app/locale/locale.constant-en_US.json
+++ b/ui/src/app/locale/locale.constant-en_US.json
@@ -63,7 +63,11 @@
         "avg": "Average",
         "sum": "Sum",
         "count": "Count",
-        "none": "None"
+        "none": "None",
+        "ratio": "Ratio",
+        "interval": "Interval",
+        "group-type": "Grouping type",
+        "values": "Number of values"
     },
     "admin": {
         "general": "General",
@@ -1561,7 +1565,8 @@
         "date-range": "Date range",
         "last": "Last",
         "time-period": "Time period",
-        "hide": "Hide"
+        "hide": "Hide",
+        "from-dashboard": "From dashboard"
     },
     "user": {
         "user": "User",

--- a/ui/src/app/locale/locale.constant-it_IT.json
+++ b/ui/src/app/locale/locale.constant-it_IT.json
@@ -61,7 +61,11 @@
         "avg": "Media",
         "sum": "Somma",
         "count": "Conteggio",
-        "none": "Nessuna"
+        "none": "Nessuna",
+        "ratio": "Rapporto",
+        "interval": "Intervallo",
+        "group-type": "Tipo di raggruppamento",
+        "values": "Numero di valori"
     },
     "admin": {
         "general": "Generale",
@@ -1383,7 +1387,8 @@
         "date-range": "Intervallo date",
         "last": "Ultimo",
         "time-period": "Intervallo temporale",
-        "hide": "Nascondi"
+        "hide": "Nascondi",
+        "from-dashboard": "Da dashboard"
     },
     "user": {
         "user": "Utente",


### PR DESCRIPTION
Currently the subscription parameters of a widget are taken either from the widget timewindow or from the general one of dashboard. It should be possible to create a mixed subscription, in which some parameters are selected locally (in the widget's timewindow), while others are taken from the global one.