### PR TITLE
Add pre/post functions in widget editor to be called before/after onInit and onDataUpdated

### DIFF
--- a/ui/src/app/api/subscription.js
+++ b/ui/src/app/api/subscription.js
@@ -794,14 +794,16 @@ export default class Subscription {
     }
 
     alarmsUpdated(alarms, apply) {
-        this.notifyDataLoaded();
-        var updated = !this.alarms || !angular.equals(this.alarms, alarms);
-        this.alarms = alarms;
-        if (this.subscriptionTimewindow && this.subscriptionTimewindow.realtimeWindowMs) {
-            this.updateTimewindow();
-        }
-        if (updated) {
-            this.onDataUpdated(apply);
+        if (this.callbacks.alarmsUpdated(alarms) !== 'skip-default') {
+            this.notifyDataLoaded();
+            var updated = !this.alarms || !angular.equals(this.alarms, alarms);
+            this.alarms = alarms;
+            if (this.subscriptionTimewindow && this.subscriptionTimewindow.realtimeWindowMs) {
+                this.updateTimewindow();
+            }
+            if (updated) {
+                this.onDataUpdated(apply);
+            }
         }
     }
 

--- a/ui/src/app/components/widget/widget-config.directive.js
+++ b/ui/src/app/components/widget/widget-config.directive.js
@@ -183,6 +183,22 @@ function WidgetConfig($compile, $templateCache, $rootScope, $translate, $timeout
                             scope.alarmSource.value = null;
                         }
                     }
+                    scope.useOnInitPre = angular.isDefined(config.useOnInitPre) ? config.useOnInitPre : false;
+                    scope.useOnInitPost = angular.isDefined(config.useOnInitPost) ? config.useOnInitPost : false;
+                    scope.useOnDataUpdatedPre = angular.isDefined(config.useOnDataUpdatedPre) ? config.useOnDataUpdatedPre : false;
+                    scope.useOnDataUpdatedPost = angular.isDefined(config.useOnDataUpdatedPost) ? config.useOnDataUpdatedPost : false;
+                    scope.useAlarmsUpdatedPre = angular.isDefined(config.useAlarmsUpdatedPre) ? config.useAlarmsUpdatedPre : false;
+                    scope.onInitPreFunction = angular.isDefined(config.onInitPreFunction) ? config.onInitPreFunction :
+                        '/*\n// If you want to override default onInit(), this function should end with:'
+                        + '\nreturn "skip-default";\n*/';
+                    scope.onInitPostFunction = angular.isDefined(config.onInitPostFunction) ? config.onInitPostFunction : '';
+                    scope.onDataUpdatedPreFunction = angular.isDefined(config.onDataUpdatedPreFunction) ? config.onDataUpdatedPreFunction :
+                        '/*\n// If you want to override default onDataUpdated(), this function should end with:'
+                        + '\nreturn "skip-default";\n*/';
+                    scope.onDataUpdatedPostFunction = angular.isDefined(config.onDataUpdatedPostFunction) ? config.onDataUpdatedPostFunction : '';
+                    scope.alarmsUpdatedPreFunction = angular.isDefined(config.alarmsUpdatedPreFunction) ? config.alarmsUpdatedPreFunction :
+                        '/*\n// If you want to override default alarmsUpdated(), this function should end with:'
+                        + '\nreturn "skip-default";\n*/';
 
                     scope.settings = config.settings;
 
@@ -247,7 +263,8 @@ function WidgetConfig($compile, $templateCache, $rootScope, $translate, $timeout
 
         scope.$watch('title + showTitleIcon + titleIcon + iconColor + iconSize + titleTooltip + showTitle + dropShadow + enableFullscreen + backgroundColor + ' +
             'color + padding + margin + widgetStyle + titleStyle + mobileOrder + mobileHeight + units + decimals + useDashboardTimewindow + ' +
-            'displayTimewindow + alarmSearchStatus + alarmsPollingInterval + alarmsMaxCountLoad + alarmsFetchSize + showLegend', function () {
+            'displayTimewindow + alarmSearchStatus + alarmsPollingInterval + alarmsMaxCountLoad + alarmsFetchSize + showLegend + useOnInitPre + useOnInitPost + useOnDataUpdatedPre + useOnDataUpdatedPost + ' +
+            'onInitPreFunction + onInitPostFunction + onDataUpdatedPreFunction + onDataUpdatedPostFunction + useAlarmsUpdatedPre + alarmsUpdatedPreFunction', function () {
             if (ngModelCtrl.$viewValue) {
                 var value = ngModelCtrl.$viewValue;
                 if (value.config) {
@@ -284,6 +301,16 @@ function WidgetConfig($compile, $templateCache, $rootScope, $translate, $timeout
                     config.alarmsMaxCountLoad = scope.alarmsMaxCountLoad;
                     config.alarmsFetchSize = scope.alarmsFetchSize;
                     config.showLegend = scope.showLegend;
+                    config.useOnInitPre = scope.useOnInitPre;
+                    config.useOnInitPost = scope.useOnInitPost;
+                    config.useOnDataUpdatedPre = scope.useOnDataUpdatedPre;
+                    config.useOnDataUpdatedPost = scope.useOnDataUpdatedPost;
+                    config.onInitPreFunction = scope.onInitPreFunction;
+                    config.onInitPostFunction = scope.onInitPostFunction;
+                    config.onDataUpdatedPreFunction = scope.onDataUpdatedPreFunction;
+                    config.onDataUpdatedPostFunction = scope.onDataUpdatedPostFunction;
+                    config.useAlarmsUpdatedPre = scope.useAlarmsUpdatedPre;
+                    config.alarmsUpdatedPreFunction = scope.alarmsUpdatedPreFunction;
                 }
                 if (value.layout) {
                     var layout = value.layout;

--- a/ui/src/app/components/widget/widget-config.tpl.html
+++ b/ui/src/app/components/widget/widget-config.tpl.html
@@ -351,6 +351,57 @@
             </ng-form>
         </md-content>
     </md-tab>
+    <md-tab label="{{ 'widget-config.custom-functions' | translate }}">
+        <md-content class="md-padding" layout="column">
+            <md-checkbox aria-label="{{ 'widget-config.use-on-init-pre' | translate }}"
+                         ng-model="useOnInitPre">{{ 'widget-config.use-on-init-pre' | translate }}
+            </md-checkbox>
+            <tb-js-func ng-show="useOnInitPre"
+                        ng-model="onInitPreFunction"
+                        function-name="{{'onInitPre'}}"
+                        function-args="{{ ['ctx'] }}"
+                        validation-args="{{ [] }}">
+            </tb-js-func>
+            <md-checkbox aria-label="{{ 'widget-config.use-on-init-post' | translate }}"
+                         ng-model="useOnInitPost">{{ 'widget-config.use-on-init-post' | translate }}
+            </md-checkbox>
+            <tb-js-func ng-show="useOnInitPost"
+                        ng-model="onInitPostFunction"
+                        function-name="{{'onInitPost'}}"
+                        function-args="{{ ['ctx'] }}"
+                        validation-args="{{ [] }}">
+            </tb-js-func>
+            <md-checkbox aria-label="{{ 'widget-config.use-on-data-updated-pre' | translate }}"
+                         ng-model="useOnDataUpdatedPre">{{ 'widget-config.use-on-data-updated-pre' | translate }}
+            </md-checkbox>
+            <tb-js-func ng-show="useOnDataUpdatedPre"
+                        ng-model="onDataUpdatedPreFunction"
+                        function-name="{{'onDataUpdatedPre'}}"
+                        function-args="{{ ['ctx'] }}"
+                        validation-args="{{ [] }}">
+            </tb-js-func>
+            <md-checkbox aria-label="{{ 'widget-config.use-on-data-updated-post' | translate }}"
+                         ng-model="useOnDataUpdatedPost">{{ 'widget-config.use-on-data-updated-post' | translate }}
+            </md-checkbox>
+            <tb-js-func ng-show="useOnDataUpdatedPost"
+                        ng-model="onDataUpdatedPostFunction"
+                        function-name="{{'onDataUpdatedPost'}}"
+                        function-args="{{ ['ctx'] }}"
+                        validation-args="{{ [] }}">
+            </tb-js-func>
+            <div ng-show="widgetType === types.widgetType.alarm.value">
+                <md-checkbox aria-label="{{ 'widget-config.use-alarms-udpated-pre' | translate }}"
+                             ng-model="useAlarmsUpdatedPre">{{ 'widget-config.use-alarms-udpated-pre' | translate }}
+                </md-checkbox>
+                <tb-js-func ng-show="useAlarmsUpdatedPre"
+                            ng-model="alarmsUpdatedPreFunction"
+                            function-name="{{'alarmsUpdatedPre'}}"
+                            function-args="{{ ['subscription', 'alarms'] }}"
+                            validation-args="{{ [] }}">
+                </tb-js-func>
+            </div>
+        </md-content>
+    </md-tab>
     <md-tab label="{{ 'widget-config.actions' | translate }}">
         <md-content class="md-padding" layout="column">
             <tb-manage-widget-actions

--- a/ui/src/app/locale/locale.constant-en_US.json
+++ b/ui/src/app/locale/locale.constant-en_US.json
@@ -1771,7 +1771,13 @@
         "delete-action-text": "Are you sure you want delete widget action with name '{{actionName}}'?",
         "display-icon": "Display title icon",
         "icon-color": "Icon color",
-        "icon-size": "Icon size"
+        "icon-size": "Icon size",
+        "custom-functions": "Custom functions",
+        "use-on-init-pre": "Execute a function before onInit() call",
+        "use-on-init-post": "Execute a function after onInit() call",
+        "use-on-data-updated-pre": "Execute a function before onDataUpdated() call",
+        "use-on-data-updated-post": "Execute a function after onDataUpdated() call",
+        "use-alarms-udpated-pre": "Execute a function before alarmsUpdated() call"
     },
     "widget-type": {
         "import": "Import widget type",

--- a/ui/src/app/locale/locale.constant-es_ES.json
+++ b/ui/src/app/locale/locale.constant-es_ES.json
@@ -1646,7 +1646,13 @@
         "delete-action-text": "¿Está seguro de que desea eliminar la acción del widget con nombre '{{actionName}}'?",
         "display-icon": "Mostrar icono del título",
         "icon-color": "Color del icono",
-        "icon-size": "Tamaño del icono"
+        "icon-size": "Tamaño del icono",
+        "custom-functions": "Funciones personalizadas",
+        "use-on-init-pre": "Ejecutar una función antes de la onInit()",
+        "use-on-init-post": "Ejecutar una función después de la onInit()",
+        "use-on-data-updated-pre": "Ejecutar una función antes de la onDataUpdated()",
+        "use-on-data-updated-post": "Ejecutar una función después de la onDataUpdated()",
+        "use-alarms-udpated-pre": "Ejecutar una función antes de la alarmsUpdated()"
     },
     "widget-type": {
         "import": "Importar tipo de widget",

--- a/ui/src/app/locale/locale.constant-fr_FR.json
+++ b/ui/src/app/locale/locale.constant-fr_FR.json
@@ -1596,7 +1596,13 @@
         "widget-style": "Style du widget",
         "display-icon": "Afficher l'icône du titre",
         "icon-color": "Couleur de l'icône",
-        "icon-size": "Taille de l'icône"
+        "icon-size": "Taille de l'icône",
+        "custom-functions": "Fonctions personnalisées",
+        "use-on-init-pre": "Exécuter une fonction avant la onInit()",
+        "use-on-init-post": "Exécuter une fonction après la onInit()",
+        "use-on-data-updated-pre": "Exécuter une fonction avant la onDataUpdated()",
+        "use-on-data-updated-post": "Exécuter une fonction après la onDataUpdated()",
+        "use-alarms-udpated-pre": "Exécuter une fonction avant la alarmsUpdated()"
     },
     "widget-type": {
         "create-new-widget-type": "Créer un nouveau type de widget",

--- a/ui/src/app/locale/locale.constant-it_IT.json
+++ b/ui/src/app/locale/locale.constant-it_IT.json
@@ -1589,7 +1589,13 @@
         "delete-action-text": "Sei sicuro di voler cancellare l'azione del widget '{{actionName}}'?",
         "display-icon": "Mostra icona titolo",
         "icon-color": "Colore dell'icona",
-        "icon-size": "Dimensione dell'icona"
+        "icon-size": "Dimensione dell'icona",
+        "custom-functions": "Funzioni personalizzate",
+        "use-on-init-pre": "Esegui una funzione prima della onInit()",
+        "use-on-init-post": "Esegui una funzione dopo la onInit()",
+        "use-on-data-updated-pre": "Esegui una funzione prima della onDataUpdated()",
+        "use-on-data-updated-post": "Esegui una funzione dopo la onDataUpdated()",
+        "use-alarms-udpated-pre": "Esegui una funzione prima della alarmsUpdated()"
     },
     "widget-type": {
         "import": "Importa un tipo di widget",


### PR DESCRIPTION
With this feature it's possible to write different custom functions in widget editor that will be called before (pre) or after (post) standard `onInit` and `onDataUpdated`. This can be useful, for example, if some data should be edited before calling the original `onDataUpdated`, or if after the original `onInit` an HTTP GET should be called to obtain a value usable in widget context. Furthermore, it's possibile to override original onInit and onDataUpdated if the 'pre' functions return **skip-default** string.