### PR TITLE
Fix query search in timeseries-table widget

### DIFF
--- a/ui/src/app/widget/lib/timeseries-table-widget.js
+++ b/ui/src/app/widget/lib/timeseries-table-widget.js
@@ -160,6 +160,12 @@ function TimeseriesTableWidgetController($element, $scope, $filter, $timeout, ty
         updateDatasources();
     }
 
+    $scope.$watch("vm.query.search", function(newVal, prevVal) {
+        if (!angular.equals(newVal, prevVal)) {
+            dataUpdated();
+        }
+    });
+
     $scope.$on('timeseries-table-data-updated', function(event, tableId) {
         if (vm.tableId == tableId) {
             dataUpdated();


### PR DESCRIPTION
When the query string was empty or closed, data didn't update to original state.

