### PR TITLE
Add possibility to select a preferred entity for alias not resolved as multiple entities

### DIFF
--- a/ui/src/app/api/entity.service.js
+++ b/ui/src/app/api/entity.service.js
@@ -413,7 +413,15 @@ function EntityService($http, $q, $filter, $translate, $log, userService, device
                 aliasInfo.resolvedEntities = result.entities;
                 aliasInfo.currentEntity = null;
                 if (aliasInfo.resolvedEntities.length) {
-                    aliasInfo.currentEntity = aliasInfo.resolvedEntities[0];
+                    var defaultEntity = [];
+                    if (!filter.resolveMultiple) {
+                        if (stateParams && stateParams.targetEntityParamName === entityAlias.alias) {
+                            defaultEntity = $filter('filter')(aliasInfo.resolvedEntities, {id: stateParams[entityAlias.alias].entityId.id});
+                        } else if (filter.defaultEntity) {
+                            defaultEntity = $filter('filter')(aliasInfo.resolvedEntities, {id: filter.defaultEntity.id});
+                        }
+                    }
+                    aliasInfo.currentEntity = defaultEntity.length ? defaultEntity[0] : aliasInfo.resolvedEntities[0];
                 }
                 deferred.resolve(aliasInfo);
             },

--- a/ui/src/app/entity/entity-filter.directive.js
+++ b/ui/src/app/entity/entity-filter.directive.js
@@ -63,14 +63,17 @@ export default function EntityFilterDirective($compile, $templateCache, $q, $doc
                     break;
                 case types.aliasFilterType.assetType.value:
                     filter.assetType = null;
+                    filter.defaultEntity = null;
                     filter.assetNameFilter = '';
                     break;
                 case types.aliasFilterType.deviceType.value:
                     filter.deviceType = null;
+                    filter.defaultEntity = null;
                     filter.deviceNameFilter = '';
                     break;
                 case types.aliasFilterType.entityViewType.value:
                     filter.entityViewType = null;
+                    filter.defaultEntity = null;
                     filter.entityViewNameFilter = '';
                     break;
                 case types.aliasFilterType.relationsQuery.value:

--- a/ui/src/app/entity/entity-filter.tpl.html
+++ b/ui/src/app/entity/entity-filter.tpl.html
@@ -91,6 +91,15 @@
                 ng-model="filter.assetType"
                 entity-type="types.entityType.asset">
         </tb-entity-subtype-autocomplete>
+        <div flex layout="column" ng-if="!filter.resolveMultiple">
+            <label class="tb-small">{{ 'alias.default-entity' | translate }}</label>
+            <tb-entity-select flex
+                              the-form="theForm"
+                              tb-required="false"
+                              allowed-entity-types="[types.entityType.asset]"
+                              ng-model="filter.defaultEntity">
+            </tb-entity-select>
+        </div>
         <md-input-container class="md-block">
             <label translate>asset.name-starts-with</label>
             <input name="assetNameFilter"
@@ -105,6 +114,15 @@
                 ng-model="filter.deviceType"
                 entity-type="types.entityType.device">
         </tb-entity-subtype-autocomplete>
+        <div flex layout="column" ng-if="!filter.resolveMultiple">
+            <label class="tb-small">{{ 'alias.default-entity' | translate }}</label>
+            <tb-entity-select flex
+                              the-form="theForm"
+                              tb-required="false"
+                              allowed-entity-types="[types.entityType.device]"
+                              ng-model="filter.defaultEntity">
+            </tb-entity-select>
+        </div>
         <md-input-container class="md-block">
             <label translate>device.name-starts-with</label>
             <input name="deviceNameFilter"
@@ -119,6 +137,15 @@
                 ng-model="filter.entityViewType"
                 entity-type="types.entityType.entityView">
         </tb-entity-subtype-autocomplete>
+        <div flex layout="column" ng-if="!filter.resolveMultiple">
+            <label class="tb-small">{{ 'alias.default-entity' | translate }}</label>
+            <tb-entity-select flex
+                              the-form="theForm"
+                              tb-required="false"
+                              allowed-entity-types="[types.entityType.entityView]"
+                              ng-model="filter.defaultEntity">
+            </tb-entity-select>
+        </div>
         <md-input-container class="md-block">
             <label translate>entity-view.name-starts-with</label>
             <input name="entityViewNameFilter"

--- a/ui/src/app/locale/locale.constant-en_US.json
+++ b/ui/src/app/locale/locale.constant-en_US.json
@@ -1397,7 +1397,8 @@
         "any-relation": "Any relation",
         "relation-filters": "Relation filters",
         "additional-info": "Additional info (JSON)",
-        "invalid-additional-info": "Unable to parse additional info json."
+        "invalid-additional-info": "Unable to parse additional info json.",
+        "default-entity": "Default entity"
     },
     "rulechain": {
         "rulechain": "Rule chain",

--- a/ui/src/app/locale/locale.constant-es_ES.json
+++ b/ui/src/app/locale/locale.constant-es_ES.json
@@ -1285,7 +1285,8 @@
         "any-relation": "Alguna relación",
         "relation-filters": "Filtros de relación",
         "additional-info": "Información adicional (JSON)",
-        "invalid-additional-info": "No se puede analizar información adicional json."
+        "invalid-additional-info": "No se puede analizar información adicional json.",
+        "default-entity": "Entidad predeterminada"
     },
     "rulechain": {
         "rulechain": "Cadena de reglas",

--- a/ui/src/app/locale/locale.constant-fr_FR.json
+++ b/ui/src/app/locale/locale.constant-fr_FR.json
@@ -1264,7 +1264,8 @@
         "to-entity-name": "vers le nom de l'entité",
         "to-entity-type": "Vers le type d'entité",
         "to-relations": "Relations entrantes",
-        "type": "Type"
+        "type": "Type",
+        "default-entity": "Entité par défaut"
     },
     "rulechain": {
         "add": "Ajouter une chaîne de règles",

--- a/ui/src/app/locale/locale.constant-it_IT.json
+++ b/ui/src/app/locale/locale.constant-it_IT.json
@@ -1230,7 +1230,8 @@
         "any-relation": "Qualsiasi relazione",
         "relation-filters": "Filtri relazioni",
         "additional-info": "Informazioni aggiuntive (JSON)",
-        "invalid-additional-info": "Impossibile analizzare le informazioni aggiuntive in JSON."
+        "invalid-additional-info": "Impossibile analizzare le informazioni aggiuntive in JSON.",
+        "default-entity": "Entità predefinita"
     },
     "rulechain": {
         "rulechain": "Rule chain",


### PR DESCRIPTION
By default, when an alias returns a list of entities and is not resolved as multiple entities, its current entity is set to the first element of this list. With this feature, it's possible to select a default entity instead of the first one found.