### PR TITLE
Update dashboard state when current alias entity changes using its select box

### DIFF
--- a/ui/src/app/components/widget/widget.controller.js
+++ b/ui/src/app/components/widget/widget.controller.js
@@ -467,33 +467,13 @@ export default function WidgetController($scope, $state, $timeout, $window, $ocL
         }
     }
 
-    function updateEntityParams(params, targetEntityParamName, targetEntityId, entityName, entityLabel) {
-        if (targetEntityId) {
-            var targetEntityParams;
-            if (targetEntityParamName && targetEntityParamName.length) {
-                targetEntityParams = params[targetEntityParamName];
-                if (!targetEntityParams) {
-                    targetEntityParams = {};
-                    params[targetEntityParamName] = targetEntityParams;
-					params.targetEntityParamName = targetEntityParamName;
-                }
-            } else {
-                targetEntityParams = params;
-            }
-            targetEntityParams.entityId = targetEntityId;
-            if (entityName) {
-                targetEntityParams.entityName = entityName;
-            }
-            if (entityLabel) {
-                targetEntityParams.entityLabel = entityLabel;
-            }
-        }
-    }
-
     function handleWidgetAction($event, descriptor, entityId, entityName, additionalParams, entityLabel) {
         var type = descriptor.type;
         var targetEntityParamName = descriptor.stateEntityParamName;
-        var targetEntityId;
+        var targetEntityId,
+            aliasId,
+            aliasInfo,
+            newEntity = [];
         if (descriptor.setEntityId) {
             targetEntityId = entityId;
         }
@@ -505,7 +485,15 @@ export default function WidgetController($scope, $state, $timeout, $window, $ocL
                 if (!params) {
                     params = {};
                 }
-                updateEntityParams(params, targetEntityParamName, targetEntityId, entityName, entityLabel);
+                aliasId = widgetContext.aliasController.getEntityAliasId(targetEntityParamName);
+                if (aliasId) {
+                    aliasInfo = widgetContext.aliasController.getInstantAliasInfo(aliasId);
+                    newEntity = aliasInfo ? $filter('filter')(aliasInfo.resolvedEntities, {id: targetEntityId.id}) : [];
+                    if (newEntity.length) {
+                        aliasInfo.currentEntity = newEntity[0];
+                    }
+                }
+                widgetContext.stateController.updateEntityParams(params, targetEntityParamName, targetEntityId, entityName, entityLabel);
                 if (type == types.widgetActionTypes.openDashboardState.value) {
                     widgetContext.stateController.openState(targetDashboardStateId, params, descriptor.openRightLayout);
                 } else {
@@ -517,7 +505,15 @@ export default function WidgetController($scope, $state, $timeout, $window, $ocL
                 targetDashboardStateId = descriptor.targetDashboardStateId;
                 var stateObject = {};
                 stateObject.params = {};
-                updateEntityParams(stateObject.params, targetEntityParamName, targetEntityId, entityName, entityLabel);
+                aliasId = widgetContext.aliasController.getEntityAliasId(targetEntityParamName);
+                if (aliasId) {
+                    aliasInfo = widgetContext.aliasController.getInstantAliasInfo(aliasId);
+                    newEntity = aliasInfo ? $filter('filter')(aliasInfo.resolvedEntities, {id: targetEntityId.id}) : [];
+                    if (newEntity.length) {
+                        aliasInfo.currentEntity = newEntity[0];
+                    }
+                }
+                widgetContext.stateController.updateEntityParams(stateObject.params, targetEntityParamName, targetEntityId, entityName, entityLabel);
                 if (targetDashboardStateId) {
                     stateObject.id = targetDashboardStateId;
                 }

--- a/ui/src/app/dashboard/dashboard.controller.js
+++ b/ui/src/app/dashboard/dashboard.controller.js
@@ -272,6 +272,25 @@ export default function DashboardController(types, utils, dashboardUtils, widget
         vm.dashboardCtx.stateController.cleanupPreservedStates();
     });
 
+    $scope.$on('entityAliasesChanged', function (event, aliasIds) {
+        var params = vm.dashboardCtx.stateController.getStateParams();
+
+        for (var a in aliasIds) {
+            var aliasId = aliasIds[a];
+            var selectedAlias = vm.dashboardCtx.aliasController.getInstantAliasInfo(aliasId);
+
+            if (selectedAlias && selectedAlias.currentEntity) {
+                var entityId = {
+                    entityType : selectedAlias.currentEntity.entityType,
+                    id: selectedAlias.currentEntity.id
+                };
+                vm.dashboardCtx.stateController.updateEntityParams(params, selectedAlias.alias, entityId, selectedAlias.currentEntity.name);
+            }
+        }
+
+        vm.dashboardCtx.stateController.updateState(null, params, null);
+    });
+    
     loadDashboard();
 
     function loadWidgetLibrary() {

--- a/ui/src/app/dashboard/states/states-component.directive.js
+++ b/ui/src/app/dashboard/states/states-component.directive.js
@@ -53,6 +53,10 @@ export default function StatesComponent($compile, $templateCache, $controller, s
                 }
             }
 
+            stateController.updateEntityParams = function(params, targetEntityParamName, targetEntityId, entityName, entityLabel) {
+                statesControllerService.updateEntityParams(params, targetEntityParamName, targetEntityId, entityName, entityLabel);
+            }
+
             stateController.cleanupPreservedStates = function() {
                 statesControllerService.cleanupPreservedStates();
             }

--- a/ui/src/app/dashboard/states/states-controller.service.js
+++ b/ui/src/app/dashboard/states/states-controller.service.js
@@ -42,10 +42,34 @@ export default function StatesControllerService() {
         getStateController: getStateController,
         preserveStateControllerState: preserveStateControllerState,
         withdrawStateControllerState: withdrawStateControllerState,
-        cleanupPreservedStates: cleanupPreservedStates
+        cleanupPreservedStates: cleanupPreservedStates,
+        updateEntityParams: updateEntityParams
     };
 
     return service;
+
+    function updateEntityParams(params, targetEntityParamName, targetEntityId, entityName, entityLabel) {
+        if (targetEntityId) {
+            var targetEntityParams;
+            if (targetEntityParamName && targetEntityParamName.length) {
+                targetEntityParams = params[targetEntityParamName];
+                if (!targetEntityParams) {
+                    targetEntityParams = {};
+                    params[targetEntityParamName] = targetEntityParams;
+                    params.targetEntityParamName = targetEntityParamName;
+                }
+            } else {
+                targetEntityParams = params;
+            }
+            targetEntityParams.entityId = targetEntityId;
+            if (entityName) {
+                targetEntityParams.entityName = entityName;
+            }	
+            if (entityLabel) {	
+                targetEntityParams.entityLabel = entityLabel;	
+            }
+        }
+    }
 
     function registerStatesController(id, stateControllerInfo) {
         statesControllers[id] = stateControllerInfo;


### PR DESCRIPTION
Actually, if an alias is not resolved as multiple entities, its entities are displayed as a list in a dedicated select box.
With this feature, current alias entity selection triggers dashboard state update, in order to refresh all dashboard components (i.e. widget or related alias).
Moreover, selected entity is also added as entity state parameter, so that on dashboard state update/open action, if there's an alias called as that entity state parameter, this current alias entity is set to that parameter value. In this way resolution of other aliases may depend on this new entity.

