### PR TITLE
Set correct cassandra datacenter

### DIFF
--- a/k8s/.env
+++ b/k8s/.env
@@ -1,6 +1,6 @@
 # Can be either basic (with single instance of Zookeeper, Kafka and Redis) or high-availability (with Zookeeper, Kafka and Redis in cluster modes).
 # According to the deployment type corresponding kubernetes resources will be deployed (see content of the directories ./basic and ./high-availability for details).
-DEPLOYMENT_TYPE=high-availability
+DEPLOYMENT_TYPE=basic
 
 # Database used by ThingsBoard, can be either postgres (PostgreSQL) or hybrid (PostgreSQL for entities database and Cassandra for timeseries database).
 # According to the database type corresponding kubernetes resources will be deployed (see postgres.yml, cassandra.yml for details).

--- a/k8s/common/cassandra.yml
+++ b/k8s/common/cassandra.yml
@@ -114,7 +114,7 @@ spec:
           - name: CASSANDRA_CLUSTER_NAME
             value: "Thingsboard Cluster"
           - name: CASSANDRA_DC
-            value: "DC1-Thingsboard-Cluster"
+            value: "datacenter1"
           - name: CASSANDRA_RACK
             value: "Rack-Thingsboard-Cluster"
           - name: CASSANDRA_AUTO_BOOTSTRAP


### PR DESCRIPTION
In 3.0.0 Cassandra datacenter is hardcoded in AbstractCassandraCluster.initSession() method.
This is just a quick fix to make scripts work.
Also changed default DEPLOYMENT_TYPE to 'basic'.