### PR TITLE
createSubscription method returns nothing, when empty datasources list provided

### DIFF
--- a/ui-ngx/src/app/core/api/alias-controller.ts
+++ b/ui-ngx/src/app/core/api/alias-controller.ts
@@ -321,12 +321,12 @@ export class AliasController implements IAliasController {
   }
 
   resolveDatasources(datasources: Array<Datasource>, singleEntity?: boolean): Observable<Array<Datasource>> {
-    if (datasources.length) {
-      const toResolve = singleEntity ? [datasources[0]] : datasources;
-      const observables = new Array<Observable<Datasource>>();
-      toResolve.forEach((datasource) => {
-        observables.push(this.resolveDatasource(datasource));
-      });
+    const toResolve = singleEntity ? [datasources[0]] : datasources;
+    const observables = new Array<Observable<Datasource>>();
+    toResolve.forEach((datasource) => {
+      observables.push(this.resolveDatasource(datasource));
+    });
+    if (observables.length) {
       return forkJoin(observables).pipe(
         map((result) => {
           let functionIndex = 0;


### PR DESCRIPTION
When _datasources_ list in _subscriptionOptions_ empty, _createSubscription_ method returns nothing at all: no result, no error.
Check for datasources length added, when forkJoin performed.
This makes it to return _subscription_ object with empty _data_ and _datasources_.