### PR TITLE
Moved convertResultToTsKvEntry to base class and updated it

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/AbstractCassandraBaseTimeseriesDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/AbstractCassandraBaseTimeseriesDao.java
@@ -31,6 +31,7 @@ import org.thingsboard.server.dao.nosql.CassandraAbstractAsyncDao;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 public abstract class AbstractCassandraBaseTimeseriesDao extends CassandraAbstractAsyncDao {
@@ -83,6 +84,24 @@ public abstract class AbstractCassandraBaseTimeseriesDao extends CassandraAbstra
         String key = row.getString(ModelConstants.KEY_COLUMN);
         long ts = row.getLong(ModelConstants.TS_COLUMN);
         return new BasicTsKvEntry(ts, toKvEntry(row, key));
+    }
+
+    protected TsKvEntry convertResultToTsKvEntry(String key, Row row) {
+        if (row != null) {
+            Optional<String> foundKeyOpt = getKey(row);
+            long ts = row.getLong(ModelConstants.TS_COLUMN);
+            return new BasicTsKvEntry(ts, toKvEntry(row, foundKeyOpt.orElse(key)));
+        } else {
+            return new BasicTsKvEntry(System.currentTimeMillis(), new StringDataEntry(key, null));
+        }
+    }
+
+    private Optional<String> getKey(Row row){
+       try{
+           return Optional.ofNullable(row.getString(ModelConstants.KEY_COLUMN));
+       } catch (IllegalArgumentException e){
+           return Optional.empty();
+       }
     }
 
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesLatestDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesLatestDao.java
@@ -186,15 +186,6 @@ public class CassandraBaseTimeseriesLatestDao extends AbstractCassandraBaseTimes
                 rows -> this.convertResultToTsKvEntryList(rows), readResultsProcessingExecutor);
     }
 
-    private TsKvEntry convertResultToTsKvEntry(String key, Row row) {
-        if (row != null) {
-            long ts = row.getLong(ModelConstants.TS_COLUMN);
-            return new BasicTsKvEntry(ts, toKvEntry(row, key));
-        } else {
-            return new BasicTsKvEntry(System.currentTimeMillis(), new StringDataEntry(key, null));
-        }
-    }
-
     private PreparedStatement getLatestStmt() {
         if (latestInsertStmt == null) {
             latestInsertStmt = prepare(INSERT_INTO + ModelConstants.TS_KV_LATEST_CF +


### PR DESCRIPTION
This changes are required to fix NullPointerException in PE _CassandraBaseTimeseriesDao_ class and line (when _rs.one()_ returns _null_) :
  _return getFuture(executeAsyncRead(tenantId, stmt), rs -> convertResultToTsKvEntry(rs.one()));_
