### PR TITLE
Moved hardcoded local datacenter name to config

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -184,6 +184,8 @@ cassandra:
   keyspace_name: "${CASSANDRA_KEYSPACE_NAME:thingsboard}"
   # Specify node list
   url: "${CASSANDRA_URL:127.0.0.1:9042}"
+  # Specify local datacenter name
+  local_datacenter: "${CASSANDRA_LOCAL_DATACENTER:datacenter1}"
   # Enable/disable secure connection
   ssl: "${CASSANDRA_USE_SSL:false}"
   # Enable/disable JMX

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/cassandra/AbstractCassandraCluster.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/cassandra/AbstractCassandraCluster.java
@@ -36,6 +36,8 @@ public abstract class AbstractCassandraCluster {
     private Boolean jmx;
     @Value("${cassandra.metrics}")
     private Boolean metrics;
+    @Value("${cassandra.local_datacenter}")
+    private String localDatacenter;
 
     @Autowired
     private CassandraDriverOptions driverOptions;
@@ -82,7 +84,7 @@ public abstract class AbstractCassandraCluster {
         if (this.keyspaceName != null) {
             this.sessionBuilder.withKeyspace(this.keyspaceName);
         }
-        this.sessionBuilder.withLocalDatacenter("datacenter1");
+        this.sessionBuilder.withLocalDatacenter(localDatacenter);
         session = sessionBuilder.build();
         if (this.metrics && this.jmx) {
             MetricRegistry registry =


### PR DESCRIPTION
Hi, I've been running Thingsboard upgrade script from v2.4.1 to v3.1 followed as [k8s doc](https://github.com/thingsboard/thingsboard/tree/v3.1/k8s).
Due to our Cassandra cluster data center has been set as other name, It would be hard to upgrade hardcoded datacenter name from original "[tb-node:3.0.0](https://hub.docker.com/layers/thingsboard/tb-node/3.0.0/images/sha256-3c82d40b4dfdebb7a218130eedac149bfb3442a36484393cb9be3d00c9eaf335?context=explore)" docker image. Hopefully this commit could be pick to [release-3.0](https://github.com/thingsboard/thingsboard/tree/release-3.1) and update tag [v3.0](https://github.com/thingsboard/thingsboard/tree/v3.0).
Many thanks!