### PR TITLE
Add full DataStax Java Driver SSL configs

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -194,8 +194,21 @@ cassandra:
   url: "${CASSANDRA_URL:127.0.0.1:9042}"
   # Specify local datacenter name
   local_datacenter: "${CASSANDRA_LOCAL_DATACENTER:datacenter1}"
-  # Enable/disable secure connection
-  ssl: "${CASSANDRA_USE_SSL:false}"
+  ssl:
+    # Enable/disable secure connection
+    enabled: "${CASSANDRA_USE_SSL:false}"
+    # Enable/disable validation of Cassandra server hostname
+    # If enabled, hostname of Cassandra server must match CN of server certificate
+    hostname_validation: "${CASSANDRA_SSL_HOSTNAME_VALIDATION:true}"
+    # Set trust store for client authentication of server (optional, uses trust store from default SSLContext if not set)
+    trust_store: "${CASSANDRA_SSL_TRUST_STORE:}"
+    trust_store_password: "${CASSANDRA_SSL_TRUST_STORE_PASSWORD:}"
+    # Set key store for server authentication of client (optional, uses key store from default SSLContext if not set)
+    # A key store is only needed if the Cassandra server requires client authentication
+    key_store: "${CASSANDRA_SSL_KEY_STORE:}"
+    key_store_password: "${CASSANDRA_SSL_KEY_STORE_PASSWORD:}"
+    # Comma separated list of cipher suites (optional, uses Java default cipher suites if not set)
+    cipher_suites: "${CASSANDRA_SSL_CIPHER_SUITES:}"
   # Enable/disable JMX
   jmx: "${CASSANDRA_USE_JMX:false}"
   # Enable/disable metrics collection.

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/cassandra/CassandraDriverOptions.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/cassandra/CassandraDriverOptions.java
@@ -80,8 +80,22 @@ public class CassandraDriverOptions {
 
     @Value("${cassandra.compression}")
     private String compression;
-    @Value("${cassandra.ssl}")
+    
+    @Value("${cassandra.ssl.enabled}")
     private Boolean ssl;
+    @Value("${cassandra.ssl.key_store}")
+    private String sslKeyStore;
+    @Value("${cassandra.ssl.key_store_password}")
+    private String sslKeyStorePassword;
+    @Value("${cassandra.ssl.trust_store}")
+    private String sslTrustStore;
+    @Value("${cassandra.ssl.trust_store_password}")
+    private String sslTrustStorePassword;
+    @Value("${cassandra.ssl.hostname_validation}")
+    private Boolean sslHostnameValidation;
+    @Value("${cassandra.ssl.cipher_suites}")
+    private List<String> sslCipherSuites;
+    
     @Value("${cassandra.metrics}")
     private Boolean metrics;
 
@@ -120,7 +134,19 @@ public class CassandraDriverOptions {
 
         if (this.ssl) {
             driverConfigBuilder.withString(DefaultDriverOption.SSL_ENGINE_FACTORY_CLASS,
-                    "DefaultSslEngineFactory");
+                    "DefaultSslEngineFactory")
+                .withBoolean(DefaultDriverOption.SSL_HOSTNAME_VALIDATION, this.sslHostnameValidation);
+            if(!this.sslTrustStore.isEmpty()) {
+                driverConfigBuilder.withString(DefaultDriverOption.SSL_TRUSTSTORE_PATH, this.sslTrustStore)
+                    .withString(DefaultDriverOption.SSL_TRUSTSTORE_PASSWORD, this.sslTrustStorePassword);
+            }
+            if(!this.sslKeyStore.isEmpty()) {
+                driverConfigBuilder.withString(DefaultDriverOption.SSL_KEYSTORE_PATH, this.sslKeyStore)
+                    .withString(DefaultDriverOption.SSL_KEYSTORE_PASSWORD, this.sslKeyStorePassword);
+            }
+            if(!this.sslCipherSuites.isEmpty()) {
+                driverConfigBuilder.withStringList(DefaultDriverOption.SSL_CIPHER_SUITES, this.sslCipherSuites);
+            }
         }
 
         if (this.metrics) {

--- a/dao/src/test/resources/cassandra-test.properties
+++ b/dao/src/test/resources/cassandra-test.properties
@@ -6,7 +6,13 @@ cassandra.url=127.0.0.1:9142
 
 cassandra.local_datacenter=datacenter1
 
-cassandra.ssl=false
+cassandra.ssl.enabled=false
+cassandra.ssl.hostname_validation=false
+cassandra.ssl.trust_store=
+cassandra.ssl.trust_store_password=
+cassandra.ssl.key_store=
+cassandra.ssl.key_store_password=
+cassandra.ssl.cipher_suites=
 
 cassandra.jmx=false
 


### PR DESCRIPTION
Inspired by the recommendations in [this issue](https://github.com/thingsboard/thingsboard/issues/3420#issue-692135699), added mechanisms to provide all DataStax DefautlSslEngineFactory properties through thingsboard.yml.

Tests passed with Cassandra SSL disabled, enabled with server-only authentication and enabled with two-way authentication. I also confirmed it works in my usual ThingsBoard dev setup, with two-way Cassandra SSL to a remote server.