### PR TITLE
Rule chain bulk import export

### DIFF
--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/rule/RuleChainService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/rule/RuleChainService.java
@@ -16,6 +16,7 @@
 package org.thingsboard.server.dao.rule;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import org.thingsboard.server.common.data.exception.ThingsboardException;
 import org.thingsboard.server.common.data.id.RuleChainId;
 import org.thingsboard.server.common.data.id.RuleNodeId;
 import org.thingsboard.server.common.data.id.TenantId;
@@ -23,6 +24,8 @@ import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
 import org.thingsboard.server.common.data.relation.EntityRelation;
 import org.thingsboard.server.common.data.rule.RuleChain;
+import org.thingsboard.server.common.data.rule.RuleChainData;
+import org.thingsboard.server.common.data.rule.RuleChainImportResult;
 import org.thingsboard.server.common.data.rule.RuleChainMetaData;
 import org.thingsboard.server.common.data.rule.RuleNode;
 
@@ -62,5 +65,9 @@ public interface RuleChainService {
     void deleteRuleChainById(TenantId tenantId, RuleChainId ruleChainId);
 
     void deleteRuleChainsByTenantId(TenantId tenantId);
+
+    RuleChainData exportTenantRuleChains(TenantId tenantId, PageLink pageLink) throws ThingsboardException;
+
+    List<RuleChainImportResult> importTenantRuleChains(TenantId tenantId, RuleChainData ruleChainData, boolean overwrite);
 
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rule/RuleChainData.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rule/RuleChainData.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright © 2016-2020 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.common.data.rule;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class RuleChainData {
+
+    List<RuleChain> ruleChains;
+    List<RuleChainMetaData> metadata;
+}

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rule/RuleChainImportResult.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rule/RuleChainImportResult.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright © 2016-2020 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.common.data.rule;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.thingsboard.server.common.data.id.RuleChainId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.plugin.ComponentLifecycleEvent;
+
+@Data
+@AllArgsConstructor
+public class RuleChainImportResult {
+
+    private TenantId tenantId;
+    private RuleChainId ruleChainId;
+    private ComponentLifecycleEvent lifecycleEvent;
+}

--- a/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
@@ -15,12 +15,16 @@
  */
 package org.thingsboard.server.dao.rule;
 
+import com.datastax.oss.driver.api.core.uuid.Uuids;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.util.concurrent.ListenableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.thingsboard.server.common.data.BaseData;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.Tenant;
@@ -30,11 +34,14 @@ import org.thingsboard.server.common.data.id.RuleNodeId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
+import org.thingsboard.server.common.data.plugin.ComponentLifecycleEvent;
 import org.thingsboard.server.common.data.relation.EntityRelation;
 import org.thingsboard.server.common.data.relation.RelationTypeGroup;
 import org.thingsboard.server.common.data.rule.NodeConnectionInfo;
 import org.thingsboard.server.common.data.rule.RuleChain;
 import org.thingsboard.server.common.data.rule.RuleChainConnectionInfo;
+import org.thingsboard.server.common.data.rule.RuleChainData;
+import org.thingsboard.server.common.data.rule.RuleChainImportResult;
 import org.thingsboard.server.common.data.rule.RuleChainMetaData;
 import org.thingsboard.server.common.data.rule.RuleNode;
 import org.thingsboard.server.dao.entity.AbstractEntityService;
@@ -46,9 +53,14 @@ import org.thingsboard.server.dao.tenant.TenantDao;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static org.thingsboard.server.common.data.DataConstants.TENANT;
 
 /**
  * Created by igor on 3/12/18.
@@ -57,6 +69,7 @@ import java.util.concurrent.ExecutionException;
 @Slf4j
 public class BaseRuleChainService extends AbstractEntityService implements RuleChainService {
 
+    private static final int DEFAULT_PAGE_SIZE = 1000;
     @Autowired
     private RuleChainDao ruleChainDao;
 
@@ -356,6 +369,141 @@ public class BaseRuleChainService extends AbstractEntityService implements RuleC
     public void deleteRuleChainsByTenantId(TenantId tenantId) {
         Validator.validateId(tenantId, "Incorrect tenant id for delete rule chains request.");
         tenantRuleChainsRemover.removeEntities(tenantId, tenantId);
+    }
+
+    @Override
+    public RuleChainData exportTenantRuleChains(TenantId tenantId, PageLink pageLink) {
+        Validator.validateId(tenantId, "Incorrect tenant id for search rule chain request.");
+        Validator.validatePageLink(pageLink);
+        PageData<RuleChain> ruleChainData = ruleChainDao.findRuleChainsByTenantId(tenantId.getId(), pageLink);
+        List<RuleChain> ruleChains = ruleChainData.getData();
+        List<RuleChainMetaData> metadata = ruleChains.stream().map(rc -> loadRuleChainMetaData(tenantId, rc.getId())).collect(Collectors.toList());
+        RuleChainData rcData = new RuleChainData();
+        rcData.setRuleChains(ruleChains);
+        rcData.setMetadata(metadata);
+        setRandomRuleChainIds(rcData);
+        resetRuleNodeIds(metadata);
+        return rcData;
+    }
+
+    @Override
+    public List<RuleChainImportResult> importTenantRuleChains(TenantId tenantId, RuleChainData ruleChainData, boolean overwrite) {
+        List<RuleChainImportResult> importResults = new ArrayList<>();
+        setRandomRuleChainIds(ruleChainData);
+        resetRuleNodeIds(ruleChainData.getMetadata());
+        resetRuleChainMetadataTenantIds(tenantId, ruleChainData.getMetadata());
+        if (overwrite) {
+            List<RuleChain> persistentRuleChains = findAllTenantRuleChains(tenantId);
+            for (RuleChain ruleChain : ruleChainData.getRuleChains()) {
+                ComponentLifecycleEvent lifecycleEvent;
+                Optional<RuleChain> persistentRuleChainOpt = persistentRuleChains.stream().filter(rc -> rc.getName().equals(ruleChain.getName())).findFirst();
+                if (persistentRuleChainOpt.isPresent()) {
+                    setNewRuleChainId(ruleChain, ruleChainData.getMetadata(), ruleChain.getId(), persistentRuleChainOpt.get().getId());
+                    ruleChain.setRoot(persistentRuleChainOpt.get().isRoot());
+                    lifecycleEvent = ComponentLifecycleEvent.UPDATED;
+                } else {
+                    ruleChain.setRoot(false);
+                    lifecycleEvent = ComponentLifecycleEvent.CREATED;
+                }
+                ruleChain.setTenantId(tenantId);
+                ruleChainDao.save(tenantId, ruleChain);
+                importResults.add(new RuleChainImportResult(tenantId, ruleChain.getId(), lifecycleEvent));
+            }
+        } else {
+            if (!CollectionUtils.isEmpty(ruleChainData.getRuleChains())) {
+                ruleChainData.getRuleChains().forEach(rc -> {
+                    rc.setTenantId(tenantId);
+                    rc.setRoot(false);
+                    RuleChain savedRc = ruleChainDao.save(tenantId, rc);
+                    importResults.add(new RuleChainImportResult(tenantId, savedRc.getId(), ComponentLifecycleEvent.CREATED));
+                });
+            }
+        }
+        if (!CollectionUtils.isEmpty(ruleChainData.getMetadata())) {
+            ruleChainData.getMetadata().forEach(md -> saveRuleChainMetaData(tenantId, md));
+        }
+        return importResults;
+    }
+
+    private void resetRuleChainMetadataTenantIds(TenantId tenantId, List<RuleChainMetaData> metaData) {
+        for (RuleChainMetaData md : metaData) {
+            for (RuleNode node : md.getNodes()) {
+                JsonNode nodeConfiguration = node.getConfiguration();
+                searchTenantIdRecursive(tenantId, nodeConfiguration);
+            }
+        }
+    }
+
+    private void searchTenantIdRecursive(TenantId tenantId, JsonNode node) {
+        Iterator<String> iter = node.fieldNames();
+        boolean isTenantId = false;
+        while (iter.hasNext()) {
+            String field = iter.next();
+            if ("entityType".equals(field) && TENANT.equals(node.get(field).asText())) {
+                isTenantId = true;
+                break;
+            }
+        }
+        if (isTenantId) {
+            ObjectNode objNode = (ObjectNode) node;
+            objNode.put("id", tenantId.getId().toString());
+        } else {
+            Iterator<JsonNode> childIter = node.iterator();
+            while (childIter.hasNext()) {
+                searchTenantIdRecursive(tenantId, childIter.next());
+            }
+        }
+    }
+
+    private void setRandomRuleChainIds(RuleChainData ruleChainData) {
+        for (RuleChain ruleChain : ruleChainData.getRuleChains()) {
+            RuleChainId oldRuleChainId = ruleChain.getId();
+            RuleChainId newRuleChainId = new RuleChainId(Uuids.timeBased());
+            setNewRuleChainId(ruleChain, ruleChainData.getMetadata(), oldRuleChainId, newRuleChainId);
+            ruleChain.setTenantId(null);
+        }
+    }
+
+    private void resetRuleNodeIds(List<RuleChainMetaData> metaData) {
+        for (RuleChainMetaData md : metaData) {
+            for (RuleNode node : md.getNodes()) {
+                node.setId(null);
+                node.setRuleChainId(null);
+            }
+        }
+    }
+
+    private List<RuleChain> findAllTenantRuleChains(TenantId tenantId) {
+        PageLink pageLink = new PageLink(DEFAULT_PAGE_SIZE);
+        return findAllTenantRuleChainsRecursive(tenantId, new ArrayList<>(), pageLink);
+    }
+
+    private List<RuleChain> findAllTenantRuleChainsRecursive(TenantId tenantId, List<RuleChain> accumulator, PageLink pageLink) {
+        PageData<RuleChain> persistentRuleChainData = findTenantRuleChains(tenantId, pageLink);
+        List<RuleChain> ruleChains = persistentRuleChainData.getData();
+        if (!CollectionUtils.isEmpty(ruleChains)) {
+            accumulator.addAll(ruleChains);
+        }
+        if (persistentRuleChainData.hasNext()) {
+            return findAllTenantRuleChainsRecursive(tenantId, accumulator, pageLink.nextPageLink());
+        }
+        return accumulator;
+    }
+
+    private void setNewRuleChainId(RuleChain ruleChain, List<RuleChainMetaData> metadata, RuleChainId oldRuleChainId, RuleChainId newRuleChainId) {
+        ruleChain.setId(newRuleChainId);
+        for (RuleChainMetaData metaData : metadata) {
+            if (metaData.getRuleChainId().equals(oldRuleChainId)) {
+                metaData.setRuleChainId(newRuleChainId);
+            }
+            if (!CollectionUtils.isEmpty(metaData.getRuleChainConnections())) {
+                for (RuleChainConnectionInfo rcConnInfo : metaData.getRuleChainConnections()) {
+                    if (rcConnInfo.getTargetRuleChainId().equals(oldRuleChainId)) {
+                        rcConnInfo.setTargetRuleChainId(newRuleChainId);
+                    }
+                }
+            }
+        }
     }
 
     private void checkRuleNodesAndDelete(TenantId tenantId, RuleChainId ruleChainId) {


### PR DESCRIPTION
Created 2 REST endpoints for bulk rule chain import & export. 
All real Rule Chain ID's are substituted by the fake ones upon export. The new UUIDs are there to ensure consistency between rule chains in the export
The Import endpoint can either a) import rule chains as new rule chains or b) overwrite the existing rule chains by name.
this is triggered by ?overwrite=true request parameter.
if overwrite is set to false (by default) or no Rule Chain with such name already exist, then the Rule chain will be given a new ID and saved to the system.
if overwrite is set to true and there is a matching rule chain found, the existing Rule Chain will be updated and ID will be preserved.

If any of the imported Rule Nodes contain Tenant ID in Rule Node configuration, it will be replaced with the current tenant id.

This feature is very useful when continuously updating the tenant configuration, e.g. from development tenant to production tenant or bulk-copying the tenant configurations across multiple instances  