### PR TITLE
set lib attribute "animatedValue" to "true" in analogue-gauge.models.ts

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/analogue-gauge.models.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/analogue-gauge.models.ts
@@ -1002,7 +1002,8 @@ export abstract class TbAnalogueGauge<S extends AnalogueGaugeSettings, O extends
       // animations
       animation: settings.animation !== false && !this.ctx.isMobile,
       animationDuration: (isDefined(settings.animationDuration) && settings.animationDuration !== null) ? settings.animationDuration : 500,
-      animationRule: settings.animationRule || 'cycle'
+      animationRule: settings.animationRule || 'cycle',
+      animatedValue: true
     } as O;
 
     this.prepareGaugeOptions(settings, gaugeData);


### PR DESCRIPTION
some gauge widgets didn't update their value, setting "animatedValue" to "true" resolves the problem