### PR TITLE
getEntityTimeseriesValues request addded

### DIFF
--- a/ui-ngx/src/app/core/http/attribute.service.ts
+++ b/ui-ngx/src/app/core/http/attribute.service.ts
@@ -22,6 +22,7 @@ import { EntityId } from '@shared/models/id/entity-id';
 import { AttributeData, AttributeScope } from '@shared/models/telemetry/telemetry.models';
 import {isDefined, isDefinedAndNotNull} from '@core/utils';
 import {AggregationType} from "@shared/models/time/time.models";
+import {TsValue} from "@shared/models/query/query.models";
 
 @Injectable({
   providedIn: 'root'
@@ -42,7 +43,7 @@ export class AttributeService {
   }
 
   public getEntityTimeseriesValues(entityId: EntityId, keys: Array<string>, startTs: number, endTs: number,
-                                   interval?: number, limit?: number, agg?: string, orderBy?: string, useStrictDataTypes?: boolean, config?: RequestConfig) {
+                                   interval?: number, limit?: number, agg?: string, orderBy?: string, useStrictDataTypes?: boolean, config?: RequestConfig): Observable<Array<TsValue>> {
     let url = `/api/plugins/telemetry/${entityId.entityType}/${entityId.id}/values/timeseries`;
       url += `?keys=${keys.join(',')}`;
       url += `&startTs=${startTs}`;

--- a/ui-ngx/src/app/core/http/attribute.service.ts
+++ b/ui-ngx/src/app/core/http/attribute.service.ts
@@ -20,7 +20,7 @@ import { forkJoin, Observable, of } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { EntityId } from '@shared/models/id/entity-id';
 import { AttributeData, AttributeScope } from '@shared/models/telemetry/telemetry.models';
-import { isDefinedAndNotNull } from '@core/utils';
+import {isDefined, isDefinedAndNotNull} from '@core/utils';
 
 @Injectable({
   providedIn: 'root'
@@ -38,6 +38,17 @@ export class AttributeService {
       url += `?keys=${keys.join(',')}`;
     }
     return this.http.get<Array<AttributeData>>(url, defaultHttpOptionsFromConfig(config));
+  }
+
+  public getEntityTimeseriesValues(entityId: EntityId, keys: Array<string>, startTs: number, endTs: number, limit?: number, config?: RequestConfig) {
+    let url = `/api/plugins/telemetry/${entityId.entityType}/${entityId.id}/values/timeseries/`;
+      url += `?keys=${keys.join(',')}`;
+      url += `?startTs=${startTs}`;
+      url += `?endTs=${endTs}`;
+      if (isDefined(limit)) {
+        url += `?keys=${limit}`;
+      }
+    return this.http.get(url, defaultHttpOptionsFromConfig(config));
   }
 
   public deleteEntityAttributes(entityId: EntityId, attributeScope: AttributeScope, attributes: Array<AttributeData>,

--- a/ui-ngx/src/app/core/http/attribute.service.ts
+++ b/ui-ngx/src/app/core/http/attribute.service.ts
@@ -21,6 +21,7 @@ import { HttpClient } from '@angular/common/http';
 import { EntityId } from '@shared/models/id/entity-id';
 import { AttributeData, AttributeScope } from '@shared/models/telemetry/telemetry.models';
 import {isDefined, isDefinedAndNotNull} from '@core/utils';
+import {AggregationType} from "@shared/models/time/time.models";
 
 @Injectable({
   providedIn: 'root'
@@ -40,14 +41,27 @@ export class AttributeService {
     return this.http.get<Array<AttributeData>>(url, defaultHttpOptionsFromConfig(config));
   }
 
-  public getEntityTimeseriesValues(entityId: EntityId, keys: Array<string>, startTs: number, endTs: number, limit?: number, config?: RequestConfig) {
-    let url = `/api/plugins/telemetry/${entityId.entityType}/${entityId.id}/values/timeseries/`;
+  public getEntityTimeseriesValues(entityId: EntityId, keys: Array<string>, startTs: number, endTs: number,
+                                   interval?: number, limit?: number, agg?: string, orderBy?: string, useStrictDataTypes?: boolean, config?: RequestConfig) {
+    let url = `/api/plugins/telemetry/${entityId.entityType}/${entityId.id}/values/timeseries`;
       url += `?keys=${keys.join(',')}`;
-      url += `?startTs=${startTs}`;
-      url += `?endTs=${endTs}`;
-      if (isDefined(limit)) {
-        url += `?keys=${limit}`;
+      url += `&startTs=${startTs}`;
+      url += `&endTs=${endTs}`;
+      if (isDefined(interval)) {
+        url += `&interval=${interval}`;
       }
+    if (isDefined(limit)) {
+      url += `&limit=${limit}`;
+    }
+    if (isDefined(agg)) {
+      url += `&agg=${agg}`;
+    }
+    if (isDefined(orderBy)) {
+      url += `&orderBy=${orderBy}`;
+    }
+    if (isDefined(useStrictDataTypes)) {
+      url += `&useStrictDataTypes=${useStrictDataTypes}`;
+    }
     return this.http.get(url, defaultHttpOptionsFromConfig(config));
   }
 

--- a/ui-ngx/src/app/core/http/attribute.service.ts
+++ b/ui-ngx/src/app/core/http/attribute.service.ts
@@ -63,7 +63,7 @@ export class AttributeService {
     if (isDefined(useStrictDataTypes)) {
       url += `&useStrictDataTypes=${useStrictDataTypes}`;
     }
-    return this.http.get(url, defaultHttpOptionsFromConfig(config));
+    return this.http.getArray<TsValue>(url, defaultHttpOptionsFromConfig(config));
   }
 
   public deleteEntityAttributes(entityId: EntityId, attributeScope: AttributeScope, attributes: Array<AttributeData>,

--- a/ui-ngx/src/app/core/http/attribute.service.ts
+++ b/ui-ngx/src/app/core/http/attribute.service.ts
@@ -63,7 +63,7 @@ export class AttributeService {
     if (isDefined(useStrictDataTypes)) {
       url += `&useStrictDataTypes=${useStrictDataTypes}`;
     }
-    return this.http.getArray<TsValue>(url, defaultHttpOptionsFromConfig(config));
+    return this.http.get<Array<TsValue>>(url, defaultHttpOptionsFromConfig(config));
   }
 
   public deleteEntityAttributes(entityId: EntityId, attributeScope: AttributeScope, attributes: Array<AttributeData>,


### PR DESCRIPTION
public getEntityTimeseriesValues(entityId: EntityId, keys: Array<string>, startTs: number, endTs: number, limit?: number, config?: RequestConfig)
Method was present in version 2.+