### PR TITLE
[3.2.1]Prevent unnecessarily converting strings to numbers when importing

### DIFF
--- a/ui-ngx/src/app/modules/home/components/import-export/import-export.models.ts
+++ b/ui-ngx/src/app/modules/home/components/import-export/import-export.models.ts
@@ -146,7 +146,7 @@ function splitCSV(str: string, sep: string): string[] {
 
 function isNumeric(str: any): boolean {
   str = str.replace(',', '.');
-  return !isNaN(parseFloat(str)) && isFinite(str);
+  return (str - parseFloat(str) + 1) >= 0 && Number(str).toString() === str;
 }
 
 function convertStringToJSType(str: string): any {


### PR DESCRIPTION
Prevents converting '0080000004027000' to 80000004027000 when importing