### PR TITLE
Fix update device profile

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/profile/ProfileState.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/profile/ProfileState.java
@@ -64,6 +64,7 @@ class ProfileState {
         alarmSettings.clear();
         alarmCreateKeys.clear();
         alarmClearKeys.clear();
+        entityKeys.clear();
         if (deviceProfile.getProfileData().getAlarms() != null) {
             alarmSettings.addAll(deviceProfile.getProfileData().getAlarms());
             for (DeviceProfileAlarm alarm : deviceProfile.getProfileData().getAlarms()) {


### PR DESCRIPTION
entityKeys are not cleared currently on device profile update. So imagine the scenario:

1. you and an attribute to the device profie, say 'my_attr'
2. the device does not have that attribute
3. you realize that and remove 'my_attr' from the device profile config
4. 'my_attr' is still present in entityKeys map, however, it is not visible to user, and the device_profile node will fail with NPE because of not finding the 'my_attr' attribute
5. 'my_attr' will only be removed from entity_keys upon server restart.

The fix is to clear and re-initialize entityKeys on profile update