### PR TITLE
Do not load all data if it is not in the current time interval

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
@@ -433,7 +433,9 @@ public class DefaultSubscriptionManagerService implements SubscriptionManagerSer
             if (curTs > value) {
                 long startTs = subscription.getStartTime() > 0 ? Math.max(subscription.getStartTime(), value + 1L) : (value + 1L);
                 long endTs = subscription.getEndTime() > 0 ? Math.min(subscription.getEndTime(), curTs) : curTs;
-                queries.add(new BaseReadTsKvQuery(key, startTs, endTs, 0, 1000, Aggregation.NONE));
+                if (startTs > 1) {
+                    queries.add(new BaseReadTsKvQuery(key, startTs, endTs, 0, 1000, Aggregation.NONE));
+                }
             }
         });
         if (!queries.isEmpty()) {


### PR DESCRIPTION
If you select a time interval that does not have any data, the system returns all the telemetry saved in the database of the selected entity and the page load is extremely slow