### PR TITLE
[3.3] Feature/attributes cache (#3593)

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/AdminController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/AdminController.java
@@ -34,6 +34,7 @@ import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.security.model.SecuritySettings;
 import org.thingsboard.server.dao.settings.AdminSettingsService;
 import org.thingsboard.server.queue.util.TbCoreComponent;
+import org.thingsboard.server.service.queue.TbClusterService;
 import org.thingsboard.server.service.security.permission.Operation;
 import org.thingsboard.server.service.security.permission.Resource;
 import org.thingsboard.server.service.security.system.SystemSecurityService;
@@ -58,6 +59,9 @@ public class AdminController extends BaseController {
 
     @Autowired
     private UpdateService updateService;
+
+    @Autowired
+    private TbClusterService clusterService;
 
     @PreAuthorize("hasAuthority('SYS_ADMIN')")
     @RequestMapping(value = "/settings/{key}", method = RequestMethod.GET)
@@ -140,6 +144,16 @@ public class AdminController extends BaseController {
         try {
             accessControlService.checkPermission(getCurrentUser(), Resource.ADMIN_SETTINGS, Operation.READ);
             smsService.sendTestSms(testSmsRequest);
+        } catch (Exception e) {
+            throw handleException(e);
+        }
+    }
+
+    @PreAuthorize("hasAuthority('SYS_ADMIN')")
+    @RequestMapping(value = "/cache/attributes/invalidate", method = RequestMethod.DELETE)
+    public void invalidateAttributesCache() throws ThingsboardException {
+        try {
+            clusterService.invalidateAttributesCache();
         } catch (Exception e) {
             throw handleException(e);
         }

--- a/application/src/main/java/org/thingsboard/server/service/attributes/AbstractAttributesTbCacheStatsService.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/AbstractAttributesTbCacheStatsService.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.beans.factory.annotation.Value;
+
+
+public abstract class AbstractAttributesTbCacheStatsService<T> implements TbCacheStatsService<T> {
+    protected static final String CACHE_STATS_NAME = "attributes";
+
+    @Value("${cache.attributes.enableStats}")
+    protected Boolean attributeCacheStatsEnabled;
+
+    @Value("${metrics.enabled:false}")
+    protected Boolean metricsEnabled;
+
+    protected MeterRegistry meterRegistry;
+
+    public AbstractAttributesTbCacheStatsService(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public boolean areCacheStatsEnabled() {
+        return metricsEnabled && attributeCacheStatsEnabled;
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/attributes/AttributeCacheEntry.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/AttributeCacheEntry.java
@@ -13,11 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.dao.service.attributes.sql;
+package org.thingsboard.server.service.attributes;
 
-import org.thingsboard.server.dao.service.DaoSqlTest;
-import org.thingsboard.server.dao.service.attributes.DaoAttributesServiceTest;
+import lombok.Getter;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
 
-@DaoSqlTest
-public class AttributesServiceSqlTest extends DaoAttributesServiceTest {
+@Getter
+public class AttributeCacheEntry {
+    private static final AttributeCacheEntry EMPTY = new AttributeCacheEntry(null);
+
+    private final AttributeKvEntry attributeKvEntry;
+
+    public AttributeCacheEntry(AttributeKvEntry attributeKvEntry) {
+        this.attributeKvEntry = attributeKvEntry;
+    }
+
+    public boolean isPresent(){
+        return attributeKvEntry != null;
+    }
+
+    public static AttributeCacheEntry empty(){
+        return EMPTY;
+    }
 }

--- a/application/src/main/java/org/thingsboard/server/service/attributes/AttributeUtils.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/AttributeUtils.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
+import org.thingsboard.server.dao.exception.IncorrectParameterException;
+import org.thingsboard.server.dao.service.Validator;
+
+public class AttributeUtils {
+    public static void validate(EntityId id, String scope) {
+        Validator.validateId(id.getId(), "Incorrect id " + id);
+        Validator.validateString(scope, "Incorrect scope " + scope);
+    }
+
+    public static void validate(AttributeKvEntry kvEntry) {
+        if (kvEntry == null) {
+            throw new IncorrectParameterException("Key value entry can't be null");
+        } else if (kvEntry.getDataType() == null) {
+            throw new IncorrectParameterException("Incorrect kvEntry. Data type can't be null");
+        } else {
+            Validator.validateString(kvEntry.getKey(), "Incorrect kvEntry. Key can't be empty");
+            Validator.validatePositiveNumber(kvEntry.getLastUpdateTs(), "Incorrect last update ts. Ts should be positive");
+        }
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/attributes/AttributesCacheConfiguration.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/AttributesCacheConfiguration.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(prefix = "cache.attributes", value = "enabled", havingValue = "true")
+@ConfigurationProperties(prefix = "cache.attributes")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AttributesCacheConfiguration {
+    private int maxSizePerTenant;
+    private int expireAfterAccessInMinutes;
+}

--- a/application/src/main/java/org/thingsboard/server/service/attributes/AttributesKey.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/AttributesKey.java
@@ -13,11 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.dao.service.attributes.sql;
+package org.thingsboard.server.service.attributes;
 
-import org.thingsboard.server.dao.service.DaoSqlTest;
-import org.thingsboard.server.dao.service.attributes.DaoAttributesServiceTest;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.thingsboard.server.common.data.id.EntityId;
 
-@DaoSqlTest
-public class AttributesServiceSqlTest extends DaoAttributesServiceTest {
+@EqualsAndHashCode
+@Getter
+@AllArgsConstructor
+public class AttributesKey {
+    private final String scope;
+    private final EntityId entityId;
+    private final String key;
 }

--- a/application/src/main/java/org/thingsboard/server/service/attributes/BaseAttributesService.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/BaseAttributesService.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.id.DeviceProfileId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
+import org.thingsboard.server.dao.attributes.AttributesService;
+import org.thingsboard.server.dao.service.Validator;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.thingsboard.server.service.attributes.AttributeUtils.validate;
+
+@Service
+@ConditionalOnProperty(prefix = "cache.attributes", value = "enabled", havingValue = "false", matchIfMissing = true)
+@Primary
+@Slf4j
+public class BaseAttributesService implements AttributesService {
+    private final AttributesService daoAttributesService;
+
+    public BaseAttributesService(@Qualifier("daoAttributesService") AttributesService daoAttributesService) {
+        this.daoAttributesService = daoAttributesService;
+    }
+
+
+    @Override
+    public ListenableFuture<Optional<AttributeKvEntry>> find(TenantId tenantId, EntityId entityId, String scope, String attributeKey) {
+        validate(entityId, scope);
+        Validator.validateString(attributeKey, "Incorrect attribute key " + attributeKey);
+        return daoAttributesService.find(tenantId, entityId, scope, attributeKey);
+    }
+
+    @Override
+    public ListenableFuture<List<AttributeKvEntry>> find(TenantId tenantId, EntityId entityId, String scope, Collection<String> attributeKeys) {
+        validate(entityId, scope);
+        attributeKeys.forEach(attributeKey -> Validator.validateString(attributeKey, "Incorrect attribute key " + attributeKey));
+        return daoAttributesService.find(tenantId, entityId, scope, attributeKeys);
+    }
+
+    @Override
+    public ListenableFuture<List<AttributeKvEntry>> findAll(TenantId tenantId, EntityId entityId, String scope) {
+        validate(entityId, scope);
+        return daoAttributesService.findAll(tenantId, entityId, scope);
+    }
+
+    @Override
+    public List<String> findAllKeysByDeviceProfileId(TenantId tenantId, DeviceProfileId deviceProfileId) {
+        return daoAttributesService.findAllKeysByDeviceProfileId(tenantId, deviceProfileId);
+    }
+
+    @Override
+    public List<String> findAllKeysByEntityIds(TenantId tenantId, EntityType entityType, List<EntityId> entityIds) {
+        return daoAttributesService.findAllKeysByEntityIds(tenantId, entityType, entityIds);
+    }
+
+    @Override
+    public ListenableFuture<List<Void>> save(TenantId tenantId, EntityId entityId, String scope, List<AttributeKvEntry> attributes) {
+        validate(entityId, scope);
+        attributes.forEach(attribute -> validate(attribute));
+
+        return daoAttributesService.save(tenantId, entityId, scope, attributes);
+    }
+
+    @Override
+    public ListenableFuture<List<Void>> removeAll(TenantId tenantId, EntityId entityId, String scope, List<String> attributeKeys) {
+        validate(entityId, scope);
+        return daoAttributesService.removeAll(tenantId, entityId, scope, attributeKeys);
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/attributes/CachedAttributesService.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/CachedAttributesService.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.id.DeviceProfileId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
+import org.thingsboard.server.common.data.kv.KvEntry;
+import org.thingsboard.server.common.msg.queue.ServiceType;
+import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
+import org.thingsboard.server.dao.attributes.AttributesService;
+import org.thingsboard.server.dao.service.Validator;
+import org.thingsboard.server.queue.discovery.PartitionService;
+import org.thingsboard.server.service.queue.TbClusterService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.thingsboard.server.service.attributes.AttributeUtils.validate;
+
+@Service
+@ConditionalOnProperty(prefix = "cache.attributes", value = "enabled", havingValue = "true")
+@Primary
+@Slf4j
+public class CachedAttributesService implements AttributesService {
+    private static final List<EntityType> LOCAL_ENTITIES = Arrays.asList(EntityType.DEVICE, EntityType.ASSET);
+    private static final List<EntityType> GLOBAL_ENTITIES = Arrays.asList(EntityType.CUSTOMER, EntityType.TENANT);
+    public static final String MAIN_QUEUE_NAME = "Main";
+
+    private final AttributesService daoAttributesService;
+    private final TbClusterService clusterService;
+    private final PartitionService partitionService;
+    private final TbAttributesCache attributesCache;
+
+    public CachedAttributesService(@Qualifier("daoAttributesService") AttributesService daoAttributesService,
+                                   TbClusterService clusterService, PartitionService partitionService,
+                                   TbAttributesCache attributesCache) {
+        this.daoAttributesService = daoAttributesService;
+        this.clusterService = clusterService;
+        this.partitionService = partitionService;
+        this.attributesCache = attributesCache;
+    }
+
+
+    @Override
+    public ListenableFuture<Optional<AttributeKvEntry>> find(TenantId userTenantId, EntityId entityId, String scope, String attributeKey) {
+        validate(entityId, scope);
+        Validator.validateString(attributeKey, "Incorrect attribute key " + attributeKey);
+
+        TenantId tenantId = updateTenantIdInCaseSysAdmin(userTenantId, entityId);
+
+        if (LOCAL_ENTITIES.contains(entityId.getEntityType())) {
+            TopicPartitionInfo tpi = partitionService.resolve(ServiceType.TB_RULE_ENGINE, MAIN_QUEUE_NAME, tenantId, entityId);
+            if (!tpi.isMyPartition()) {
+                return daoAttributesService.find(tenantId, entityId, scope, attributeKey);
+            } else {
+                return findAndPopulateCache(tenantId, entityId, scope, attributeKey);
+            }
+        } else if (GLOBAL_ENTITIES.contains(entityId.getEntityType())) {
+            return findAndPopulateCache(tenantId, entityId, scope, attributeKey);
+        } else {
+            return daoAttributesService.find(tenantId, entityId, scope, attributeKey);
+        }
+    }
+
+    @Override
+    public ListenableFuture<List<AttributeKvEntry>> find(TenantId userTenantId, EntityId entityId, String scope, Collection<String> attributeKeys) {
+        validate(entityId, scope);
+        attributeKeys.forEach(attributeKey -> Validator.validateString(attributeKey, "Incorrect attribute key " + attributeKey));
+
+        TenantId tenantId = updateTenantIdInCaseSysAdmin(userTenantId, entityId);
+
+        if (LOCAL_ENTITIES.contains(entityId.getEntityType())) {
+            TopicPartitionInfo tpi = partitionService.resolve(ServiceType.TB_RULE_ENGINE, MAIN_QUEUE_NAME, tenantId, entityId);
+            if (!tpi.isMyPartition()) {
+                return daoAttributesService.find(tenantId, entityId, scope, attributeKeys);
+            } else {
+                return findAndPopulateCache(tenantId, entityId, scope, attributeKeys);
+            }
+        } else if (GLOBAL_ENTITIES.contains(entityId.getEntityType())) {
+            return findAndPopulateCache(tenantId, entityId, scope, attributeKeys);
+        } else {
+            return daoAttributesService.find(tenantId, entityId, scope, attributeKeys);
+        }
+    }
+
+    private ListenableFuture<Optional<AttributeKvEntry>> findAndPopulateCache(TenantId tenantId, EntityId entityId, String scope, String attributeKey) {
+        AttributeCacheEntry cachedEntry = attributesCache.find(tenantId, entityId, scope, attributeKey);
+        if (cachedEntry != null) {
+            return Futures.immediateFuture(Optional.of(cachedEntry.getAttributeKvEntry()));
+        } else {
+            ListenableFuture<Optional<AttributeKvEntry>> result = daoAttributesService.find(tenantId, entityId, scope, attributeKey);
+            return Futures.transform(result, foundAttrKvEntry -> {
+                attributesCache.put(tenantId, entityId, scope, attributeKey, foundAttrKvEntry.orElse(null));
+                return foundAttrKvEntry;
+            }, MoreExecutors.directExecutor());
+        }
+    }
+
+    private ListenableFuture<List<AttributeKvEntry>> findAndPopulateCache(TenantId tenantId, EntityId entityId, String scope, Collection<String> attributeKeys) {
+        Collection<String> notFoundInCacheAttributeKeys = new HashSet<>();
+        List<AttributeKvEntry> foundInCacheAttributes = new ArrayList<>();
+        for (String attributeKey : attributeKeys) {
+            AttributeCacheEntry cachedEntry = attributesCache.find(tenantId, entityId, scope, attributeKey);
+            if (cachedEntry != null) {
+                if (cachedEntry.isPresent()) {
+                    foundInCacheAttributes.add(cachedEntry.getAttributeKvEntry());
+                }
+            } else {
+                notFoundInCacheAttributeKeys.add(attributeKey);
+            }
+        }
+        if (notFoundInCacheAttributeKeys.isEmpty()) {
+            return Futures.immediateFuture(foundInCacheAttributes);
+        } else {
+            ListenableFuture<List<AttributeKvEntry>> result = daoAttributesService.find(tenantId, entityId, scope, notFoundInCacheAttributeKeys);
+            return Futures.transform(result, foundInDbAttributes -> {
+                for (AttributeKvEntry foundInDbAttribute : foundInDbAttributes) {
+                    attributesCache.put(tenantId, entityId, scope, foundInDbAttribute.getKey(), foundInDbAttribute);
+                    notFoundInCacheAttributeKeys.remove(foundInDbAttribute.getKey());
+                }
+                for (String key : notFoundInCacheAttributeKeys){
+                    attributesCache.put(tenantId, entityId, scope, key, null);
+                }
+                List<AttributeKvEntry> mergedAttributes = new ArrayList<>(foundInCacheAttributes);
+                mergedAttributes.addAll(foundInDbAttributes);
+                return mergedAttributes;
+            }, MoreExecutors.directExecutor());
+        }
+    }
+
+    @Override
+    public ListenableFuture<List<AttributeKvEntry>> findAll(TenantId userTenantId, EntityId entityId, String scope) {
+        validate(entityId, scope);
+        TenantId tenantId = updateTenantIdInCaseSysAdmin(userTenantId, entityId);
+        return daoAttributesService.findAll(tenantId, entityId, scope);
+    }
+
+    @Override
+    public List<String> findAllKeysByDeviceProfileId(TenantId tenantId, DeviceProfileId deviceProfileId) {
+        return daoAttributesService.findAllKeysByDeviceProfileId(tenantId, deviceProfileId);
+    }
+
+    @Override
+    public List<String> findAllKeysByEntityIds(TenantId tenantId, EntityType entityType, List<EntityId> entityIds) {
+        return daoAttributesService.findAllKeysByEntityIds(tenantId, entityType, entityIds);
+    }
+
+    @Override
+    public ListenableFuture<List<Void>> save(TenantId userTenantId, EntityId entityId, String scope, List<AttributeKvEntry> attributes) {
+        validate(entityId, scope);
+        attributes.forEach(attribute -> validate(attribute));
+
+        TenantId tenantId = updateTenantIdInCaseSysAdmin(userTenantId, entityId);
+        return Futures.transform(daoAttributesService.save(tenantId, entityId, scope, attributes),
+                result -> {
+                    try {
+                        TopicPartitionInfo tpi = partitionService.resolve(ServiceType.TB_RULE_ENGINE, MAIN_QUEUE_NAME, tenantId, entityId);
+                        if (LOCAL_ENTITIES.contains(entityId.getEntityType()) && tpi.isMyPartition()) {
+                            updateCache(tenantId, entityId, scope, attributes);
+                        } else if (GLOBAL_ENTITIES.contains(entityId.getEntityType())) {
+                            if (tpi.getTenantId().isPresent()) {
+                                updateCache(tenantId, entityId, scope, attributes);
+                            } else {
+                                // TODO maybe first check if it's already in cache
+                                clusterService.onAttributesCacheUpdated(tenantId, entityId, scope, attributes.stream()
+                                        .map(KvEntry::getKey)
+                                        .collect(Collectors.toList())
+                                );
+                            }
+                        }
+                    } catch (Exception e) {
+                        log.error("[{}][{}] Failed to update cache.", tenantId, entityId, e);
+                    }
+                    return result;
+                },
+                MoreExecutors.directExecutor());
+    }
+
+    private void updateCache(TenantId tenantId, EntityId entityId, String scope, List<AttributeKvEntry> attributes) {
+        for (AttributeKvEntry attribute : attributes) {
+            if (Objects.nonNull(attributesCache.find(tenantId, entityId, scope, attribute.getKey()))) {
+                attributesCache.put(tenantId, entityId, scope, attribute.getKey(), attribute);
+            }
+        }
+    }
+
+    @Override
+    public ListenableFuture<List<Void>> removeAll(TenantId userTenantId, EntityId entityId, String scope, List<String> attributeKeys) {
+        validate(entityId, scope);
+        TenantId tenantId = updateTenantIdInCaseSysAdmin(userTenantId, entityId);
+        return Futures.transform(daoAttributesService.removeAll(tenantId, entityId, scope, attributeKeys),
+                result -> {
+                    try {
+                        TopicPartitionInfo tpi = partitionService.resolve(ServiceType.TB_RULE_ENGINE, MAIN_QUEUE_NAME, tenantId, entityId);
+                        if (LOCAL_ENTITIES.contains(entityId.getEntityType())) {
+                            attributesCache.evict(tenantId, entityId, scope, attributeKeys);
+                        } else if (GLOBAL_ENTITIES.contains(entityId.getEntityType())) {
+                            if (tpi.getTenantId().isPresent()) {
+                                attributesCache.evict(tenantId, entityId, scope, attributeKeys);
+                            } else {
+                                // TODO maybe first check if it's already in cache
+                                clusterService.onAttributesCacheUpdated(tenantId, entityId, scope, attributeKeys);
+                            }
+                        }
+                    } catch (Exception e) {
+                        log.error("[{}][{}] Failed to remove values from cache.", tenantId, entityId, e);
+                    }
+                    return result;
+                },
+                MoreExecutors.directExecutor());
+    }
+
+    private TenantId updateTenantIdInCaseSysAdmin(TenantId tenantId, EntityId entityId) {
+        if (tenantId.isNullUid() && EntityType.TENANT.equals(entityId.getEntityType())) {
+            return new TenantId(entityId.getId());
+        } else {
+            return tenantId;
+        }
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/attributes/CaffeineAttributesTbCacheStatsService.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/CaffeineAttributesTbCacheStatsService.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.thingsboard.server.common.data.id.TenantId;
+
+
+@Service
+@Qualifier("CaffeineCacheStats")
+public class CaffeineAttributesTbCacheStatsService extends AbstractAttributesTbCacheStatsService<Cache<AttributesKey, AttributeCacheEntry>> {
+    private static final String CACHE_MANAGER = "CaffeineCacheManager";
+
+    public CaffeineAttributesTbCacheStatsService(MeterRegistry meterRegistry) {
+        super(meterRegistry);
+    }
+
+    @Override
+    public void registerCacheStats(Cache<AttributesKey, AttributeCacheEntry> cache, TenantId tenantId) {
+        CaffeineCacheMetrics.monitor(meterRegistry, cache, CACHE_STATS_NAME,
+                "cacheManager", CACHE_MANAGER,
+                "name", tenantId.getId().toString());
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/attributes/CaffeineTbAttributesCache.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/CaffeineTbAttributesCache.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Ticker;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Service;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@ConditionalOnExpression("'${cache.attributes.enabled}'=='true' && '${cache.attributes.type:caffeine}'=='caffeine'")
+@Service
+public class CaffeineTbAttributesCache implements TbAttributesCache {
+    private final Map<TenantId, Cache<AttributesKey, AttributeCacheEntry>> tenantsCache = new ConcurrentHashMap<>();
+
+    private final AttributesCacheConfiguration cacheConfiguration;
+    private final TbCacheStatsService<Cache<AttributesKey, AttributeCacheEntry>> cacheStatsService;
+
+    public CaffeineTbAttributesCache(AttributesCacheConfiguration cacheConfiguration,
+                                     @Qualifier("CaffeineCacheStats") TbCacheStatsService<Cache<AttributesKey, AttributeCacheEntry>> cacheStatsService) {
+        this.cacheConfiguration = cacheConfiguration;
+        this.cacheStatsService = cacheStatsService;
+    }
+
+    private Cache<AttributesKey, AttributeCacheEntry> getTenantCache(TenantId tenantId) {
+        return tenantsCache.computeIfAbsent(tenantId,
+                id -> {
+                    Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder()
+                            .maximumSize(cacheConfiguration.getMaxSizePerTenant())
+                            .expireAfterAccess(cacheConfiguration.getExpireAfterAccessInMinutes(), TimeUnit.MINUTES);
+                    if (customTicker != null){
+                        cacheBuilder.ticker(customTicker);
+                    }
+                    if (cacheStatsService.areCacheStatsEnabled()) {
+                        cacheBuilder.recordStats();
+                    }
+                    Cache<AttributesKey, AttributeCacheEntry> cache = cacheBuilder.build();
+
+                    if (cacheStatsService.areCacheStatsEnabled()) {
+                        cacheStatsService.registerCacheStats(cache, tenantId);
+                    }
+                    return cache;
+                }
+        );
+    }
+
+    @Override
+    public AttributeCacheEntry find(TenantId tenantId, EntityId entityId, String scope, String key) {
+        return getTenantCache(tenantId).getIfPresent(new AttributesKey(scope, entityId, key));
+    }
+
+    @Override
+    public void put(TenantId tenantId, EntityId entityId, String scope, String key, AttributeKvEntry entry) {
+        getTenantCache(tenantId).put(new AttributesKey(scope, entityId, key), entry != null ?
+                new AttributeCacheEntry(entry) : AttributeCacheEntry.empty());
+    }
+
+    @Override
+    public void evict(TenantId tenantId, EntityId entityId, String scope, List<String> attributeKeys) {
+        List<AttributesKey> keys = attributeKeys.stream().map(key -> new AttributesKey(scope, entityId, key)).collect(Collectors.toList());
+        getTenantCache(tenantId).invalidateAll(keys);
+    }
+
+    @Override
+    public void invalidateAll() {
+        tenantsCache.forEach((tenantId, cache) -> {
+            cache.invalidateAll();
+        });
+    }
+
+    private Ticker customTicker;
+
+    public void setCustomTicker(Ticker customTicker) {
+        this.customTicker = customTicker;
+    }
+
+}

--- a/application/src/main/java/org/thingsboard/server/service/attributes/GoogleAttributesTbCacheStatsService.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/GoogleAttributesTbCacheStatsService.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import com.google.common.cache.Cache;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.thingsboard.server.common.data.id.TenantId;
+
+
+@Service
+@Qualifier("GuavaCacheStats")
+public class GoogleAttributesTbCacheStatsService extends AbstractAttributesTbCacheStatsService<Cache<AttributesKey, AttributeCacheEntry>> {
+    private static final String CACHE_MANAGER = "GuavaCacheManager";
+
+    public GoogleAttributesTbCacheStatsService(MeterRegistry meterRegistry) {
+        super(meterRegistry);
+    }
+
+    @Override
+    public void registerCacheStats(Cache<AttributesKey, AttributeCacheEntry> cache, TenantId tenantId) {
+        GuavaCacheMetrics.monitor(meterRegistry, cache, CACHE_STATS_NAME,
+                "cacheManager", CACHE_MANAGER,
+                "name", tenantId.getId().toString());
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/attributes/GoogleTbAttributesCache.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/GoogleTbAttributesCache.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import com.google.common.base.Ticker;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Service;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@ConditionalOnExpression("'${cache.attributes.enabled}'=='true' && '${cache.attributes.type:caffeine}'=='guava'")
+@Service
+public class GoogleTbAttributesCache implements TbAttributesCache {
+    private final Map<TenantId, Cache<AttributesKey, AttributeCacheEntry>> tenantsCache = new ConcurrentHashMap<>();
+
+    private final AttributesCacheConfiguration cacheConfiguration;
+    private final TbCacheStatsService<Cache<AttributesKey, AttributeCacheEntry>> cacheStatsService;
+
+    public GoogleTbAttributesCache(AttributesCacheConfiguration cacheConfiguration,
+                                   @Qualifier("GuavaCacheStats") TbCacheStatsService<Cache<AttributesKey, AttributeCacheEntry>> cacheStatsService) {
+        this.cacheConfiguration = cacheConfiguration;
+        this.cacheStatsService = cacheStatsService;
+    }
+
+    private Cache<AttributesKey, AttributeCacheEntry> getTenantCache(TenantId tenantId) {
+        return tenantsCache.computeIfAbsent(tenantId,
+                id -> {
+                    CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
+                            .maximumSize(cacheConfiguration.getMaxSizePerTenant())
+                            .expireAfterAccess(cacheConfiguration.getExpireAfterAccessInMinutes(), TimeUnit.MINUTES);
+                    if (customTicker != null){
+                        cacheBuilder.ticker(customTicker);
+                    }
+                    if (cacheStatsService.areCacheStatsEnabled()) {
+                        cacheBuilder.recordStats();
+                    }
+                    Cache<AttributesKey, AttributeCacheEntry> cache = cacheBuilder.build();
+
+                    if (cacheStatsService.areCacheStatsEnabled()) {
+                        cacheStatsService.registerCacheStats(cache, tenantId);
+                    }
+                    return cache;
+                }
+        );
+    }
+
+    @Override
+    public AttributeCacheEntry find(TenantId tenantId, EntityId entityId, String scope, String key) {
+        return getTenantCache(tenantId).getIfPresent(new AttributesKey(scope, entityId, key));
+    }
+
+    @Override
+    public void put(TenantId tenantId, EntityId entityId, String scope, String key, AttributeKvEntry entry) {
+        getTenantCache(tenantId).put(new AttributesKey(scope, entityId, key), entry != null ?
+                new AttributeCacheEntry(entry) : AttributeCacheEntry.empty());
+    }
+
+    @Override
+    public void evict(TenantId tenantId, EntityId entityId, String scope, List<String> attributeKeys) {
+        List<AttributesKey> keys = attributeKeys.stream().map(key -> new AttributesKey(scope, entityId, key)).collect(Collectors.toList());
+        getTenantCache(tenantId).invalidateAll(keys);
+    }
+
+    @Override
+    public void invalidateAll() {
+        tenantsCache.forEach((tenantId, cache) -> {
+            cache.invalidateAll();
+        });
+    }
+
+    private Ticker customTicker;
+
+    public void setCustomTicker(Ticker customTicker) {
+        this.customTicker = customTicker;
+    }
+
+}

--- a/application/src/main/java/org/thingsboard/server/service/attributes/TbAttributesCache.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/TbAttributesCache.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TbAttributesCache {
+    AttributeCacheEntry find(TenantId tenantId, EntityId entityId, String scope, String key);
+    void put(TenantId tenantId, EntityId entityId, String scope, String key, AttributeKvEntry entry);
+    void evict(TenantId tenantId, EntityId entityId, String scope, List<String> attributeKeys);
+    void invalidateAll();
+}

--- a/application/src/main/java/org/thingsboard/server/service/attributes/TbCacheStatsService.java
+++ b/application/src/main/java/org/thingsboard/server/service/attributes/TbCacheStatsService.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.dao.service.attributes.sql;
+package org.thingsboard.server.service.attributes;
 
-import org.thingsboard.server.dao.service.DaoSqlTest;
-import org.thingsboard.server.dao.service.attributes.DaoAttributesServiceTest;
+import org.thingsboard.server.common.data.id.TenantId;
 
-@DaoSqlTest
-public class AttributesServiceSqlTest extends DaoAttributesServiceTest {
+public interface TbCacheStatsService<C> {
+    boolean areCacheStatsEnabled();
+    void registerCacheStats(C cache, TenantId tenantId);
 }

--- a/application/src/main/java/org/thingsboard/server/service/queue/TbClusterService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/TbClusterService.java
@@ -32,6 +32,7 @@ import org.thingsboard.server.gen.transport.TransportProtos.ToTransportMsg;
 import org.thingsboard.server.queue.TbQueueCallback;
 import org.thingsboard.server.service.rpc.FromDeviceRpcResponse;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface TbClusterService {
@@ -53,6 +54,10 @@ public interface TbClusterService {
     void pushNotificationToTransport(String targetServiceId, ToTransportMsg response, TbQueueCallback callback);
 
     void onEntityStateChange(TenantId tenantId, EntityId entityId, ComponentLifecycleEvent state);
+
+    void onAttributesCacheUpdated(TenantId tenantId, EntityId entityId, String scope, List<String> attributeKeys);
+
+    void invalidateAttributesCache();
 
     void onDeviceProfileChange(DeviceProfile deviceProfile, TbQueueCallback callback);
 

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -322,6 +322,13 @@ actors:
 cache:
   # caffeine or redis
   type: "${CACHE_TYPE:caffeine}"
+  attributes:
+    enabled: "${CACHE_ATTRIBUTES_ENABLED:false}"
+    # caffeine or guava
+    type: "${CACHE_ATTRIBUTES_TYPE:caffeine}"
+    maxSizePerTenant: "${CACHE_ATTRIBUTES_MAX_SIZE_PER_TENANT:100000}"
+    expireAfterAccessInMinutes: "${CACHE_ATTRIBUTES_EXPIRE_AFTER_ACCESS_IN_MINUTES:10}"
+    enableStats: "${CACHE_ATTRIBUTES_ENABLE_STATS:false}"
 
 caffeine:
   specs:

--- a/application/src/test/java/org/thingsboard/server/service/attributes/CachedAttributesServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/attributes/CachedAttributesServiceTest.java
@@ -1,0 +1,288 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import com.google.common.cache.Cache;
+import com.google.common.util.concurrent.Futures;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+import org.thingsboard.server.common.data.id.CustomerId;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.BaseAttributeKvEntry;
+import org.thingsboard.server.common.data.kv.StringDataEntry;
+import org.thingsboard.server.common.msg.queue.ServiceType;
+import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
+import org.thingsboard.server.dao.attributes.AttributesService;
+import org.thingsboard.server.queue.discovery.PartitionService;
+import org.thingsboard.server.service.queue.TbClusterService;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@Slf4j
+@RunWith(Parameterized.class)
+public class CachedAttributesServiceTest {
+    private static final String scope = "scope";
+    private static final String key = "testKey";
+    private static final String value = "testValue";
+    private static final String firstKey = "firstTestKey";
+    private static final String secondKey = "secondTestKey";
+    private static final List<String> keys = Arrays.asList(firstKey, secondKey);
+
+    private static final TenantId tenantId = new TenantId(UUID.randomUUID());
+    private static final CustomerId customerId = new CustomerId(UUID.randomUUID());
+    private static final DeviceId deviceId = new DeviceId(UUID.randomUUID());
+
+    private final TbAttributesCache attributesCache;
+    private TbClusterService clusterService;
+    private PartitionService partitionService;
+    private AttributesService daoAttributesService;
+    private CachedAttributesService cachedAttributesService;
+
+    public CachedAttributesServiceTest(TbAttributesCache attributesCache) {
+        this.attributesCache = attributesCache;
+    }
+
+    @Parameterized.Parameters
+    public static Collection data() {
+        AttributesCacheConfiguration cacheConfiguration = AttributesCacheConfiguration.builder()
+                .expireAfterAccessInMinutes(1)
+                .maxSizePerTenant(10)
+                .build();
+        TbCacheStatsService<?> mockedStatsService = mock(TbCacheStatsService.class);
+        when(mockedStatsService.areCacheStatsEnabled()).thenReturn(false);
+        Object[][] data = new Object[][] {
+                {new GoogleTbAttributesCache(cacheConfiguration, (TbCacheStatsService<Cache<AttributesKey, AttributeCacheEntry>>) mockedStatsService)},
+                {new CaffeineTbAttributesCache(cacheConfiguration, (TbCacheStatsService<com.github.benmanes.caffeine.cache.Cache<AttributesKey, AttributeCacheEntry>>) mockedStatsService)}
+        };
+        return Arrays.asList(data);
+    }
+
+    @Before
+    public void before(){
+
+        this.attributesCache.invalidateAll();
+
+        this.clusterService = mock(TbClusterService.class);
+        this.partitionService = mock(PartitionService.class);
+        this.daoAttributesService = mock(AttributesService.class);
+
+        this.cachedAttributesService = new CachedAttributesService(daoAttributesService, clusterService,
+                partitionService, attributesCache);
+    }
+
+    @Test
+    public void testFindCustomerAttributeOnLocalPartition() throws Exception{
+        BaseAttributeKvEntry entry = new BaseAttributeKvEntry(0, new StringDataEntry(key, value));
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(Futures.immediateFuture(Optional.of(entry)));
+
+        for (int i = 0; i < 10; i++) {
+            Assert.assertEquals(entry, cachedAttributesService.find(tenantId, customerId, scope, key).get().get());
+            verify(daoAttributesService, times(1)).find(tenantId, customerId, scope, key);
+        }
+    }
+
+    @Test
+    public void testFindCustomerAttributeOnRemotePartition() throws Exception{
+        BaseAttributeKvEntry entry = new BaseAttributeKvEntry(0, new StringDataEntry(key, value));
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(Futures.immediateFuture(Optional.of(entry)));
+
+        for (int i = 0; i < 10; i++) {
+            Assert.assertEquals(entry, cachedAttributesService.find(tenantId, customerId, scope, key).get().get());
+            verify(daoAttributesService, times(1)).find(tenantId, customerId, scope, key);
+        }
+    }
+
+    @Test
+    public void testFindDeviceAttributeOnLocalPartition() throws Exception{
+        BaseAttributeKvEntry entry = new BaseAttributeKvEntry(0, new StringDataEntry(key, value));
+
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(Futures.immediateFuture(Optional.of(entry)));
+        when(partitionService.resolve(Mockito.any(ServiceType.class), Mockito.anyString(), Mockito.any(TenantId.class), Mockito.any(EntityId.class)))
+                .thenReturn(new TopicPartitionInfo("", null, 0, true));
+
+        for (int i = 0; i < 10; i++) {
+            Assert.assertEquals(entry, cachedAttributesService.find(tenantId, deviceId, scope, key).get().get());
+            verify(daoAttributesService, times(1)).find(tenantId, deviceId, scope, key);
+        }
+    }
+
+    @Test
+    public void testFindDeviceAttributeOnRemotePartition() throws Exception{
+        BaseAttributeKvEntry entry = new BaseAttributeKvEntry(0, new StringDataEntry(key, value));
+
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(Futures.immediateFuture(Optional.of(entry)));
+        when(partitionService.resolve(Mockito.any(ServiceType.class), Mockito.anyString(), Mockito.any(TenantId.class), Mockito.any(EntityId.class)))
+                .thenReturn(new TopicPartitionInfo("", null, 0, false));
+
+        for (int i = 0; i < 10; i++) {
+            Assert.assertEquals(entry, cachedAttributesService.find(tenantId, deviceId, scope, key).get().get());
+            verify(daoAttributesService, times(i+1)).find(tenantId, deviceId, scope, key);
+        }
+    }
+
+    @Test
+    public void testFindMultipleDeviceAttributeOnLocalPartition() throws Exception{
+        BaseAttributeKvEntry firstEntry = new BaseAttributeKvEntry(0, new StringDataEntry(firstKey, "value1"));
+        BaseAttributeKvEntry secondEntry = new BaseAttributeKvEntry(0, new StringDataEntry(secondKey, "value2"));
+
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyCollection()))
+                .thenReturn(Futures.immediateFuture(Arrays.asList(firstEntry, secondEntry)));
+        when(partitionService.resolve(Mockito.any(ServiceType.class), Mockito.anyString(), Mockito.any(TenantId.class), Mockito.any(EntityId.class)))
+                .thenReturn(new TopicPartitionInfo("", null, 0, true));
+
+        Assert.assertEquals(2, cachedAttributesService.find(tenantId, deviceId, scope, keys).get().size());
+        verify(daoAttributesService, times(1)).find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyCollection());
+        Assert.assertEquals(firstEntry, cachedAttributesService.find(tenantId, deviceId, scope, firstKey).get().get());
+        Assert.assertEquals(secondEntry, cachedAttributesService.find(tenantId, deviceId, scope, secondKey).get().get());
+        verify(daoAttributesService, times(0)).find(tenantId, deviceId, scope, firstKey);
+        verify(daoAttributesService, times(0)).find(tenantId, deviceId, scope, secondKey);
+    }
+
+    @Test
+    public void testFindMultipleDeviceAttributeOnLocalPartition_2() throws Exception{
+        BaseAttributeKvEntry firstEntry = new BaseAttributeKvEntry(0, new StringDataEntry(firstKey, "value1"));
+        BaseAttributeKvEntry secondEntry = new BaseAttributeKvEntry(0, new StringDataEntry(secondKey, "value2"));
+
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.eq(firstKey)))
+                .thenReturn(Futures.immediateFuture(Optional.of(firstEntry)));
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.eq(secondKey)))
+                .thenReturn(Futures.immediateFuture(Optional.of(secondEntry)));
+        when(partitionService.resolve(Mockito.any(ServiceType.class), Mockito.anyString(), Mockito.any(TenantId.class), Mockito.any(EntityId.class)))
+                .thenReturn(new TopicPartitionInfo("", null, 0, true));
+
+        Assert.assertEquals(firstEntry, cachedAttributesService.find(tenantId, deviceId, scope, firstKey).get().get());
+        Assert.assertEquals(secondEntry, cachedAttributesService.find(tenantId, deviceId, scope, secondKey).get().get());
+        verify(daoAttributesService, times(1)).find(tenantId, deviceId, scope, firstKey);
+        verify(daoAttributesService, times(1)).find(tenantId, deviceId, scope, secondKey);
+        Assert.assertEquals(2, cachedAttributesService.find(tenantId, deviceId, scope, keys).get().size());
+        verify(daoAttributesService, times(0)).find(tenantId, deviceId, scope, keys);
+    }
+
+    @Test
+    public void testFindMultipleDeviceAttributeOnLocalPartition_3() throws Exception{
+        BaseAttributeKvEntry firstEntry = new BaseAttributeKvEntry(0, new StringDataEntry(firstKey, "value1"));
+        BaseAttributeKvEntry secondEntry = new BaseAttributeKvEntry(0, new StringDataEntry(secondKey, "value2"));
+
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.eq(firstKey)))
+                .thenReturn(Futures.immediateFuture(Optional.of(firstEntry)));
+        when(partitionService.resolve(Mockito.any(ServiceType.class), Mockito.anyString(), Mockito.any(TenantId.class), Mockito.any(EntityId.class)))
+                .thenReturn(new TopicPartitionInfo("", null, 0, true));
+
+        Assert.assertEquals(firstEntry, cachedAttributesService.find(tenantId, deviceId, scope, firstKey).get().get());
+        verify(daoAttributesService, times(1)).find(tenantId, deviceId, scope, firstKey);
+
+        Set<String> secondKeyCollection = new HashSet<>();
+        secondKeyCollection.add(secondKey);
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.eq(secondKeyCollection)))
+                .thenReturn(Futures.immediateFuture(Arrays.asList(secondEntry)));
+        Assert.assertEquals(2, cachedAttributesService.find(tenantId, deviceId, scope, keys).get().size());
+        Assert.assertEquals(secondEntry, cachedAttributesService.find(tenantId, deviceId, scope, secondKey).get().get());
+        verify(daoAttributesService, times(0)).find(tenantId, deviceId, scope, secondKey);
+    }
+
+    @Test
+    public void testSaveDeviceAttributeOnLocalPartition() throws Exception{
+        BaseAttributeKvEntry firstEntry = new BaseAttributeKvEntry(0, new StringDataEntry(firstKey, "value1"));
+        BaseAttributeKvEntry secondEntry = new BaseAttributeKvEntry(0, new StringDataEntry(secondKey, "value2"));
+
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyCollection()))
+                .thenReturn(Futures.immediateFuture(Arrays.asList(firstEntry, secondEntry)));
+        when(partitionService.resolve(Mockito.any(ServiceType.class), Mockito.anyString(), Mockito.any(TenantId.class), Mockito.any(EntityId.class)))
+                .thenReturn(new TopicPartitionInfo("", null, 0, true));
+
+        Assert.assertEquals(2, cachedAttributesService.find(tenantId, deviceId, scope, keys).get().size());
+        verify(daoAttributesService, times(1)).find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyCollection());
+
+        when(daoAttributesService.save(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(Futures.immediateFuture(Collections.emptyList()));
+        BaseAttributeKvEntry newSecondEntry = new BaseAttributeKvEntry(1, new StringDataEntry(secondKey, "newValue2"));
+        cachedAttributesService.save(tenantId, deviceId, scope, Arrays.asList(newSecondEntry));
+
+        Assert.assertEquals(2, cachedAttributesService.find(tenantId, deviceId, scope, keys).get().size());
+        verify(daoAttributesService, times(1)).find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyCollection());
+
+        Assert.assertEquals(firstEntry, cachedAttributesService.find(tenantId, deviceId, scope, firstKey).get().get());
+        verify(daoAttributesService, times(0)).find(tenantId, deviceId, scope, firstKey);
+
+        Assert.assertEquals(newSecondEntry, cachedAttributesService.find(tenantId, deviceId, scope, secondKey).get().get());
+        verify(daoAttributesService, times(0)).find(tenantId, deviceId, scope, firstKey);
+    }
+
+    @Test
+    public void testRemoveDeviceAttributeOnLocalPartition() throws Exception{
+        BaseAttributeKvEntry firstEntry = new BaseAttributeKvEntry(0, new StringDataEntry(firstKey, "value1"));
+        BaseAttributeKvEntry secondEntry = new BaseAttributeKvEntry(0, new StringDataEntry(secondKey, "value2"));
+
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyCollection()))
+                .thenReturn(Futures.immediateFuture(Arrays.asList(firstEntry, secondEntry)));
+        when(partitionService.resolve(Mockito.any(ServiceType.class), Mockito.anyString(), Mockito.any(TenantId.class), Mockito.any(EntityId.class)))
+                .thenReturn(new TopicPartitionInfo("", null, 0, true));
+
+        Assert.assertEquals(2, cachedAttributesService.find(tenantId, deviceId, scope, keys).get().size());
+        verify(daoAttributesService, times(1)).find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyCollection());
+
+        when(daoAttributesService.removeAll(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(Futures.immediateFuture(Collections.emptyList()));
+        cachedAttributesService.removeAll(tenantId, deviceId, scope, Arrays.asList(secondKey));
+
+        Assert.assertEquals(firstEntry, cachedAttributesService.find(tenantId, deviceId, scope, firstKey).get().get());
+        verify(daoAttributesService, times(0)).find(tenantId, deviceId, scope, firstKey);
+
+        when(daoAttributesService.find(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.eq(secondKey)))
+                .thenReturn(Futures.immediateFuture(Optional.empty()));
+        Assert.assertNull(cachedAttributesService.find(tenantId, deviceId, scope, secondKey).get().orElse(null));
+        verify(daoAttributesService, times(1)).find(tenantId, deviceId, scope, secondKey);
+    }
+
+    @Test
+    public void testRemoveClientAttribute() throws Exception{
+        BaseAttributeKvEntry entry = new BaseAttributeKvEntry(1, new StringDataEntry(key, "value1"));
+
+        when(partitionService.resolve(Mockito.any(ServiceType.class), Mockito.anyString(), Mockito.any(TenantId.class), Mockito.any(EntityId.class)))
+                .thenReturn(new TopicPartitionInfo("", null, 0, true));
+        when(daoAttributesService.save(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyList()))
+                .thenReturn(Futures.immediateFuture(Collections.emptyList()));
+
+        cachedAttributesService.save(tenantId, customerId, scope, Arrays.asList(entry));
+        verify(clusterService, times(1))
+                .onAttributesCacheUpdated(Mockito.any(TenantId.class), Mockito.any(EntityId.class), Mockito.anyString(), Mockito.anyList());
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/service/attributes/CaffeineTbAttributesCacheTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/attributes/CaffeineTbAttributesCacheTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Ticker;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.BaseAttributeKvEntry;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+@RunWith(MockitoJUnitRunner.class)
+public class CaffeineTbAttributesCacheTest {
+
+    private static TbCacheStatsService<Cache<AttributesKey, AttributeCacheEntry>> mockedStatsService = mock(TbCacheStatsService.class);
+
+    @BeforeClass
+    public static void initStatsMock(){
+        when(mockedStatsService.areCacheStatsEnabled()).thenReturn(false);
+    }
+
+    @Test
+    public void testCacheExpiration() {
+        AttributesCacheConfiguration cacheConfiguration = new AttributesCacheConfiguration();
+        cacheConfiguration.setExpireAfterAccessInMinutes(1);
+        cacheConfiguration.setMaxSizePerTenant(10);
+        CaffeineTbAttributesCache attributesCache = new CaffeineTbAttributesCache(cacheConfiguration, mockedStatsService);
+        CustomTicker customTicker = new CustomTicker();
+        attributesCache.setCustomTicker(customTicker);
+        TenantId tenantId = new TenantId(UUID.randomUUID());
+        DeviceId entityId = new DeviceId(UUID.randomUUID());
+        String scope = "scope";
+        String key = "test";
+        BaseAttributeKvEntry entry = new BaseAttributeKvEntry(0, null);
+        attributesCache.put(tenantId, entityId, scope, key, entry);
+        long insertTime = System.nanoTime();
+        Assert.assertNotNull(attributesCache.find(tenantId, entityId, scope, key));
+        Assert.assertEquals(entry, attributesCache.find(tenantId, entityId, scope, key).getAttributeKvEntry());
+        customTicker.supplierRef.getAndSet(() -> insertTime + TimeUnit.SECONDS.toNanos(61));
+        Assert.assertNull(attributesCache.find(tenantId, entityId, scope, key));
+    }
+
+    // caffeine can exceed the size limit so cannot properly test this case
+    public void testCacheCleanupBySize() {
+    }
+
+    private static class CustomTicker implements Ticker {
+        AtomicReference<Supplier<Long>> supplierRef = new AtomicReference<>(System::nanoTime);
+
+        @Override
+        public long read() {
+            return supplierRef.get().get();
+        }
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/service/attributes/GoogleTbAttributesCacheTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/attributes/GoogleTbAttributesCacheTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.attributes;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Ticker;
+import com.google.common.cache.Cache;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.BaseAttributeKvEntry;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+@RunWith(MockitoJUnitRunner.class)
+public class GoogleTbAttributesCacheTest {
+
+    private static TbCacheStatsService<Cache<AttributesKey, AttributeCacheEntry>> mockedStatsService = mock(TbCacheStatsService.class);
+
+    @BeforeClass
+    public static void initStatsMock(){
+        when(mockedStatsService.areCacheStatsEnabled()).thenReturn(false);
+    }
+
+    @Test
+    public void testCacheExpiration() {
+        AttributesCacheConfiguration cacheConfiguration = new AttributesCacheConfiguration();
+        cacheConfiguration.setExpireAfterAccessInMinutes(1);
+        cacheConfiguration.setMaxSizePerTenant(10);
+        GoogleTbAttributesCache attributesCache = new GoogleTbAttributesCache(cacheConfiguration, mockedStatsService);
+        CustomTicker customTicker = new CustomTicker();
+        attributesCache.setCustomTicker(customTicker);
+        TenantId tenantId = new TenantId(UUID.randomUUID());
+        DeviceId entityId = new DeviceId(UUID.randomUUID());
+        String scope = "scope";
+        String key = "test";
+        BaseAttributeKvEntry entry = new BaseAttributeKvEntry(0, null);
+        attributesCache.put(tenantId, entityId, scope, key, entry);
+        long insertTime = System.nanoTime();
+        Assert.assertNotNull(attributesCache.find(tenantId, entityId, scope, key));
+        Assert.assertEquals(entry, attributesCache.find(tenantId, entityId, scope, key).getAttributeKvEntry());
+        customTicker.supplierRef.getAndSet(() -> insertTime + TimeUnit.SECONDS.toNanos(61));
+        Assert.assertNull(attributesCache.find(tenantId, entityId, scope, key));
+    }
+
+    @Test
+    public void testCacheCleanupBySize() {
+        AttributesCacheConfiguration cacheConfiguration = new AttributesCacheConfiguration();
+        cacheConfiguration.setExpireAfterAccessInMinutes(10);
+        cacheConfiguration.setMaxSizePerTenant(5);
+        GoogleTbAttributesCache attributesCache = new GoogleTbAttributesCache(cacheConfiguration, mockedStatsService);
+        TenantId tenantId = new TenantId(UUID.randomUUID());
+        DeviceId entityId = new DeviceId(UUID.randomUUID());
+        String scope = "scope";
+        BaseAttributeKvEntry entry = new BaseAttributeKvEntry(0, null);
+        for (int i = 0; i < 10; i++) {
+            attributesCache.put(tenantId, entityId, scope, Integer.toString(i), entry);
+        }
+        for (int i = 0; i < 10; i++) {
+            if (i < 5) {
+                Assert.assertNull(attributesCache.find(tenantId, entityId, scope, Integer.toString(i)));
+            } else {
+                Assert.assertNotNull(attributesCache.find(tenantId, entityId, scope, Integer.toString(i)));
+            }
+        }
+    }
+
+    private static class CustomTicker extends Ticker {
+        AtomicReference<Supplier<Long>> supplierRef = new AtomicReference<>(System::nanoTime);
+
+        @Override
+        public long read() {
+            return supplierRef.get().get();
+        }
+    }
+}

--- a/common/message/src/main/java/org/thingsboard/server/common/msg/MsgType.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/MsgType.java
@@ -101,6 +101,13 @@ public enum MsgType {
     /**
      * Message that is sent by TransportRuleEngineService to Device Actor. Represents messages from the device itself.
      */
-    TRANSPORT_TO_DEVICE_ACTOR_MSG;
+    TRANSPORT_TO_DEVICE_ACTOR_MSG,
+
+
+    /**
+     * Message that is sent by RuleNode to all nodes.
+     */
+    ATTRIBUTES_CACHE_UPDATED_MSG
+    ;
 
 }

--- a/common/message/src/main/java/org/thingsboard/server/common/msg/cache/AttributesCacheUpdatedMsg.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/cache/AttributesCacheUpdatedMsg.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.common.msg.cache;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.msg.MsgType;
+import org.thingsboard.server.common.msg.aware.TenantAwareMsg;
+import org.thingsboard.server.common.msg.cluster.ToAllNodesMsg;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@ToString
+@EqualsAndHashCode
+public class AttributesCacheUpdatedMsg implements TenantAwareMsg, ToAllNodesMsg {
+    public static final AttributesCacheUpdatedMsg INVALIDATE_ALL_CACHE_MSG = new AttributesCacheUpdatedMsg(TenantId.SYS_TENANT_ID, TenantId.SYS_TENANT_ID,
+            null, Collections.emptyList());
+    @Getter
+    private final TenantId tenantId;
+    @Getter
+    private final EntityId entityId;
+    @Getter
+    private final String scope;
+    @Getter
+    private final List<String> attributeKeys;
+
+    public AttributesCacheUpdatedMsg(TenantId tenantId, EntityId entityId, String scope, List<String> attributeKeys) {
+        this.tenantId = tenantId;
+        this.entityId = entityId;
+        this.scope = scope;
+        this.attributeKeys = attributeKeys;
+    }
+
+    @Override
+    public MsgType getMsgType() {
+        return MsgType.ATTRIBUTES_CACHE_UPDATED_MSG;
+    }
+}

--- a/common/queue/src/main/proto/queue.proto
+++ b/common/queue/src/main/proto/queue.proto
@@ -549,6 +549,7 @@ message ToCoreNotificationMsg {
   LocalSubscriptionServiceMsgProto toLocalSubscriptionServiceMsg = 1;
   FromDeviceRPCResponseProto fromDeviceRpcResponse = 2;
   bytes componentLifecycleMsg = 3;
+  bytes attributesCacheUpdatedMsg = 4;
 }
 
 /* Messages that are handled by ThingsBoard RuleEngine Service */
@@ -563,6 +564,7 @@ message ToRuleEngineMsg {
 message ToRuleEngineNotificationMsg {
   bytes componentLifecycleMsg = 1;
   FromDeviceRPCResponseProto fromDeviceRpcResponse = 2;
+  bytes attributesCacheUpdatedMsg = 3;
 }
 
 /* Messages that are handled by ThingsBoard Transport Service */

--- a/dao/src/main/java/org/thingsboard/server/dao/attributes/DaoAttributesService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/attributes/DaoAttributesService.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.id.DeviceProfileId;
@@ -35,29 +36,24 @@ import java.util.Optional;
 /**
  * @author Andrew Shvayka
  */
-@Service
-public class BaseAttributesService implements AttributesService {
+@Service("daoAttributesService")
+public class DaoAttributesService implements AttributesService {
 
     @Autowired
     private AttributesDao attributesDao;
 
     @Override
     public ListenableFuture<Optional<AttributeKvEntry>> find(TenantId tenantId, EntityId entityId, String scope, String attributeKey) {
-        validate(entityId, scope);
-        Validator.validateString(attributeKey, "Incorrect attribute key " + attributeKey);
         return attributesDao.find(tenantId, entityId, scope, attributeKey);
     }
 
     @Override
     public ListenableFuture<List<AttributeKvEntry>> find(TenantId tenantId, EntityId entityId, String scope, Collection<String> attributeKeys) {
-        validate(entityId, scope);
-        attributeKeys.forEach(attributeKey -> Validator.validateString(attributeKey, "Incorrect attribute key " + attributeKey));
         return attributesDao.find(tenantId, entityId, scope, attributeKeys);
     }
 
     @Override
     public ListenableFuture<List<AttributeKvEntry>> findAll(TenantId tenantId, EntityId entityId, String scope) {
-        validate(entityId, scope);
         return attributesDao.findAll(tenantId, entityId, scope);
     }
 
@@ -73,8 +69,6 @@ public class BaseAttributesService implements AttributesService {
 
     @Override
     public ListenableFuture<List<Void>> save(TenantId tenantId, EntityId entityId, String scope, List<AttributeKvEntry> attributes) {
-        validate(entityId, scope);
-        attributes.forEach(attribute -> validate(attribute));
         List<ListenableFuture<Void>> futures = Lists.newArrayListWithExpectedSize(attributes.size());
         for (AttributeKvEntry attribute : attributes) {
             futures.add(attributesDao.save(tenantId, entityId, scope, attribute));
@@ -84,24 +78,7 @@ public class BaseAttributesService implements AttributesService {
 
     @Override
     public ListenableFuture<List<Void>> removeAll(TenantId tenantId, EntityId entityId, String scope, List<String> keys) {
-        validate(entityId, scope);
         return attributesDao.removeAll(tenantId, entityId, scope, keys);
-    }
-
-    private static void validate(EntityId id, String scope) {
-        Validator.validateId(id.getId(), "Incorrect id " + id);
-        Validator.validateString(scope, "Incorrect scope " + scope);
-    }
-
-    private static void validate(AttributeKvEntry kvEntry) {
-        if (kvEntry == null) {
-            throw new IncorrectParameterException("Key value entry can't be null");
-        } else if (kvEntry.getDataType() == null) {
-            throw new IncorrectParameterException("Incorrect kvEntry. Data type can't be null");
-        } else {
-            Validator.validateString(kvEntry.getKey(), "Incorrect kvEntry. Key can't be empty");
-            Validator.validatePositiveNumber(kvEntry.getLastUpdateTs(), "Incorrect last update ts. Ts should be positive");
-        }
     }
 
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/service/attributes/DaoAttributesServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/attributes/DaoAttributesServiceTest.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 /**
  * @author Andrew Shvayka
  */
-public abstract class BaseAttributesServiceTest extends AbstractServiceTest {
+public abstract class DaoAttributesServiceTest extends AbstractServiceTest {
 
     @Autowired
     private AttributesService attributesService;

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <cassandra-all.version>3.11.9</cassandra-all.version>
         <takari-cpsuite.version>1.2.7</takari-cpsuite.version>
         <guava.version>28.2-jre</guava.version>
-        <caffeine.version>2.6.1</caffeine.version>
+        <caffeine.version>2.8.8</caffeine.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <commons-io.version>2.5</commons-io.version>
         <commons-csv.version>1.4</commons-csv.version>


### PR DESCRIPTION
* Use TenantCacheService interface in AttributesCache

* Added Google cache with loader

* Implemented cache for attributes

* Moved cache logic to separate class

* Updated AttributesCacheConfiguration

* Added tests for AttributesCache with google-cache

* Update cache after save/remove

* Added test for CachedAttributesService

* Changed Optional to CacheEntry

* Broadcast cache updated msg to RuleEngines too

* Process cache update in RuleEngines

* Made attributes cache optional

* Added endpoint to invalidate attributes cache

* Added stats for attributesCache

* Fixed bug with SysAdmin working with Tenant's attributes

* Fixed merge

* Refactored and fixed AttributeCacheTests

* Removed .* imports for Attributes feature

* Added Caffeine attr cache, updated caffeine version

* Fixed merge