### PR TITLE
Make file input work properly when there are multiple on page

### DIFF
--- a/ui-ngx/src/app/shared/components/file-input.component.ts
+++ b/ui-ngx/src/app/shared/components/file-input.component.ts
@@ -34,6 +34,7 @@ import { Subscription } from 'rxjs';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { FlowDirective } from '@flowjs/ngx-flow';
 import { TranslateService } from '@ngx-translate/core';
+import { UtilsService } from '@core/services/utils.service';
 
 @Component({
   selector: 'tb-file-input',
@@ -59,7 +60,7 @@ export class FileInputComponent extends PageComponent implements AfterViewInit, 
   noFileText = 'import.no-file';
 
   @Input()
-  inputId = 'select';
+  inputId = this.utils.guid();
 
   @Input()
   allowedExtensions: string;
@@ -114,6 +115,7 @@ export class FileInputComponent extends PageComponent implements AfterViewInit, 
   private propagateChange = null;
 
   constructor(protected store: Store<AppState>,
+              private utils: UtilsService,
               public translate: TranslateService) {
     super(store);
   }


### PR DESCRIPTION
Currently, when there are multiple file inputs on the page attempt of file selection in the second triggers file selection in the first one.