### PR TITLE
Authorized USERS able to adjust Device Attributes

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/security/permission/CustomerUserPermissions.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/permission/CustomerUserPermissions.java
@@ -40,6 +40,11 @@ public class CustomerUserPermissions extends AbstractPermissions {
         put(Resource.USER, userPermissionChecker);
         put(Resource.WIDGETS_BUNDLE, widgetsPermissionChecker);
         put(Resource.WIDGET_TYPE, widgetsPermissionChecker);
+        
+        // Make it possible that autorised USERS (that are logged in), 
+        // have the ability to change a server/shared Attribute value from the dashboard.
+        // Withoud this line, only logged in TENANTS can adjust the attribute, not logged in USERS
+        put(Resource.DEVICE, TenantAdminPermissions.tenantEntityPermissionChecker);
     }
 
     private static final PermissionChecker customerEntityPermissionChecker =


### PR DESCRIPTION
Fixes bug #1726 and #4237 

Currently only logged in TENANTS are able to change device attributes using a dashboard.
This should also be logged in USERS as this was already possible in versions prior thingsboard 2.3.0
I think this option was removed by accident due the new security engine implementation in thingsboard.