### PR TITLE
[3.2.2] [PROD-851] Fix invalid alarm clearing behaviour in the cluster mode

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbClusterService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbClusterService.java
@@ -283,10 +283,12 @@ public class DefaultTbClusterService implements TbClusterService {
         byte[] msgBytes = encodingService.encode(msg);
         TbQueueProducer<TbProtoQueueMsg<ToRuleEngineNotificationMsg>> toRuleEngineProducer = producerProvider.getRuleEngineNotificationsMsgProducer();
         Set<String> tbRuleEngineServices = new HashSet<>(partitionService.getAllServiceIds(ServiceType.TB_RULE_ENGINE));
-        if (msg.getEntityId().getEntityType().equals(EntityType.TENANT)
-                || msg.getEntityId().getEntityType().equals(EntityType.TENANT_PROFILE)
-                || msg.getEntityId().getEntityType().equals(EntityType.DEVICE_PROFILE)
-                || msg.getEntityId().getEntityType().equals(EntityType.API_USAGE_STATE)) {
+        EntityType entityType = msg.getEntityId().getEntityType();
+        if (entityType.equals(EntityType.TENANT)
+                || entityType.equals(EntityType.TENANT_PROFILE)
+                || entityType.equals(EntityType.DEVICE_PROFILE)
+                || entityType.equals(EntityType.API_USAGE_STATE)
+                || (entityType.equals(EntityType.DEVICE) && msg.getEvent() == ComponentLifecycleEvent.UPDATED)) {
             TbQueueProducer<TbProtoQueueMsg<ToCoreNotificationMsg>> toCoreNfProducer = producerProvider.getTbCoreNotificationsMsgProducer();
             Set<String> tbCoreServices = partitionService.getAllServiceIds(ServiceType.TB_CORE);
             for (String serviceId : tbCoreServices) {


### PR DESCRIPTION
**The case:**
When profile of a device is changed, the event is pushed to specific partition that is responsible for this device and thus the device profile cache on this core service instance will be updated, unlike other core instances' caches. If we create new alarm it will go correctly to the new rule chain, but when we then clear this alarm from UI the request may go to the core instance with outdated device profile cache, and therefore the clear alarm event will be pushed to the wrong rule chain that is assigned to the old device profile, and сonsequently when a new alarm comes it will be processed by the new rule chain where there is no clear alarm event and so the alarm will no be created but updated.