### PR TITLE
[WIP][3.3.1] Change decimal separator for different languages

### DIFF
--- a/ui-ngx/src/app/core/utils.ts
+++ b/ui-ngx/src/app/core/utils.ts
@@ -127,26 +127,6 @@ export function isEmpty(obj: any): boolean {
   return true;
 }
 
-export function formatValue(value: any, dec?: number, units?: string, showZeroDecimals?: boolean): string | undefined {
-  if (isDefinedAndNotNull(value) && isNumeric(value) &&
-    (isDefinedAndNotNull(dec) || isDefinedAndNotNull(units) || Number(value).toString() === value)) {
-    let formatted: string | number = Number(value);
-    if (isDefinedAndNotNull(dec)) {
-      formatted = formatted.toFixed(dec);
-    }
-    if (!showZeroDecimals) {
-      formatted = (Number(formatted));
-    }
-    formatted = formatted.toString();
-    if (isDefinedAndNotNull(units) && units.length > 0) {
-      formatted += ' ' + units;
-    }
-    return formatted;
-  } else {
-    return value !== null ? value : '';
-  }
-}
-
 export function objectValues(obj: any): any[] {
   return Object.keys(obj).map(e => obj[e]);
 }

--- a/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
@@ -333,7 +333,8 @@ export class TbFlot {
 
       if (this.options.series.pie.label.show) {
         this.options.series.pie.label.formatter = (label, series) => {
-          return `<div class='pie-label'>${series.dataKey.label}<br/>${Math.round(series.percent)}%</div>`;
+          return `<div class='pie-label'>${series.dataKey.label}<br/>` +
+            `${this.ctx.utils.formatValue(series.percent,0,'%')}</div>`;
         };
         this.options.series.pie.label.radius = 3 / 4;
         this.options.series.pie.label.background = {
@@ -977,7 +978,7 @@ export class TbFlot {
       valueContent = this.ctx.utils.formatValue(value, trackDecimals, units);
     }
     if (isNumber(percent)) {
-      valueContent += ' (' + Math.round(percent) + ' %)';
+      valueContent += ' (' + this.ctx.utils.formatValue(percent, 0, '%', true) + ')';
     }
     const valueSpan =  $(`<span>${valueContent}</span>`);
     valueSpan.css({


### PR DESCRIPTION
This PR implements the feature requested in https://github.com/thingsboard/thingsboard/issues/3967 

Workings:
- The globally used util function 'formatValue' is moved to its single declaration location, where it has access to the stored locale.
- The function retrieves this locale and uses it to update the displayed value with JavaScript's built-in toLocaleString function.

Note:
The main change is that for some language a value 3.14 is translated to 3,14. 
For languages with a different numerical alphabet this change is odd because it is not consistent in all places. To fix this, I have a PR open at https://github.com/thingsboard/thingsboard/pull/4358
Please let me know if you like this solution or if you would like me to make some modifications, in this PR or the other one.