### PR TITLE
added a fix for string value RPC params: removed redundant escaped characters

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/RpcController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/RpcController.java
@@ -97,9 +97,13 @@ public class RpcController extends BaseController {
     private DeferredResult<ResponseEntity> handleDeviceRPCRequest(boolean oneWay, DeviceId deviceId, String requestBody) throws ThingsboardException {
         try {
             JsonNode rpcRequestBody = jsonMapper.readTree(requestBody);
-            RpcRequest cmd = new RpcRequest(rpcRequestBody.get("method").asText(),
-                    jsonMapper.writeValueAsString(rpcRequestBody.get("params")));
-
+            String requestData;
+            if (rpcRequestBody.get("params").isTextual()) {
+                requestData = rpcRequestBody.get("params").asText();
+            } else {
+                requestData = jsonMapper.writeValueAsString(rpcRequestBody.get("params"));
+            }
+            RpcRequest cmd = new RpcRequest(rpcRequestBody.get("method").asText(), requestData);
             if (rpcRequestBody.has("timeout")) {
                 cmd.setTimeout(rpcRequestBody.get("timeout").asLong());
             }

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/adaptor/JsonConverter.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/adaptor/JsonConverter.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.stream.MalformedJsonException;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.util.StringUtils;
 import org.thingsboard.server.common.data.DataConstants;
@@ -108,7 +109,7 @@ public class JsonConverter {
     public static ClaimDeviceMsg convertToClaimDeviceProto(DeviceId deviceId, String json) {
         long durationMs = 0L;
         if (json != null && !json.isEmpty()) {
-            return convertToClaimDeviceProto(deviceId, new JsonParser().parse(json));
+            return convertToClaimDeviceProto(deviceId, JSON_PARSER.parse(json));
         }
         return buildClaimDeviceMsg(deviceId, DataConstants.DEFAULT_SECRET_KEY, durationMs);
     }
@@ -157,7 +158,15 @@ public class JsonConverter {
             result.addProperty("id", msg.getRequestId());
         }
         result.addProperty("method", msg.getMethodName());
-        result.add("params", new JsonParser().parse(msg.getParams()));
+        try {
+            result.add("params", JSON_PARSER.parse(msg.getParams()));
+        } catch (JsonSyntaxException ex) {
+            if (ex.getCause() instanceof MalformedJsonException) {
+                result.addProperty("params", msg.getParams());
+            } else {
+                throw ex;
+            }
+        }
         return result;
     }
 
@@ -406,7 +415,7 @@ public class JsonConverter {
 
     public static JsonElement toJson(TransportProtos.ToServerRpcResponseMsg msg) {
         if (StringUtils.isEmpty(msg.getError())) {
-            return new JsonParser().parse(msg.getPayload());
+            return JSON_PARSER.parse(msg.getPayload());
         } else {
             JsonObject errorMsg = new JsonObject();
             errorMsg.addProperty("error", msg.getError());
@@ -562,7 +571,7 @@ public class JsonConverter {
     }
 
     public static TransportProtos.ProvisionDeviceRequestMsg convertToProvisionRequestMsg(String json) {
-        JsonElement jsonElement = new JsonParser().parse(json);
+        JsonElement jsonElement = JSON_PARSER.parse(json);
         if (jsonElement.isJsonObject()) {
             return buildProvisionRequestMsg(jsonElement.getAsJsonObject());
         } else {


### PR DESCRIPTION
fix needed for Protobuf, cause in the protobuf adaptors we sending directly TransportProtos.ToDeviceRpcRequestMsg bytes.