### PR TITLE
[WIP][3.6.x] Chart locale consistency

### DIFF
--- a/ui-ngx/angular.json
+++ b/ui-ngx/angular.json
@@ -111,6 +111,7 @@
               "classnames",
               "raf",
               "moment-timezone",
+              "moment",
               "tinycolor2",
               "json-schema-defaults",
               "leaflet-providers",

--- a/ui-ngx/src/app/core/settings/settings.utils.ts
+++ b/ui-ngx/src/app/core/settings/settings.utils.ts
@@ -17,6 +17,27 @@
 import { environment as env } from '@env/environment';
 import { TranslateService } from '@ngx-translate/core';
 import * as _moment from 'moment';
+// Supported Langs: cs_CZ,de_DE,el_GR,en_US,es_ES,fa_IR,fr_FR,it_IT,ja_JA,ka_GE,ko_KR,lv_LV,pt_BR,ro_RO,ru_RU,
+// sl_SI,tr_TR,uk_UA,zh_CN,zh_TW
+import 'moment/locale/cs';
+import 'moment/locale/de';
+import 'moment/locale/el';
+import 'moment/locale/es';
+import 'moment/locale/fa';
+import 'moment/locale/fr';
+import 'moment/locale/it';
+import 'moment/locale/ja';
+import 'moment/locale/ka';
+import 'moment/locale/ko';
+import 'moment/locale/lv';
+import 'moment/locale/pt';
+import 'moment/locale/ro';
+import 'moment/locale/ru';
+import 'moment/locale/sl';
+import 'moment/locale/tr';
+import 'moment/locale/uk';
+import 'moment/locale/zh-cn';
+import 'moment/locale/zh-tw';
 
 export function updateUserLang(translate: TranslateService, userLang: string) {
   let targetLang = userLang;

--- a/ui-ngx/src/app/core/utils.ts
+++ b/ui-ngx/src/app/core/utils.ts
@@ -127,26 +127,6 @@ export function isEmpty(obj: any): boolean {
   return true;
 }
 
-export function formatValue(value: any, dec?: number, units?: string, showZeroDecimals?: boolean): string | undefined {
-  if (isDefinedAndNotNull(value) && isNumeric(value) &&
-    (isDefinedAndNotNull(dec) || isDefinedAndNotNull(units) || Number(value).toString() === value)) {
-    let formatted: string | number = Number(value);
-    if (isDefinedAndNotNull(dec)) {
-      formatted = formatted.toFixed(dec);
-    }
-    if (!showZeroDecimals) {
-      formatted = (Number(formatted));
-    }
-    formatted = formatted.toString();
-    if (isDefinedAndNotNull(units) && units.length > 0) {
-      formatted += ' ' + units;
-    }
-    return formatted;
-  } else {
-    return value !== null ? value : '';
-  }
-}
-
 export function objectValues(obj: any): any[] {
   return Object.keys(obj).map(e => obj[e]);
 }

--- a/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
@@ -333,7 +333,8 @@ export class TbFlot {
 
       if (this.options.series.pie.label.show) {
         this.options.series.pie.label.formatter = (label, series) => {
-          return `<div class='pie-label'>${series.dataKey.label}<br/>${Math.round(series.percent)}%</div>`;
+          return `<div class='pie-label'>${series.dataKey.label}<br/>` +
+            `${this.ctx.utils.formatValue(series.percent,0,'%')}</div>`;
         };
         this.options.series.pie.label.radius = 3 / 4;
         this.options.series.pie.label.background = {
@@ -977,7 +978,7 @@ export class TbFlot {
       valueContent = this.ctx.utils.formatValue(value, trackDecimals, units);
     }
     if (isNumber(percent)) {
-      valueContent += ' (' + Math.round(percent) + ' %)';
+      valueContent += ' (' + this.ctx.utils.formatValue(percent, 0, '%', true) + ')';
     }
     const valueSpan =  $(`<span>${valueContent}</span>`);
     valueSpan.css({


### PR DESCRIPTION
The master branch of this fork implements (only)number formatting in widgets according to the user's locale. I have a separate PR https://github.com/thingsboard/thingsboard/pull/4300 open for only this feature.

This branch implements the feature request in https://github.com/thingsboard/thingsboard/issues/4357

This branch includes an update of the whole chart content according to locale, i.e.:

- Y-axis of charts is formatted in the same way as values
- X-axis of charts is formatted according to the user's locale time format (using moment's time representation)

The chart layout for the Persian language in the master:
![Screenshot from 2021-03-24 15-19-13](https://user-images.githubusercontent.com/23525731/112325987-6d425e00-8cb4-11eb-872f-5840c82c7a4c.png)

The chart layout for the Persian language in current branch:
![Screenshot from 2021-03-24 15-16-25](https://user-images.githubusercontent.com/23525731/112325592-1fc5f100-8cb4-11eb-9359-aec70d36d793.png)
