### PR TITLE
UI: Fixed: entity tables config for edge_customer_user; edge component; translation

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/asset/assets-table-config.resolver.ts
+++ b/ui-ngx/src/app/modules/home/pages/asset/assets-table-config.resolver.ts
@@ -104,7 +104,7 @@ export class AssetsTableConfigResolver implements Resolve<EntityTableConfig<Asse
         ));
     };
     this.config.onEntityAction = action => this.onAssetAction(action);
-    this.config.detailsReadonly = () => this.config.componentsData.assetScope === 'customer_user';
+    this.config.detailsReadonly = () => (this.config.componentsData.assetScope === 'customer_user' || this.config.componentsData.assetScope === 'edge_customer_user');
 
     this.config.headerComponent = AssetTableHeaderComponent;
 
@@ -151,7 +151,7 @@ export class AssetsTableConfigResolver implements Resolve<EntityTableConfig<Asse
         this.config.cellActionDescriptors = this.configureCellActions(this.config.componentsData.assetScope);
         this.config.groupActionDescriptors = this.configureGroupActions(this.config.componentsData.assetScope);
         this.config.addActionDescriptors = this.configureAddActions(this.config.componentsData.assetScope);
-        this.config.addEnabled = this.config.componentsData.assetScope !== 'customer_user';
+        this.config.addEnabled = !(this.config.componentsData.assetScope === 'customer_user' || this.config.componentsData.assetScope === 'edge_customer_user');
         this.config.entitiesDeleteEnabled = this.config.componentsData.assetScope === 'tenant';
         this.config.deleteEnabled = () => this.config.componentsData.assetScope === 'tenant';
         return this.config;

--- a/ui-ngx/src/app/modules/home/pages/dashboard/dashboards-table-config.resolver.ts
+++ b/ui-ngx/src/app/modules/home/pages/dashboard/dashboards-table-config.resolver.ts
@@ -103,7 +103,7 @@ export class DashboardsTableConfigResolver implements Resolve<EntityTableConfig<
       return this.dashboardService.saveDashboard(dashboard as Dashboard);
     };
     this.config.onEntityAction = action => this.onDashboardAction(action);
-    this.config.detailsReadonly = () => this.config.componentsData.dashboardScope === 'customer_user';
+    this.config.detailsReadonly = () => (this.config.componentsData.dashboardScope === 'customer_user' || this.config.componentsData.dashboardScope === 'edge_customer_user');
   }
 
   resolve(route: ActivatedRouteSnapshot): Observable<EntityTableConfig<DashboardInfo | Dashboard>> {
@@ -147,7 +147,7 @@ export class DashboardsTableConfigResolver implements Resolve<EntityTableConfig<
         this.config.cellActionDescriptors = this.configureCellActions(this.config.componentsData.dashboardScope);
         this.config.groupActionDescriptors = this.configureGroupActions(this.config.componentsData.dashboardScope);
         this.config.addActionDescriptors = this.configureAddActions(this.config.componentsData.dashboardScope);
-        this.config.addEnabled = this.config.componentsData.dashboardScope !== 'customer_user';
+        this.config.addEnabled = !(this.config.componentsData.dashboardScope === 'customer_user' || this.config.componentsData.dashboardScope === 'edge_customer_user');
         this.config.entitiesDeleteEnabled = this.config.componentsData.dashboardScope === 'tenant';
         this.config.deleteEnabled = () => this.config.componentsData.dashboardScope === 'tenant';
         return this.config;

--- a/ui-ngx/src/app/modules/home/pages/device/devices-table-config.resolver.ts
+++ b/ui-ngx/src/app/modules/home/pages/device/devices-table-config.resolver.ts
@@ -112,7 +112,7 @@ export class DevicesTableConfigResolver implements Resolve<EntityTableConfig<Dev
       ));
     };
     this.config.onEntityAction = action => this.onDeviceAction(action);
-    this.config.detailsReadonly = () => this.config.componentsData.deviceScope === 'customer_user';
+    this.config.detailsReadonly = () => (this.config.componentsData.deviceScope === 'customer_user' || this.config.componentsData.deviceScope === 'edge_customer_user');
 
     this.config.headerComponent = DeviceTableHeaderComponent;
 
@@ -161,7 +161,7 @@ export class DevicesTableConfigResolver implements Resolve<EntityTableConfig<Dev
         this.config.cellActionDescriptors = this.configureCellActions(this.config.componentsData.deviceScope);
         this.config.groupActionDescriptors = this.configureGroupActions(this.config.componentsData.deviceScope);
         this.config.addActionDescriptors = this.configureAddActions(this.config.componentsData.deviceScope);
-        this.config.addEnabled = this.config.componentsData.deviceScope !== 'customer_user';
+        this.config.addEnabled = !(this.config.componentsData.deviceScope === 'customer_user' || this.config.componentsData.deviceScope === 'edge_customer_user');
         this.config.entitiesDeleteEnabled = this.config.componentsData.deviceScope === 'tenant';
         this.config.deleteEnabled = () => this.config.componentsData.deviceScope === 'tenant';
         return this.config;

--- a/ui-ngx/src/app/modules/home/pages/edge/edge.component.html
+++ b/ui-ngx/src/app/modules/home/pages/edge/edge.component.html
@@ -44,31 +44,31 @@
     <button mat-raised-button color="primary"
             [disabled]="(isLoading$ | async)"
             (click)="onEntityAction($event, 'openEdgeAssets')"
-            [fxShow]="!isEdit">
+            [fxShow]="!isEdit && edgeScope !== 'customer'">
       {{'edge.manage-edge-assets' | translate }}
     </button>
     <button mat-raised-button color="primary"
             [disabled]="(isLoading$ | async)"
             (click)="onEntityAction($event, 'openEdgeDevices')"
-            [fxShow]="!isEdit">
+            [fxShow]="!isEdit && edgeScope !== 'customer'">
       {{'edge.manage-edge-devices' | translate }}
     </button>
     <button mat-raised-button color="primary"
             [disabled]="(isLoading$ | async)"
             (click)="onEntityAction($event, 'openEdgeEntityViews')"
-            [fxShow]="!isEdit">
+            [fxShow]="!isEdit && edgeScope !== 'customer'">
       {{'edge.manage-edge-entity-views' | translate }}
     </button>
     <button mat-raised-button color="primary"
             [disabled]="(isLoading$ | async)"
             (click)="onEntityAction($event, 'openEdgeDashboards')"
-            [fxShow]="!isEdit">
+            [fxShow]="!isEdit && edgeScope !== 'customer'">
       {{'edge.manage-edge-dashboards' | translate }}
     </button>
     <button mat-raised-button color="primary"
             [disabled]="(isLoading$ | async)"
             (click)="onEntityAction($event, 'openEdgeRuleChains')"
-            [fxShow]="!isEdit && (edgeScope === 'tenant' || edgeScope === 'customer')">
+            [fxShow]="!isEdit && edgeScope === 'tenant'">
       {{'edge.manage-edge-rulechains' | translate }}
     </button>
   </div>
@@ -85,7 +85,7 @@
             ngxClipboard
             (cbOnSuccess)="onEdgeInfoCopied('key')"
             [cbContent]="entity?.routingKey"
-            [fxShow]="!isEdit && (edgeScope === 'tenant' || edgeScope === 'customer')">
+            [fxShow]="!isEdit && edgeScope !== 'customer_user'">
       <mat-icon svgIcon="mdi:clipboard-arrow-left"></mat-icon>
       <span translate>edge.copy-edge-key</span>
     </button>
@@ -93,7 +93,7 @@
             ngxClipboard
             (cbOnSuccess)="onEdgeInfoCopied('secret')"
             [cbContent]="entity?.secret"
-            [fxShow]="!isEdit && (edgeScope === 'tenant' || edgeScope === 'customer')">
+            [fxShow]="!isEdit && edgeScope !== 'customer_user'">
       <mat-icon svgIcon="mdi:clipboard-arrow-left"></mat-icon>
       <span translate>edge.copy-edge-secret</span>
     </button>
@@ -101,7 +101,7 @@
             ngxClipboard
             [disabled]="(isLoading$ | async)"
             (click)="onEntityAction($event, 'syncEdge')"
-            [fxShow]="!isEdit && (edgeScope === 'tenant' || edgeScope === 'customer')">
+            [fxShow]="!isEdit && edgeScope !== 'customer_user'">
       <mat-icon svgIcon="mdi:sync"></mat-icon>
       <span translate>edge.sync</span>
     </button>
@@ -132,7 +132,7 @@
         [required]="true"
         [entityType]="entityType.EDGE">
       </tb-entity-subtype-autocomplete>
-      <div [fxShow]="(edgeScope === 'tenant' || edgeScope === 'customer')">
+      <div [fxShow]="edgeScope !== 'customer_user'">
         <div class="tb-hint" [innerHTML]="'edge.edge-license-key-hint' | translate"></div>
         <mat-form-field class="mat-block">
           <mat-label translate>edge.edge-license-key</mat-label>
@@ -142,7 +142,7 @@
           </mat-error>
         </mat-form-field>
       </div>
-      <div [fxShow]="(edgeScope === 'tenant' || edgeScope === 'customer')">
+      <div [fxShow]="edgeScope !== 'customer_user'">
         <div translate class="tb-hint">edge.cloud-endpoint-hint</div>
         <mat-form-field class="mat-block">
           <mat-label translate>edge.cloud-endpoint</mat-label>
@@ -153,7 +153,7 @@
         </mat-form-field>
       </div>
     </fieldset>
-    <div fxLayout="row" [fxShow]="(edgeScope === 'tenant' || edgeScope === 'customer')">
+    <div fxLayout="row" [fxShow]="edgeScope !== 'customer_user'">
         <mat-form-field class="mat-block" fxFlex>
           <mat-label translate>edge.edge-key</mat-label>
           <input matInput formControlName="routingKey">
@@ -164,7 +164,7 @@
         <mat-icon svgIcon="mdi:clipboard-arrow-left"></mat-icon>
       </button>
     </div>
-    <div fxLayout="row" [fxShow]="(edgeScope === 'tenant' || edgeScope === 'customer')">
+    <div fxLayout="row" [fxShow]="edgeScope !== 'customer_user'">
         <mat-form-field class="mat-block" fxFlex>
           <mat-label translate>edge.edge-secret</mat-label>
           <input matInput formControlName="secret">

--- a/ui-ngx/src/app/modules/home/pages/edge/edges-table-config.resolver.ts
+++ b/ui-ngx/src/app/modules/home/pages/edge/edges-table-config.resolver.ts
@@ -477,8 +477,8 @@ export class EdgesTableConfigResolver implements Resolve<EntityTableConfig<EdgeI
       $event.stopPropagation();
     }
     this.dialogService.confirm(
-      this.translate.instant('edge.unassign-edge-title', {count: edges.length}),
-      this.translate.instant('edge.unassign-edge-text'),
+      this.translate.instant('edge.unassign-edges-title', {count: edges.length}),
+      this.translate.instant('edge.unassign-edges-text'),
       this.translate.instant('action.no'),
       this.translate.instant('action.yes'),
       true

--- a/ui-ngx/src/app/modules/home/pages/entity-view/entity-views-table-config.resolver.ts
+++ b/ui-ngx/src/app/modules/home/pages/entity-view/entity-views-table-config.resolver.ts
@@ -104,7 +104,7 @@ export class EntityViewsTableConfigResolver implements Resolve<EntityTableConfig
         ));
     };
     this.config.onEntityAction = action => this.onEntityViewAction(action);
-    this.config.detailsReadonly = () => this.config.componentsData.entityViewScope === 'customer_user';
+    this.config.detailsReadonly = () => (this.config.componentsData.entityViewScope === 'customer_user' || this.config.componentsData.entityViewScope === 'edge_customer_user');
 
     this.config.headerComponent = EntityViewTableHeaderComponent;
 
@@ -152,7 +152,7 @@ export class EntityViewsTableConfigResolver implements Resolve<EntityTableConfig
         this.config.cellActionDescriptors = this.configureCellActions(this.config.componentsData.entityViewScope);
         this.config.groupActionDescriptors = this.configureGroupActions(this.config.componentsData.entityViewScope);
         this.config.addActionDescriptors = this.configureAddActions(this.config.componentsData.entityViewScope);
-        this.config.addEnabled = this.config.componentsData.entityViewScope !== 'customer_user';
+        this.config.addEnabled = !(this.config.componentsData.entityViewScope === 'customer_user' || this.config.componentsData.entityViewScope !== 'edge_customer_user');
         this.config.entitiesDeleteEnabled = this.config.componentsData.entityViewScope === 'tenant';
         this.config.deleteEnabled = () => this.config.componentsData.entityViewScope === 'tenant';
         return this.config;


### PR DESCRIPTION
Changes:
1) Assets, Devices, EntityViews, Dashboards table-config resolver: 'edge_customer_user' - enable detailsReadonly; disable addEnabled.
2) edge.component: Manage assigned entities buttons: hide for 'customer' scope; minor refactoring.
3) edges-table-config: fixed translation reference.