### PR TITLE
dependency upgrade: grpc.version up to 1.36.0. explicitly added proto…

### DIFF
--- a/common/queue/pom.xml
+++ b/common/queue/pom.xml
@@ -113,6 +113,10 @@
             <artifactId>protobuf-java</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <curator.version>4.2.0</curator.version>
         <zookeeper.version>3.5.5</zookeeper.version>
         <protobuf.version>3.11.4</protobuf.version>
-        <grpc.version>1.22.1</grpc.version>
+        <grpc.version>1.36.0</grpc.version>
         <lombok.version>1.18.18</lombok.version>
         <paho.client.version>1.2.4</paho.client.version>
         <netty.version>4.1.60.Final</netty.version>
@@ -1299,6 +1299,11 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
+                <version>${protobuf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java-util</artifactId>
                 <version>${protobuf.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
…buf-java-util due to grpc not depends on it anymore