### PR TITLE
UI: Flot widget, fix thresholds appearing when threshold attribute is not set

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
@@ -24,6 +24,7 @@ import {
   isDefinedAndNotNull,
   isEqual,
   isNumber,
+  isNumeric,
   isUndefined
 } from '@app/core/utils';
 import { IWidgetSubscription, WidgetSubscriptionOptions } from '@core/api/widget-api.models';
@@ -841,7 +842,7 @@ export class TbFlot {
     data.forEach((keyData) => {
       if (keyData && keyData.data && keyData.data[0]) {
         const attrValue = keyData.data[0][1];
-        if (isFinite(attrValue)) {
+        if (isNumeric(attrValue) && isFinite(attrValue)) {
           const settings: TbFlotThresholdKeySettings = keyData.dataKey.settings;
           const colorIndex = this.subscription.data.length + allThresholds.length;
           this.generateThreshold(allThresholds, settings.yaxis, settings.lineWidth, settings.color, colorIndex, attrValue);


### PR DESCRIPTION
Empty string received, when threshold attribute isn't set, was treated as zero, and the threshold was displayed.