### PR TITLE
fix: do not "uppercase" unit title of digital gauges

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/canvas-digital-gauge.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/canvas-digital-gauge.ts
@@ -772,7 +772,7 @@ function drawDigitalLabel(context: DigitalGaugeCanvasRenderingContext2D, options
   context.textAlign = 'center';
   context.font = Drawings.font(options, 'Label', fontSizeFactor);
   context.lineWidth = 0;
-  drawText(context, options, 'Label', options.label.toUpperCase(), textX, textY);
+  drawText(context, options, 'Label', options.label, textX, textY);
 }
 
 function drawDigitalMinMax(context: DigitalGaugeCanvasRenderingContext2D, options: CanvasDigitalGaugeOptions) {


### PR DESCRIPTION
Unit titles of digital gauges are automatically changed to uppercase.
That is an issue when the unit is a greek letter. e.g. for the measure of a conductivity, the unit is µS/cm.
Capitalizing it makes it MS/CM, which does not have the same meaning. Additionally, I don't understand the benefit of capitalizing this by default.

This PR proposal removes the ".toUpperCase()" on the unit title labels.

![image](https://user-images.githubusercontent.com/30724004/118621285-83593000-b7c6-11eb-8001-761a8436ba43.png)
