### PR TITLE
UI: Entity data subscription: remove duplicate call of onData function

### DIFF
--- a/ui-ngx/src/app/core/api/entity-data-subscription.ts
+++ b/ui-ngx/src/app/core/api/entity-data-subscription.ts
@@ -667,8 +667,7 @@ export class EntityDataSubscription {
         if (prevDataCb) {
           dataAggregator.updateOnDataCb(prevDataCb);
         }
-      }
-      if (!this.history && !isUpdate) {
+      } else if (!this.history && !isUpdate) {
         this.onData(subscriptionData, DataKeyType.timeseries, dataIndex, true, dataUpdatedCb);
       }
     }


### PR DESCRIPTION
This affects timeseries widgets with paginated data (particularly route map and trip animation).

On the very first _processEntityData_ function call for timeseries widget with paginated data _dataAggregators_ already exist, which causes duplicate _onData_ function call: first time taking into account data aggregator, and second time without it. The second call, in this case, is redundant, also it returns data in reverse order relative to the first function call.

Currently, this may cause a blinking effect on route map initialization: at the very first moment marker could be placed at the start point of the route, after a second it will be at its correct position at the route end.