### PR TITLE
Added prompt login parameter to oauth2 authorize request fixing oauth2 sign out bug

### DIFF
--- a/application/src/main/java/org/thingsboard/server/config/CustomOAuth2AuthorizationRequestResolver.java
+++ b/application/src/main/java/org/thingsboard/server/config/CustomOAuth2AuthorizationRequestResolver.java
@@ -115,6 +115,7 @@ public class CustomOAuth2AuthorizationRequestResolver implements OAuth2Authoriza
                 // scope
                 // 		REQUIRED. OpenID Connect requests MUST contain the "openid" scope value.
                 addNonceParameters(attributes, additionalParameters);
+                addPromptLogin(additionalParameters);
             }
             if (ClientAuthenticationMethod.NONE.equals(clientRegistration.getClientAuthenticationMethod())) {
                 addPkceParameters(attributes, additionalParameters);
@@ -265,4 +266,9 @@ public class CustomOAuth2AuthorizationRequestResolver implements OAuth2Authoriza
         byte[] digest = md.digest(value.getBytes(StandardCharsets.US_ASCII));
         return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
     }
+
+    private void addPromptLogin(Map<String, Object> additionalParameters) {
+        additionalParameters.put("prompt", "login");
+    }
+
 }


### PR DESCRIPTION
Added prompt login parameter to oauth2 authorize request forcing user to login after being logged out fixing the current oauth2 sign out bug. 