### PR TITLE
kafka commit sync

### DIFF
--- a/common/actor/src/test/java/org/thingsboard/server/actors/SlowCreateActor.java
+++ b/common/actor/src/test/java/org/thingsboard/server/actors/SlowCreateActor.java
@@ -17,13 +17,18 @@ package org.thingsboard.server.actors;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 @Slf4j
 public class SlowCreateActor extends TestRootActor {
 
-    public SlowCreateActor(TbActorId actorId, ActorTestCtx testCtx) {
+    public static final int TIMEOUT_AWAIT_MAX_MS = 5000;
+
+    public SlowCreateActor(TbActorId actorId, ActorTestCtx testCtx, CountDownLatch initLatch) {
         super(actorId, testCtx);
         try {
-            Thread.sleep(500);
+            initLatch.await(TIMEOUT_AWAIT_MAX_MS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -34,10 +39,12 @@ public class SlowCreateActor extends TestRootActor {
 
         private final TbActorId actorId;
         private final ActorTestCtx testCtx;
+        private final CountDownLatch initLatch;
 
-        public SlowCreateActorCreator(TbActorId actorId, ActorTestCtx testCtx) {
+        public SlowCreateActorCreator(TbActorId actorId, ActorTestCtx testCtx, CountDownLatch initLatch) {
             this.actorId = actorId;
             this.testCtx = testCtx;
+            this.initLatch = initLatch;
         }
 
         @Override
@@ -47,7 +54,7 @@ public class SlowCreateActor extends TestRootActor {
 
         @Override
         public TbActor createActor() {
-            return new SlowCreateActor(actorId, testCtx);
+            return new SlowCreateActor(actorId, testCtx, initLatch);
         }
     }
 }

--- a/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaConsumerTemplate.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaConsumerTemplate.java
@@ -99,7 +99,7 @@ public class TbKafkaConsumerTemplate<T extends TbQueueMsg> extends AbstractTbQue
 
     @Override
     protected void doCommit() {
-        consumer.commitAsync();
+        consumer.commitSync();
     }
 
     @Override


### PR DESCRIPTION
This fixes the situation when many short requests polled rapidly and **async commit** the consumed offset is **racing** on Kafka single thread client with the poll.
In the previous version, this issue did not appear because after each pool thread falls asleep to gain the pooling interval (unwanted latency). This version with no latency on the consumer, so we have to commit the offset before getting new messages. While we committing new messages to accumulate in the topic and will be pulled as a batch at the next moment after commit offset.
Low latency is very important for js-executors, for example within the long-chain js-script-based rule chain.
This reduces Kafka's load.
Below you can find an example logs from the real issue:
```
{"log":"2021-05-26 10:05:37,899 [tb-queue-request-template-js_eval.responses.tb-node-0-27-thread-1] ERROR o.a.k.c.c.i.ConsumerCoordinator - [Consumer clientId=js-tb-node-0, groupId=rule-engine-node-tb-node-0] Offset commit with offsets {js_eval.responses.tb-node-0-0=OffsetAndMetadata{offset=1023387308, leaderEpoch=50, metadata=''}} failed\n","stream":"stdout","container_name":"server","namespace_name":"some-prod","pod_name":"tb-node-0"}
{"log":"2021-05-26 10:05:37,899 [tb-queue-request-template-js_eval.responses.tb-node-0-27-thread-1] ERROR o.a.k.c.c.i.ConsumerCoordinator - [Consumer clientId=js-tb-node-0, groupId=rule-engine-node-tb-node-0] Offset commit with offsets {js_eval.responses.tb-node-0-0=OffsetAndMetadata{offset=1023387317, leaderEpoch=50, metadata=''}} failed\n","stream":"stdout","container_name":"server","namespace_name":"some-prod","pod_name":"tb-node-0"}
{"log":"2021-05-26 10:05:37,899 [tb-queue-request-template-js_eval.responses.tb-node-0-27-thread-1] ERROR o.a.k.c.c.i.ConsumerCoordinator - [Consumer clientId=js-tb-node-0, groupId=rule-engine-node-tb-node-0] Offset commit with offsets {js_eval.responses.tb-node-0-0=OffsetAndMetadata{offset=1023387325, leaderEpoch=50, metadata=''}} failed\n","stream":"stdout","container_name":"server","namespace_name":"some-prod","pod_name":"tb-node-0"}
{"log":"2021-05-26 10:05:37,899 [tb-queue-request-template-js_eval.responses.tb-node-0-27-thread-1] ERROR o.a.k.c.c.i.ConsumerCoordinator - [Consumer clientId=js-tb-node-0, groupId=rule-engine-node-tb-node-0] Offset commit with offsets {js_eval.responses.tb-node-0-0=OffsetAndMetadata{offset=1023387330, leaderEpoch=50, metadata=''}} failed\n","stream":"stdout","container_name":"server","namespace_name":"some-prod","pod_name":"tb-node-0"}
{"log":"2021-05-26 10:05:37,899 [tb-queue-request-template-js_eval.responses.tb-node-0-27-thread-1] ERROR o.a.k.c.c.i.ConsumerCoordinator - [Consumer clientId=js-tb-node-0, groupId=rule-engine-node-tb-node-0] Offset commit with offsets {js_eval.responses.tb-node-0-0=OffsetAndMetadata{offset=1023387335, leaderEpoch=50, metadata=''}} failed\n","stream":"stdout","container_name":"server","namespace_name":"some-prod","pod_name":"tb-node-0"}
{"log":"2021-05-26 10:05:37,899 [tb-queue-request-template-js_eval.responses.tb-node-0-27-thread-1] ERROR o.a.k.c.c.i.ConsumerCoordinator - [Consumer clientId=js-tb-node-0, groupId=rule-engine-node-tb-node-0] Offset commit with offsets {js_eval.responses.tb-node-0-0=OffsetAndMetadata{offset=1023387340, leaderEpoch=50, metadata=''}} failed\n","stream":"stdout","container_name":"server","namespace_name":"some-prod","pod_name":"tb-node-0"}
{"log":"2021-05-26 10:05:37,899 [tb-queue-request-template-js_eval.responses.tb-node-0-27-thread-1] ERROR o.a.k.c.c.i.ConsumerCoordinator - [Consumer clientId=js-tb-node-0, groupId=rule-engine-node-tb-node-0] Offset commit with offsets {js_eval.responses.tb-node-0-0=OffsetAndMetadata{offset=1023387345, leaderEpoch=50, metadata=''}} failed\n","stream":"stdout","container_name":"server","namespace_name":"some-prod","pod_name":"tb-node-0"}
{"log":"2021-05-26 10:05:37,899 [tb-queue-request-template-js_eval.responses.tb-node-0-27-thread-1] ERROR o.a.k.c.c.i.ConsumerCoordinator - [Consumer clientId=js-tb-node-0, groupId=rule-engine-node-tb-node-0] Offset commit with offsets {js_eval.responses.tb-node-0-0=OffsetAndMetadata{offset=1023387348, leaderEpoch=50, metadata=''}} failed\n","stream":"stdout","container_name":"server","namespace_name":"some-prod","pod_name":"tb-node-0"}
{"log":"2021-05-26 10:05:37,899 [tb-queue-request-template-js_eval.responses.tb-node-0-27-thread-1] ERROR o.a.k.c.c.i.ConsumerCoordinator - [Consumer clientId=js-tb-node-0, groupId=rule-engine-node-tb-node-0] Offset commit with offsets {js_eval.responses.tb-node-0-0=OffsetAndMetadata{offset=1023387353, leaderEpoch=50, metadata=''}} failed\n","stream":"stdout","container_name":"server","namespace_name":"some-prod","pod_name":"tb-node-0"}
{"log":"2021-05-26 10:05:37,900 [tb-queue-request-template-js_eval.responses.tb-node-0-27-thread-1] ERROR o.a.k.c.c.i.ConsumerCoordinator - [Consumer clientId=js-tb-node-0, groupId=rule-engine-node-tb-node-0] Offset commit with offsets {js_eval.responses.tb-node-0-0=OffsetAndMetadata{offset=1023387359, leaderEpoch=50, metadata=''}} failed\n","stream":"stdout","container_name":"server","namespace_name":"some-prod","pod_name":"tb-node-0"}
```