### PR TITLE
Feature/device state service repartition and performance improvements

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -499,7 +499,7 @@ public class DefaultDeviceStateService extends TbApplicationEventListener<Partit
 
     @Nonnull
     private DeviceStateData getOrFetchDeviceStateData(DeviceId deviceId) {
-        DeviceStateData deviceStateData = getOrFetchDeviceStateData(deviceId);
+        DeviceStateData deviceStateData = deviceStates.get(deviceId);
         if (deviceStateData != null) {
             return deviceStateData;
         }

--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -555,7 +555,6 @@ public class DefaultDeviceStateService extends TbApplicationEventListener<Partit
         return transformInactivityTimeout(future);
     }
 
-    // voba - schwarz fix to use timeseries/attributes for inactivity timeout
     private ListenableFuture<DeviceStateData> transformInactivityTimeout(ListenableFuture<DeviceStateData> future) {
         return Futures.transformAsync(future, deviceStateData -> {
             if (!persistToTelemetry || deviceStateData.getState().getInactivityTimeout() != TimeUnit.SECONDS.toMillis(defaultInactivityTimeoutInSec)) {

--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -367,7 +367,7 @@ public class DefaultDeviceStateService extends TbApplicationEventListener<Partit
 
             addedPartitions.forEach(tpi -> partitionedDevices.computeIfAbsent(tpi, key -> ConcurrentHashMap.newKeySet()));
 
-            initDeviceStatesForPartitions(addedPartitions);
+            initPartitions(addedPartitions);
 
             log.info("Managing following partitions:");
             partitionedDevices.forEach((tpi, devices) -> {
@@ -379,8 +379,8 @@ public class DefaultDeviceStateService extends TbApplicationEventListener<Partit
     }
 
     //TODO 3.0: replace this dummy search with new functionality to search by partitions using SQL capabilities.
-    // Adding only devices that are in new partitions
-    boolean initDeviceStatesForPartitions(Set<TopicPartitionInfo> addedPartitions) {
+    //Adding only entities that are in new partitions
+    boolean initPartitions(Set<TopicPartitionInfo> addedPartitions) {
         if (addedPartitions.isEmpty()) {
             return false;
         }

--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -60,7 +60,7 @@ import org.thingsboard.server.queue.discovery.PartitionService;
 import org.thingsboard.server.queue.discovery.TbApplicationEventListener;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 import org.thingsboard.server.service.queue.TbClusterService;
-import org.thingsboard.server.service.telemetry.TelemetrySubscriptionService
+import org.thingsboard.server.service.telemetry.TelemetrySubscriptionService;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -456,6 +456,7 @@ public class DefaultDeviceStateService extends TbApplicationEventListener<Partit
             deviceIds.add(state.getDeviceId());
             deviceStates.put(state.getDeviceId(), state);
         } else {
+            log.warn("Device belongs to external partition {}" + tpi.getFullTopicName());
             new RuntimeException("Device belongs to external partition " + tpi.getFullTopicName() + "!");
         }
     }

--- a/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
@@ -1,0 +1,98 @@
+/**
+ * ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
+ *
+ * Copyright © 2016-2021 ThingsBoard, Inc. All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains
+ * the property of ThingsBoard, Inc. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to ThingsBoard, Inc.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ *
+ * Dissemination of this information or reproduction of this material is strictly forbidden
+ * unless prior written permission is obtained from COMPANY.
+ *
+ * Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees,
+ * managers or contractors who have executed Confidentiality and Non-disclosure agreements
+ * explicitly covering such access.
+ *
+ * The copyright notice above does not evidence any actual or intended publication
+ * or disclosure  of  this source code, which includes
+ * information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.
+ * ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
+ * OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT
+ * THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED,
+ * AND IN VIOLATION OF APPLICABLE LAWS AND INTERNATIONAL TREATIES.
+ * THE RECEIPT OR POSSESSION OF THIS SOURCE CODE AND/OR RELATED INFORMATION
+ * DOES NOT CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS,
+ * OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+ */
+package org.thingsboard.server.service.state;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.dao.attributes.AttributesService;
+import org.thingsboard.server.dao.device.DeviceService;
+import org.thingsboard.server.dao.tenant.TenantService;
+import org.thingsboard.server.dao.timeseries.TimeseriesService;
+import org.thingsboard.server.queue.discovery.PartitionService;
+import org.thingsboard.server.service.queue.TbClusterService;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultDeviceStateServiceTest {
+
+    @Mock
+    TenantService tenantService;
+    @Mock
+    DeviceService deviceService;
+    @Mock
+    AttributesService attributesService;
+    @Mock
+    TimeseriesService tsService;
+    @Mock
+    TbClusterService clusterService;
+    @Mock
+    PartitionService partitionService;
+    @Mock
+    DeviceStateData deviceStateDataMock;
+
+    DeviceId deviceId = DeviceId.fromString("00797a3b-7aeb-4b5b-b57a-c2a810d0f112");
+
+    DefaultDeviceStateService service;
+
+    @Before
+    public void setUp() {
+        service = spy(new DefaultDeviceStateService(tenantService, deviceService, attributesService, tsService, clusterService, partitionService));
+    }
+
+    @Test
+    public void givenDeviceIdFromDeviceStatesMap_whenGetOrFetchDeviceStateData_thenNoStackOverflow() {
+        DeviceStateData deviceStateDataMock = Mockito.mock(DeviceStateData.class);
+        service.deviceStates.put(deviceId, deviceStateDataMock);
+        DeviceStateData deviceStateData = service.getOrFetchDeviceStateData(deviceId);
+        assertThat(deviceStateData, is(deviceStateDataMock));
+        Mockito.verify(service, never()).fetchDeviceStateData(deviceId);
+    }
+
+    @Test
+    public void givenDeviceIdWithoutDeviceStateInMap_whenGetOrFetchDeviceStateData_thenFetchDeviceStateData() {
+        service.deviceStates.clear();
+        DeviceStateData deviceStateData = service.getOrFetchDeviceStateData(deviceId);
+        assertThat(deviceStateData, is(deviceStateDataMock));
+        Mockito.verify(service, never()).fetchDeviceStateData(deviceId);
+    }
+
+
+}

--- a/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
@@ -1,32 +1,17 @@
 /**
- * ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
+ * Copyright © 2016-2021 The Thingsboard Authors
  *
- * Copyright © 2016-2021 ThingsBoard, Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * NOTICE: All information contained herein is, and remains
- * the property of ThingsBoard, Inc. and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to ThingsBoard, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Dissemination of this information or reproduction of this material is strictly forbidden
- * unless prior written permission is obtained from COMPANY.
- *
- * Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees,
- * managers or contractors who have executed Confidentiality and Non-disclosure agreements
- * explicitly covering such access.
- *
- * The copyright notice above does not evidence any actual or intended publication
- * or disclosure  of  this source code, which includes
- * information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.
- * ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
- * OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT
- * THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED,
- * AND IN VIOLATION OF APPLICABLE LAWS AND INTERNATIONAL TREATIES.
- * THE RECEIPT OR POSSESSION OF THIS SOURCE CODE AND/OR RELATED INFORMATION
- * DOES NOT CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS,
- * OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.thingsboard.server.service.state;
 
@@ -36,7 +21,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.dao.attributes.AttributesService;
 import org.thingsboard.server.dao.device.DeviceService;
@@ -47,8 +31,10 @@ import org.thingsboard.server.service.queue.TbClusterService;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultDeviceStateServiceTest {
@@ -79,7 +65,6 @@ public class DefaultDeviceStateServiceTest {
 
     @Test
     public void givenDeviceIdFromDeviceStatesMap_whenGetOrFetchDeviceStateData_thenNoStackOverflow() {
-        DeviceStateData deviceStateDataMock = Mockito.mock(DeviceStateData.class);
         service.deviceStates.put(deviceId, deviceStateDataMock);
         DeviceStateData deviceStateData = service.getOrFetchDeviceStateData(deviceId);
         assertThat(deviceStateData, is(deviceStateDataMock));
@@ -89,10 +74,10 @@ public class DefaultDeviceStateServiceTest {
     @Test
     public void givenDeviceIdWithoutDeviceStateInMap_whenGetOrFetchDeviceStateData_thenFetchDeviceStateData() {
         service.deviceStates.clear();
+        willReturn(deviceStateDataMock).given(service).fetchDeviceStateData(deviceId);
         DeviceStateData deviceStateData = service.getOrFetchDeviceStateData(deviceId);
         assertThat(deviceStateData, is(deviceStateDataMock));
-        Mockito.verify(service, never()).fetchDeviceStateData(deviceId);
+        Mockito.verify(service, times(1)).fetchDeviceStateData(deviceId);
     }
-
 
 }

--- a/common/message/src/test/java/org/thingsboard/server/common/msg/queue/TopicPartitionInfoTest.java
+++ b/common/message/src/test/java/org/thingsboard/server/common/msg/queue/TopicPartitionInfoTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright © 2016-2021 The Thingsboard Authors
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/common/message/src/test/java/org/thingsboard/server/common/msg/queue/TopicPartitionInfoTest.java
+++ b/common/message/src/test/java/org/thingsboard/server/common/msg/queue/TopicPartitionInfoTest.java
@@ -1,0 +1,142 @@
+/**
+ * ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
+ *
+ * Copyright © 2016-2021 ThingsBoard, Inc. All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains
+ * the property of ThingsBoard, Inc. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to ThingsBoard, Inc.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ *
+ * Dissemination of this information or reproduction of this material is strictly forbidden
+ * unless prior written permission is obtained from COMPANY.
+ *
+ * Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees,
+ * managers or contractors who have executed Confidentiality and Non-disclosure agreements
+ * explicitly covering such access.
+ *
+ * The copyright notice above does not evidence any actual or intended publication
+ * or disclosure  of  this source code, which includes
+ * information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.
+ * ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
+ * OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT
+ * THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED,
+ * AND IN VIOLATION OF APPLICABLE LAWS AND INTERNATIONAL TREATIES.
+ * THE RECEIPT OR POSSESSION OF THIS SOURCE CODE AND/OR RELATED INFORMATION
+ * DOES NOT CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS,
+ * OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+ */
+package org.thingsboard.server.common.msg.queue;
+
+import org.junit.Test;
+import org.thingsboard.server.common.data.id.TenantId;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TopicPartitionInfoTest {
+
+    @Test
+    public void givenTopicPartitionInfo_whenEquals_thenTrue() {
+
+        TopicPartitionInfo tpiExpected = TopicPartitionInfo.builder()
+                .topic("tb_core")
+                .tenantId(null)
+                .partition(4)
+                .myPartition(true) //will ignored on equals
+                .build();
+
+        assertThat(TopicPartitionInfo.builder()
+                        .topic("tb_core")
+                        .tenantId(null)
+                        .partition(4)
+                        .myPartition(true) //will ignored on equals
+                        .build()
+                , is(tpiExpected));
+
+        assertThat(TopicPartitionInfo.builder()
+                        .topic("tb_core")
+                        .tenantId(null)
+                        .partition(4)
+                        .myPartition(false) //will ignored on equals
+                        .build()
+                , is(tpiExpected));
+
+        assertThat(TopicPartitionInfo.builder()
+                        .topic("tb_core")
+                        .tenantId(TenantId.SYS_TENANT_ID)
+                        .partition(4)
+                        .myPartition(true) //will ignored on equals
+                        .build()
+                , is(TopicPartitionInfo.builder()
+                        .topic("tb_core")
+                        .tenantId(TenantId.SYS_TENANT_ID)
+                        .partition(4)
+                        .myPartition(true) //will ignored on equals
+                        .build()));
+
+    }
+
+    @Test
+    public void givenTopicPartitionInfo_whenEquals_thenFalse() {
+
+        TopicPartitionInfo tpiExpected = TopicPartitionInfo.builder()
+                .topic("tb_core")
+                .tenantId(null)
+                .partition(4)
+                .myPartition(true) //will ignored on equals
+                .build();
+
+        assertThat(TopicPartitionInfo.builder()
+                        .topic("tb_core")
+                        .tenantId(null)
+                        .partition(1)
+                        .myPartition(true) //will ignored on equals
+                        .build()
+                , not(tpiExpected));
+
+        assertThat(TopicPartitionInfo.builder()
+                        .topic("tb_core")
+                        .tenantId(null)
+                        .partition(1)
+                        .myPartition(false) //will ignored on equals
+                        .build()
+                , not(tpiExpected));
+
+        assertThat(TopicPartitionInfo.builder()
+                        .topic("js_eval")
+                        .tenantId(null)
+                        .partition(4)
+                        .myPartition(true) //will ignored on equals
+                        .build()
+                , not(tpiExpected));
+
+        assertThat(TopicPartitionInfo.builder()
+                        .topic("js_eval")
+                        .tenantId(null)
+                        .partition(4)
+                        .myPartition(false) //will ignored on equals
+                        .build()
+                , not(tpiExpected));
+
+        assertThat(TopicPartitionInfo.builder()
+                        .topic("tb_core")
+                        .tenantId(TenantId.SYS_TENANT_ID)
+                        .partition(4)
+                        .myPartition(true) //will ignored on equals
+                        .build()
+                , not(tpiExpected));
+
+        assertThat(TopicPartitionInfo.builder()
+                        .topic("tb_core")
+                        .tenantId(TenantId.SYS_TENANT_ID)
+                        .partition(4)
+                        .myPartition(false) //will ignored on equals
+                        .build()
+                , not(tpiExpected));
+
+    }
+}

--- a/common/message/src/test/java/org/thingsboard/server/common/msg/queue/TopicPartitionInfoTest.java
+++ b/common/message/src/test/java/org/thingsboard/server/common/msg/queue/TopicPartitionInfoTest.java
@@ -1,32 +1,17 @@
 /**
- * ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
- *
- * Copyright © 2016-2021 ThingsBoard, Inc. All Rights Reserved.
- *
- * NOTICE: All information contained herein is, and remains
- * the property of ThingsBoard, Inc. and its suppliers,
- * if any.  The intellectual and technical concepts contained
- * herein are proprietary to ThingsBoard, Inc.
- * and its suppliers and may be covered by U.S. and Foreign Patents,
- * patents in process, and are protected by trade secret or copyright law.
- *
- * Dissemination of this information or reproduction of this material is strictly forbidden
- * unless prior written permission is obtained from COMPANY.
- *
- * Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees,
- * managers or contractors who have executed Confidentiality and Non-disclosure agreements
- * explicitly covering such access.
- *
- * The copyright notice above does not evidence any actual or intended publication
- * or disclosure  of  this source code, which includes
- * information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.
- * ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
- * OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT
- * THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED,
- * AND IN VIOLATION OF APPLICABLE LAWS AND INTERNATIONAL TREATIES.
- * THE RECEIPT OR POSSESSION OF THIS SOURCE CODE AND/OR RELATED INFORMATION
- * DOES NOT CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS,
- * OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+ * Copyright © 2016-2021 The Thingsboard Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.thingsboard.server.common.msg.queue;
 

--- a/common/queue/src/main/java/org/thingsboard/server/queue/discovery/event/PartitionChangeEvent.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/discovery/event/PartitionChangeEvent.java
@@ -16,13 +16,14 @@
 package org.thingsboard.server.queue.discovery.event;
 
 import lombok.Getter;
+import lombok.ToString;
 import org.thingsboard.server.common.msg.queue.ServiceQueueKey;
 import org.thingsboard.server.common.msg.queue.ServiceType;
 import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
 
 import java.util.Set;
 
-
+@ToString(callSuper = true)
 public class PartitionChangeEvent extends TbApplicationEvent {
 
     private static final long serialVersionUID = -8731788167026510559L;

--- a/common/queue/src/main/java/org/thingsboard/server/queue/discovery/event/TbApplicationEvent.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/discovery/event/TbApplicationEvent.java
@@ -16,10 +16,12 @@
 package org.thingsboard.server.queue.discovery.event;
 
 import lombok.Getter;
+import lombok.ToString;
 import org.springframework.context.ApplicationEvent;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+@ToString
 public class TbApplicationEvent extends ApplicationEvent {
 
     private static final long serialVersionUID = 3884264064887765146L;


### PR DESCRIPTION
Features list:
1. reimplemented repartition to process only the latest known state and skip any previous states
2. reliable, check and update activity state (fixed with unconditional  check state onDeviceConnect, onActivityEvent)
3. efficient max session check and remove the eldest
4. refactored to exclude any similar logic duplication
5. handle negative timeout same as 0 (more reliable)
6. onEvents - changed commands order: first - persist, second - push to rule engine. This prevents any issues with consistency and prevents race conditions between DeviceStateService and rule engine threads
7. fixed case when **active** flag was not properly updated in the DB - state service calculated active on the fly and doesn't consider the current value in the DB. This leads to a situation when the device receiving data constantly, but **active** flag in the DB remains false.

P.S.: working fine on production with 150k+ devices