### PR TITLE
UI: Fixed generate invalid name function in widgetTypeFunctionBody

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/widget-component.service.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-component.service.ts
@@ -384,7 +384,7 @@ export class WidgetComponentService {
   }
 
   private createWidgetControllerDescriptor(widgetInfo: WidgetInfo, name: string): WidgetControllerDescriptor {
-    let widgetTypeFunctionBody = `return function ${name} (ctx) {\n` +
+    let widgetTypeFunctionBody = `return function _${name} (ctx) {\n` +
       '    var self = this;\n' +
       '    self.ctx = ctx;\n\n'; /*+
 


### PR DESCRIPTION
According to the ECMAScript standard, the function name can't start with a number.