### PR TITLE
Upgrade kafka client version to 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         </sonar.exclusions>
         <elasticsearch.version>5.0.2</elasticsearch.version>
         <delight-nashorn-sandbox.version>0.1.16</delight-nashorn-sandbox.version>
-        <kafka.version>2.6.0</kafka.version>
+        <kafka.version>2.8.0</kafka.version>
         <bucket4j.version>4.1.1</bucket4j.version>
         <fst.version>2.57</fst.version>
         <antlr.version>2.7.7</antlr.version>


### PR DESCRIPTION
Kafka java client  2.8.0    Released April 19, 2021 
Working fine on production with the previous version of Kafka broker 2.7
No breaking changes.
Run and drive.
Author @volodymyr-babak 