### PR TITLE
[3.3.0] Edge - add missing fields to device profile and widget bundle protos

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/DeviceProfileMsgConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/DeviceProfileMsgConstructor.java
@@ -25,6 +25,8 @@ import org.thingsboard.server.gen.edge.v1.DeviceProfileUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.UpdateMsgType;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 
+import java.nio.charset.StandardCharsets;
+
 @Component
 @TbCoreComponent
 public class DeviceProfileMsgConstructor {
@@ -60,6 +62,9 @@ public class DeviceProfileMsgConstructor {
         }
         if (deviceProfile.getProvisionDeviceKey() != null) {
             builder.setProvisionDeviceKey(deviceProfile.getProvisionDeviceKey());
+        }
+        if (deviceProfile.getImage() != null) {
+            builder.setImage(ByteString.copyFrom(deviceProfile.getImage().getBytes(StandardCharsets.UTF_8)));
         }
         return builder.build();
     }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/WidgetsBundleMsgConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/WidgetsBundleMsgConstructor.java
@@ -40,6 +40,9 @@ public class WidgetsBundleMsgConstructor {
         if (widgetsBundle.getImage() != null) {
             builder.setImage(ByteString.copyFrom(widgetsBundle.getImage().getBytes(StandardCharsets.UTF_8)));
         }
+        if (widgetsBundle.getDescription() != null) {
+            builder.setDescription(widgetsBundle.getDescription());
+        }
         if (widgetsBundle.getTenantId().equals(TenantId.SYS_TENANT_ID)) {
             builder.setIsSystem(true);
         }

--- a/common/edge-api/src/main/proto/edge.proto
+++ b/common/edge-api/src/main/proto/edge.proto
@@ -210,6 +210,7 @@ message DeviceProfileUpdateMsg {
   string defaultQueueName = 12;
   bytes profileDataBytes = 13;
   string provisionDeviceKey = 14;
+  bytes image = 15;
 }
 
 message DeviceCredentialsUpdateMsg {
@@ -312,6 +313,7 @@ message WidgetsBundleUpdateMsg {
   string alias = 5;
   bytes image = 6;
   bool isSystem = 7;
+  string description = 8;
 }
 
 message WidgetTypeUpdateMsg {


### PR DESCRIPTION
1. Added image field to edge device profile proto to send it to edge
2. Added description filed to edge widget bundle proto to send it to edge