### PR TITLE
[3.3.0] Fixed Failed to claim the device when use redis as cache

### DIFF
--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/device/claim/ClaimData.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/device/claim/ClaimData.java
@@ -18,9 +18,11 @@ package org.thingsboard.server.dao.device.claim;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.io.Serializable;
+
 @AllArgsConstructor
 @Data
-public class ClaimData {
+public class ClaimData implements Serializable {
 
     private final String secretKey;
     private final long expirationTime;


### PR DESCRIPTION
when use redis as the cache, this interface
http(s)://host:port/api/v1/$ACCESS_TOKEN/claim  throw 
a
SerializationFailedException but ignored by AbstractTransformFuture
,and when do  Device Claiming API
Request(http(s)://host:port/api/customer/device/$DEVICE_NAME/claim),the
system show :Failed to claim the device

show like this 
![1626842256(1)](https://user-images.githubusercontent.com/29371240/126434145-0b25bb42-b861-4f11-a8de-4b713c3a78b1.jpg)
![1626843018(1)](https://user-images.githubusercontent.com/29371240/126434147-84f165a4-01c8-4aac-b826-e13bf4544a2b.jpg)
