### PR TITLE
[3.3.0] minor update for push to edge/cloud nodes: use attribute scope from node configuration instead metadata

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/edge/TbMsgPushToCloudNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/edge/TbMsgPushToCloudNode.java
@@ -53,7 +53,7 @@ import org.thingsboard.server.common.msg.TbMsg;
                 "Message will be routed via <b>Failure</b> route if node was not able to save cloud event to database or unsupported originator type/message type arrived. " +
                 "In case successful storage cloud event to database message will be routed via <b>Success</b> route.",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
-        configDirective = "tbNodeEmptyConfig",
+        configDirective = "tbActionNodePushToCloudConfig",
         icon = "cloud_upload",
         ruleChainTypes = RuleChainType.EDGE
 )

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/edge/TbMsgPushToEdgeNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/edge/TbMsgPushToEdgeNode.java
@@ -21,7 +21,6 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.util.StringUtils;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.rule.engine.api.RuleNode;
 import org.thingsboard.rule.engine.api.TbContext;
@@ -32,6 +31,7 @@ import org.thingsboard.rule.engine.api.util.TbNodeUtils;
 import org.thingsboard.server.common.data.DataConstants;
 import org.thingsboard.server.common.data.EdgeUtils;
 import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.edge.EdgeEvent;
 import org.thingsboard.server.common.data.edge.EdgeEventActionType;
 import org.thingsboard.server.common.data.edge.EdgeEventType;
@@ -80,7 +80,7 @@ import static org.thingsboard.rule.engine.api.TbRelationTypes.SUCCESS;
                 "Message will be routed via <b>Failure</b> route if node was not able to save edge event to database or unsupported originator type/message type arrived. " +
                 "In case successful storage edge event to database message will be routed via <b>Success</b> route.",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
-        configDirective = "tbNodeEmptyConfig",
+        configDirective = "tbActionNodePushToEdgeConfig",
         icon = "cloud_download",
         ruleChainTypes = RuleChainType.CORE
 )
@@ -182,13 +182,13 @@ public class TbMsgPushToEdgeNode implements TbNode {
                 case ATTRIBUTES_UPDATED:
                 case POST_ATTRIBUTES:
                     entityBody.put("kv", dataJson);
-                    entityBody.put(SCOPE, getScope(metadata));
+                    entityBody.put(SCOPE, config.getScope());
                     break;
                 case ATTRIBUTES_DELETED:
                     List<String> keys = JacksonUtil.convertValue(dataJson.get("attributes"), new TypeReference<>() {
                     });
                     entityBody.put("keys", keys);
-                    entityBody.put(SCOPE, getScope(metadata));
+                    entityBody.put(SCOPE, config.getScope());
                     break;
                 case TIMESERIES_UPDATED:
                     entityBody.put("data", dataJson);


### PR DESCRIPTION
tbActionNodePushToCloudConfig and tbActionNodePushToEdgeConfig directives already merged and are available in the rulenode-core-config.js file