### PR TITLE
[3.3.0] Update inactivity timeout for device state in case timeseries used for device states

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
@@ -31,6 +31,7 @@ import org.thingsboard.server.common.data.kv.Aggregation;
 import org.thingsboard.server.common.data.kv.AttributeKvEntry;
 import org.thingsboard.server.common.data.kv.BaseReadTsKvQuery;
 import org.thingsboard.server.common.data.kv.BasicTsKvEntry;
+import org.thingsboard.server.common.data.kv.KvEntry;
 import org.thingsboard.server.common.data.kv.ReadTsKvQuery;
 import org.thingsboard.server.common.data.kv.StringDataEntry;
 import org.thingsboard.server.common.data.kv.TsKvEntry;
@@ -222,6 +223,9 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
                     }
                     return subscriptionUpdate;
                 });
+        if (entityId.getEntityType() == EntityType.DEVICE) {
+            updateDeviceInactivityTimeout(entityId, ts);
+        }
         callback.onSuccess();
     }
 
@@ -255,11 +259,7 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
                 });
         if (entityId.getEntityType() == EntityType.DEVICE) {
             if (TbAttributeSubscriptionScope.SERVER_SCOPE.name().equalsIgnoreCase(scope)) {
-                for (AttributeKvEntry attribute : attributes) {
-                    if (attribute.getKey().equals(DefaultDeviceStateService.INACTIVITY_TIMEOUT)) {
-                        deviceStateService.onDeviceInactivityTimeoutUpdate(new DeviceId(entityId.getId()), attribute.getLongValue().orElse(0L));
-                    }
-                }
+                updateDeviceInactivityTimeout(entityId, attributes);
             } else if (TbAttributeSubscriptionScope.SHARED_SCOPE.name().equalsIgnoreCase(scope) && notifyDevice) {
                 clusterService.pushMsgToCore(DeviceAttributesEventNotificationMsg.onUpdate(tenantId,
                         new DeviceId(entityId.getId()), DataConstants.SHARED_SCOPE, new ArrayList<>(attributes))
@@ -267,6 +267,14 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
             }
         }
         callback.onSuccess();
+    }
+
+    private void updateDeviceInactivityTimeout(EntityId entityId, List<? extends KvEntry> kvEntries) {
+        for (KvEntry kvEntry : kvEntries) {
+            if (kvEntry.getKey().equals(DefaultDeviceStateService.INACTIVITY_TIMEOUT)) {
+                deviceStateService.onDeviceInactivityTimeoutUpdate(new DeviceId(entityId.getId()), kvEntry.getLongValue().orElse(0L));
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
At the moment if you use timeseries as storage for the device state, updating in the real time of inactivityTimeout will not trigger any updates to device state service.
Added listener to timeseries update and push event to device state service.