### PR TITLE
[3.3.0] UI: Fixed update state: not clear state params

### DIFF
--- a/ui-ngx/src/app/modules/home/components/dashboard-page/states/state-controller.component.ts
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/states/state-controller.component.ts
@@ -129,7 +129,8 @@ export abstract class StateControllerComponent implements IStateControllerCompon
   protected updateStateParam(newState: string, replaceCurrentHistoryUrl = false) {
     this.currentState = newState;
     if (this.syncStateWithQueryParam) {
-      const queryParams: Params = {state: encodeURIComponent(this.currentState)};
+      const state = this.currentState ? encodeURIComponent(this.currentState) : this.currentState;
+      const queryParams: Params = {state};
       this.ngZone.run(() => {
         this.router.navigate(
           [],


### PR DESCRIPTION
When calling encodeURIComponent for value null return string.
Function navigate add query params state in value null, but not clear this parameter. 