### PR TITLE
[3.3.0] Fixes for device state service in cluster mode to avoid 'dead' device monitoring on incorrect nodes

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -381,11 +381,11 @@ class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcessor {
     }
 
     private void reportSessionOpen() {
-        systemContext.getDeviceStateService().onDeviceConnect(deviceId);
+        systemContext.getDeviceStateService().onDeviceConnect(tenantId, deviceId);
     }
 
     private void reportSessionClose() {
-        systemContext.getDeviceStateService().onDeviceDisconnect(deviceId);
+        systemContext.getDeviceStateService().onDeviceDisconnect(tenantId, deviceId);
     }
 
     private void handleGetAttributesRequest(TbActorCtx context, SessionInfoProto sessionInfo, GetAttributeRequestMsg request) {
@@ -590,7 +590,7 @@ class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcessor {
             if (sessions.size() == 1) {
                 reportSessionOpen();
             }
-            systemContext.getDeviceStateService().onDeviceActivity(deviceId, System.currentTimeMillis());
+            systemContext.getDeviceStateService().onDeviceActivity(tenantId, deviceId, System.currentTimeMillis());
             dumpSessions();
         } else if (msg.getEvent() == SessionEvent.CLOSED) {
             log.debug("[{}] Canceling subscriptions for closed session [{}]", deviceId, sessionId);
@@ -620,7 +620,7 @@ class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcessor {
         if (subscriptionInfo.getRpcSubscription()) {
             rpcSubscriptions.putIfAbsent(sessionId, sessionMD.getSessionInfo());
         }
-        systemContext.getDeviceStateService().onDeviceActivity(deviceId, subscriptionInfo.getLastActivityTime());
+        systemContext.getDeviceStateService().onDeviceActivity(tenantId, deviceId, subscriptionInfo.getLastActivityTime());
         dumpSessions();
     }
 

--- a/application/src/main/java/org/thingsboard/server/service/state/DeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DeviceStateService.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.service.state;
 import org.springframework.context.ApplicationListener;
 import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.queue.discovery.event.PartitionChangeEvent;
 import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.common.msg.queue.TbCallback;
@@ -33,13 +34,13 @@ public interface DeviceStateService extends ApplicationListener<PartitionChangeE
 
     void onDeviceDeleted(Device device);
 
-    void onDeviceConnect(DeviceId deviceId);
+    void onDeviceConnect(TenantId tenantId, DeviceId deviceId);
 
-    void onDeviceActivity(DeviceId deviceId, long lastReportedActivityTime);
+    void onDeviceActivity(TenantId tenantId, DeviceId deviceId, long lastReportedActivityTime);
 
-    void onDeviceDisconnect(DeviceId deviceId);
+    void onDeviceDisconnect(TenantId tenantId, DeviceId deviceId);
 
-    void onDeviceInactivityTimeoutUpdate(DeviceId deviceId, long inactivityTimeout);
+    void onDeviceInactivityTimeoutUpdate(TenantId tenantId, DeviceId deviceId, long inactivityTimeout);
 
     void onQueueMsg(TransportProtos.DeviceStateServiceMsgProto proto, TbCallback bytes);
 

--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
@@ -224,7 +224,7 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
                     return subscriptionUpdate;
                 });
         if (entityId.getEntityType() == EntityType.DEVICE) {
-            updateDeviceInactivityTimeout(entityId, ts);
+            updateDeviceInactivityTimeout(tenantId, entityId, ts);
         }
         callback.onSuccess();
     }
@@ -259,7 +259,7 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
                 });
         if (entityId.getEntityType() == EntityType.DEVICE) {
             if (TbAttributeSubscriptionScope.SERVER_SCOPE.name().equalsIgnoreCase(scope)) {
-                updateDeviceInactivityTimeout(entityId, attributes);
+                updateDeviceInactivityTimeout(tenantId, entityId, attributes);
             } else if (TbAttributeSubscriptionScope.SHARED_SCOPE.name().equalsIgnoreCase(scope) && notifyDevice) {
                 clusterService.pushMsgToCore(DeviceAttributesEventNotificationMsg.onUpdate(tenantId,
                         new DeviceId(entityId.getId()), DataConstants.SHARED_SCOPE, new ArrayList<>(attributes))
@@ -269,10 +269,10 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
         callback.onSuccess();
     }
 
-    private void updateDeviceInactivityTimeout(EntityId entityId, List<? extends KvEntry> kvEntries) {
+    private void updateDeviceInactivityTimeout(TenantId tenantId, EntityId entityId, List<? extends KvEntry> kvEntries) {
         for (KvEntry kvEntry : kvEntries) {
             if (kvEntry.getKey().equals(DefaultDeviceStateService.INACTIVITY_TIMEOUT)) {
-                deviceStateService.onDeviceInactivityTimeoutUpdate(new DeviceId(entityId.getId()), kvEntry.getLongValue().orElse(0L));
+                deviceStateService.onDeviceInactivityTimeoutUpdate(tenantId, new DeviceId(entityId.getId()), kvEntry.getLongValue().orElse(0L));
             }
         }
     }


### PR DESCRIPTION
Added additional check that device belongs to the current node before adding to states map. 
Added clean up in case device doesn't belong to this node anymore