### PR TITLE
[3.3.0] mqtt transport close channel on processing exception for handleGatewayPublishMsg method

### DIFF
--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -304,6 +304,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
             }
         } catch (RuntimeException | AdaptorException e) {
             log.warn("[{}] Failed to process publish msg [{}][{}]", sessionId, topicName, msgId, e);
+            ctx.close();
         }
     }
 


### PR DESCRIPTION
mqtt transport close channel on processing exception for handleGatewayPublishMsg method