### PR TITLE
[3.3.0] Gateway session handler improvements

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -290,6 +290,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/common/transport/mqtt/pom.xml
+++ b/common/transport/mqtt/pom.xml
@@ -89,6 +89,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandler.java
@@ -34,6 +34,7 @@ import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.ConcurrentReferenceHashMap;
 import org.springframework.util.StringUtils;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.transport.TransportService;
@@ -66,6 +67,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.springframework.util.ConcurrentReferenceHashMap.ReferenceType;
+
 /**
  * Created by ashvayka on 19.01.17.
  */
@@ -82,7 +85,7 @@ public class GatewaySessionHandler {
     private final UUID sessionId;
     private final ConcurrentMap<String, Lock> deviceCreationLockMap;
     private final ConcurrentMap<String, GatewayDeviceSessionCtx> devices;
-    private final ConcurrentMap<String, SettableFuture<GatewayDeviceSessionCtx>> deviceFutures;
+    private final ConcurrentMap<String, ListenableFuture<GatewayDeviceSessionCtx>> deviceFutures;
     private final ConcurrentMap<MqttTopicMatcher, Integer> mqttQoSMap;
     private final ChannelHandlerContext channel;
     private final DeviceSessionCtx deviceSessionCtx;
@@ -98,6 +101,10 @@ public class GatewaySessionHandler {
         this.deviceCreationLockMap = new ConcurrentHashMap<>();
         this.mqttQoSMap = deviceSessionCtx.getMqttQoSMap();
         this.channel = deviceSessionCtx.getChannel();
+    }
+
+    ConcurrentReferenceHashMap<String, Lock> createWeakMap() {
+        return new ConcurrentReferenceHashMap<>(16, ReferenceType.WEAK);
     }
 
     public void onDeviceConnect(MqttPublishMessage mqttMsg) throws AdaptorException {
@@ -228,21 +235,22 @@ public class GatewaySessionHandler {
                 if (result == null) {
                     return getDeviceCreationFuture(deviceName, deviceType);
                 } else {
-                    return toCompletedFuture(result);
+                    return Futures.immediateFuture(result);
                 }
             } finally {
                 deviceCreationLock.unlock();
             }
         } else {
-            return toCompletedFuture(result);
+            return Futures.immediateFuture(result);
         }
     }
 
     private ListenableFuture<GatewayDeviceSessionCtx> getDeviceCreationFuture(String deviceName, String deviceType) {
-        SettableFuture<GatewayDeviceSessionCtx> future = deviceFutures.get(deviceName);
-        if (future == null) {
-            final SettableFuture<GatewayDeviceSessionCtx> futureToSet = SettableFuture.create();
-            deviceFutures.put(deviceName, futureToSet);
+        final SettableFuture<GatewayDeviceSessionCtx> futureToSet = SettableFuture.create();
+        ListenableFuture<GatewayDeviceSessionCtx> future = deviceFutures.putIfAbsent(deviceName, futureToSet);
+        if (future != null) {
+            return future;
+        }
             try {
                 transportService.process(GetOrCreateDeviceFromGatewayRequestMsg.newBuilder()
                                 .setDeviceName(deviceName)
@@ -282,15 +290,6 @@ public class GatewaySessionHandler {
                 deviceFutures.remove(deviceName);
                 throw e;
             }
-        } else {
-            return future;
-        }
-    }
-
-    private ListenableFuture<GatewayDeviceSessionCtx> toCompletedFuture(GatewayDeviceSessionCtx result) {
-        SettableFuture<GatewayDeviceSessionCtx> future = SettableFuture.create();
-        future.set(result);
-        return future;
     }
 
     private int getMsgId(MqttPublishMessage mqttMsg) {

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandler.java
@@ -352,6 +352,7 @@ public class GatewaySessionHandler {
                                     processPostTelemetryMsg(deviceCtx, postTelemetryMsg, deviceName, msgId);
                                 } catch (Throwable e) {
                                     log.warn("[{}][{}] Failed to convert telemetry: {}", gateway.getDeviceId(), deviceName, deviceEntry.getValue(), e);
+                                    channel.close();
                                 }
                             }
 
@@ -383,6 +384,7 @@ public class GatewaySessionHandler {
                                         processPostTelemetryMsg(deviceCtx, postTelemetryMsg, deviceName, msgId);
                                     } catch (Throwable e) {
                                         log.warn("[{}][{}] Failed to convert telemetry: {}", gateway.getDeviceId(), deviceName, msg, e);
+                                        channel.close();
                                     }
                                 }
 

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandler.java
@@ -98,7 +98,7 @@ public class GatewaySessionHandler {
         this.sessionId = sessionId;
         this.devices = new ConcurrentHashMap<>();
         this.deviceFutures = new ConcurrentHashMap<>();
-        this.deviceCreationLockMap = new ConcurrentHashMap<>();
+        this.deviceCreationLockMap = createWeakMap();
         this.mqttQoSMap = deviceSessionCtx.getMqttQoSMap();
         this.channel = deviceSessionCtx.getChannel();
     }

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandlerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.thingsboard.server.transport.mqtt.session;
 
 import org.junit.Test;

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandlerTest.java
@@ -1,0 +1,46 @@
+package org.thingsboard.server.transport.mqtt.session;
+
+import org.junit.Test;
+
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.willCallRealMethod;
+import static org.mockito.Mockito.mock;
+
+public class GatewaySessionHandlerTest {
+
+    @Test
+    public void givenWeakHashMap_WhenGC_thenMapIsEmpty() {
+        WeakHashMap<String, Lock> map = new WeakHashMap<>();
+
+        String deviceName = new String("device"); //constants are static and doesn't affected by GC, so use new instead
+        map.put(deviceName, new ReentrantLock());
+        assertTrue(map.containsKey(deviceName));
+
+        deviceName = null;
+        System.gc();
+
+        await().atMost(10, TimeUnit.SECONDS).until(() -> !map.containsKey("device"));
+    }
+
+    @Test
+    public void givenConcurrentReferenceHashMap_WhenGC_thenMapIsEmpty() {
+        GatewaySessionHandler gsh = mock(GatewaySessionHandler.class);
+        willCallRealMethod().given(gsh).createWeakMap();
+
+        ConcurrentMap<String, Lock> map = gsh.createWeakMap();
+        map.put("device", new ReentrantLock());
+        assertTrue(map.containsKey("device"));
+
+        System.gc();
+
+        await().atMost(10, TimeUnit.SECONDS).until(() -> !map.containsKey("device"));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <json-path.version>2.2.0</json-path.version>
         <junit.version>4.12</junit.version>
         <jupiter.version>5.7.1</jupiter.version>
+        <awaitility.version>4.1.0</awaitility.version>
         <hamcrest.version>2.2</hamcrest.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.3</logback.version>
@@ -1435,6 +1436,12 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Gateway session handler improvements:
weakmap for device lock, refactored getDeviceCreationFuture with putIfAbsent, refactored SettableFuture usage, test with awaitility.

**close channel** if processPostTelemetryMsg exception (Failed to convert telemetry)
