### PR TITLE
[3.4] Null ordering default is none (previous was last [DESC NULLS LAST])

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -463,7 +463,7 @@ spring.servlet.multipart.max-file-size: "50MB"
 spring.servlet.multipart.max-request-size: "50MB"
 
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation: "true"
-spring.jpa.properties.hibernate.order_by.default_null_ordering: "none"
+spring.jpa.properties.hibernate.order_by.default_null_ordering: "${SPRING_JPA_PROPERTIES_HIBERNATE_ORDER_BY_DEFAULT_NULL_ORDERING:none}"
 
 # SQL DAO Configuration
 spring:

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -463,7 +463,7 @@ spring.servlet.multipart.max-file-size: "50MB"
 spring.servlet.multipart.max-request-size: "50MB"
 
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation: "true"
-spring.jpa.properties.hibernate.order_by.default_null_ordering: "last"
+spring.jpa.properties.hibernate.order_by.default_null_ordering: "none"
 
 # SQL DAO Configuration
 spring:


### PR DESCRIPTION
spring.jpa.properties.hibernate.order_by.default_null_ordering: "${SPRING_JPA_PROPERTIES_HIBERNATE_ORDER_BY_DEFAULT_NULL_ORDERING:none}"

The motivation is well described by @limejeroen on https://github.com/thingsboard/thingsboard/issues/4519