### PR TITLE
[3.3.0] Lwm2m test fix with Awaitility (detailed example with logs and javadoc to demonstrate the flow and benefits of async testing)

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -290,6 +290,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
@@ -27,6 +27,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.common.util.ThingsBoardThreadFactory;
 import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.DeviceProfile;
 import org.thingsboard.server.common.data.DeviceProfileProvisionType;
@@ -261,7 +262,7 @@ public class AbstractLwM2MIntegrationTest extends AbstractWebsocketTest {
 
     @Before
     public void beforeTest() throws Exception {
-        executor = Executors.newScheduledThreadPool(10);
+        executor = Executors.newScheduledThreadPool(10, ThingsBoardThreadFactory.forName("test-lwm2m-scheduled"));
         loginTenantAdmin();
 
         String[] resources = new String[]{"1.xml", "2.xml", "3.xml", "5.xml", "9.xml"};

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <json-path.version>2.2.0</json-path.version>
         <junit.version>4.12</junit.version>
         <jupiter.version>5.7.1</jupiter.version>
+        <awaitility.version>4.1.0</awaitility.version>
         <hamcrest.version>2.2</hamcrest.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.3</logback.version>
@@ -1435,6 +1436,12 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Lwm2m test fix with Awaitility (detailed example with logs and javadoc to demonstrate the flow and benefits of async testing)
 * This is the example how to use the AWAITILITY instead Thread.sleep()
 * Test will finish as fast as possible, but will await until TIMEOUT if a build machine is busy or slow
 * Check the detailed log output to learn how Awaitility polling the API and when exactly expected result appears

Screenshot and logs you can find below:

![image](https://user-images.githubusercontent.com/79898499/127699410-928e67fb-d3ce-4914-a8ca-a88fd10e6402.png)


```
2021-07-30 21:28:59,877 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Saving by API Device [tenantId=015b0ce0-f164-11eb-b53b-09ae3f425f9a, customerId=13814000-1dd2-11b2-8080-808080808080, name=Device A, type=LwM2M, label=null, deviceProfileId=01fb1d70-f164-11eb-b53b-09ae3f425f9a, deviceData=null, firmwareId=DeviceData(configuration=DefaultDeviceConfiguration(), transportConfiguration=Lwm2mDeviceTransportConfiguration(properties={})), additionalInfo=null, createdTime=1627669739753, id=02004d90-f164-11eb-b53b-09ae3f425f9a]
2021-07-30 21:28:59,928 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Device saved by API Device [tenantId=015b0ce0-f164-11eb-b53b-09ae3f425f9a, customerId=13814000-1dd2-11b2-8080-808080808080, name=Device A, type=LwM2M, label=null, deviceProfileId=01fb1d70-f164-11eb-b53b-09ae3f425f9a, deviceData=null, firmwareId=DeviceData(configuration=DefaultDeviceConfiguration(), transportConfiguration=Lwm2mDeviceTransportConfiguration(properties={})), additionalInfo=null, createdTime=1627669739753, id=02004d90-f164-11eb-b53b-09ae3f425f9a]
2021-07-30 21:28:59,928 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - AWAIT atMost 30 SECONDS on get device by API...
2021-07-30 21:29:00,050 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched device by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, device is Device [tenantId=015b0ce0-f164-11eb-b53b-09ae3f425f9a, customerId=13814000-1dd2-11b2-8080-808080808080, name=Device A, type=LwM2M, label=null, deviceProfileId=01fb1d70-f164-11eb-b53b-09ae3f425f9a, deviceData=null, firmwareId=DeviceData(configuration=DefaultDeviceConfiguration(), transportConfiguration=Lwm2mDeviceTransportConfiguration(properties={})), additionalInfo=null, createdTime=1627669739753, id=02004d90-f164-11eb-b53b-09ae3f425f9a]
2021-07-30 21:29:00,053 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Got device by API.
2021-07-30 21:29:00,054 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Init the client...
2021-07-30 21:29:00,086 [main] INFO  o.e.l.c.californium.LeshanClient - Starting Leshan client ...
2021-07-30 21:29:00,090 [main] INFO  o.e.l.c.c.CaliforniumEndpointsManager - New endpoint created for server coap://localhost:5685 at coap://0.0.0.0:11000
2021-07-30 21:29:00,090 [main] INFO  o.e.l.c.californium.LeshanClient - Leshan client[endpoint:OTA_deviceAEndpoint] started.
2021-07-30 21:29:00,091 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Init done
2021-07-30 21:29:00,091 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - AWAIT atMost 30 SECONDS on timeseries List<TsKvEntry> by API with list size 8...
2021-07-30 21:29:00,091 [test-lwm2m-scheduled-48-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Trying to register to coap://localhost:5685 ...
2021-07-30 21:29:00,170 [test-lwm2m-scheduled-48-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Registered with location '/rd/84bmOyAvGv'.
2021-07-30 21:29:00,171 [test-lwm2m-scheduled-48-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Next registration update to coap://localhost:5685 in 53s...
2021-07-30 21:29:00,259 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:00,378 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:00,489 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:00,597 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:00,707 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:00,817 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:00,928 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:01,039 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:01,149 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:01,259 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:01,369 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:01,478 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:01,589 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:01,698 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:01,809 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:01,918 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:02,027 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:02,135 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:02,245 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:02,357 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:02,467 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:02,576 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:02,684 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:02,792 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:02,900 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:03,007 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:03,115 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 2, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:03,225 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 4, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743030, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743032, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:03,332 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 5, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743030, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743032, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743034, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:03,441 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 6, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743030, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743032, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743034, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743037, kv=StringDataEntry{value='DOWNLOADED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:03,551 [awaitility-thread] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 8, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743030, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743032, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743034, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743037, kv=StringDataEntry{value='DOWNLOADED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743040, kv=StringDataEntry{value='VERIFIED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743043, kv=StringDataEntry{value='UPDATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:03,552 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Got an expected await condition!
2021-07-30 21:29:03,552 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetching ts for the final asserts
2021-07-30 21:29:03,561 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Fetched telemetry by API for deviceId 02004d90-f164-11eb-b53b-09ae3f425f9a, list size 8, tsKvEntries [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743030, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743032, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743034, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743037, kv=StringDataEntry{value='DOWNLOADED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743040, kv=StringDataEntry{value='VERIFIED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743043, kv=StringDataEntry{value='UPDATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:03,561 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Got an ts [BasicTsKvEntry{ts=1627669739906, kv=StringDataEntry{value='QUEUED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669739928, kv=StringDataEntry{value='INITIATED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743030, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743032, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743034, kv=StringDataEntry{value='DOWNLOADING'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743037, kv=StringDataEntry{value='DOWNLOADED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743040, kv=StringDataEntry{value='VERIFIED'} BasicKvEntry{key='sw_state'}}, BasicTsKvEntry{ts=1627669743043, kv=StringDataEntry{value='UPDATED'} BasicKvEntry{key='sw_state'}}]
2021-07-30 21:29:03,562 [main] WARN  o.t.s.t.l.NoSecLwM2MIntegrationTest - Converted ts to statuses [QUEUED, INITIATED, DOWNLOADING, DOWNLOADING, DOWNLOADING, DOWNLOADED, VERIFIED, UPDATED]
2021-07-30 21:29:03,564 [main] INFO  o.e.l.c.californium.LeshanClient - Destroying Leshan client ...
2021-07-30 21:29:03,564 [main] INFO  o.e.l.c.e.DefaultRegistrationEngine - Trying to deregister to coap://localhost:5685 ...
2021-07-30 21:29:03,602 [main] INFO  o.e.l.c.e.DefaultRegistrationEngine - De-register response DELETED null.
2021-07-30 21:29:03,603 [main] INFO  o.e.l.c.californium.LeshanClient - Leshan client destroyed.
2021-07-30 21:29:03,615 [WebSocketConnectReadThread-153] ERROR o.t.s.c.TbTestWebSocketClient - CLOSED:
```