### PR TITLE
[3.3.1] enqueue newly created messages

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/profile/AlarmState.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/profile/AlarmState.java
@@ -188,7 +188,7 @@ class AlarmState {
         setAlarmConditionMetadata(ruleState, metaData);
         TbMsg newMsg = ctx.newMsg(lastMsgQueueName != null ? lastMsgQueueName : ServiceQueue.MAIN, "ALARM",
                 originator, msg != null ? msg.getCustomerId() : null, metaData, data);
-        ctx.tellNext(newMsg, relationType);
+        ctx.enqueueForTellNext(newMsg, relationType);
     }
 
     protected void setAlarmConditionMetadata(AlarmRuleState ruleState, TbMsgMetaData metaData) {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/rpc/TbSendRPCRequestNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/rpc/TbSendRPCRequestNode.java
@@ -120,7 +120,7 @@ public class TbSendRPCRequestNode implements TbNode {
                     ctx.enqueueForTellNext(next, TbRelationTypes.SUCCESS);
                 } else {
                     TbMsg next = ctx.newMsg(msg.getQueueName(), msg.getType(), msg.getOriginator(), msg.getCustomerId(), msg.getMetaData(), wrap("error", ruleEngineDeviceRpcResponse.getError().get().name()));
-                    ctx.tellFailure(next, new RuntimeException(ruleEngineDeviceRpcResponse.getError().get().name()));
+                    ctx.enqueueForTellFailure(next, ruleEngineDeviceRpcResponse.getError().get().name());
                 }
             });
             ctx.ack(msg);


### PR DESCRIPTION
enqueueForTellFailure needed to prevent the case when someone catches a Failure message and continue processing the logic (e.g. send failed message to remote service using rest api). If the rest api fails, the message will not be reprocessed without enqueueForTellFailure.