### PR TITLE
[3.3.1] Mqtt transport handler test with cleanup old netty versions

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -588,6 +588,7 @@ transport:
     bind_address: "${MQTT_BIND_ADDRESS:0.0.0.0}"
     bind_port: "${MQTT_BIND_PORT:1883}"
     timeout: "${MQTT_TIMEOUT:10000}"
+    msg_queue_size_per_device_limit: "${MQTT_MSG_QUEUE_SIZE_PER_DEVICE_LIMIT:100}" # messages await in the queue before device connected state. This limit works on low level before TenantProfileLimits mechanism
     netty:
       leak_detector_level: "${NETTY_LEAK_DETECTOR_LVL:DISABLED}"
       boss_group_thread_count: "${NETTY_BOSS_GROUP_THREADS:1}"

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportContext.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportContext.java
@@ -68,6 +68,6 @@ public class MqttTransportContext extends TransportContext {
     private int messageQueueSizePerDeviceLimit;
 
     @Getter
-    private final ExecutorService msqProcessorExecutor = ThingsBoardExecutors.newWorkStealingPool(Runtime.getRuntime().availableProcessors() + 1, getClass());
+    private final ExecutorService msqProcessorExecutor = ThingsBoardExecutors.newWorkStealingPool(Runtime.getRuntime().availableProcessors() + 1, "msg-processor-on-device-connect");
 
 }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportContext.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportContext.java
@@ -68,23 +68,4 @@ public class MqttTransportContext extends TransportContext {
     @Value("${transport.mqtt.msg_queue_size_per_device_limit:100}")
     private int messageQueueSizePerDeviceLimit;
 
-    @Getter
-    private ExecutorService msqProcessorExecutor;
-
-    @Override
-    @PostConstruct
-    public void init() {
-        super.init();
-        msqProcessorExecutor = ThingsBoardExecutors.newWorkStealingPool(Runtime.getRuntime().availableProcessors() + 1, "msg-processor-on-device-connect");
-    }
-
-    @Override
-    @PreDestroy
-    public void stop() {
-        super.stop();
-        if (msqProcessorExecutor != null) {
-            msqProcessorExecutor.shutdownNow();
-        }
-    }
-
 }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportContext.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportContext.java
@@ -23,9 +23,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
+import org.thingsboard.common.util.ThingsBoardExecutors;
 import org.thingsboard.server.common.transport.TransportContext;
 import org.thingsboard.server.transport.mqtt.adaptors.JsonMqttAdaptor;
 import org.thingsboard.server.transport.mqtt.adaptors.ProtoMqttAdaptor;
+
+import javax.annotation.PostConstruct;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Created by ashvayka on 04.10.18.
@@ -58,5 +62,12 @@ public class MqttTransportContext extends TransportContext {
     @Getter
     @Setter
     private SslHandler sslHandler;
+
+    @Getter
+    @Value("${transport.mqtt.msg_queue_size_per_device_limit:10000}")
+    private int messageQueueSizePerDeviceLimit;
+
+    @Getter
+    private final ExecutorService msqProcessorExecutor = ThingsBoardExecutors.newWorkStealingPool(Runtime.getRuntime().availableProcessors() + 1, getClass());
 
 }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportContext.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportContext.java
@@ -65,7 +65,7 @@ public class MqttTransportContext extends TransportContext {
     private SslHandler sslHandler;
 
     @Getter
-    @Value("${transport.mqtt.msg_queue_size_per_device_limit:10000}")
+    @Value("${transport.mqtt.msg_queue_size_per_device_limit:100}")
     private int messageQueueSizePerDeviceLimit;
 
     @Getter

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportContext.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportContext.java
@@ -29,6 +29,7 @@ import org.thingsboard.server.transport.mqtt.adaptors.JsonMqttAdaptor;
 import org.thingsboard.server.transport.mqtt.adaptors.ProtoMqttAdaptor;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -68,6 +69,22 @@ public class MqttTransportContext extends TransportContext {
     private int messageQueueSizePerDeviceLimit;
 
     @Getter
-    private final ExecutorService msqProcessorExecutor = ThingsBoardExecutors.newWorkStealingPool(Runtime.getRuntime().availableProcessors() + 1, "msg-processor-on-device-connect");
+    private ExecutorService msqProcessorExecutor;
+
+    @Override
+    @PostConstruct
+    public void init() {
+        super.init();
+        msqProcessorExecutor = ThingsBoardExecutors.newWorkStealingPool(Runtime.getRuntime().availableProcessors() + 1, "msg-processor-on-device-connect");
+    }
+
+    @Override
+    @PreDestroy
+    public void stop() {
+        super.stop();
+        if (msqProcessorExecutor != null) {
+            msqProcessorExecutor.shutdownNow();
+        }
+    }
 
 }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -123,9 +123,9 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     private final SslHandler sslHandler;
     private final ConcurrentMap<MqttTopicMatcher, Integer> mqttQoSMap;
 
-    private final DeviceSessionCtx deviceSessionCtx;
-    private volatile InetSocketAddress address;
-    private volatile GatewaySessionHandler gatewaySessionHandler;
+    final DeviceSessionCtx deviceSessionCtx;
+    volatile InetSocketAddress address;
+    volatile GatewaySessionHandler gatewaySessionHandler;
 
     private final ConcurrentHashMap<String, String> otaPackSessions;
     private final ConcurrentHashMap<String, Integer> chunkSizes;
@@ -227,7 +227,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         }
     }
 
-    private void enqueueRegularSessionMsg(ChannelHandlerContext ctx, MqttMessage msg) {
+    void enqueueRegularSessionMsg(ChannelHandlerContext ctx, MqttMessage msg) {
         final int queueSize = deviceSessionCtx.getMsgQueueSize().incrementAndGet();
         if (queueSize > context.getMessageQueueSizePerDeviceLimit()) {
             log.warn("Closing current session because msq queue size for device {} exceed limit {} with msgQueueSize counter {} and actual queue size {}",
@@ -262,7 +262,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         }
     }
 
-    private void processRegularSessionMsg(ChannelHandlerContext ctx, MqttMessage msg) {
+    void processRegularSessionMsg(ChannelHandlerContext ctx, MqttMessage msg) {
         switch (msg.fixedHeader().messageType()) {
             case PUBLISH:
                 processPublish(ctx, (MqttPublishMessage) msg);
@@ -627,7 +627,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         return new MqttMessage(mqttFixedHeader, mqttMessageIdVariableHeader);
     }
 
-    private void processConnect(ChannelHandlerContext ctx, MqttConnectMessage msg) {
+    void processConnect(ChannelHandlerContext ctx, MqttConnectMessage msg) {
         log.info("[{}] Processing connect msg for client: {}!", sessionId, msg.payload().clientIdentifier());
         String userName = msg.payload().userName();
         String clientId = msg.payload().clientIdentifier();
@@ -713,7 +713,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         return null;
     }
 
-    private void processDisconnect(ChannelHandlerContext ctx) {
+    void processDisconnect(ChannelHandlerContext ctx) {
         ctx.close();
         log.info("[{}] Client disconnected!", sessionId);
         doDisconnect();

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -177,7 +177,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         } else if (deviceSessionCtx.isProvisionOnly()) {
             processProvisionSessionMsg(ctx, msg);
         } else {
-            processRegularSessionMsg(ctx, msg);
+            enqueueRegularSessionMsg(ctx, msg);
         }
     }
 
@@ -220,6 +220,41 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                     processDisconnect(ctx);
                 }
                 break;
+        }
+    }
+
+    private void enqueueRegularSessionMsg(ChannelHandlerContext ctx, MqttMessage msg) {
+        final int queueSize = deviceSessionCtx.getMsgQueueSize().incrementAndGet();
+        if (queueSize >= context.getMessageQueueSizePerDeviceLimit()) {
+            log.warn("Closing current session because msq queue size for device {} exceed limit {} with msgQueueSize counter {} and actual queue size {}",
+                    deviceSessionCtx.getDeviceId(), context.getMessageQueueSizePerDeviceLimit(), queueSize, deviceSessionCtx.getMsgQueue().size());
+            ctx.close();
+            return;
+        }
+
+        deviceSessionCtx.getMsgQueue().add(msg);
+        processMsgQueue(ctx); //Under the normal conditions the msg queue will contain 0 messages. Many messages will be processed on device connect event in separate thread pool
+    }
+
+    private void processMsgQueue(ChannelHandlerContext ctx) {
+        if (!deviceSessionCtx.isConnected()) {
+            log.trace("[{}][{}] Postpone processing msg due to device is not connected. Msg queue size is {}", sessionId, deviceSessionCtx.getDeviceId(), deviceSessionCtx.getMsgQueue().size());
+            return;
+        }
+        while (!deviceSessionCtx.getMsgQueue().isEmpty()) {
+            if (deviceSessionCtx.getMsgQueueProcessorLock().tryLock()) {
+                try {
+                    MqttMessage msg;
+                    while ((msg = deviceSessionCtx.getMsgQueue().poll()) != null) {
+                        deviceSessionCtx.getMsgQueueSize().decrementAndGet();
+                        processRegularSessionMsg(ctx, msg);
+                    }
+                } finally {
+                    deviceSessionCtx.getMsgQueueProcessorLock().unlock();
+                }
+            } else {
+                return;
+            }
         }
     }
 
@@ -761,6 +796,11 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
             }
             deviceSessionCtx.setDisconnected();
         }
+
+        if (!deviceSessionCtx.getMsgQueue().isEmpty()) {
+            log.warn("doDisconnect for device {} but unprocessed messages {} left in the msg queue", deviceSessionCtx.getDeviceId(), deviceSessionCtx.getMsgQueue().size());
+            deviceSessionCtx.getMsgQueue().clear();
+        }
     }
 
 
@@ -778,7 +818,9 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                     SessionMetaData sessionMetaData = transportService.registerAsyncSession(deviceSessionCtx.getSessionInfo(), MqttTransportHandler.this);
                     checkGatewaySession(sessionMetaData);
                     ctx.writeAndFlush(createMqttConnAckMsg(CONNECTION_ACCEPTED, connectMessage));
+                    deviceSessionCtx.setConnected(true);
                     log.info("[{}] Client connected!", sessionId);
+                    context.getMsqProcessorExecutor().execute(()->processMsgQueue(ctx));
                 }
 
                 @Override

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -824,7 +824,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                     ctx.writeAndFlush(createMqttConnAckMsg(CONNECTION_ACCEPTED, connectMessage));
                     deviceSessionCtx.setConnected(true);
                     log.info("[{}] Client connected!", sessionId);
-                    processMsgQueue(ctx);
+                    transportService.getCallbackExecutor().execute(() -> processMsgQueue(ctx)); //this callback will execute in Producer worker thread and hard or blocking work have to be submitted to the separate thread.
                 }
 
                 @Override

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -229,7 +229,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
 
     private void enqueueRegularSessionMsg(ChannelHandlerContext ctx, MqttMessage msg) {
         final int queueSize = deviceSessionCtx.getMsgQueueSize().incrementAndGet();
-        if (queueSize >= context.getMessageQueueSizePerDeviceLimit()) {
+        if (queueSize > context.getMessageQueueSizePerDeviceLimit()) {
             log.warn("Closing current session because msq queue size for device {} exceed limit {} with msgQueueSize counter {} and actual queue size {}",
                     deviceSessionCtx.getDeviceId(), context.getMessageQueueSizePerDeviceLimit(), queueSize, deviceSessionCtx.getMsgQueue().size());
             ctx.close();

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/DeviceSessionCtx.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/DeviceSessionCtx.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.transport.mqtt.session;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttMessage;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -35,8 +36,11 @@ import org.thingsboard.server.transport.mqtt.util.MqttTopicFilter;
 import org.thingsboard.server.transport.mqtt.util.MqttTopicFilterFactory;
 
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * @author Andrew Shvayka
@@ -45,12 +49,22 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class DeviceSessionCtx extends MqttDeviceAwareSessionContext {
 
     @Getter
+    @Setter
     private ChannelHandlerContext channel;
 
     @Getter
-    private MqttTransportContext context;
+    private final MqttTransportContext context;
 
     private final AtomicInteger msgIdSeq = new AtomicInteger(0);
+
+    @Getter
+    private final ConcurrentLinkedQueue<MqttMessage> msgQueue = new ConcurrentLinkedQueue<>();
+
+    @Getter
+    private final Lock msgQueueProcessorLock = new ReentrantLock();
+
+    @Getter
+    private final AtomicInteger msgQueueSize = new AtomicInteger(0);
 
     @Getter
     @Setter
@@ -71,10 +85,6 @@ public class DeviceSessionCtx extends MqttDeviceAwareSessionContext {
     public DeviceSessionCtx(UUID sessionId, ConcurrentMap<MqttTopicMatcher, Integer> mqttQoSMap, MqttTransportContext context) {
         super(sessionId, mqttQoSMap);
         this.context = context;
-    }
-
-    public void setChannel(ChannelHandlerContext channel) {
-        this.channel = channel;
     }
 
     public int nextMsgId() {

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewayDeviceSessionCtx.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewayDeviceSessionCtx.java
@@ -60,6 +60,7 @@ public class GatewayDeviceSessionCtx extends MqttDeviceAwareSessionContext imple
                 .setDeviceProfileIdLSB(deviceInfo.getDeviceProfileId().getId().getLeastSignificantBits())
                 .build());
         setDeviceInfo(deviceInfo);
+        setConnected(true);
         setDeviceProfile(deviceProfile);
         this.transportService = transportService;
     }

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.mqtt;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.EmptyByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttConnectPayload;
+import io.netty.handler.codec.mqtt.MqttConnectVariableHeader;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.ssl.SslHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.thingsboard.common.util.ThingsBoardThreadFactory;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@Slf4j
+@RunWith(MockitoJUnitRunner.class)
+public class MqttTransportHandlerTest {
+
+    public static final int MSG_QUEUE_LIMIT = 10;
+    public static final InetSocketAddress IP_ADDR = new InetSocketAddress("127.0.0.1", 9876);
+    public static final int TIMEOUT = 30;
+
+    @Mock
+    MqttTransportContext context;
+    @Mock
+    SslHandler sslHandler;
+    @Mock
+    ChannelHandlerContext ctx;
+
+    AtomicInteger packedId = new AtomicInteger();
+    ExecutorService executor;
+    MqttTransportHandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+        willReturn(MSG_QUEUE_LIMIT).given(context).getMessageQueueSizePerDeviceLimit();
+
+        handler = spy(new MqttTransportHandler(context, sslHandler));
+        willReturn(IP_ADDR).given(handler).getAddress(any());
+    }
+
+    @After
+    public void tearDown() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void givenMessageWithoutFixedHeader_whenProcessMqttMsg_thenProcessDisconnect() {
+        MqttFixedHeader mqttFixedHeader = null;
+        MqttMessage msg = new MqttMessage(mqttFixedHeader);
+        willDoNothing().given(handler).processDisconnect(ctx);
+
+        handler.processMqttMsg(ctx, msg);
+
+        assertThat(handler.address, is(IP_ADDR));
+        verify(handler, times(1)).processDisconnect(ctx);
+    }
+
+    MqttConnectMessage getMqttConnectMessage() {
+        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.CONNECT, true, MqttQoS.AT_LEAST_ONCE, false, 123);
+        MqttConnectVariableHeader variableHeader = new MqttConnectVariableHeader("device", packedId.incrementAndGet(), true, true, true, 1, true, false, 60);
+        MqttConnectPayload payload = new MqttConnectPayload("clientId", "topic", "message".getBytes(StandardCharsets.UTF_8), "username", "password".getBytes(StandardCharsets.UTF_8));
+        return new MqttConnectMessage(mqttFixedHeader, variableHeader, payload);
+    }
+
+    MqttPublishMessage getMqttPublishMessage() {
+        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, true, MqttQoS.AT_LEAST_ONCE, false, 123);
+        MqttPublishVariableHeader variableHeader = new MqttPublishVariableHeader("v1/gateway/telemetry", packedId.incrementAndGet());
+        ByteBuf payload = new EmptyByteBuf(new PooledByteBufAllocator());
+        return new MqttPublishMessage(mqttFixedHeader, variableHeader, payload);
+    }
+
+    @Test
+    public void givenMqttConnectMessage_whenProcessMqttMsg_thenProcessConnect() {
+        MqttConnectMessage msg = getMqttConnectMessage();
+        willDoNothing().given(handler).processConnect(ctx, msg);
+
+        handler.processMqttMsg(ctx, msg);
+
+        assertThat(handler.address, is(IP_ADDR));
+        assertThat(handler.deviceSessionCtx.getChannel(), is(ctx));
+        verify(handler, never()).processDisconnect(any());
+        verify(handler, times(1)).processConnect(ctx, msg);
+    }
+
+    @Test
+    public void givenQueueLimit_whenEnqueueRegularSessionMsgOverLimit_thenOK() {
+        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(MSG_QUEUE_LIMIT).collect(Collectors.toList());
+        messages.forEach(msg -> handler.enqueueRegularSessionMsg(ctx, msg));
+        assertThat(handler.deviceSessionCtx.getMsgQueueSize().get(), is(MSG_QUEUE_LIMIT));
+        assertThat(handler.deviceSessionCtx.getMsgQueue(), contains(messages.toArray()));
+    }
+
+    @Test
+    public void givenQueueLimit_whenEnqueueRegularSessionMsgOverLimit_thenCtxClose() {
+        final int limit = MSG_QUEUE_LIMIT + 1;
+        willDoNothing().given(handler).processMsgQueue(ctx);
+        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(limit).collect(Collectors.toList());
+
+        messages.forEach((msg) -> handler.enqueueRegularSessionMsg(ctx, msg));
+
+        assertThat(handler.deviceSessionCtx.getMsgQueueSize().get(), is(limit));
+        verify(handler, times(limit)).enqueueRegularSessionMsg(any(), any());
+        verify(handler, times(MSG_QUEUE_LIMIT)).processMsgQueue(any());
+        verify(ctx, times(1)).close();
+    }
+
+    @Test
+    public void givenMqttConnectMessageAndPublishImmediately_whenProcessMqttMsg_thenEnqueueRegularSessionMsg() {
+        givenMqttConnectMessage_whenProcessMqttMsg_thenProcessConnect();
+
+        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(MSG_QUEUE_LIMIT).collect(Collectors.toList());
+
+        messages.forEach((msg) -> handler.processMqttMsg(ctx, msg));
+
+        assertThat(handler.address, is(IP_ADDR));
+        assertThat(handler.deviceSessionCtx.getChannel(), is(ctx));
+        assertThat(handler.deviceSessionCtx.getMsgQueueSize().get(), is(MSG_QUEUE_LIMIT));
+        assertThat(handler.deviceSessionCtx.getMsgQueue(), contains(messages.toArray()));
+        verify(handler, never()).processDisconnect(any());
+        verify(handler, times(1)).processConnect(any(), any());
+        verify(handler, times(MSG_QUEUE_LIMIT)).enqueueRegularSessionMsg(any(), any());
+        messages.forEach((msg) -> verify(handler, times(1)).enqueueRegularSessionMsg(ctx, msg));
+    }
+
+    @Test
+    public void givenMessageQueue_whenProcessMqttMsg_thenEnqueueRegularSessionMsg() throws InterruptedException {
+        //given
+        assertThat(handler.deviceSessionCtx.isConnected(), is(false));
+        assertThat(MSG_QUEUE_LIMIT, greaterThan(2));
+        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(MSG_QUEUE_LIMIT).collect(Collectors.toList());
+        messages.forEach((msg) -> handler.enqueueRegularSessionMsg(ctx, msg));
+        willDoNothing().given(handler).processRegularSessionMsg(any(), any());
+        executor = Executors.newCachedThreadPool(ThingsBoardThreadFactory.forName(getClass().getName()));
+
+        CountDownLatch readyLatch = new CountDownLatch(MSG_QUEUE_LIMIT);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch finishLatch = new CountDownLatch(MSG_QUEUE_LIMIT);
+
+        Stream.iterate(0, i -> i + 1).limit(MSG_QUEUE_LIMIT).forEach(x ->
+                executor.submit(() -> {
+                    try {
+                        readyLatch.countDown();
+                        assertThat(startLatch.await(TIMEOUT, TimeUnit.SECONDS), is(true));
+                        handler.processMsgQueue(ctx);
+                        finishLatch.countDown();
+                    } catch (Exception e) {
+                        log.error("Failed to run processMsgQueue", e);
+                        fail("Failed to run processMsgQueue");
+                    }
+                }));
+
+        //when
+        assertThat(readyLatch.await(TIMEOUT, TimeUnit.SECONDS), is(true));
+        handler.deviceSessionCtx.setConnected(true);
+        startLatch.countDown();
+        assertThat(finishLatch.await(TIMEOUT, TimeUnit.SECONDS), is(true));
+
+        //then
+        assertThat(handler.deviceSessionCtx.getMsgQueueSize().get(), is(0));
+        assertThat(handler.deviceSessionCtx.getMsgQueue(), empty());
+        verify(handler, times(MSG_QUEUE_LIMIT)).processRegularSessionMsg(any(), any());
+        messages.forEach((msg) -> verify(handler, times(1)).processRegularSessionMsg(ctx, msg));
+    }
+
+}

--- a/common/transport/snmp/src/main/java/org/thingsboard/server/transport/snmp/SnmpTransportContext.java
+++ b/common/transport/snmp/src/main/java/org/thingsboard/server/transport/snmp/SnmpTransportContext.java
@@ -188,6 +188,7 @@ public class SnmpTransportContext extends TransportContext {
 
                             deviceSessionContext.setSessionInfo(sessionInfo);
                             deviceSessionContext.setDeviceInfo(msg.getDeviceInfo());
+                            deviceSessionContext.setConnected(true);
                         } else {
                             log.warn("[{}] Failed to process device auth", deviceSessionContext.getDeviceId());
                         }

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/TransportService.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/TransportService.java
@@ -56,6 +56,8 @@ import org.thingsboard.server.gen.transport.TransportProtos.ValidateDeviceLwM2MC
 import org.thingsboard.server.gen.transport.TransportProtos.ValidateDeviceTokenRequestMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.ValidateDeviceX509CertRequestMsg;
 
+import java.util.concurrent.ExecutorService;
+
 /**
  * Created by ashvayka on 04.10.18.
  */
@@ -131,4 +133,6 @@ public interface TransportService {
     void log(SessionInfoProto sessionInfo, String msg);
 
     void notifyAboutUplink(SessionInfoProto sessionInfo, TransportProtos.UplinkNotificationMsg build, TransportServiceCallback<Void> empty);
+
+    ExecutorService getCallbackExecutor();
 }

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
@@ -1141,4 +1141,9 @@ public class DefaultTransportService implements TransportService {
             callback.onError(e);
         }
     }
+
+    @Override
+    public ExecutorService getCallbackExecutor() {
+        return transportCallbackExecutor;
+    }
 }

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/session/DeviceAwareSessionContext.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/session/DeviceAwareSessionContext.java
@@ -46,6 +46,7 @@ public abstract class DeviceAwareSessionContext implements SessionContext {
     @Setter
     private volatile TransportProtos.SessionInfoProto sessionInfo;
 
+    @Setter
     private volatile boolean connected;
 
     public DeviceId getDeviceId() {
@@ -54,7 +55,6 @@ public abstract class DeviceAwareSessionContext implements SessionContext {
 
     public void setDeviceInfo(TransportDeviceInfo deviceInfo) {
         this.deviceInfo = deviceInfo;
-        this.connected = true;
         this.deviceId = deviceInfo.getDeviceId();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1382,6 +1382,12 @@
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-netty</artifactId>
                 <version>${grpc.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.grpc</groupId>
@@ -1580,6 +1586,12 @@
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-servicebus</artifactId>
                 <version>${azure-servicebus.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.passay</groupId>

--- a/transport/mqtt/src/main/resources/tb-mqtt-transport.yml
+++ b/transport/mqtt/src/main/resources/tb-mqtt-transport.yml
@@ -89,7 +89,7 @@ transport:
     bind_address: "${MQTT_BIND_ADDRESS:0.0.0.0}"
     bind_port: "${MQTT_BIND_PORT:1883}"
     timeout: "${MQTT_TIMEOUT:10000}"
-    msg_queue_size_per_device_limit: "${MQTT_MSG_QUEUE_SIZE_PER_DEVICE_LIMIT:10000}" # messages await in the queue before device connected state. This limit works on low level before TenantProfileLimits mechanism
+    msg_queue_size_per_device_limit: "${MQTT_MSG_QUEUE_SIZE_PER_DEVICE_LIMIT:100}" # messages await in the queue before device connected state. This limit works on low level before TenantProfileLimits mechanism
     netty:
       leak_detector_level: "${NETTY_LEAK_DETECTOR_LVL:DISABLED}"
       boss_group_thread_count: "${NETTY_BOSS_GROUP_THREADS:1}"

--- a/transport/mqtt/src/main/resources/tb-mqtt-transport.yml
+++ b/transport/mqtt/src/main/resources/tb-mqtt-transport.yml
@@ -89,6 +89,7 @@ transport:
     bind_address: "${MQTT_BIND_ADDRESS:0.0.0.0}"
     bind_port: "${MQTT_BIND_PORT:1883}"
     timeout: "${MQTT_TIMEOUT:10000}"
+    msg_queue_size_per_device_limit: "${MQTT_MSG_QUEUE_SIZE_PER_DEVICE_LIMIT:10000}" # messages await in the queue before device connected state. This limit works on low level before TenantProfileLimits mechanism
     netty:
       leak_detector_level: "${NETTY_LEAK_DETECTOR_LVL:DISABLED}"
       boss_group_thread_count: "${NETTY_BOSS_GROUP_THREADS:1}"


### PR DESCRIPTION
Its a continue of https://github.com/thingsboard/thingsboard/pull/5001
During the testing, I found that netty dependency has many versions and unit tests get Implementation from version 66. but Interface from 45. This cause 
```
SLF4J: Failed toString() invocation on an object of type [io.netty.handler.codec.mqtt.MqttPublishMessage]
java.lang.NoSuchMethodError: 'io.netty.buffer.ByteBuf io.netty.buffer.ByteBufUtil.ensureAccessible(io.netty.buffer.ByteBuf)'
```
To test perfectly, we need to add a blackbox test for:
* grpc integration
* azure-servicebus https://github.com/azure/azurite
https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&tabs=docker-hub
![image](https://user-images.githubusercontent.com/79898499/128053658-48d63872-29d0-463c-80ec-1961d2603236.png)
