### PR TITLE
[3.3.0] fixed warn message on startup: Rule Chains initialized by unexpected message: PartitionChangeMsg ...

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
@@ -55,7 +55,7 @@ public class AppActor extends ContextAwareActor {
     private final TbTenantProfileCache tenantProfileCache;
     private final TenantService tenantService;
     private final Set<TenantId> deletedTenants;
-    private boolean ruleChainsInitialized;
+    private volatile boolean ruleChainsInitialized;
 
     private AppActor(ActorSystemContext systemContext) {
         super(systemContext);
@@ -69,7 +69,7 @@ public class AppActor extends ContextAwareActor {
         if (!ruleChainsInitialized) {
             initTenantActors();
             ruleChainsInitialized = true;
-            if (msg.getMsgType() != MsgType.APP_INIT_MSG) {
+            if (msg.getMsgType() != MsgType.APP_INIT_MSG && msg.getMsgType() != MsgType.PARTITION_CHANGE_MSG) {
                 log.warn("Rule Chains initialized by unexpected message: {}", msg);
             }
         }


### PR DESCRIPTION
Fixed warn message on startup: 
```
2021-08-04 05:10:06,204 [app-dispatcher-3578-thread-1] WARN  o.t.server.actors.app.AppActor - Rule Chains initialized by unexpected message: PartitionChangeMsg(serviceQueueKey=ServiceQueueKey(serviceQueue=ServiceQueue(type=TB_CORE, queue=Main), tenantId=13814000-1dd2-11b2-8080-808080808080), partitions=[TopicPartitionInfo(topic=tb_core, tenantId=Optional.empty, partition=Optional[5], fullTopicName=tb_core.5, myPartition=true), TopicPartitionInfo(topic=tb_core, tenantId=Optional.empty, partition=Optional[6], fullTopicName=tb_core.6, myPartition=true), TopicPartitionInfo(topic=tb_core, tenantId=Optional.empty, partition=Optional[3], fullTopicName=tb_core.3, myPartition=true), TopicPartitionInfo(topic=tb_core, tenantId=Optional.empty, partition=Optional[4], fullTopicName=tb_core.4, myPartition=true), TopicPartitionInfo(topic=tb_core, tenantId=Optional.empty, partition=Optional[1], fullTopicName=tb_core.1, myPartition=true), TopicPartitionInfo(topic=tb_core, tenantId=Optional.empty, partition=Optional[2], fullTopicName=tb_core.2, myPartition=true), TopicPartitionInfo(topic=tb_core, tenantId=Optional.empty, partition=Optional[0], fullTopicName=tb_core.0, myPartition=true), TopicPartitionInfo(topic=tb_core, tenantId=Optional.empty, partition=Optional[9], fullTopicName=tb_core.9, myPartition=true), TopicPartitionInfo(topic=tb_core, tenantId=Optional.empty, partition=Optional[7], fullTopicName=tb_core.7, myPartition=true), TopicPartitionInfo(topic=tb_core, tenantId=Optional.empty, partition=Optional[8], fullTopicName=tb_core.8, myPartition=true)])
```