### PR TITLE
[3.3.1] UI: changed slider thumbnail size

### DIFF
--- a/ui-ngx/src/app/shared/components/time/timewindow-panel.component.scss
+++ b/ui-ngx/src/app/shared/components/time/timewindow-panel.component.scss
@@ -79,4 +79,10 @@
       }
     }
   }
+  .mat-slider-horizontal .mat-slider-thumb-label {
+    width: 38px;
+    height: 38px;
+    top: -46px;
+    right: -19px;
+  }
 }


### PR DESCRIPTION
Made timewindow panel max values slider thumbnail bigger, so numbers value fits in now