### PR TITLE
Fix: resources-library page can't be redirected

### DIFF
--- a/ui-ngx/src/app/core/services/menu.service.ts
+++ b/ui-ngx/src/app/core/services/menu.service.ts
@@ -219,7 +219,7 @@ export class MenuService {
           {
             name: 'resource.resources-library',
             icon: 'folder',
-            path: '/resources-library'
+            path: '/settings/resources-library'
           }
         ]
       }


### PR DESCRIPTION
In SysAdmin HomePage, "resources-library" page can't be redirected