### PR TITLE
[3.3.2]lwm2m: fix bug execute

### DIFF
--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportUtil.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportUtil.java
@@ -23,8 +23,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.leshan.core.attributes.Attribute;
 import org.eclipse.leshan.core.attributes.AttributeSet;
+import org.eclipse.leshan.core.model.LwM2mModel;
+import org.eclipse.leshan.core.model.ObjectLoader;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
+import org.eclipse.leshan.core.model.StaticModel;
 import org.eclipse.leshan.core.node.LwM2mMultipleResource;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
@@ -520,6 +523,10 @@ public class LwM2mTransportUtil {
     private static String opaqueToString(byte[] value) {
         String opaque = Hex.encodeHexString(value);
         return opaque.length() > 1024 ? opaque.substring(0, 1024) : opaque;
+    }
+
+    public static LwM2mModel createModelsDefault() {
+        return new StaticModel(ObjectLoader.loadDefault());
     }
 
 }


### PR DESCRIPTION
RPC, Operation - Execute
If ResourceModel with idVer is absent in system
- ResourceModel used from system :
- - version 1.1:
new String[] { "0-1_0.xml", "0-1_1.xml", "1-1_0.xml", "1-1_1.xml", "2-1_0.xml",
                            "3-1_0.xml", "3-1_1.xml", "4-1_0.xml", "4-1_1.xml", "4-1_2.xml", "5-1_0.xml", "6.xml",
                            "7.xml", "21-1_0.xml", };

Only If ResourceModel - is executable