### PR TITLE
Rule chain actor message processor on tell next NullPointerException fix

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/ruleChain/RuleChainActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/ruleChain/RuleChainActorMessageProcessor.java
@@ -283,6 +283,7 @@ public class RuleChainActorMessageProcessor extends ComponentMsgProcessor<RuleCh
         } catch (RuleNodeException rne) {
             msg.getCallback().onFailure(rne);
         } catch (Exception e) {
+            log.warn("[" + tenantId + "]" + "[" + entityId + "]" + "[" + msg.getId() + "]" + " onTellNext failure", e);
             msg.getCallback().onFailure(new RuleEngineException("onTellNext - " + e.getMessage()));
         }
     }

--- a/application/src/main/java/org/thingsboard/server/actors/ruleChain/RuleChainActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/ruleChain/RuleChainActorMessageProcessor.java
@@ -250,10 +250,17 @@ public class RuleChainActorMessageProcessor extends ComponentMsgProcessor<RuleCh
             checkActive(msg);
             EntityId entityId = msg.getOriginator();
             TopicPartitionInfo tpi = systemContext.resolve(ServiceType.TB_RULE_ENGINE, msg.getQueueName(), tenantId, entityId);
-            List<RuleNodeRelation> relations = nodeRoutes.get(originatorNodeId).stream()
+
+            List<RuleNodeRelation> ruleNodeRelations = nodeRoutes.get(originatorNodeId);
+            if (ruleNodeRelations == null) { // When unchecked, this will cause NullPointerException when rule node doesn't exist anymore
+                log.warn("[{}][{}][{}] No outbound relations (null). Probably rule node does not exist. Probably old message.", tenantId, entityId, msg.getId());
+                ruleNodeRelations = Collections.emptyList();
+            }
+
+            List<RuleNodeRelation> relationsByTypes = ruleNodeRelations.stream()
                     .filter(r -> contains(relationTypes, r.getType()))
                     .collect(Collectors.toList());
-            int relationsCount = relations.size();
+            int relationsCount = relationsByTypes.size();
             if (relationsCount == 0) {
                 log.trace("[{}][{}][{}] No outbound relations to process", tenantId, entityId, msg.getId());
                 if (relationTypes.contains(TbRelationTypes.FAILURE)) {
@@ -268,14 +275,14 @@ public class RuleChainActorMessageProcessor extends ComponentMsgProcessor<RuleCh
                     msg.getCallback().onSuccess();
                 }
             } else if (relationsCount == 1) {
-                for (RuleNodeRelation relation : relations) {
+                for (RuleNodeRelation relation : relationsByTypes) {
                     log.trace("[{}][{}][{}] Pushing message to single target: [{}]", tenantId, entityId, msg.getId(), relation.getOut());
                     pushToTarget(tpi, msg, relation.getOut(), relation.getType());
                 }
             } else {
                 MultipleTbQueueTbMsgCallbackWrapper callbackWrapper = new MultipleTbQueueTbMsgCallbackWrapper(relationsCount, msg.getCallback());
-                log.trace("[{}][{}][{}] Pushing message to multiple targets: [{}]", tenantId, entityId, msg.getId(), relations);
-                for (RuleNodeRelation relation : relations) {
+                log.trace("[{}][{}][{}] Pushing message to multiple targets: [{}]", tenantId, entityId, msg.getId(), relationsByTypes);
+                for (RuleNodeRelation relation : relationsByTypes) {
                     EntityId target = relation.getOut();
                     putToQueue(tpi, msg, callbackWrapper, target);
                 }


### PR DESCRIPTION
The issue was the Main queue was blocked (infinite repeat strategy) due to message tried to tellNext by relations [Success] ,
but rule node already deleted and get relations was already instead some collection. this fires NullPointerException.
The only workaround is to delete and import the rulechain (rule chain id performs mush earlier than this issue appears)

The message that cause error:
`2021-09-01 14:58:01,312 [rule-dispatcher-1-1] DEBUG o.t.server.actors.TbActorMailbox - [RULE_CHAIN|81c3ebc0-2362-11eb-9d7b-05919825a1a8] Going to process message: QueueToRuleEngineMsg(tenantId=4360dc00-849b-11ea-b908-fb276498eb8c, relationTypes=[Success], failureMessage=)`

`2021-09-01 14:58:01,312 [rule-dispatcher-1-1] TRACE o.t.s.a.r.RuleChainActorMessageProcessor - [81c3ebc0-2362-11eb-9d7b-05919825a1a8][ecc26390-5a2e-11eb-91a2-01dc71e02f16] Processing message [0d83f617-f296-42c6-b453-45e225ad4d4f]: TbMsg(queueName=Main, id=0d83f617-f296-42c6-b453-45e225ad4d4f, ts=1630455657372, type=POST_TELEMETRY_REQUEST, originator=250ab3f0-5a3f-11eb-91a2-01dc71e02f16, metaData=TbMsgMetaData(data={ts=1630455657250}), dataType=JSON, data={"tAlarmsCount":0,"mcAlarmsCount":0,"mcAlarmsCount3":0,"tAlarmsCount9":0}, ruleChainId=81c3ebc0-2362-11eb-9d7b-05919825a1a8, ruleNodeId=956190a0-71c4-11eb-b285-1523f5ed8108, ruleNodeExecCounter=0, deadline=1297559474442602, callback=org.thingsboard.server.service.queue.TbMsgPackCallback@17a037db)`

`2021-09-01 14:58:01,312 [rule-dispatcher-1-1] WARN  o.t.s.a.r.RuleChainActorMessageProcessor - [4360dc00-849b-11ea-b908-fb276498eb8c][81c3ebc0-2362-11eb-9d7b-05919825a1a8][0d83f617-f296-42c6-b453-45e225ad4d4f] onTellNext failure
java.lang.NullPointerException: null
`

**SQL**:
Is rule chain exists? Yes!
`SELECT count(*) FROM rule_chain rc  WHERE rc.id='81c3ebc0-2362-11eb-9d7b-05919825a1a8'`
![image](https://user-images.githubusercontent.com/79898499/131705486-9b5a12f0-e7e0-4941-bf5b-ef7e9cb0cf17.png)

**Is rule node exist? No!**
`SELECT rc.name rc, rn.name rn FROM rule_node rn LEFT JOIN rule_chain rc ON rn.rule_chain_id = rc.id
    WHERE rn.id = '956190a0-71c4-11eb-b285-1523f5ed8108'`
![image](https://user-images.githubusercontent.com/79898499/131705797-858d4fe2-3bb8-4e28-bc7a-442816632227.png)


![image](https://user-images.githubusercontent.com/79898499/131704510-df9303ba-4c72-4253-b14f-0b49daf45b2a.png)

The result: processing is unblocked!
![image](https://user-images.githubusercontent.com/79898499/131706536-95081e92-32be-477f-883e-747ccc8b5a9a.png)
