### PR TITLE
[3.3.2] NullPointerException after upgrading device profiles from 3.2.2 to 3.3.0

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/install/update/DefaultDataUpdateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/update/DefaultDataUpdateService.java
@@ -150,22 +150,22 @@ public class DefaultDataUpdateService implements DataUpdateService {
                     if (deviceProfile.getProfileData().has("alarms") &&
                             !deviceProfile.getProfileData().get("alarms").isNull()) {
                         boolean isUpdated = false;
-                        JsonNode array = deviceProfile.getProfileData().get("alarms");
-                        for (JsonNode node : array) {
-                            if (node.has("createRules")) {
-                                JsonNode createRules = node.get("createRules");
+                        JsonNode alarms = deviceProfile.getProfileData().get("alarms");
+                        for (JsonNode alarm : alarms) {
+                            if (alarm.has("createRules")) {
+                                JsonNode createRules = alarm.get("createRules");
                                 for (AlarmSeverity severity : AlarmSeverity.values()) {
                                     if (createRules.has(severity.name())) {
                                         JsonNode spec = createRules.get(severity.name()).get("condition").get("spec");
-                                        boolean convertResult = convertDeviceProfileAlarmRulesForVersion330(spec);
-                                        isUpdated = convertResult || isUpdated;
+                                        if (convertDeviceProfileAlarmRulesForVersion330(spec))
+                                            isUpdated = true;
                                     }
                                 }
                             }
-                            if (node.has("clearRule") && !node.get("clearRule").isNull()) {
-                                JsonNode spec = node.get("clearRule").get("condition").get("spec");
-                                boolean convertResult = convertDeviceProfileAlarmRulesForVersion330(spec);
-                                isUpdated = convertResult || isUpdated;
+                            if (alarm.has("clearRule") && !alarm.get("clearRule").isNull()) {
+                                JsonNode spec = alarm.get("clearRule").get("condition").get("spec");
+                                if (convertDeviceProfileAlarmRulesForVersion330(spec))
+                                    isUpdated = true;
                             }
                         }
                         if (isUpdated) {

--- a/application/src/main/java/org/thingsboard/server/service/install/update/DefaultDataUpdateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/update/DefaultDataUpdateService.java
@@ -156,12 +156,16 @@ public class DefaultDataUpdateService implements DataUpdateService {
                                 JsonNode createRules = node.get("createRules");
                                 for (AlarmSeverity severity : AlarmSeverity.values()) {
                                     if (createRules.has(severity.name())) {
-                                        isUpdated = isUpdated || convertDeviceProfileAlarmRulesForVersion330(createRules.get(severity.name()).get("condition").get("spec"));
+                                        JsonNode spec = createRules.get(severity.name()).get("condition").get("spec");
+                                        boolean convertResult = convertDeviceProfileAlarmRulesForVersion330(spec);
+                                        isUpdated = convertResult || isUpdated;
                                     }
                                 }
                             }
                             if (node.has("clearRule") && !node.get("clearRule").isNull()) {
-                                isUpdated = isUpdated || convertDeviceProfileAlarmRulesForVersion330(node.get("clearRule").get("condition").get("spec"));
+                                JsonNode spec = node.get("clearRule").get("condition").get("spec");
+                                boolean convertResult = convertDeviceProfileAlarmRulesForVersion330(spec);
+                                isUpdated = convertResult || isUpdated;
                             }
                         }
                         if (isUpdated) {


### PR DESCRIPTION
NullPointerException was caused by wrong upgrading of Device Profile and its profile_data json from 3.2.2 to 3.3.0. Only the first alarm was affected, the others received null as value of "predicate" property.
In the first case `boolean isUpdated = false;` initialized before the cycle and changed inside it by the next equation:
`isUpdated = isUpdated || convertDeviceProfileAlarmRulesForVersion330(createRules.get(severity.name()).get("condition").get("spec"));`
variable `isUpdated` always remained true after the first execution of `convertDeviceProfileAlarmRulesForVersion330(...)` method and this method wouldn't be executed again.