### PR TITLE
[3.3.2] Fix checkbox Inherit from owner Device Profile Alarm Rules

### DIFF
--- a/ui-ngx/src/app/modules/home/components/profile/alarm/alarm-duration-predicate-value.component.ts
+++ b/ui-ngx/src/app/modules/home/components/profile/alarm/alarm-duration-predicate-value.component.ts
@@ -127,6 +127,8 @@ export class AlarmDurationPredicateValueComponent implements ControlValueAccesso
         inherit: predicateValue?.dynamicValue ? predicateValue.dynamicValue.inherit : null
       }
     }, {emitEvent: false});
+
+    this.updateShowInheritMode(this.alarmDurationPredicateValueFormGroup.get('dynamicValue').get('sourceType').value);
   }
 
   private updateModel() {


### PR DESCRIPTION
Edit alarm rule condition (icon - pencil) or view alarm rule condition, press button "(X)" Switch to dynamic value - not displayed the checkbox "Inherit from owner"
![image](https://user-images.githubusercontent.com/83352633/133589599-a8819afd-3065-43c4-bc78-6ec1681d1543.png)
Fix:
![Screenshot from 2021-09-16 12-48-08](https://user-images.githubusercontent.com/83352633/133590723-723d2c74-49fa-412f-b1b8-d0fe5d318181.png)
