### PR TITLE
[3.2.2] Fixed multiple input widget sending double requests and saving required input by Enter keypress

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/multiple-input-widget.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/multiple-input-widget.component.html
@@ -108,7 +108,7 @@
       </div>
     </fieldset>
     <div class="mat-padding" fxLayout="row" fxLayoutAlign="end center"
-         *ngIf="entityDetected && settings.showActionButtons">
+         [fxShow]="entityDetected && settings.showActionButtons">
       <button mat-button color="primary" type="button"
               (click)="discardAll()" style="max-height: 50px; margin-right:20px;"
               [disabled]="!multipleInputFormGroup.dirty">

--- a/ui-ngx/src/app/modules/home/components/widget/lib/multiple-input-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/multiple-input-widget.component.ts
@@ -121,6 +121,8 @@ export class MultipleInputWidgetComponent extends PageComponent implements OnIni
 
   multipleInputFormGroup: FormGroup;
 
+  isSavingInProgress: boolean = false;
+
   toastTargetId = 'multiple-input-widget' + this.utils.guid();
 
   constructor(protected store: Store<AppState>,
@@ -466,7 +468,8 @@ export class MultipleInputWidgetComponent extends PageComponent implements OnIni
   }
 
   public inputChanged(source: MultipleInputWidgetSource, key: MultipleInputWidgetDataKey) {
-    if (!this.settings.showActionButtons) {
+    if (!this.settings.showActionButtons && !this.isSavingInProgress) {
+      this.isSavingInProgress = true;
       const currentValue = this.multipleInputFormGroup.get(key.formId).value;
       if (!key.settings.required || (key.settings.required && isDefined(currentValue))) {
         const dataToSave: MultipleInputWidgetSource = {
@@ -479,7 +482,8 @@ export class MultipleInputWidgetComponent extends PageComponent implements OnIni
   }
 
   public save(dataToSave?: MultipleInputWidgetSource) {
-    if (document && document.activeElement) {
+    if (document?.activeElement && !this.isSavingInProgress) {
+      this.isSavingInProgress = true;
       (document.activeElement as HTMLElement).blur();
     }
     const config: RequestConfig = {
@@ -569,6 +573,7 @@ export class MultipleInputWidgetComponent extends PageComponent implements OnIni
         () => {
           this.multipleInputFormGroup.markAsPristine();
           this.ctx.detectChanges();
+          this.isSavingInProgress = false;
           if (this.settings.showResultMessage) {
             this.ctx.showSuccessToast(this.translate.instant('widgets.input-widgets.update-successful'),
               1000, 'bottom', 'left', this.toastTargetId);
@@ -583,6 +588,7 @@ export class MultipleInputWidgetComponent extends PageComponent implements OnIni
     } else {
       this.multipleInputFormGroup.markAsPristine();
       this.ctx.detectChanges();
+      this.isSavingInProgress = false;
     }
   }
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/multiple-input-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/multiple-input-widget.component.ts
@@ -109,6 +109,7 @@ export class MultipleInputWidgetComponent extends PageComponent implements OnIni
   private datasources: Array<Datasource>;
   private destroy$ = new Subject();
   public sources: Array<MultipleInputWidgetSource> = [];
+  private isSavingInProgress = false;
 
   isVerticalAlignment: boolean;
   inputWidthSettings: string;
@@ -120,8 +121,6 @@ export class MultipleInputWidgetComponent extends PageComponent implements OnIni
   isAllParametersValid = true;
 
   multipleInputFormGroup: FormGroup;
-
-  isSavingInProgress: boolean = false;
 
   toastTargetId = 'multiple-input-widget' + this.utils.guid();
 
@@ -580,6 +579,7 @@ export class MultipleInputWidgetComponent extends PageComponent implements OnIni
           }
         },
         () => {
+          this.isSavingInProgress = false;
           if (this.settings.showResultMessage) {
             this.ctx.showErrorToast(this.translate.instant('widgets.input-widgets.update-failed'),
               'bottom', 'left', this.toastTargetId);


### PR DESCRIPTION
1) Saving required input field by Enter keypress if 'Show action buttons' disabled.
![image](https://user-images.githubusercontent.com/83352633/134016113-b89daba1-aed2-4efe-8b8d-b83d9cc2598a.png)
Fix: change ngIf on button block  to fxShow(for correct work Enter event)
2) Sending double requests by Enter keypress if 'Show action buttons' disabled.
![image](https://user-images.githubusercontent.com/83352633/134016524-a32ccaaf-fd24-4612-ad6f-eb708c26dba8.png)
![image](https://user-images.githubusercontent.com/83352633/134016899-79630087-8e70-4469-9490-61d1e3d45cf3.png)
Fix: add variable isSavingInProgress and write logic for correct submitting form if 'Show action buttons' disabled.

