### PR TITLE
[3.3.2] UI: Edge Downlinks table minor fixes

### DIFF
--- a/ui-ngx/src/app/core/http/entity.service.ts
+++ b/ui-ngx/src/app/core/http/entity.service.ts
@@ -83,7 +83,7 @@ import {
 import { alarmFields } from '@shared/models/alarm.models';
 import { OtaPackageService } from '@core/http/ota-package.service';
 import { EdgeService } from '@core/http/edge.service';
-import { Edge, EdgeEvent, EdgeEventType } from '@shared/models/edge.models';
+import { Edge, EdgeEvent, EdgeEventActionType, EdgeEventType } from '@shared/models/edge.models';
 import { RuleChainMetaData, RuleChainType } from '@shared/models/rule-chain.models';
 import { WidgetService } from '@core/http/widget.service';
 import { DeviceProfileService } from '@core/http/device-profile.service';
@@ -1391,6 +1391,7 @@ export class EntityService {
     let entityObservable: Observable<BaseData<HasId> | RuleChainMetaData | string>;
     const entityId: string = entity.entityId;
     const entityType: any = entity.type;
+    const entityAction: EdgeEventActionType = entity.action;
     switch (entityType) {
       case EdgeEventType.DASHBOARD:
       case EdgeEventType.ALARM:
@@ -1402,7 +1403,15 @@ export class EntityService {
       case EdgeEventType.ASSET:
       case EdgeEventType.DEVICE:
       case EdgeEventType.ENTITY_VIEW:
-        entityObservable = this.getEntity(entityType, entityId, { ignoreLoading: true, ignoreErrors: true });
+        if (entityAction === EdgeEventActionType.POST_ATTRIBUTES ||
+            entityAction === EdgeEventActionType.ATTRIBUTES_UPDATED ||
+            entityAction === EdgeEventActionType.ATTRIBUTES_DELETED ||
+            entityAction === EdgeEventActionType.TIMESERIES_UPDATED ||
+            entityAction === EdgeEventActionType.RPC_CALL) {
+          return of(entity.body);
+        } else {
+          entityObservable = this.getEntity(entityType, entityId, { ignoreLoading: true, ignoreErrors: true });
+        }
         break;
       case EdgeEventType.RULE_CHAIN_METADATA:
         entityObservable = this.ruleChainService.getRuleChainMetadata(entityId);

--- a/ui-ngx/src/app/core/http/entity.service.ts
+++ b/ui-ngx/src/app/core/http/entity.service.ts
@@ -1407,7 +1407,7 @@ export class EntityService {
       case EdgeEventType.ASSET:
       case EdgeEventType.DEVICE:
       case EdgeEventType.ENTITY_VIEW:
-        if (bodyContentEdgeEventActionTypes.indexOf(entity.action) > -1) {
+        if (bodyContentEdgeEventActionTypes.includes(entity.action)) {
           entityObservable = of(entity.body);
         } else {
           entityObservable = this.getEntity(entityType, entityId, { ignoreLoading: true, ignoreErrors: true });

--- a/ui-ngx/src/app/core/http/entity.service.ts
+++ b/ui-ngx/src/app/core/http/entity.service.ts
@@ -83,7 +83,12 @@ import {
 import { alarmFields } from '@shared/models/alarm.models';
 import { OtaPackageService } from '@core/http/ota-package.service';
 import { EdgeService } from '@core/http/edge.service';
-import { Edge, EdgeEvent, EdgeEventActionType, EdgeEventType } from '@shared/models/edge.models';
+import {
+  Edge,
+  EdgeEvent,
+  EdgeEventType,
+  bodyContentEdgeEventActionTypes
+} from '@shared/models/edge.models';
 import { RuleChainMetaData, RuleChainType } from '@shared/models/rule-chain.models';
 import { WidgetService } from '@core/http/widget.service';
 import { DeviceProfileService } from '@core/http/device-profile.service';
@@ -1391,7 +1396,6 @@ export class EntityService {
     let entityObservable: Observable<BaseData<HasId> | RuleChainMetaData | string>;
     const entityId: string = entity.entityId;
     const entityType: any = entity.type;
-    const entityAction: EdgeEventActionType = entity.action;
     switch (entityType) {
       case EdgeEventType.DASHBOARD:
       case EdgeEventType.ALARM:
@@ -1403,12 +1407,8 @@ export class EntityService {
       case EdgeEventType.ASSET:
       case EdgeEventType.DEVICE:
       case EdgeEventType.ENTITY_VIEW:
-        if (entityAction === EdgeEventActionType.POST_ATTRIBUTES ||
-            entityAction === EdgeEventActionType.ATTRIBUTES_UPDATED ||
-            entityAction === EdgeEventActionType.ATTRIBUTES_DELETED ||
-            entityAction === EdgeEventActionType.TIMESERIES_UPDATED ||
-            entityAction === EdgeEventActionType.RPC_CALL) {
-          return of(entity.body);
+        if (bodyContentEdgeEventActionTypes.indexOf(entity.action) > -1) {
+          entityObservable = of(entity.body);
         } else {
           entityObservable = this.getEntity(entityType, entityId, { ignoreLoading: true, ignoreErrors: true });
         }

--- a/ui-ngx/src/app/shared/models/edge.models.ts
+++ b/ui-ngx/src/app/shared/models/edge.models.ts
@@ -137,6 +137,14 @@ export const edgeEventActionTypeTranslations = new Map<EdgeEventActionType, stri
   ]
 );
 
+export const bodyContentEdgeEventActionTypes = [
+  EdgeEventActionType.POST_ATTRIBUTES,
+  EdgeEventActionType.ATTRIBUTES_UPDATED,
+  EdgeEventActionType.ATTRIBUTES_DELETED,
+  EdgeEventActionType.TIMESERIES_UPDATED,
+  EdgeEventActionType.RPC_CALL
+];
+
 export const edgeEventStatusColor = new Map<EdgeEventStatus, string>(
   [
     [EdgeEventStatus.DEPLOYED, '#000000'],

--- a/ui-ngx/src/app/shared/models/edge.models.ts
+++ b/ui-ngx/src/app/shared/models/edge.models.ts
@@ -137,7 +137,7 @@ export const edgeEventActionTypeTranslations = new Map<EdgeEventActionType, stri
   ]
 );
 
-export const bodyContentEdgeEventActionTypes = [
+export const bodyContentEdgeEventActionTypes: EdgeEventActionType[] = [
   EdgeEventActionType.POST_ATTRIBUTES,
   EdgeEventActionType.ATTRIBUTES_UPDATED,
   EdgeEventActionType.ATTRIBUTES_DELETED,


### PR DESCRIPTION
- show entity.body for POST_ATTRIBUTES, ATTRIBUTES_UPDATED, ATTRIBUTES_DELETED, TIMESERIES_UPDATED;
- update status pending/deployed color without refresh page;
- for RELATION type show empty 'entityId';