### PR TITLE
[3.3.2]fixed double sending rpc and timeout for lwm2m

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -619,7 +619,7 @@ class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcessor {
             if (md.getMsg().getMsg().isPersisted()) {
                 systemContext.getTbRpcService().save(tenantId, new RpcId(rpcId), status, null);
             }
-            if (status != RpcStatus.SENT) {
+            if (status != RpcStatus.SENT && !(status == RpcStatus.FAILED && md.isDelivered())) {
                 sendNextPendingRequest(context);
             }
         } else {

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/rpc/RpcDownlinkRequestCallbackProxy.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/rpc/RpcDownlinkRequestCallbackProxy.java
@@ -67,7 +67,7 @@ public abstract class RpcDownlinkRequestCallbackProxy<R, T> implements DownlinkR
 
     @Override
     public void onError(String params, Exception e) {
-        if (e instanceof TimeoutException) {
+        if (e instanceof TimeoutException || e instanceof org.eclipse.leshan.core.request.exception.TimeoutException) {
             transportService.process(client.getSession(), this.request, RpcStatus.TIMEOUT, TransportServiceCallback.EMPTY);
         } else if (!(e instanceof ClientSleepingException)) {
             sendRpcReplyOnError(e);


### PR DESCRIPTION
When an actor received RPC status DELIVERED or FAILED we will send the next RPC but when we received the status FAILED after DELIVERED it will second sending the same RPC which was sent after status DELIVERED.