### PR TITLE
[3.3.2] Fix bug while deleting devices with relations to one another

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/relation/BaseRelationService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/relation/BaseRelationService.java
@@ -204,7 +204,7 @@ public class BaseRelationService implements RelationService {
 
             relationDao.deleteOutboundRelations(tenantId, entityId);
         } catch (ConcurrencyFailureException e) {
-            log.error("Concurrency exception while deleting relations [{}]",entityId, e);
+            log.debug("Concurrency exception while deleting relations [{}]",entityId, e);
         }
     }
 


### PR DESCRIPTION
![image-2021-09-21-13-06-38-496](https://user-images.githubusercontent.com/54314019/135494974-b27fd479-e099-46d4-ae92-da6c0f82a0d4.png)

Exception occurred trying to delete a few selected devices with common relations. Front-end sends HTTP delete request on each entity independently, so the platform processes those requests concurrently. On every request all the entity relations are deleted. This can lead to cases when repository tries to delete relation which already been deleted by previous request. And then Runtime Exception doesn't let the system finish entity deleting successfully. The most harmless way is to catch such situations and prevent system from cutting off deleting process.