### PR TITLE
CPU usage reduced on TbNodeUtils

### DIFF
--- a/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/util/TbNodeUtils.java
+++ b/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/util/TbNodeUtils.java
@@ -39,11 +39,7 @@ public class TbNodeUtils {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    private static final String METADATA_VARIABLE_TEMPLATE = "${%s}";
-
     private static final Pattern DATA_PATTERN = Pattern.compile("(\\$\\[)(.*?)(])");
-
-    private static final String DATA_VARIABLE_TEMPLATE = "$[%s]";
 
     public static <T> T convert(TbNodeConfiguration configuration, Class<T> clazz) throws TbNodeException {
         try {
@@ -80,7 +76,7 @@ public class TbNodeUtils {
                     }
 
                     if (jsonNode != null && jsonNode.isValueNode()) {
-                        result = result.replace(String.format(DATA_VARIABLE_TEMPLATE, group), jsonNode.asText());
+                        result = result.replace(formatDataVarTemplate(group), jsonNode.asText());
                     }
                 }
             }
@@ -106,8 +102,14 @@ public class TbNodeUtils {
     }
 
     private static String processVar(String pattern, String key, String val) {
-        String varPattern = String.format(METADATA_VARIABLE_TEMPLATE, key);
-        return pattern.replace(varPattern, val);
+        return pattern.replace(formatMetadataVarTemplate(key), val);
     }
 
+    static String formatDataVarTemplate(String key) {
+        return "$[" + key + ']';
+    }
+
+    static String formatMetadataVarTemplate(String key) {
+        return "${" + key + '}';
+    }
 }

--- a/rule-engine/rule-engine-api/src/test/java/org/thingsboard/rule/engine/api/util/TbNodeUtilsTest.java
+++ b/rule-engine/rule-engine-api/src/test/java/org/thingsboard/rule/engine/api/util/TbNodeUtilsTest.java
@@ -16,6 +16,7 @@
 package org.thingsboard.rule.engine.api.util;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,8 +26,14 @@ import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
 import org.thingsboard.common.util.JacksonUtil;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 @RunWith(MockitoJUnitRunner.class)
 public class TbNodeUtilsTest {
+
+    private static final String DATA_VARIABLE_TEMPLATE = "$[%s]";
+    private static final String METADATA_VARIABLE_TEMPLATE = "${%s}";
 
     @Test
     public void testSimpleReplacement() {
@@ -112,4 +119,27 @@ public class TbNodeUtilsTest {
         Assert.assertEquals("ABC metadata_value $[key1.key2[0].key3]", result);
     }
 
+    @Test
+    public void givenKey_whenFormatDataVarTemplate_thenReturnTheSameStringAsFormat() {
+        assertThat(TbNodeUtils.formatDataVarTemplate("key"), is("$[key]"));
+        assertThat(TbNodeUtils.formatDataVarTemplate("key"), is(String.format(DATA_VARIABLE_TEMPLATE, "key")));
+
+        assertThat(TbNodeUtils.formatDataVarTemplate(""), is("$[]"));
+        assertThat(TbNodeUtils.formatDataVarTemplate(""), is(String.format(DATA_VARIABLE_TEMPLATE, "")));
+
+        assertThat(TbNodeUtils.formatDataVarTemplate(null), is("$[null]"));
+        assertThat(TbNodeUtils.formatDataVarTemplate(null), is(String.format(DATA_VARIABLE_TEMPLATE, (String) null)));
+    }
+
+    @Test
+    public void givenKey_whenFormatMetadataVarTemplate_thenReturnTheSameStringAsFormat() {
+        assertThat(TbNodeUtils.formatMetadataVarTemplate("key"), is("${key}"));
+        assertThat(TbNodeUtils.formatMetadataVarTemplate("key"), is(String.format(METADATA_VARIABLE_TEMPLATE, "key")));
+
+        assertThat(TbNodeUtils.formatMetadataVarTemplate(""), is("${}"));
+        assertThat(TbNodeUtils.formatMetadataVarTemplate(""), is(String.format(METADATA_VARIABLE_TEMPLATE, "")));
+
+        assertThat(TbNodeUtils.formatMetadataVarTemplate(null), is("${null}"));
+        assertThat(TbNodeUtils.formatMetadataVarTemplate(null), is(String.format(METADATA_VARIABLE_TEMPLATE, (String) null)));
+    }
 }


### PR DESCRIPTION
The issue with CPU load was detected during CPU sampling.
The **String.format()** method compiles a pattern on each call for one-time usage. The internal implementation of **String.format()** is quite CPU expensive for our simple pattern.
Replaced with string concatenation (string builder).
Tests added.
That piece of code is widely used on getting attributes rule nodes. It is hard to identify the problem without a heavy load.
Works fine on the production about one week. CPU is fine
