### PR TITLE
Clear alarm node default script changed to avoid infinite metadata grow

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNodeConfiguration.java
@@ -31,7 +31,7 @@ public class TbClearAlarmNodeConfiguration extends TbAbstractAlarmNodeConfigurat
                 "if (metadata.prevAlarmDetails) {\n" +
                 "    details = JSON.parse(metadata.prevAlarmDetails);\n" +
                 "    //remove prevAlarmDetails from metadata\n" +
-                "    metadata.delete('prevAlarmDetails')\n" +
+                "    delete metadata.prevAlarmDetails;\n" +
                 "    //now metadata is the same as it comes IN this rule node" +
                 "}\n" +
                 "//***PLACE YOUR CODE BELOW***\n" +


### PR DESCRIPTION
The previous script does not decouple actual metadata and previous data.
Previous data added internally inside the rule node as a regular metadata field with key "**prevAlarmDetails**"
Users may believe that metadata is the same as shown in debug messages.
When the user saves metadata as details, it brings all previous details and made inbounded details grow on each alarm.
Users will end up with the permanent exception like message size exceeds the limit (when sending to js-executor) and Postgres, pgpool cpu/memory overhead when saving huge alarm details inside alarm entity.
The script is clarify and decouples prevAlarmDetails and actual metadata.

See changed files for details