### PR TITLE
Delay node is deprecated

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
@@ -41,7 +41,10 @@ import static org.thingsboard.rule.engine.api.TbRelationTypes.SUCCESS;
         name = "delay (deprecated)",
         configClazz = TbMsgDelayNodeConfiguration.class,
         nodeDescription = "Delays incoming message (deprecated)",
-        nodeDetails = "Deprecated! Delays messages for configurable period. Please note, this node acknowledges the message from the current queue (message will be removed from queue)",
+        nodeDetails = "Delays messages for a configurable period. " +
+                "Please note, this node acknowledges the message from the current queue (message will be removed from queue). " +
+                "Deprecated because the acknowledged message still stays in memory (to be delayed) and this " +
+                "does not guarantee that message will be processed even if the \"retry failures and timeouts\" processing strategy will be chosen.",
         icon = "pause",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
         configDirective = "tbActionNodeMsgDelayConfig"


### PR DESCRIPTION
The Delay node does not guarantee that message will be processed because of ack.
It accumulates fast msg in memory up to "Max limit of pending messages reached".
After that produced artificial failures that may retry with retry strategy up to infinite times.
Obvious it's a bad practice to use delay nodes in the production environment.
Deprecated to get prevent users to use that node in future rule chains