### PR TITLE
[3.3.2] UI: Fixed double requests on aliases entity autocomplete

### DIFF
--- a/ui-ngx/src/app/modules/home/components/alias/aliases-entity-autocomplete.component.ts
+++ b/ui-ngx/src/app/modules/home/components/alias/aliases-entity-autocomplete.component.ts
@@ -17,7 +17,7 @@
 import { AfterViewInit, Component, ElementRef, forwardRef, Input, OnInit, ViewChild } from '@angular/core';
 import { ControlValueAccessor, FormBuilder, FormGroup, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Observable, of } from 'rxjs';
-import { catchError, debounceTime, distinctUntilChanged, map, startWith, switchMap, tap } from 'rxjs/operators';
+import { catchError, debounceTime, distinctUntilChanged, map, share, switchMap, tap } from 'rxjs/operators';
 import { emptyPageData, PageData } from '@shared/models/page/page-data';
 import { Store } from '@ngrx/store';
 import { AppState } from '@app/core/core.state';
@@ -26,6 +26,7 @@ import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { EntityInfo } from '@shared/models/entity.models';
 import { EntityFilter } from '@shared/models/query/query.models';
 import { EntityService } from '@core/http/entity.service';
+import { isDefinedAndNotNull } from '@core/utils';
 
 @Component({
   selector: 'tb-aliases-entity-autocomplete',
@@ -98,10 +99,10 @@ export class AliasesEntityAutocompleteComponent implements ControlValueAccessor,
           }
           this.updateView(modelValue);
         }),
-        startWith<string | EntityInfo>(''),
         map(value => value ? (typeof value === 'string' ? value : value.name) : ''),
         distinctUntilChanged(),
-        switchMap(name => this.fetchEntityInfos(name))
+        switchMap(name => this.fetchEntityInfos(name)),
+        share()
       );
   }
 
@@ -114,12 +115,12 @@ export class AliasesEntityAutocompleteComponent implements ControlValueAccessor,
 
   writeValue(value: EntityInfo | null): void {
     this.searchText = '';
-    if (value != null) {
+    if (isDefinedAndNotNull(value)) {
       this.modelValue = value;
       this.selectEntityInfoFormGroup.get('entityInfo').patchValue(value, {emitEvent: true});
     } else {
       this.modelValue = null;
-      this.selectEntityInfoFormGroup.get('entityInfo').patchValue(null, {emitEvent: true});
+      this.selectEntityInfoFormGroup.get('entityInfo').patchValue(null, {emitEvent: false});
     }
   }
 


### PR DESCRIPTION
![Screenshot from 2021-10-20 10-34-41](https://user-images.githubusercontent.com/83352633/138048453-931cffb6-0def-4906-bc46-a8db4cedebac.png)
When we first click on entity aliases we have four requests, after we have double requests for all actions.
![Screenshot from 2021-10-20 10-50-00](https://user-images.githubusercontent.com/83352633/138051817-a935eecc-cc63-4429-b615-f2ae9bd7659e.png)
Fixed add share and remove startWith from Observable.
