### PR TITLE
[3.3.2] UI: Added ace editor for protobuf content

### DIFF
--- a/ui-ngx/src/app/modules/home/components/profile/device/coap-device-profile-transport-configuration.component.html
+++ b/ui-ngx/src/app/modules/home/components/profile/device/coap-device-profile-transport-configuration.component.html
@@ -47,35 +47,50 @@
             </mat-error>
           </mat-form-field>
           <div *ngIf="protoPayloadType" fxLayout="column">
-            <mat-form-field fxFlex>
-              <mat-label translate>device-profile.telemetry-proto-schema</mat-label>
-              <textarea matInput required formControlName="deviceTelemetryProtoSchema" rows="5"></textarea>
+            <ng-container>
+              <tb-protobuf-content
+                fxFlex
+                formControlName="deviceTelemetryProtoSchema"
+                label="{{ 'device-profile.telemetry-proto-schema' | translate }}"
+                [fillHeight]="true">
+              </tb-protobuf-content>
               <mat-error *ngIf="coapTransportConfigurationFormGroup.get('coapDeviceTypeConfiguration.transportPayloadTypeConfiguration.deviceTelemetryProtoSchema').hasError('required')">
                 {{ 'device-profile.telemetry-proto-schema-required' | translate}}
               </mat-error>
-            </mat-form-field>
-            <mat-form-field fxFlex>
-              <mat-label translate>device-profile.attributes-proto-schema</mat-label>
-              <textarea matInput required formControlName="deviceAttributesProtoSchema" rows="5"></textarea>
+            </ng-container>
+            <ng-container>
+              <tb-protobuf-content
+                fxFlex
+                formControlName="deviceAttributesProtoSchema"
+                label="{{ 'device-profile.attributes-proto-schema' | translate }}"
+                [fillHeight]="true">
+              </tb-protobuf-content>
               <mat-error *ngIf="coapTransportConfigurationFormGroup.get('coapDeviceTypeConfiguration.transportPayloadTypeConfiguration.deviceAttributesProtoSchema').hasError('required')">
                 {{ 'device-profile.attributes-proto-schema-required' | translate}}
               </mat-error>
-            </mat-form-field>
-            <mat-form-field style="padding-bottom: 20px" fxFlex>
-              <mat-label translate>device-profile.rpc-request-proto-schema</mat-label>
-              <textarea matInput required formControlName="deviceRpcRequestProtoSchema" rows="5"></textarea>
+            </ng-container>
+            <ng-container>
+              <tb-protobuf-content
+                fxFlex
+                formControlName="deviceRpcRequestProtoSchema"
+                label="{{ 'device-profile.rpc-request-proto-schema' | translate }}"
+                [fillHeight]="true">
+              </tb-protobuf-content>
               <mat-error *ngIf="coapTransportConfigurationFormGroup.get('coapDeviceTypeConfiguration.transportPayloadTypeConfiguration.deviceRpcRequestProtoSchema').hasError('required')">
                 {{ 'device-profile.rpc-request-proto-schema-required' | translate}}
               </mat-error>
-              <mat-hint class="tb-hint" translate>device-profile.rpc-request-proto-schema-hint</mat-hint>
-            </mat-form-field>
-            <mat-form-field fxFlex>
-              <mat-label translate>device-profile.rpc-response-proto-schema</mat-label>
-              <textarea matInput required formControlName="deviceRpcResponseProtoSchema" rows="5"></textarea>
+            </ng-container>
+            <ng-container>
+              <tb-protobuf-content
+                fxFlex
+                formControlName="deviceRpcResponseProtoSchema"
+                label="{{ 'device-profile.rpc-response-proto-schema' | translate }}"
+                [fillHeight]="true">
+              </tb-protobuf-content>
               <mat-error *ngIf="coapTransportConfigurationFormGroup.get('coapDeviceTypeConfiguration.transportPayloadTypeConfiguration.deviceRpcResponseProtoSchema').hasError('required')">
                 {{ 'device-profile.rpc-response-proto-schema-required' | translate}}
               </mat-error>
-            </mat-form-field>
+            </ng-container>
           </div>
         </div>
       </fieldset>

--- a/ui-ngx/src/app/modules/home/components/profile/device/mqtt-device-profile-transport-configuration.component.html
+++ b/ui-ngx/src/app/modules/home/components/profile/device/mqtt-device-profile-transport-configuration.component.html
@@ -74,9 +74,8 @@
           </mat-error>
         </mat-form-field>
         <div *ngIf="protoPayloadType" fxLayout="column">
-          <div>
+          <ng-container>
             <tb-protobuf-content
-              [disabled]="disabled"
               fxFlex
               formControlName="deviceTelemetryProtoSchema"
               label="{{ 'device-profile.telemetry-proto-schema' | translate }}"
@@ -85,10 +84,9 @@
             <mat-error *ngIf="mqttDeviceProfileTransportConfigurationFormGroup.get('transportPayloadTypeConfiguration.deviceTelemetryProtoSchema').hasError('required')">
               {{ 'device-profile.telemetry-proto-schema-required' | translate}}
             </mat-error>
-          </div>
-          <div>
+          </ng-container>
+          <ng-container>
             <tb-protobuf-content
-              [disabled]="disabled"
               fxFlex
               formControlName="deviceAttributesProtoSchema"
               label="{{ 'device-profile.attributes-proto-schema' | translate }}"
@@ -97,10 +95,9 @@
             <mat-error *ngIf="mqttDeviceProfileTransportConfigurationFormGroup.get('transportPayloadTypeConfiguration.deviceAttributesProtoSchema').hasError('required')">
               {{ 'device-profile.attributes-proto-schema-required' | translate}}
             </mat-error>
-          </div>
-          <div>
+          </ng-container>
+          <ng-container>
             <tb-protobuf-content
-              [disabled]="disabled"
               fxFlex
               formControlName="deviceRpcRequestProtoSchema"
               label="{{ 'device-profile.rpc-request-proto-schema' | translate }}"
@@ -109,10 +106,9 @@
             <mat-error *ngIf="mqttDeviceProfileTransportConfigurationFormGroup.get('transportPayloadTypeConfiguration.deviceRpcRequestProtoSchema').hasError('required')">
               {{ 'device-profile.rpc-request-proto-required' | translate}}
             </mat-error>
-          </div>
-          <div>
+          </ng-container>
+          <ng-container>
             <tb-protobuf-content
-              [disabled]="disabled"
               fxFlex
               formControlName="deviceRpcResponseProtoSchema"
               label="{{ 'device-profile.rpc-response-proto-schema' | translate }}"
@@ -121,7 +117,7 @@
             <mat-error *ngIf="mqttDeviceProfileTransportConfigurationFormGroup.get('transportPayloadTypeConfiguration.deviceRpcResponseProtoSchema').hasError('required')">
               {{ 'device-profile.rpc-response-proto-schema-required' | translate}}
             </mat-error>
-          </div>
+          </ng-container>
         </div>
       </div>
     </fieldset>

--- a/ui-ngx/src/app/modules/home/components/profile/device/mqtt-device-profile-transport-configuration.component.html
+++ b/ui-ngx/src/app/modules/home/components/profile/device/mqtt-device-profile-transport-configuration.component.html
@@ -74,35 +74,54 @@
           </mat-error>
         </mat-form-field>
         <div *ngIf="protoPayloadType" fxLayout="column">
-          <mat-form-field fxFlex>
-            <mat-label translate>device-profile.telemetry-proto-schema</mat-label>
-            <textarea matInput required formControlName="deviceTelemetryProtoSchema" rows="5"></textarea>
+          <div>
+            <tb-protobuf-content
+              [disabled]="disabled"
+              fxFlex
+              formControlName="deviceTelemetryProtoSchema"
+              label="{{ 'device-profile.telemetry-proto-schema' | translate }}"
+              [fillHeight]="true">
+            </tb-protobuf-content>
             <mat-error *ngIf="mqttDeviceProfileTransportConfigurationFormGroup.get('transportPayloadTypeConfiguration.deviceTelemetryProtoSchema').hasError('required')">
               {{ 'device-profile.telemetry-proto-schema-required' | translate}}
             </mat-error>
-          </mat-form-field>
-          <mat-form-field fxFlex>
-            <mat-label translate>device-profile.attributes-proto-schema</mat-label>
-            <textarea matInput required formControlName="deviceAttributesProtoSchema" rows="5"></textarea>
+          </div>
+          <div>
+            <tb-protobuf-content
+              [disabled]="disabled"
+              fxFlex
+              formControlName="deviceAttributesProtoSchema"
+              label="{{ 'device-profile.attributes-proto-schema' | translate }}"
+              [fillHeight]="true">
+            </tb-protobuf-content>
             <mat-error *ngIf="mqttDeviceProfileTransportConfigurationFormGroup.get('transportPayloadTypeConfiguration.deviceAttributesProtoSchema').hasError('required')">
               {{ 'device-profile.attributes-proto-schema-required' | translate}}
             </mat-error>
-          </mat-form-field>
-          <mat-form-field style="padding-bottom: 20px" fxFlex>
-            <mat-label translate>device-profile.rpc-request-proto-schema</mat-label>
-            <textarea matInput required formControlName="deviceRpcRequestProtoSchema" rows="5"></textarea>
+          </div>
+          <div>
+            <tb-protobuf-content
+              [disabled]="disabled"
+              fxFlex
+              formControlName="deviceRpcRequestProtoSchema"
+              label="{{ 'device-profile.rpc-request-proto-schema' | translate }}"
+              [fillHeight]="true">
+            </tb-protobuf-content>
             <mat-error *ngIf="mqttDeviceProfileTransportConfigurationFormGroup.get('transportPayloadTypeConfiguration.deviceRpcRequestProtoSchema').hasError('required')">
-              {{ 'device-profile.rpc-request-proto-schema-required' | translate}}
+              {{ 'device-profile.rpc-request-proto-required' | translate}}
             </mat-error>
-            <mat-hint class="tb-hint" translate>device-profile.rpc-request-proto-schema-hint</mat-hint>
-          </mat-form-field>
-          <mat-form-field fxFlex>
-            <mat-label translate>device-profile.rpc-response-proto-schema</mat-label>
-            <textarea matInput required formControlName="deviceRpcResponseProtoSchema" rows="5"></textarea>
+          </div>
+          <div>
+            <tb-protobuf-content
+              [disabled]="disabled"
+              fxFlex
+              formControlName="deviceRpcResponseProtoSchema"
+              label="{{ 'device-profile.rpc-response-proto-schema' | translate }}"
+              [fillHeight]="true">
+            </tb-protobuf-content>
             <mat-error *ngIf="mqttDeviceProfileTransportConfigurationFormGroup.get('transportPayloadTypeConfiguration.deviceRpcResponseProtoSchema').hasError('required')">
               {{ 'device-profile.rpc-response-proto-schema-required' | translate}}
             </mat-error>
-          </mat-form-field>
+          </div>
         </div>
       </div>
     </fieldset>

--- a/ui-ngx/src/app/modules/home/components/profile/device/mqtt-device-profile-transport-configuration.component.html
+++ b/ui-ngx/src/app/modules/home/components/profile/device/mqtt-device-profile-transport-configuration.component.html
@@ -104,7 +104,7 @@
               [fillHeight]="true">
             </tb-protobuf-content>
             <mat-error *ngIf="mqttDeviceProfileTransportConfigurationFormGroup.get('transportPayloadTypeConfiguration.deviceRpcRequestProtoSchema').hasError('required')">
-              {{ 'device-profile.rpc-request-proto-required' | translate}}
+              {{ 'device-profile.rpc-request-proto-schema-required' | translate}}
             </mat-error>
           </ng-container>
           <ng-container>

--- a/ui-ngx/src/app/modules/home/components/profile/device/mqtt-device-profile-transport-configuration.component.ts
+++ b/ui-ngx/src/app/modules/home/components/profile/device/mqtt-device-profile-transport-configuration.component.ts
@@ -56,6 +56,10 @@ export class MqttDeviceProfileTransportConfigurationComponent implements Control
 
   transportPayloadTypes = Object.keys(TransportPayloadType);
 
+  get protobufControls() {
+    return this.getProtobufControls();
+  }
+
   transportPayloadTypeTranslations = transportPayloadTypeTranslationMap;
 
   mqttDeviceProfileTransportConfigurationFormGroup: FormGroup;
@@ -210,5 +214,22 @@ export class MqttDeviceProfileTransportConfigurationComponent implements Control
       }
     }
     return null;
+  }
+
+  getProtobufControls() {
+    return [
+      {
+        name: 'deviceAttributesProtoSchema',
+        label: 'device-profile.attributes-proto-schema',
+        errorControl: 'transportPayloadTypeConfiguration.deviceAttributesProtoSchema',
+        errorText: 'device-profile.attributes-proto-schema-required'
+      },
+      {
+        deviceTelemetryProtoSchema: 'deviceRpcRequestProtoSchema',
+        label: 'device-profile.rpc-request-proto-schema',
+        errorControl: 'transportPayloadTypeConfiguration.deviceRpcRequestProtoSchema',
+        errorText: 'device-profile.rpc-request-proto-required'
+      }
+    ];
   }
 }

--- a/ui-ngx/src/app/modules/home/components/profile/device/mqtt-device-profile-transport-configuration.component.ts
+++ b/ui-ngx/src/app/modules/home/components/profile/device/mqtt-device-profile-transport-configuration.component.ts
@@ -56,10 +56,6 @@ export class MqttDeviceProfileTransportConfigurationComponent implements Control
 
   transportPayloadTypes = Object.keys(TransportPayloadType);
 
-  get protobufControls() {
-    return this.getProtobufControls();
-  }
-
   transportPayloadTypeTranslations = transportPayloadTypeTranslationMap;
 
   mqttDeviceProfileTransportConfigurationFormGroup: FormGroup;
@@ -214,22 +210,5 @@ export class MqttDeviceProfileTransportConfigurationComponent implements Control
       }
     }
     return null;
-  }
-
-  getProtobufControls() {
-    return [
-      {
-        name: 'deviceAttributesProtoSchema',
-        label: 'device-profile.attributes-proto-schema',
-        errorControl: 'transportPayloadTypeConfiguration.deviceAttributesProtoSchema',
-        errorText: 'device-profile.attributes-proto-schema-required'
-      },
-      {
-        deviceTelemetryProtoSchema: 'deviceRpcRequestProtoSchema',
-        label: 'device-profile.rpc-request-proto-schema',
-        errorControl: 'transportPayloadTypeConfiguration.deviceRpcRequestProtoSchema',
-        errorText: 'device-profile.rpc-request-proto-required'
-      }
-    ];
   }
 }

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.html
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.html
@@ -2,7 +2,7 @@
      tb-fullscreen
      [fullscreen]="fullscreen" (fullscreenChanged)="onFullscreen()" fxLayout="column">
   <div fxLayout="row" fxLayoutAlign="start center" style="height: 40px;" class="tb-protobuf-content-toolbar">
-    <label class="tb-title no-padding" [ngClass]="{'tb-error': !contentValid}">{{ label }}</label>
+    <label class="tb-title no-padding">{{ label }}</label>
     <span fxFlex></span>
     <button type="button"
             mat-button *ngIf="!readonly && !disabled" class="tidy" (click)="beautifyProtobuf()">

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.html
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.html
@@ -1,3 +1,20 @@
+<!--
+
+    Copyright © 2016-2021 The Thingsboard Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <div style="background: #fff;" [ngClass]="{'fill-height': fillHeight}"
      tb-fullscreen
      [fullscreen]="fullscreen" (fullscreenChanged)="onFullscreen()" fxLayout="column">

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.html
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.html
@@ -1,0 +1,30 @@
+<div style="background: #fff;" [ngClass]="{'fill-height': fillHeight}"
+     tb-fullscreen
+     [fullscreen]="fullscreen" (fullscreenChanged)="onFullscreen()" fxLayout="column">
+  <div fxLayout="row" fxLayoutAlign="start center" style="height: 40px;" class="tb-protobuf-content-toolbar">
+    <label class="tb-title no-padding" [ngClass]="{'tb-error': !contentValid}">{{ label }}</label>
+    <span fxFlex></span>
+    <button type="button"
+            mat-button *ngIf="!readonly && !disabled" class="tidy" (click)="beautifyJSON()">
+      {{'js-func.tidy' | translate }}
+    </button>
+    <button type="button"
+            mat-button *ngIf="!readonly && !disabled" class="tidy" (click)="minifyJSON()">
+      {{'js-func.mini' | translate }}
+    </button>
+    <fieldset style="width: initial">
+      <div matTooltip="{{(fullscreen ? 'fullscreen.exit' : 'fullscreen.expand') | translate}}"
+           matTooltipPosition="above"
+           style="border-radius: 50%"
+           (click)="fullscreen = !fullscreen">
+        <button type='button' mat-button mat-icon-button class="tb-mat-32">
+          <mat-icon class="material-icons">{{ fullscreen ? 'fullscreen_exit' : 'fullscreen' }}</mat-icon>
+        </button>
+      </div>
+    </fieldset>
+  </div>
+  <div id="tb-protobuf-panel" tb-toast toastTarget="{{toastTargetId}}"
+       class="tb-protobuf-content-panel" fxLayout="column">
+    <div #protobufEditor id="tb-protobuf-input" [ngStyle]="editorStyle" [ngClass]="{'fill-height': fillHeight}"></div>
+  </div>
+</div>

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.html
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.html
@@ -5,12 +5,8 @@
     <label class="tb-title no-padding" [ngClass]="{'tb-error': !contentValid}">{{ label }}</label>
     <span fxFlex></span>
     <button type="button"
-            mat-button *ngIf="!readonly && !disabled" class="tidy" (click)="beautifyJSON()">
+            mat-button *ngIf="!readonly && !disabled" class="tidy" (click)="beautifyProtobuf()">
       {{'js-func.tidy' | translate }}
-    </button>
-    <button type="button"
-            mat-button *ngIf="!readonly && !disabled" class="tidy" (click)="minifyJSON()">
-      {{'js-func.mini' | translate }}
     </button>
     <fieldset style="width: initial">
       <div matTooltip="{{(fullscreen ? 'fullscreen.exit' : 'fullscreen.expand') | translate}}"

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.scss
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.scss
@@ -28,13 +28,12 @@
   height: 100%;
   margin-left: 15px;
   border: 1px solid #c0c0c0;
-  overflow: auto;
-  resize: vertical;
 
   #tb-protobuf-input {
     width: 100%;
     min-width: 200px;
     min-height: 100px;
+    height: 100%;
 
     &:not(.fill-height) {
       min-height: 200px;

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.scss
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.scss
@@ -1,0 +1,43 @@
+:host {
+  position: relative;
+
+  .fill-height {
+    height: 100%;
+  }
+}
+
+.tb-protobuf-content-toolbar {
+  button.mat-button, button.mat-icon-button, button.mat-icon-button.tb-mat-32 {
+    align-items: center;
+    vertical-align: middle;
+    min-width: 32px;
+    min-height: 15px;
+    padding: 4px;
+    margin: 0;
+    font-size: .8rem;
+    line-height: 15px;
+    color: #7b7b7b;
+    background: rgba(220, 220, 220, .35);
+    &:not(:last-child) {
+      margin-right: 4px;
+    }
+  }
+}
+
+.tb-protobuf-content-panel {
+  height: 100%;
+  margin-left: 15px;
+  border: 1px solid #c0c0c0;
+  overflow: auto;
+  resize: vertical;
+
+  #tb-protobuf-input {
+    width: 100%;
+    min-width: 200px;
+    min-height: 100px;
+
+    &:not(.fill-height) {
+      min-height: 200px;
+    }
+  }
+}

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.scss
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.scss
@@ -32,7 +32,7 @@
   #tb-protobuf-input {
     width: 100%;
     min-width: 200px;
-    min-height: 100px;
+    min-height: 160px;
     height: 100%;
 
     &:not(.fill-height) {

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.scss
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.scss
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 :host {
   position: relative;
 

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.ts
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.ts
@@ -1,0 +1,221 @@
+import {
+  Component,
+  ElementRef,
+  forwardRef,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
+import { ControlValueAccessor, FormControl, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validator } from '@angular/forms';
+import { Ace } from 'ace-builds';
+import { CancelAnimationFrame, RafService } from '@core/services/raf.service';
+import { ResizeObserver } from '@juggle/resize-observer';
+import { guid } from '@core/utils';
+import { ContentType } from '@shared/models/constants';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { Store } from '@ngrx/store';
+import { AppState } from '@core/core.state';
+import { getAce } from '@shared/models/ace/ace.models';
+import { beautifyJs } from '@shared/models/beautify.models';
+import { ActionNotificationHide, ActionNotificationShow } from '@core/notification/notification.actions';
+
+@Component({
+  selector: 'tb-protobuf-content',
+  templateUrl: './protobuf-content.component.html',
+  styleUrls: ['./protobuf-content.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ProtobufContentComponent),
+      multi: true
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => ProtobufContentComponent),
+      multi: true,
+    }
+  ]
+})
+export class ProtobufContentComponent implements OnInit, ControlValueAccessor, Validator, OnChanges, OnDestroy {
+
+  @ViewChild('protobufEditor', {static: true})
+  protobufEditorElmRef: ElementRef;
+
+  private protobufEditor: Ace.Editor;
+  private editorsResizeCaf: CancelAnimationFrame;
+  private editorResize$: ResizeObserver;
+  private ignoreChange = false;
+
+  toastTargetId = `protobufContentEditor-${guid()}`;
+
+  @Input() label: string;
+
+  contentType: ContentType = ContentType.TEXT;
+
+  @Input() disabled: boolean;
+
+  @Input() fillHeight: boolean;
+
+  @Input() editorStyle: {[klass: string]: any};
+
+  @Input() tbPlaceholder: string;
+
+  private readonlyValue: boolean;
+  get readonly(): boolean {
+    return this.readonlyValue;
+  }
+  @Input()
+  set readonly(value: boolean) {
+    this.readonlyValue = coerceBooleanProperty(value);
+  }
+
+  fullscreen = false;
+
+  contentBody: string;
+
+  contentValid: boolean;
+
+  errorShowed = false;
+
+  private propagateChange = null;
+
+  constructor(public elementRef: ElementRef,
+              protected store: Store<AppState>,
+              private raf: RafService) {
+  }
+
+  ngOnInit(): void {
+    const editorElement = this.protobufEditorElmRef.nativeElement;
+    let mode = 'protobuf';
+    let editorOptions: Partial<Ace.EditorOptions> = {
+      mode: `ace/mode/${mode}`,
+      showGutter: true,
+      showPrintMargin: false,
+      readOnly: this.disabled || this.readonly,
+    };
+
+    const advancedOptions = {
+      enableSnippets: true,
+      enableBasicAutocompletion: true,
+      enableLiveAutocompletion: true,
+      autoScrollEditorIntoView: true
+    };
+
+    editorOptions = {...editorOptions, ...advancedOptions};
+    getAce().subscribe(
+      (ace) => {
+        this.protobufEditor = ace.edit(editorElement, editorOptions);
+        this.protobufEditor.session.setUseWrapMode(true);
+        this.protobufEditor.setValue(this.contentBody ? this.contentBody : '', -1);
+        this.protobufEditor.setReadOnly(this.disabled || this.readonly);
+        this.protobufEditor.on('change', () => {
+          if (!this.ignoreChange) {
+            this.updateView();
+          }
+        });
+        this.editorResize$ = new ResizeObserver(() => {
+          this.onAceEditorResize();
+        });
+        this.editorResize$.observe(editorElement);
+      }
+    );
+  }
+
+  ngOnDestroy(): void {
+    if (this.editorResize$) {
+      this.editorResize$.disconnect();
+    }
+  }
+
+  private onAceEditorResize() {
+    if (this.editorsResizeCaf) {
+      this.editorsResizeCaf();
+      this.editorsResizeCaf = null;
+    }
+    this.editorsResizeCaf = this.raf.raf(() => {
+      this.protobufEditor.resize();
+      this.protobufEditor.renderer.updateFull();
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    for (const propName of Object.keys(changes)) {
+      const change = changes[propName];
+      if (!change.firstChange && change.currentValue !== change.previousValue) {
+        if (propName === 'contentType') {
+          if (this.protobufEditor) {
+            let mode = 'protobuf';
+            this.protobufEditor.session.setMode(`ace/mode/${mode}`);
+          }
+        }
+      }
+    }
+  }
+
+  registerOnChange(fn: any): void {
+    this.propagateChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+    if (this.protobufEditor) {
+      this.protobufEditor.setReadOnly(this.disabled || this.readonly);
+    }
+  }
+
+  public validate(c: FormControl) {
+    return (this.contentValid) ? null : {
+      contentBody: {
+        valid: false,
+      },
+    };
+  }
+
+  writeValue(value: string): void {
+    this.contentBody = value;
+    this.contentValid = true;
+    if (this.protobufEditor) {
+      this.ignoreChange = true;
+      this.protobufEditor.setValue(this.contentBody ? this.contentBody : '', -1);
+      this.ignoreChange = false;
+    }
+  }
+
+  updateView() {
+    const editorValue = this.protobufEditor.getValue();
+    if (this.contentBody !== editorValue) {
+      this.contentBody = editorValue;
+      this.propagateChange(this.contentBody);
+    }
+  }
+
+  beautifyJSON() {
+    beautifyJs(this.contentBody, {indent_size: 4, wrap_line_length: 60}).subscribe(
+      (res) => {
+        this.protobufEditor.setValue(res ? res : '', -1);
+        this.updateView();
+      }
+    );
+  }
+
+  minifyJSON() {
+    const res = JSON.stringify(this.contentBody);
+    this.protobufEditor.setValue(res ? res : '', -1);
+    this.updateView();
+  }
+
+  onFullscreen() {
+    if (this.protobufEditor) {
+      setTimeout(() => {
+        this.protobufEditor.resize();
+      }, 0);
+    }
+  }
+
+}

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.ts
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.ts
@@ -1,3 +1,19 @@
+///
+/// Copyright © 2016-2021 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
 import {
   Component,
   ElementRef,

--- a/ui-ngx/src/app/shared/components/protobuf-content.component.ts
+++ b/ui-ngx/src/app/shared/components/protobuf-content.component.ts
@@ -3,13 +3,11 @@ import {
   ElementRef,
   forwardRef,
   Input,
-  OnChanges,
   OnDestroy,
   OnInit,
-  SimpleChanges,
   ViewChild
 } from '@angular/core';
-import { ControlValueAccessor, FormControl, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validator } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Ace } from 'ace-builds';
 import { CancelAnimationFrame, RafService } from '@core/services/raf.service';
 import { ResizeObserver } from '@juggle/resize-observer';
@@ -29,15 +27,10 @@ import { beautifyJs } from '@shared/models/beautify.models';
       provide: NG_VALUE_ACCESSOR,
       useExisting: forwardRef(() => ProtobufContentComponent),
       multi: true
-    },
-    {
-      provide: NG_VALIDATORS,
-      useExisting: forwardRef(() => ProtobufContentComponent),
-      multi: true,
     }
   ]
 })
-export class ProtobufContentComponent implements OnInit, ControlValueAccessor, Validator, OnDestroy {
+export class ProtobufContentComponent implements OnInit, ControlValueAccessor, OnDestroy {
 
   @ViewChild('protobufEditor', {static: true})
   protobufEditorElmRef: ElementRef;
@@ -71,8 +64,6 @@ export class ProtobufContentComponent implements OnInit, ControlValueAccessor, V
   fullscreen = false;
 
   contentBody: string;
-
-  contentValid: boolean;
 
   errorShowed = false;
 
@@ -138,17 +129,8 @@ export class ProtobufContentComponent implements OnInit, ControlValueAccessor, V
     }
   }
 
-  validate(c: FormControl) {
-    return (this.contentValid) ? null : {
-      contentBody: {
-        valid: false,
-      },
-    };
-  }
-
   writeValue(value: string): void {
     this.contentBody = value;
-    this.contentValid = true;
     if (this.protobufEditor) {
       this.ignoreChange = true;
       this.protobufEditor.setValue(this.contentBody ? this.contentBody : '', -1);

--- a/ui-ngx/src/app/shared/models/ace/ace.models.ts
+++ b/ui-ngx/src/app/shared/models/ace/ace.models.ts
@@ -36,6 +36,7 @@ export function loadAceDependencies(): Observable<any> {
     aceObservables.push(from(import('ace-builds/src-noconflict/mode-text')));
     aceObservables.push(from(import('ace-builds/src-noconflict/mode-markdown')));
     aceObservables.push(from(import('ace-builds/src-noconflict/mode-html')));
+    aceObservables.push(from(import('ace-builds/src-noconflict/mode-protobuf')));
     aceObservables.push(from(import('ace-builds/src-noconflict/snippets/java')));
     aceObservables.push(from(import('ace-builds/src-noconflict/snippets/css')));
     aceObservables.push(from(import('ace-builds/src-noconflict/snippets/json')));

--- a/ui-ngx/src/app/shared/models/ace/ace.models.ts
+++ b/ui-ngx/src/app/shared/models/ace/ace.models.ts
@@ -36,6 +36,7 @@ export function loadAceDependencies(): Observable<any> {
     aceObservables.push(from(import('ace-builds/src-noconflict/mode-text')));
     aceObservables.push(from(import('ace-builds/src-noconflict/mode-markdown')));
     aceObservables.push(from(import('ace-builds/src-noconflict/mode-html')));
+    aceObservables.push(from(import('ace-builds/src-noconflict/mode-c_cpp')));
     aceObservables.push(from(import('ace-builds/src-noconflict/mode-protobuf')));
     aceObservables.push(from(import('ace-builds/src-noconflict/snippets/java')));
     aceObservables.push(from(import('ace-builds/src-noconflict/snippets/css')));
@@ -44,6 +45,8 @@ export function loadAceDependencies(): Observable<any> {
     aceObservables.push(from(import('ace-builds/src-noconflict/snippets/text')));
     aceObservables.push(from(import('ace-builds/src-noconflict/snippets/markdown')));
     aceObservables.push(from(import('ace-builds/src-noconflict/snippets/html')));
+    aceObservables.push(from(import('ace-builds/src-noconflict/snippets/c_cpp')));
+    aceObservables.push(from(import('ace-builds/src-noconflict/snippets/protobuf')));
     aceObservables.push(from(import('ace-builds/src-noconflict/theme-textmate')));
     aceObservables.push(from(import('ace-builds/src-noconflict/theme-github')));
     return forkJoin(aceObservables).pipe(

--- a/ui-ngx/src/app/shared/shared.module.ts
+++ b/ui-ngx/src/app/shared/shared.module.ts
@@ -155,6 +155,7 @@ import { MarkedOptionsService } from '@shared/components/marked-options.service'
 import { TbPopoverService } from '@shared/components/popover.service';
 import { HELP_MARKDOWN_COMPONENT_TOKEN, SHARED_MODULE_TOKEN } from '@shared/components/tokens';
 import { TbMarkdownComponent } from '@shared/components/markdown.component';
+import { ProtobufContentComponent } from './components/protobuf-content.component';
 
 export function MarkedOptionsFactory(markedOptionsService: MarkedOptionsService) {
   return markedOptionsService;
@@ -268,7 +269,8 @@ export function MarkedOptionsFactory(markedOptionsService: MarkedOptionsService)
     OtaPackageAutocompleteComponent,
     WidgetsBundleSearchComponent,
     CopyButtonComponent,
-    TogglePasswordComponent
+    TogglePasswordComponent,
+    ProtobufContentComponent
   ],
   imports: [
     CommonModule,
@@ -458,7 +460,8 @@ export function MarkedOptionsFactory(markedOptionsService: MarkedOptionsService)
     OtaPackageAutocompleteComponent,
     WidgetsBundleSearchComponent,
     CopyButtonComponent,
-    TogglePasswordComponent
+    TogglePasswordComponent,
+    ProtobufContentComponent
   ]
 })
 export class SharedModule { }


### PR DESCRIPTION
UI changes in Device profiles -> Transport configuration -> Transport type: MQTT/CoAP.

- Added component ProtobufComponent in Shared module;
- Load 4 new modules in loadAceDependencies():
1. 'ace-builds/src-noconflict/mode-c_cpp'
2. 'ace-builds/src-noconflict/mode-protobuf'
3. 'ace-builds/src-noconflict/snippets/c_cpp'
4. 'ace-builds/src-noconflict/snippets/protobuf'