### PR TITLE
[3.3.2] Fixed analyze reprocessing decision in TbRuleEngineProcessingStrategyFactory

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/queue/processing/TbRuleEngineProcessingStrategyFactory.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/processing/TbRuleEngineProcessingStrategyFactory.java
@@ -17,6 +17,7 @@ package org.thingsboard.server.service.queue.processing;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.queue.TbMsgCallback;
 import org.thingsboard.server.gen.transport.TransportProtos;
@@ -77,6 +78,7 @@ public class TbRuleEngineProcessingStrategyFactory {
         @Override
         public TbRuleEngineProcessingDecision analyze(TbRuleEngineProcessingResult result) {
             if (result.isSuccess()) {
+                log.debug("[{}] The result of the msg pack processing is successful, going to proceed with processing of the following msgs", queueName);
                 return new TbRuleEngineProcessingDecision(true, null);
             } else {
                 if (retryCount == 0) {
@@ -91,6 +93,7 @@ public class TbRuleEngineProcessingStrategyFactory {
                     log.debug("[{}] Skip reprocess of the rule engine pack due to max allowed failure percentage", queueName);
                     return new TbRuleEngineProcessingDecision(true, null);
                 } else {
+                    log.debug("[{}] The result of msg pack processing is unsuccessful, checking unprocessed msgs and going to reprocess them", queueName);
                     ConcurrentMap<UUID, TbProtoQueueMsg<TransportProtos.ToRuleEngineMsg>> toReprocess = new ConcurrentHashMap<>(initialTotalCount);
                     if (retryFailed) {
                         result.getFailedMap().forEach(toReprocess::put);
@@ -100,6 +103,15 @@ public class TbRuleEngineProcessingStrategyFactory {
                     }
                     if (retrySuccessful) {
                         result.getSuccessMap().forEach(toReprocess::put);
+                    }
+                    if (CollectionUtils.isEmpty(toReprocess)) {
+                        log.debug("[{}] Stopping the reprocessing logic due to reprocessing map is empty", queueName);
+                        if (retryFailed) {
+                            log.debug("[{}] Probably there are timedOut msgs, but the strategy is not set to reprocess them. Reprocess of the failed msgs is set", queueName);
+                        } else if (retryTimeout) {
+                            log.debug("[{}] Probably there are failed msgs, but the strategy is not set to reprocess them. Reprocess of the timedOut msgs is set", queueName);
+                        }
+                        return new TbRuleEngineProcessingDecision(true, null);
                     }
                     log.debug("[{}] Going to reprocess {} messages", queueName, toReprocess.size());
                     if (log.isTraceEnabled()) {

--- a/application/src/main/java/org/thingsboard/server/service/queue/processing/TbRuleEngineProcessingStrategyFactory.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/processing/TbRuleEngineProcessingStrategyFactory.java
@@ -97,19 +97,22 @@ public class TbRuleEngineProcessingStrategyFactory {
                     ConcurrentMap<UUID, TbProtoQueueMsg<TransportProtos.ToRuleEngineMsg>> toReprocess = new ConcurrentHashMap<>(initialTotalCount);
                     if (retryFailed) {
                         result.getFailedMap().forEach(toReprocess::put);
+                    } else if (log.isDebugEnabled() && !result.getFailedMap().isEmpty()) {
+                        log.debug("[{}] Skipped {} failed messages due to the processing strategy configuration", queueName, result.getFailedMap().size());
                     }
                     if (retryTimeout) {
                         result.getPendingMap().forEach(toReprocess::put);
+                    } else if (log.isDebugEnabled() && !result.getPendingMap().isEmpty()) {
+                        log.debug("[{}] Skipped {} timedOut messages due to the processing strategy configuration", queueName, result.getPendingMap().size());
                     }
                     if (retrySuccessful) {
                         result.getSuccessMap().forEach(toReprocess::put);
+                    } else if (log.isDebugEnabled() && !result.getSuccessMap().isEmpty()) {
+                        log.debug("[{}] Skipped {} successful messages due to the processing strategy configuration", queueName, result.getSuccessMap().size());
                     }
                     if (CollectionUtils.isEmpty(toReprocess)) {
-                        log.debug("[{}] Stopping the reprocessing logic due to reprocessing map is empty", queueName);
-                        if (retryFailed) {
-                            log.debug("[{}] Probably there are timedOut msgs, but the strategy is not set to reprocess them. Reprocess of the failed msgs is set", queueName);
-                        } else if (retryTimeout) {
-                            log.debug("[{}] Probably there are failed msgs, but the strategy is not set to reprocess them. Reprocess of the timedOut msgs is set", queueName);
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] Stopping the reprocessing logic due to reprocessing map is empty", queueName);
                         }
                         return new TbRuleEngineProcessingDecision(true, null);
                     }

--- a/application/src/main/java/org/thingsboard/server/service/queue/processing/TbRuleEngineProcessingStrategyFactory.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/processing/TbRuleEngineProcessingStrategyFactory.java
@@ -78,7 +78,7 @@ public class TbRuleEngineProcessingStrategyFactory {
         @Override
         public TbRuleEngineProcessingDecision analyze(TbRuleEngineProcessingResult result) {
             if (result.isSuccess()) {
-                log.debug("[{}] The result of the msg pack processing is successful, going to proceed with processing of the following msgs", queueName);
+                log.trace("[{}] The result of the msg pack processing is successful, going to proceed with processing of the following msgs", queueName);
                 return new TbRuleEngineProcessingDecision(true, null);
             } else {
                 if (retryCount == 0) {
@@ -107,8 +107,8 @@ public class TbRuleEngineProcessingStrategyFactory {
                     }
                     if (retrySuccessful) {
                         result.getSuccessMap().forEach(toReprocess::put);
-                    } else if (log.isDebugEnabled() && !result.getSuccessMap().isEmpty()) {
-                        log.debug("[{}] Skipped {} successful messages due to the processing strategy configuration", queueName, result.getSuccessMap().size());
+                    } else if (log.isTraceEnabled() && !result.getSuccessMap().isEmpty()) {
+                        log.trace("[{}] Skipped {} successful messages due to the processing strategy configuration", queueName, result.getSuccessMap().size());
                     }
                     if (CollectionUtils.isEmpty(toReprocess)) {
                         if (log.isDebugEnabled()) {


### PR DESCRIPTION
Fixing the issue for the unnecessary consumer waiting for messages reprocessing when no messages are needed to be reprocessed.

Example of the current logic:
processing-strategy.type = RETRY_TIMED_OUT
10 messages are sent for processing in a pack. Result: 9 successful, 1 is failed.
if (retryFailed) { // false
    result.getFailedMap().forEach(toReprocess::put);
}
if (retryTimeout) { // true
    result.getPendingMap().forEach(toReprocess::put);  -> will not add anthing to the map since there are 0 timedOut messages
}

then
return new TbRuleEngineProcessingDecision(false, toReprocess); // empty map

So, no messages will be sent for the processing, but the consumer will wait approximately:
X retries * pack-processing-timeout + X retries * pause-between-retries (plus max-pause-between-retries could be set)
until the decision will be to commit the current pack and next messages will be consumed for processing.

If I am right, this could happen in 2 cases. When processing-strategy.type = RETRY_TIMED_OUT and we have failed messages in the pack and when processing-strategy.type = RETRY_FAILED and we have timedOut messages in the pack.