### PR TITLE
ui: event table: default interval is 5 minutes

### DIFF
--- a/ui-ngx/src/app/modules/home/components/event/event-table-config.ts
+++ b/ui-ngx/src/app/modules/home/components/event/event-table-config.ts
@@ -48,6 +48,7 @@ import {
   EventFilterPanelData,
   FilterEntityColumn
 } from '@home/components/event/event-filter-panel.component';
+import {historyInterval, MINUTE} from '@shared/models/time/time.models';
 
 export class EventTableConfig extends EntityTableConfig<Event, TimePageLink> {
 
@@ -87,6 +88,7 @@ export class EventTableConfig extends EntityTableConfig<Event, TimePageLink> {
     this.loadDataOnInit = false;
     this.tableTitle = '';
     this.useTimePageLink = true;
+    this.defaultTimewindowInterval = historyInterval(MINUTE * 5);
     this.detailsPanelEnabled = false;
     this.selectionEnabled = false;
     this.searchEnabled = false;


### PR DESCRIPTION
To open events on the rule node when you have a few million since the last 24h. (even index did not help)
![image](https://user-images.githubusercontent.com/79898499/139872424-bf31f24d-53e8-42b5-a2a6-f5f2fadf9154.png)
@ViacheslavKlimov FYI