### PR TITLE
Set serialVersionUID for DeviceProfile class

### DIFF
--- a/common/data/src/main/java/org/thingsboard/server/common/data/DeviceProfile.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/DeviceProfile.java
@@ -42,6 +42,8 @@ import static org.thingsboard.server.common.data.SearchTextBasedWithAdditionalIn
 @Slf4j
 public class DeviceProfile extends SearchTextBased<DeviceProfileId> implements HasName, HasTenantId, HasOtaPackage {
 
+    private static final long serialVersionUID = 6998485460273302018L;
+
     @ApiModelProperty(position = 3, value = "JSON object with Tenant Id that owns the profile.", readOnly = true)
     private TenantId tenantId;
     @NoXss


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56742475/140039762-3749fb06-aad5-440b-b5bb-593bfe26be3e.png)

serialVersionUID is set as it was before the f47de8cfa60220c12f1eef357f132b0e1a8173af commit (latest change to DeviceProfile class) 