### PR TITLE
[3.3.3] fixed EntityDataAdapter.convertValue that convert "500D" (valid Java number) into "500.0" as double

### DIFF
--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -256,7 +256,7 @@
                 <configuration>
                     <excludes>
                         <exclude>**/sql/*Test.java</exclude>
-                        <exclude>**/sql/*/*Test.java</exclude>
+                        <exclude>**/sql/*/*DaoTest.java</exclude>
                         <exclude>**/psql/*Test.java</exclude>
                         <exclude>**/nosql/*Test.java</exclude>
                     </excludes>

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/EntityDataAdapter.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/EntityDataAdapter.java
@@ -79,7 +79,7 @@ public class EntityDataAdapter {
         return entityData;
     }
 
-    private static String convertValue(Object value) {
+    static String convertValue(Object value) {
         if (value != null) {
             String strVal = value.toString();
             // check number

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/EntityDataAdapter.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/EntityDataAdapter.java
@@ -83,7 +83,7 @@ public class EntityDataAdapter {
         if (value != null) {
             String strVal = value.toString();
             // check number
-            if (NumberUtils.isNumber(strVal)) {
+            if (strVal.length() > 0 && NumberUtils.isParsable(strVal)) {
                 try {
                     long longVal = Long.parseLong(strVal);
                     return Long.toString(longVal);

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/query/EntityDataAdapterTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/query/EntityDataAdapterTest.java
@@ -15,14 +15,14 @@
  */
 package org.thingsboard.server.dao.sql.query;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class EntityDataAdapterTest {
+public class EntityDataAdapterTest {
 
     @Test
-    void testConvertValue() {
+    public void testConvertValue() {
         assertThat(EntityDataAdapter.convertValue("500")).isEqualTo("500");
         assertThat(EntityDataAdapter.convertValue("500D")).isEqualTo("500D"); //do not convert to Double !!!
     }

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/query/EntityDataAdapterTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/query/EntityDataAdapterTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.sql.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EntityDataAdapterTest {
+
+    @Test
+    void testConvertValue() {
+        assertThat(EntityDataAdapter.convertValue("500")).isEqualTo("500");
+        assertThat(EntityDataAdapter.convertValue("500D")).isEqualTo("500D"); //do not convert to Double !!!
+    }
+}


### PR DESCRIPTION
fixed EntityDataAdapter.convertValue that convert "500D" ("valid Java number") into "500.0" as double. 
For the String attribute "gatewayType", the text value "500D" was converted as 500.0 that confuses a user.
EntityDataAdapterTest added.
![image](https://user-images.githubusercontent.com/79898499/140316570-156a92da-047b-4bd2-a878-ece540775f87.png)
![image](https://user-images.githubusercontent.com/79898499/140318001-f52e1ef3-c060-451f-a781-e6df1425128e.png)
![image](https://user-images.githubusercontent.com/79898499/140318133-2680c8dd-fd99-41b9-a93a-ba15088b4ad8.png)
