### PR TITLE
[3.3.2] Create relation rule node fix and tests

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateRelationNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateRelationNode.java
@@ -18,6 +18,7 @@ package org.thingsboard.rule.engine.action;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.CollectionUtils;
 import org.thingsboard.rule.engine.api.RuleNode;
 import org.thingsboard.rule.engine.api.TbContext;
 import org.thingsboard.rule.engine.api.TbNodeConfiguration;
@@ -69,41 +70,31 @@ public class TbCreateRelationNode extends TbAbstractRelationActionNode<TbCreateR
 
     @Override
     protected ListenableFuture<RelationContainer> doProcessEntityRelationAction(TbContext ctx, TbMsg msg, EntityContainer entity, String relationType) {
-        ListenableFuture<Boolean> future = createIfAbsent(ctx, msg, entity, relationType);
+        ListenableFuture<Boolean> future = createRelationIfAbsent(ctx, msg, entity, relationType);
         return Futures.transform(future, result -> {
-            RelationContainer container = new RelationContainer();
             if (result && config.isChangeOriginatorToRelatedEntity()) {
                 TbMsg tbMsg = ctx.transformMsg(msg, msg.getType(), entity.getEntityId(), msg.getMetaData(), msg.getData());
-                container.setMsg(tbMsg);
-            } else {
-                container.setMsg(msg);
+                return new RelationContainer(tbMsg, result);
             }
-            container.setResult(result);
-            return container;
+            return new RelationContainer(msg, result);
         }, ctx.getDbCallbackExecutor());
     }
 
-    private ListenableFuture<Boolean> createIfAbsent(TbContext ctx, TbMsg msg, EntityContainer entityContainer, String relationType) {
+    private ListenableFuture<Boolean> createRelationIfAbsent(TbContext ctx, TbMsg msg, EntityContainer entityContainer, String relationType) {
         SearchDirectionIds sdId = processSingleSearchDirection(msg, entityContainer);
-        ListenableFuture<Boolean> checkRelationFuture = Futures.transformAsync(ctx.getRelationService().checkRelation(ctx.getTenantId(), sdId.getFromId(), sdId.getToId(), relationType, RelationTypeGroup.COMMON), result -> {
-            if (!result) {
-                if (config.isRemoveCurrentRelations()) {
-                    return processDeleteRelations(ctx, processFindRelations(ctx, msg, sdId, relationType));
-                }
-                return Futures.immediateFuture(false);
-            }
-            return Futures.immediateFuture(true);
-        }, ctx.getDbCallbackExecutor());
-
-        return Futures.transformAsync(checkRelationFuture, result -> {
-            if (!result) {
-                return processCreateRelation(ctx, entityContainer, sdId, relationType);
-            }
-            return Futures.immediateFuture(true);
-        }, ctx.getDbCallbackExecutor());
+        return Futures.transformAsync(deleteCurrentRelationsIfNeeded(ctx, msg, sdId, relationType), v ->
+                        checkRelationAndCreateIfAbsent(ctx, entityContainer, relationType, sdId),
+                ctx.getDbCallbackExecutor());
     }
 
-    private ListenableFuture<List<EntityRelation>> processFindRelations(TbContext ctx, TbMsg msg, SearchDirectionIds sdId, String relationType) {
+    private ListenableFuture<Void> deleteCurrentRelationsIfNeeded(TbContext ctx, TbMsg msg, SearchDirectionIds sdId, String relationType) {
+        if (config.isRemoveCurrentRelations()) {
+            return deleteOriginatorRelations(ctx, findOriginatorRelations(ctx, msg, sdId, relationType));
+        }
+        return Futures.immediateFuture(null);
+    }
+
+    private ListenableFuture<List<EntityRelation>> findOriginatorRelations(TbContext ctx, TbMsg msg, SearchDirectionIds sdId, String relationType) {
         if (sdId.isOriginatorDirectionFrom()) {
             return ctx.getRelationService().findByFromAndTypeAsync(ctx.getTenantId(), msg.getOriginator(), relationType, RelationTypeGroup.COMMON);
         } else {
@@ -111,17 +102,29 @@ public class TbCreateRelationNode extends TbAbstractRelationActionNode<TbCreateR
         }
     }
 
-    private ListenableFuture<Boolean> processDeleteRelations(TbContext ctx, ListenableFuture<List<EntityRelation>> listListenableFuture) {
-        return Futures.transformAsync(listListenableFuture, entityRelations -> {
-            if (!entityRelations.isEmpty()) {
-                List<ListenableFuture<Boolean>> list = new ArrayList<>();
-                for (EntityRelation relation : entityRelations) {
+    private ListenableFuture<Void> deleteOriginatorRelations(TbContext ctx, ListenableFuture<List<EntityRelation>> originatorRelationsFuture) {
+        return Futures.transformAsync(originatorRelationsFuture, originatorRelations -> {
+            List<ListenableFuture<Boolean>> list = new ArrayList<>();
+            if (!CollectionUtils.isEmpty(originatorRelations)) {
+                for (EntityRelation relation : originatorRelations) {
                     list.add(ctx.getRelationService().deleteRelationAsync(ctx.getTenantId(), relation));
                 }
-                return Futures.transform(Futures.allAsList(list), result -> false, ctx.getDbCallbackExecutor());
             }
-            return Futures.immediateFuture(false);
+            return Futures.transform(Futures.allAsList(list), result -> null, ctx.getDbCallbackExecutor());
         }, ctx.getDbCallbackExecutor());
+    }
+
+    private ListenableFuture<Boolean> checkRelationAndCreateIfAbsent(TbContext ctx, EntityContainer entityContainer, String relationType, SearchDirectionIds sdId) {
+        return Futures.transformAsync(checkRelation(ctx, sdId, relationType), relationPresent -> {
+            if (relationPresent) {
+                return Futures.immediateFuture(true);
+            }
+            return processCreateRelation(ctx, entityContainer, sdId, relationType);
+        }, ctx.getDbCallbackExecutor());
+    }
+
+    private ListenableFuture<Boolean> checkRelation(TbContext ctx, SearchDirectionIds sdId, String relationType) {
+        return ctx.getRelationService().checkRelation(ctx.getTenantId(), sdId.getFromId(), sdId.getToId(), relationType, RelationTypeGroup.COMMON);
     }
 
     private ListenableFuture<Boolean> processCreateRelation(TbContext ctx, EntityContainer entityContainer, SearchDirectionIds sdId, String relationType) {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateRelationNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateRelationNodeTest.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright © 2016-2021 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.action;
+
+import com.datastax.oss.driver.api.core.uuid.Uuids;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.thingsboard.common.util.ListeningExecutor;
+import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.rule.engine.api.TbNodeConfiguration;
+import org.thingsboard.rule.engine.api.TbNodeException;
+import org.thingsboard.rule.engine.api.TbRelationTypes;
+import org.thingsboard.server.common.data.DataConstants;
+import org.thingsboard.server.common.data.asset.Asset;
+import org.thingsboard.server.common.data.id.AssetId;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.RuleChainId;
+import org.thingsboard.server.common.data.id.RuleNodeId;
+import org.thingsboard.server.common.data.relation.EntityRelation;
+import org.thingsboard.server.common.data.relation.EntitySearchDirection;
+import org.thingsboard.server.common.data.relation.RelationTypeGroup;
+import org.thingsboard.server.common.msg.TbMsg;
+import org.thingsboard.server.common.msg.TbMsgDataType;
+import org.thingsboard.server.common.msg.TbMsgMetaData;
+import org.thingsboard.server.dao.asset.AssetService;
+import org.thingsboard.server.dao.relation.RelationService;
+
+import java.util.Collections;
+import java.util.concurrent.Callable;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TbCreateRelationNodeTest {
+
+    private static final String RELATION_TYPE_CONTAINS = "Contains";
+
+    private TbCreateRelationNode node;
+
+    @Mock
+    private TbContext ctx;
+    @Mock
+    private AssetService assetService;
+    @Mock
+    private RelationService relationService;
+
+    private TbMsg msg;
+
+    private RuleChainId ruleChainId = new RuleChainId(Uuids.timeBased());
+    private RuleNodeId ruleNodeId = new RuleNodeId(Uuids.timeBased());
+
+    private ListeningExecutor dbExecutor;
+
+    @Before
+    public void before() {
+        dbExecutor = new ListeningExecutor() {
+            @Override
+            public <T> ListenableFuture<T> executeAsync(Callable<T> task) {
+                try {
+                    return Futures.immediateFuture(task.call());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+        };
+    }
+
+    @Test
+    public void testCreateNewRelation() throws TbNodeException {
+        init(createRelationNodeConfig());
+
+        DeviceId deviceId = new DeviceId(Uuids.timeBased());
+
+        AssetId assetId = new AssetId(Uuids.timeBased());
+        Asset asset = new Asset();
+        asset.setId(assetId);
+
+        when(assetService.findAssetByTenantIdAndName(any(), eq("AssetName"))).thenReturn(asset);
+        when(assetService.findAssetByIdAsync(any(), eq(assetId))).thenReturn(Futures.immediateFuture(asset));
+
+        TbMsgMetaData metaData = new TbMsgMetaData();
+        metaData.putValue("name", "AssetName");
+        metaData.putValue("type", "AssetType");
+        msg = TbMsg.newMsg(DataConstants.ENTITY_CREATED, deviceId, metaData, TbMsgDataType.JSON, "{}", ruleChainId, ruleNodeId);
+
+        when(ctx.getRelationService().checkRelation(any(), eq(assetId), eq(deviceId), eq(RELATION_TYPE_CONTAINS), eq(RelationTypeGroup.COMMON)))
+                .thenReturn(Futures.immediateFuture(false));
+        when(ctx.getRelationService().saveRelationAsync(any(), eq(new EntityRelation(assetId, deviceId, RELATION_TYPE_CONTAINS, RelationTypeGroup.COMMON))))
+                .thenReturn(Futures.immediateFuture(true));
+
+        node.onMsg(ctx, msg);
+        verify(ctx).tellNext(msg, TbRelationTypes.SUCCESS);
+    }
+
+    @Test
+    public void testDeleteCurrentRelationsCreateNewRelation() throws TbNodeException {
+        init(createRelationNodeConfigWithRemoveCurrentRelations());
+
+        DeviceId deviceId = new DeviceId(Uuids.timeBased());
+
+        AssetId assetId = new AssetId(Uuids.timeBased());
+        Asset asset = new Asset();
+        asset.setId(assetId);
+
+        when(assetService.findAssetByTenantIdAndName(any(), eq("AssetName"))).thenReturn(asset);
+        when(assetService.findAssetByIdAsync(any(), eq(assetId))).thenReturn(Futures.immediateFuture(asset));
+
+        TbMsgMetaData metaData = new TbMsgMetaData();
+        metaData.putValue("name", "AssetName");
+        metaData.putValue("type", "AssetType");
+        msg = TbMsg.newMsg(DataConstants.ENTITY_CREATED, deviceId, metaData, TbMsgDataType.JSON, "{}", ruleChainId, ruleNodeId);
+
+        EntityRelation relation = new EntityRelation();
+        when(ctx.getRelationService().findByToAndTypeAsync(any(), eq(msg.getOriginator()), eq(RELATION_TYPE_CONTAINS), eq(RelationTypeGroup.COMMON)))
+                .thenReturn(Futures.immediateFuture(Collections.singletonList(relation)));
+        when(ctx.getRelationService().deleteRelationAsync(any(), eq(relation))).thenReturn(Futures.immediateFuture(true));
+        when(ctx.getRelationService().checkRelation(any(), eq(assetId), eq(deviceId), eq(RELATION_TYPE_CONTAINS), eq(RelationTypeGroup.COMMON)))
+                .thenReturn(Futures.immediateFuture(false));
+        when(ctx.getRelationService().saveRelationAsync(any(), eq(new EntityRelation(assetId, deviceId, RELATION_TYPE_CONTAINS, RelationTypeGroup.COMMON))))
+                .thenReturn(Futures.immediateFuture(true));
+
+        node.onMsg(ctx, msg);
+        verify(ctx).tellNext(msg, TbRelationTypes.SUCCESS);
+    }
+
+    public void init(TbCreateRelationNodeConfiguration configuration) throws TbNodeException {
+        ObjectMapper mapper = new ObjectMapper();
+        TbNodeConfiguration nodeConfiguration = new TbNodeConfiguration(mapper.valueToTree(configuration));
+
+        when(ctx.getDbCallbackExecutor()).thenReturn(dbExecutor);
+        when(ctx.getRelationService()).thenReturn(relationService);
+        when(ctx.getAssetService()).thenReturn(assetService);
+
+        node = new TbCreateRelationNode();
+        node.init(ctx, nodeConfiguration);
+    }
+
+    private TbCreateRelationNodeConfiguration createRelationNodeConfig() {
+        TbCreateRelationNodeConfiguration configuration = new TbCreateRelationNodeConfiguration();
+        configuration.setDirection(EntitySearchDirection.FROM.name());
+        configuration.setRelationType(RELATION_TYPE_CONTAINS);
+        configuration.setEntityCacheExpiration(300);
+        configuration.setEntityType("ASSET");
+        configuration.setEntityNamePattern("${name}");
+        configuration.setEntityTypePattern("${type}");
+        configuration.setCreateEntityIfNotExists(false);
+        configuration.setChangeOriginatorToRelatedEntity(false);
+        configuration.setRemoveCurrentRelations(false);
+        return configuration;
+    }
+
+    private TbCreateRelationNodeConfiguration createRelationNodeConfigWithRemoveCurrentRelations() {
+        TbCreateRelationNodeConfiguration configuration = createRelationNodeConfig();
+        configuration.setRemoveCurrentRelations(true);
+        return configuration;
+    }
+}


### PR DESCRIPTION
Improved create relation rule node logic related to the "Remove current relations" (hint on the UI - Removes current relations from the originator of the incoming message based on direction and type.) checkbox.

Currently, if it is selected, it is removing the relations only if the new one that should be created from the originator to the target configured entity is not present yet. That could cause many discrepancies in the hierarchy of the relationships and this logic does not reflect what should be and how the hint is described. This causes confusion.

Improved to delete the current relations if selected in any case and refactored the code. Added tests.