### PR TITLE
Fix for mqtt duplication sending on sent failed

### DIFF
--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttClientImpl.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttClientImpl.java
@@ -368,6 +368,7 @@ final class MqttClientImpl implements MqttClient {
         if (channelFuture != null) {
             pendingPublish.setSent(true);
             if (channelFuture.cause() != null) {
+                this.pendingPublishes.remove(pendingPublish.getMessageId());
                 future.setFailure(channelFuture.cause());
                 return future;
             }

--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttClientImpl.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttClientImpl.java
@@ -156,9 +156,11 @@ final class MqttClientImpl implements MqttClient {
                     if (callback != null) {
                         callback.connectionLost(e);
                     }
+                    pendingSubscriptions.forEach((id, mqttPendingSubscription) -> mqttPendingSubscription.onChannelClosed());
                     pendingSubscriptions.clear();
                     serverSubscriptions.clear();
                     subscriptions.clear();
+                    pendingServerUnsubscribes.forEach((id, mqttPendingServerUnsubscribes) -> mqttPendingServerUnsubscribes.onChannelClosed());
                     pendingServerUnsubscribes.clear();
                     qos2PendingIncomingPublishes.clear();
                     pendingPublishes.forEach((id, mqttPendingPublish) -> mqttPendingPublish.onChannelClosed());

--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttPendingPublish.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttPendingPublish.java
@@ -24,7 +24,7 @@ import io.netty.util.concurrent.Promise;
 
 import java.util.function.Consumer;
 
-final class MqttPendingPublish {
+final class MqttPendingPublish{
 
     private final int messageId;
     private final Promise<Void> future;
@@ -99,7 +99,7 @@ final class MqttPendingPublish {
         this.pubrelRetransmissionHandler.stop();
     }
 
-    void onChannelClosed() {
+    void onChannelClosed(){
         this.publishRetransmissionHandler.stop();
         this.pubrelRetransmissionHandler.stop();
     }

--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttPendingPublish.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttPendingPublish.java
@@ -98,4 +98,9 @@ final class MqttPendingPublish {
     void onPubcompReceived() {
         this.pubrelRetransmissionHandler.stop();
     }
+
+    void onChannelClosed() {
+        this.publishRetransmissionHandler.stop();
+        this.pubrelRetransmissionHandler.stop();
+    }
 }

--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttPendingSubscription.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttPendingSubscription.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-final class MqttPendingSubscription {
+final class MqttPendingSubscription{
 
     private final Promise<Void> future;
     private final String topic;
@@ -98,5 +98,9 @@ final class MqttPendingSubscription {
         boolean isOnce() {
             return once;
         }
+    }
+
+    void onChannelClosed(){
+        this.retransmissionHandler.stop();
     }
 }

--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttPendingUnsubscription.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttPendingUnsubscription.java
@@ -21,7 +21,7 @@ import io.netty.util.concurrent.Promise;
 
 import java.util.function.Consumer;
 
-final class MqttPendingUnsubscription {
+final class MqttPendingUnsubscription{
 
     private final Promise<Void> future;
     private final String topic;
@@ -50,6 +50,10 @@ final class MqttPendingUnsubscription {
     }
 
     void onUnsubackReceived(){
+        this.retransmissionHandler.stop();
+    }
+
+    void onChannelClosed(){
         this.retransmissionHandler.stop();
     }
 }


### PR DESCRIPTION
If sending future was failed - we didn't remove a message from pending map and processed it again.