### PR TITLE
Fixed NPE in case of incorrect partitioning name parameter 

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/NoSqlTsPartitionDate.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/NoSqlTsPartitionDate.java
@@ -66,6 +66,6 @@ public enum NoSqlTsPartitionDate {
                 }
             }
         }
-        return Optional.of(partition);
+        return Optional.ofNullable(partition);
     }
 }


### PR DESCRIPTION
Fixed NPE in case of incorrect partitioning name parameter 
(now you will see the normal log message with error)