### PR TITLE
[3.3.3] improve equals for BaseReadTsKvQuery

### DIFF
--- a/common/data/src/main/java/org/thingsboard/server/common/data/kv/BaseReadTsKvQuery.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/kv/BaseReadTsKvQuery.java
@@ -16,8 +16,10 @@
 package org.thingsboard.server.common.data.kv;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class BaseReadTsKvQuery extends BaseTsKvQuery implements ReadTsKvQuery {
 
     private final long interval;


### PR DESCRIPTION
When we compare two BaseReadTsKvQuery objects, which have all field equals, except key, startTs, and endTs. Without @EqualsAndHashCode(callSuper = true), these objects are equals, but it is incorrect because key, startTs, and endTs are different. But with this annotation result is correct