### PR TITLE
[3.3.3] no class entity with id exists for relation fix

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/sql/relation/JpaRelationDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/relation/JpaRelationDao.java
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 import org.thingsboard.server.common.data.EntityType;
@@ -159,7 +160,7 @@ public class JpaRelationDao extends JpaAbstractDaoListeningExecutorService imple
         if (relationExistsBeforeDelete) {
             try {
                 relationRepository.deleteById(key);
-            } catch (ConcurrencyFailureException e) {
+            } catch (DataAccessException e) {
                 log.debug("[{}] Concurrency exception while deleting relation", key, e);
             }
         }
@@ -200,7 +201,7 @@ public class JpaRelationDao extends JpaAbstractDaoListeningExecutorService imple
         return (root, criteriaQuery, criteriaBuilder) -> {
             List<Predicate> predicates = new ArrayList<>();
             if (from != null) {
-                Predicate fromIdPredicate = criteriaBuilder.equal(root.get("fromId"),  from.getId());
+                Predicate fromIdPredicate = criteriaBuilder.equal(root.get("fromId"), from.getId());
                 predicates.add(fromIdPredicate);
                 Predicate fromEntityTypePredicate = criteriaBuilder.equal(root.get("fromType"), from.getEntityType().name());
                 predicates.add(fromEntityTypePredicate);


### PR DESCRIPTION
Improving the fix for concurrent relation deletion to fix the bug shown below.

![image (1)](https://user-images.githubusercontent.com/10978307/142437191-abd25c70-6417-4792-af87-6942754606e3.png)

On the following screenshot, two messages has the same originator.
![image](https://user-images.githubusercontent.com/10978307/142437205-0c1b0860-b82d-4af8-8ded-6c8ae5452abc.png)
