### PR TITLE
[3.3.3] UI: Bugs fixing for LwM2M transport

### DIFF
--- a/ui-ngx/src/app/modules/home/components/profile/device/lwm2m/lwm2m-device-profile-transport-configuration.component.ts
+++ b/ui-ngx/src/app/modules/home/components/profile/device/lwm2m/lwm2m-device-profile-transport-configuration.component.ts
@@ -14,7 +14,7 @@
 /// limitations under the License.
 ///
 
-import { Component, forwardRef, Input, OnDestroy } from '@angular/core';
+import { ChangeDetectorRef, Component, forwardRef, Input, OnDestroy } from '@angular/core';
 import {
   ControlValueAccessor,
   FormBuilder,
@@ -95,6 +95,7 @@ export class Lwm2mDeviceProfileTransportConfigurationComponent implements Contro
   }
 
   constructor(private fb: FormBuilder,
+              private cd: ChangeDetectorRef,
               private deviceProfileService: DeviceProfileService) {
     this.lwm2mDeviceProfileFormGroup = this.fb.group({
       objectIds: [null],
@@ -236,6 +237,7 @@ export class Lwm2mDeviceProfileTransportConfigurationComponent implements Contro
       this.lwm2mDeviceProfileFormGroup.get('clientLwM2mSettings.fwUpdateStrategy').updateValueAndValidity({onlySelf: true});
       this.lwm2mDeviceProfileFormGroup.get('clientLwM2mSettings.swUpdateStrategy').updateValueAndValidity({onlySelf: true});
     }
+    this.cd.detectChanges();
   }
 
   private updateModel = (): void => {

--- a/ui-ngx/src/app/modules/home/components/profile/device/lwm2m/lwm2m-device-profile-transport-configuration.component.ts
+++ b/ui-ngx/src/app/modules/home/components/profile/device/lwm2m/lwm2m-device-profile-transport-configuration.component.ts
@@ -237,7 +237,7 @@ export class Lwm2mDeviceProfileTransportConfigurationComponent implements Contro
       this.lwm2mDeviceProfileFormGroup.get('clientLwM2mSettings.fwUpdateStrategy').updateValueAndValidity({onlySelf: true});
       this.lwm2mDeviceProfileFormGroup.get('clientLwM2mSettings.swUpdateStrategy').updateValueAndValidity({onlySelf: true});
     }
-    this.cd.detectChanges();
+    this.cd.markForCheck();
   }
 
   private updateModel = (): void => {

--- a/ui-ngx/src/app/modules/home/components/wizard/device-wizard-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/wizard/device-wizard-dialog.component.ts
@@ -252,6 +252,14 @@ export class DeviceWizardDialogComponent extends
   private deviceProfileTransportTypeChanged(deviceTransportType: DeviceTransportType): void {
     this.transportConfigFormGroup.patchValue(
       {transportConfiguration: createDeviceProfileTransportConfiguration(deviceTransportType)});
+    const setCredentialBox = this.credentialsFormGroup.get('setCredential');
+    if (deviceTransportType === DeviceTransportType.LWM2M) {
+      setCredentialBox.patchValue(true);
+      setCredentialBox.disable();
+    } else {
+      setCredentialBox.patchValue(false);
+      setCredentialBox.enable();
+    }
   }
 
   add(): void {


### PR DESCRIPTION
1. Fixed bug with missing the required credential-config when new device-profile(with LwM2m transport) was created via "Device wizard dialog"
2. Fixed bug with UI updating of bootstrap-config for LwM2M device-profiles when the user is switching between two profile table-rows with opened "Details" side-panel.