### PR TITLE
[3.3.3] lwm2m - info about previous update Ota

### DIFF
--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/DefaultLwM2MOtaUpdateService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/DefaultLwM2MOtaUpdateService.java
@@ -399,12 +399,12 @@ public class DefaultLwM2MOtaUpdateService extends LwM2MExecutorAwareService impl
                     log.debug("[{}] Starting update to [{}{}] using binary", client.getEndpoint(), fwInfo.getTargetName(), fwInfo.getTargetVersion());
                     startUpdateUsingBinary(client, fwInfo);
                 }
-            } else if (fwInfo.updateState != null) {
-                log.debug("[{}] failed to process firmware update: [{}]. Previous update failed.", client.getEndpoint(), fwInfo);
-                logService.log(client, "Failed to process firmware update: " + fwInfo + ". Previous update failed.");
+            } else if (fwInfo.getResult() != null && fwInfo.getResult().getCode() > 1) {
+                log.trace("[{}] Previous update failed. [{}]", client.getEndpoint(), fwInfo);
+                logService.log(client, "Previous update firmware failed. Result: " + fwInfo.getResult().name());
             }
         } catch (Exception e) {
-            log.info("[{}] failed to update client: {}", client.getEndpoint(), fwInfo, e);
+            log.error("[{}] failed to update client: {}", client.getEndpoint(), fwInfo, e);
             sendStateUpdateToTelemetry(client, fwInfo, OtaPackageUpdateStatus.FAILED, "Internal server error: " + e.getMessage());
         }
     }
@@ -427,9 +427,9 @@ public class DefaultLwM2MOtaUpdateService extends LwM2MExecutorAwareService impl
                         startUpdateUsingBinary(client, swInfo);
                     }
                 }
-            } else if (swInfo.updateState != null) {
-                log.debug("[{}] failed to update client: [{}], previous update failed.", client.getEndpoint(), swInfo);
-                logService.log(client, "Failed to process software update: " + swInfo + ". Previous update failed.");
+            } else if (swInfo.getResult() != null && swInfo.getResult().code >= 50) {
+                log.trace("[{}] Previous update failed. [{}]", client.getEndpoint(), swInfo);
+                logService.log(client, "Previous update software failed. Result: " + swInfo.getResult().name());
             }
         } catch (Exception e) {
             log.info("[{}] failed to update client: {}", client.getEndpoint(), swInfo, e);

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/DefaultLwM2MOtaUpdateService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/DefaultLwM2MOtaUpdateService.java
@@ -74,6 +74,8 @@ import static org.thingsboard.server.common.data.ota.OtaPackageUpdateStatus.UPDA
 import static org.thingsboard.server.common.data.ota.OtaPackageUpdateStatus.UPDATING;
 import static org.thingsboard.server.common.data.ota.OtaPackageUpdateStatus.VERIFIED;
 import static org.thingsboard.server.common.data.ota.OtaPackageUtil.getAttributeKey;
+import static org.thingsboard.server.transport.lwm2m.server.ota.firmware.FirmwareUpdateResult.UPDATE_SUCCESSFULLY;
+import static org.thingsboard.server.transport.lwm2m.server.ota.software.SoftwareUpdateResult.NOT_ENOUGH_STORAGE;
 import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.LOG_LWM2M_TELEMETRY;
 import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.convertObjectIdToVersionedId;
 
@@ -399,7 +401,7 @@ public class DefaultLwM2MOtaUpdateService extends LwM2MExecutorAwareService impl
                     log.debug("[{}] Starting update to [{}{}] using binary", client.getEndpoint(), fwInfo.getTargetName(), fwInfo.getTargetVersion());
                     startUpdateUsingBinary(client, fwInfo);
                 }
-            } else if (fwInfo.getResult() != null && fwInfo.getResult().getCode() > 1) {
+            } else if (fwInfo.getResult() != null && fwInfo.getResult().getCode() >  UPDATE_SUCCESSFULLY.getCode()) {
                 log.trace("[{}] Previous update failed. [{}]", client.getEndpoint(), fwInfo);
                 logService.log(client, "Previous update firmware failed. Result: " + fwInfo.getResult().name());
             }
@@ -427,7 +429,7 @@ public class DefaultLwM2MOtaUpdateService extends LwM2MExecutorAwareService impl
                         startUpdateUsingBinary(client, swInfo);
                     }
                 }
-            } else if (swInfo.getResult() != null && swInfo.getResult().code >= 50) {
+            } else if (swInfo.getResult() != null && swInfo.getResult().getCode() >= NOT_ENOUGH_STORAGE.getCode()) {
                 log.trace("[{}] Previous update failed. [{}]", client.getEndpoint(), swInfo);
                 logService.log(client, "Previous update software failed. Result: " + swInfo.getResult().name());
             }

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/firmware/FirmwareUpdateState.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/firmware/FirmwareUpdateState.java
@@ -15,6 +15,8 @@
  */
 package org.thingsboard.server.transport.lwm2m.server.ota.firmware;
 
+import lombok.Getter;
+
 /**
  * /** State R
  * 0: Idle (before downloading or after successful updating)
@@ -28,8 +30,10 @@ public enum FirmwareUpdateState {
     DOWNLOADED(2, "Downloaded"),
     UPDATING(3, "Updating");
 
-    public int code;
-    public String type;
+    @Getter
+    private int code;
+    @Getter
+    private String type;
 
     FirmwareUpdateState(int code, String type) {
         this.code = code;

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/software/SoftwareUpdateResult.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/software/SoftwareUpdateResult.java
@@ -56,10 +56,12 @@ public enum SoftwareUpdateResult {
     INSTALL_FAILURE(58, "Software installation failure", true),
     UN_INSTALL_FAILURE(59, "Uninstallation Failure during forUpdate(arg=0)", true);
 
-    public int code;
-    public String type;
     @Getter
-    public boolean isAgain;
+    private int code;
+    @Getter
+    private String type;
+    @Getter
+    private boolean isAgain;
 
     SoftwareUpdateResult(int code, String type, boolean isAgain) {
         this.code = code;

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/software/SoftwareUpdateState.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/software/SoftwareUpdateState.java
@@ -15,6 +15,8 @@
  */
 package org.thingsboard.server.transport.lwm2m.server.ota.software;
 
+import lombok.Getter;
+
 /**
  * SW Update State R
  * 0: INITIAL Before downloading. (see 5.1.2.1)
@@ -33,8 +35,10 @@ public enum SoftwareUpdateState {
     DELIVERED(3, "Delivered"),
     INSTALLED(4, "Installed");
 
-    public int code;
-    public String type;
+    @Getter
+    private int code;
+    @Getter
+    private String type;
 
     SoftwareUpdateState(int code, String type) {
         this.code = code;

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
@@ -150,7 +150,7 @@ public class LwM2MTransportUtil {
         if (path != null) {
             if (FW_STATE_ID.equals(path)) {
                 lwM2mOtaConvert.setCurrentType(STRING);
-                lwM2mOtaConvert.setValue(FirmwareUpdateState.fromStateFwByCode(((Long) value).intValue()).type);
+                lwM2mOtaConvert.setValue(FirmwareUpdateState.fromStateFwByCode(((Long) value).intValue()).getType());
                 return lwM2mOtaConvert;
             } else if (FW_RESULT_ID.equals(path)) {
                 lwM2mOtaConvert.setCurrentType(STRING);
@@ -158,11 +158,11 @@ public class LwM2MTransportUtil {
                 return lwM2mOtaConvert;
             } else if (SW_STATE_ID.equals(path)) {
                 lwM2mOtaConvert.setCurrentType(STRING);
-                lwM2mOtaConvert.setValue(SoftwareUpdateState.fromUpdateStateSwByCode(((Long) value).intValue()).type);
+                lwM2mOtaConvert.setValue(SoftwareUpdateState.fromUpdateStateSwByCode(((Long) value).intValue()).getType());
                 return lwM2mOtaConvert;
             } else if (SW_RESULT_ID.equals(path)) {
                 lwM2mOtaConvert.setCurrentType(STRING);
-                lwM2mOtaConvert.setValue(SoftwareUpdateResult.fromUpdateResultSwByCode(((Long) value).intValue()).type);
+                lwM2mOtaConvert.setValue(SoftwareUpdateResult.fromUpdateResultSwByCode(((Long) value).intValue()).getType());
                 return lwM2mOtaConvert;
             }
         }


### PR DESCRIPTION
fix bug:
- if in profile: objectId=5 and ojbjectId =3 with resourceId="State", info to device - always 

> Failed to process firmware update: LwM2MClientFwOtaInfo(super=LwM2MClientOtaInfo(endpoint=867723030209919, baseUrl=null, targetName=null, targetVersion=null, targetTag=null, targetUrl=null, strategy=OBJ_5_BINARY, updateState=IDLE, result=null, status=null, failedPackageId=null, retryAttempts=0, currentName=null, currentVersion3=null, currentVersion=null), deliveryMethod=null). Previous update failed.
