### PR TITLE
[3.3.3] UI: Change translation rsa-key to certificate-pem-format and delete in other languages

### DIFF
--- a/ui-ngx/src/app/modules/home/components/device/device-credentials.component.html
+++ b/ui-ngx/src/app/modules/home/components/device/device-credentials.component.html
@@ -39,10 +39,10 @@
     </ng-template>
     <ng-template [ngSwitchCase]="deviceCredentialsType.X509_CERTIFICATE">
       <mat-form-field class="mat-block">
-        <mat-label translate>device.rsa-key</mat-label>
+        <mat-label translate>device.certificate-pem-format</mat-label>
         <textarea matInput formControlName="credentialsValue" cols="15" rows="5" required></textarea>
         <mat-error *ngIf="deviceCredentialsFormGroup.get('credentialsValue').hasError('required')">
-          {{ 'device.rsa-key-required' | translate }}
+          {{ 'device.certificate-pem-format-required' | translate }}
         </mat-error>
       </mat-form-field>
     </ng-template>

--- a/ui-ngx/src/assets/locale/locale.constant-cs_CZ.json
+++ b/ui-ngx/src/assets/locale/locale.constant-cs_CZ.json
@@ -954,8 +954,6 @@
         "access-token": "Přístupový token",
         "access-token-required": "Přístupový token je povinný.",
         "access-token-invalid": "Délka přístupového tokenu musí být od 1 do 32 znaků.",
-        "rsa-key": "RSA veřejný klíč",
-        "rsa-key-required": "RSA veřejný klíč je povinný.",
         "lwm2m-security-config": {
           "identity": "Identita klienta",
           "identity-required": "Identita klienta je povinná.",

--- a/ui-ngx/src/assets/locale/locale.constant-de_DE.json
+++ b/ui-ngx/src/assets/locale/locale.constant-de_DE.json
@@ -699,8 +699,6 @@
     "access-token": "Zugangs-Token",
     "access-token-required": "Zugangs-Token ist erforderlich.",
     "access-token-invalid": "Die Länge des Zugangs-Tokens muss zwischen 1 und 32 Zeichen betragen.",
-    "rsa-key": "RSA öffentlicher Schlüssel",
-    "rsa-key-required": "RSA öffentlicher Schlüssel ist erforderlich.",
     "secret": "Geheimnis",
     "secret-required": "Geheimnis ist erforderlich.",
     "device-type": "Gerätetyp",

--- a/ui-ngx/src/assets/locale/locale.constant-el_GR.json
+++ b/ui-ngx/src/assets/locale/locale.constant-el_GR.json
@@ -799,8 +799,6 @@
     "access-token": "Διακριτικό πρόσβασης",
     "access-token-required": "Απαιτείται διακριτικό πρόσβασης.",
     "access-token-invalid": "Access token length must be from 1 to 32 characters.",
-    "rsa-key": "RSA public key",
-    "rsa-key-required": "Απαιτείται RSA public key.",
     "secret": "Secret",
     "secret-required": "Απαιτείται secret.",
     "device-type": "Τύπος συσκευής",

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -980,8 +980,8 @@
         "access-token": "Access token",
         "access-token-required": "Access token is required.",
         "access-token-invalid": "Access token length must be from 1 to 32 characters.",
-        "rsa-key": "RSA public key",
-        "rsa-key-required": "RSA public key is required.",
+        "certificate-pem-format": "Certificate in PEM format",
+        "certificate-pem-format-required": "Certificate is required.",
         "lwm2m-security-config": {
           "identity": "Client Identity",
           "identity-required": "Client Identity is required.",

--- a/ui-ngx/src/assets/locale/locale.constant-es_ES.json
+++ b/ui-ngx/src/assets/locale/locale.constant-es_ES.json
@@ -894,8 +894,6 @@
         "access-token": "Tóken de acceso",
         "access-token-required": "Access token requerido.",
         "access-token-invalid": "Access token debe tener entre 1 a 32 caracteres.",
-        "rsa-key": "Clave pública RSA",
-        "rsa-key-required": "Clave pública RSA requerida.",
         "client-id": "ID Cliente",
         "client-id-pattern": "Contiene carácter inválido.",
         "user-name": "Nombre Usuario",

--- a/ui-ngx/src/assets/locale/locale.constant-fa_IR.json
+++ b/ui-ngx/src/assets/locale/locale.constant-fa_IR.json
@@ -641,8 +641,6 @@
         "access-token": "شناسه دسترسي",
         "access-token-required": ".شناسه دسترسي مورد نياز است",
         "access-token-invalid": ".طول شناسه دسترسي بايد از 1 تا 32 حرف باشد",
-        "rsa-key": "RSA کليد عمومي",
-        "rsa-key-required": ".مورد نياز است RSA کليد عمومي",
         "secret": "محرمانه",
         "secret-required": ".شناسه محرمانه مورد نياز است",
         "device-type": "نوع دستگاه",

--- a/ui-ngx/src/assets/locale/locale.constant-fr_FR.json
+++ b/ui-ngx/src/assets/locale/locale.constant-fr_FR.json
@@ -714,8 +714,6 @@
         "no-keys-found": "Aucune clé trouvée",
         "public": "Public",
         "remove-alias": "Supprimer l'alias du dispositif",
-        "rsa-key": "Clé publique RSA",
-        "rsa-key-required": "La clé publique RSA est requise.",
         "secret": "Secret",
         "secret-required": "Code secret est requis.",
         "select-device": "Selectionner un dispositif",

--- a/ui-ngx/src/assets/locale/locale.constant-it_IT.json
+++ b/ui-ngx/src/assets/locale/locale.constant-it_IT.json
@@ -666,8 +666,6 @@
         "access-token": "Token di accesso",
         "access-token-required": "Token di accesso obbligatorio.",
         "access-token-invalid": "Il token di accesso deve avere una lunghezza compresa tra 1 e 32 caratteri.",
-        "rsa-key": "Chiave pubblica RSA",
-        "rsa-key-required": "Chiave pubblica RSA obbligatoria.",
         "secret": "Secret",
         "secret-required": "Secret obbligatorio.",
         "device-type": "Tipo dispositivo",

--- a/ui-ngx/src/assets/locale/locale.constant-ja_JA.json
+++ b/ui-ngx/src/assets/locale/locale.constant-ja_JA.json
@@ -624,8 +624,6 @@
 		"access-token": "アクセストークン",
 		"access-token-required": "アクセストークンが必要です。",
 		"access-token-invalid": "アクセストークンの長さは、1〜32文字でなければなりません。",
-		"rsa-key": "RSA公開鍵",
-		"rsa-key-required": "RSA公開鍵が必要です。",
 		"secret": "秘密",
 		"secret-required": "秘密が必要です。",
 		"device-type": "デバイスタイプ",

--- a/ui-ngx/src/assets/locale/locale.constant-ka_GE.json
+++ b/ui-ngx/src/assets/locale/locale.constant-ka_GE.json
@@ -684,8 +684,6 @@
     "access-token": "ტოკენი",
     "access-token-required": "ტოკენი სავალდებულოა",
     "access-token-invalid": "ტოკენის სიგრძე უნდა იყოს 1 დან 32 სიმბოლომდე",
-    "rsa-key": "ღია გასაღები RSA",
-    "rsa-key-required": "ღია გასაღები RSA  აუცილებელია",
     "secret": "საიდუმლო",
     "secret-required": "საიდუმლო აუცილებელია",
     "device-type": "მოწყობილობის ტიპი",

--- a/ui-ngx/src/assets/locale/locale.constant-ko_KR.json
+++ b/ui-ngx/src/assets/locale/locale.constant-ko_KR.json
@@ -870,8 +870,6 @@
         "access-token": "억세스 토큰",
         "access-token-required": "액세스 토큰을 입력하세요.",
         "access-token-invalid": "액세스 토큰 길이는 1 - 32 자 여야합니다.",
-        "rsa-key": "RSA public key",
-        "rsa-key-required": "RSA public key 를 입력하세요.",
         "client-id": "클라이언트 ID",
         "client-id-pattern": "잘못된 문자가 포함되어 있습니다.",
         "user-name": "사용자 이름",

--- a/ui-ngx/src/assets/locale/locale.constant-lv_LV.json
+++ b/ui-ngx/src/assets/locale/locale.constant-lv_LV.json
@@ -642,8 +642,6 @@
         "access-token": "Piekļuves tokens",
         "access-token-required": "Piekļuves tokens ir nepieciešams.",
         "access-token-invalid": "Piekļuves tokena garumam ir jābūt no 1 līdz 32 rakstzīmēm.",
-        "rsa-key": "RSA publiskā atslēga",
-        "rsa-key-required": "RSA publiskā atslēga ir nepieciešama.",
         "secret": "Noslēpums",
         "secret-required": "Noslēpums ir nepieciešams.",
         "device-type": "Iekārtas tips",

--- a/ui-ngx/src/assets/locale/locale.constant-pt_BR.json
+++ b/ui-ngx/src/assets/locale/locale.constant-pt_BR.json
@@ -716,8 +716,6 @@
     "access-token": "Token de acesso",
     "access-token-required": "O token de acesso é obrigatório.",
     "access-token-invalid": "O token de acesso deve ter de 1 a 32 caracteres.",
-    "rsa-key": "Chave pública RSA",
-    "rsa-key-required": "A chave pública RSA é obrigatória.",
     "secret": "Segredo",
     "secret-required": "O segredo é obrigatório.",
     "device-type": "Tipo de dispositivo",

--- a/ui-ngx/src/assets/locale/locale.constant-ro_RO.json
+++ b/ui-ngx/src/assets/locale/locale.constant-ro_RO.json
@@ -675,8 +675,6 @@
         "access-token": "Token Acces",
         "access-token-required": "Tokenul de acces este necesar",
         "access-token-invalid": "Dimensiunea tokenului de acces trebuie să fie de 1-32 caractere",
-        "rsa-key": "Cheie RSA publică",
-        "rsa-key-required": "Cheia RSA publică key este necesară",
         "secret": "Cod Secret",
         "secret-required": "Codul secret este necesar",
         "device-type": "Tip Dispozitiv",

--- a/ui-ngx/src/assets/locale/locale.constant-ru_RU.json
+++ b/ui-ngx/src/assets/locale/locale.constant-ru_RU.json
@@ -678,8 +678,6 @@
         "access-token": "Токен",
         "access-token-required": "Токен обязателен.",
         "access-token-invalid": "Длина токена должна быть от 1 до 32 символов.",
-        "rsa-key": "Открытый ключ RSA",
-        "rsa-key-required": "Открытый ключ RSA обязателен.",
         "secret": "Секрет",
         "secret-required": "Секрет обязателен.",
         "device-type": "Тип устройства",

--- a/ui-ngx/src/assets/locale/locale.constant-sl_SI.json
+++ b/ui-ngx/src/assets/locale/locale.constant-sl_SI.json
@@ -870,8 +870,6 @@
     "access-token": "Dostopni žeton",
     "access-token-required": "Zahtevan je žeton za dostop.",
     "access-token-invalid": "Dolžina žetona za dostop mora biti od 1 do 32 znakov.",
-    "rsa-key": "Javni ključ RSA",
-    "rsa-key-required": "Potreben je javni ključ RSA.",
     "client-id": "Client ID",
     "client-id-pattern": "Contains invalid character.",
     "user-name": "User Name",

--- a/ui-ngx/src/assets/locale/locale.constant-tr_TR.json
+++ b/ui-ngx/src/assets/locale/locale.constant-tr_TR.json
@@ -957,8 +957,6 @@
     "access-token": "Erişim şifresi",
     "access-token-required": "Erişim şifresi gerekli.",
     "access-token-invalid": "Erişim şifresi uzunluğu 1 ile 32 karakter arasında olmalıdır.",
-    "rsa-key": "RSA açık anahtarı",
-    "rsa-key-required": "RSA açık anahtarı gerekli.",
     "lwm2m-security-config": {
       "identity": "İstemci Kimliği",
       "identity-required": "İstemci Kimliği gerekli.",

--- a/ui-ngx/src/assets/locale/locale.constant-uk_UA.json
+++ b/ui-ngx/src/assets/locale/locale.constant-uk_UA.json
@@ -795,8 +795,6 @@
         "access-token": "Маркер доступу",
         "access-token-required": "Необхідно вказати маркер доступу.",
         "access-token-invalid": "Маркер доступу має бути від 1 до 32 символів.",
-        "rsa-key": "Публічний ключ RSA",
-        "rsa-key-required": "Необхідно вказати публічний ключ RSA.",
         "secret": "Секрет",
         "secret-required": "Необхідно вказати секрет.",
         "device-type": "Тип пристрою",

--- a/ui-ngx/src/assets/locale/locale.constant-zh_CN.json
+++ b/ui-ngx/src/assets/locale/locale.constant-zh_CN.json
@@ -1081,8 +1081,6 @@
     "password": "密码",
     "public": "公开",
     "remove-alias": "删除设备别名",
-    "rsa-key": "RSA公钥",
-    "rsa-key-required": "RSA公钥必填",
     "search": "查找设备",
     "secret": "密钥",
     "secret-required": "密钥必填",

--- a/ui-ngx/src/assets/locale/locale.constant-zh_TW.json
+++ b/ui-ngx/src/assets/locale/locale.constant-zh_TW.json
@@ -625,8 +625,6 @@
     "access-token": "存取令牌",
     "access-token-required": "需要存取令牌",
     "access-token-invalid": "存取令牌長度必須為1到32個字符。",
-    "rsa-key": "RSA公鑰",
-    "rsa-key-required": "需要RSA公鑰",
     "secret": "密鑰",
     "secret-required": "密鑰必填",
     "device-type": "設備類型",


### PR DESCRIPTION
From:
"rsa-key": "RSA public key",
"rsa-key-required": "RSA public key is required."
To:
"certificate-pem-format": "Certificate in PEM format",
"certificate-pem-format-required": "Certificate is required."