### PR TITLE
Add option to configure spring's server.forward_headers_strategy

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -19,6 +19,8 @@ server:
   address: "${HTTP_BIND_ADDRESS:0.0.0.0}"
   # Server bind port
   port: "${HTTP_BIND_PORT:8080}"
+  # Server forward headers strategy
+  forward_headers_strategy: "${HTTP_FORWARD_HEADERS_STRATEGY:NONE}"
   # Server SSL configuration
   ssl:
     # Enable/disable SSL support


### PR DESCRIPTION
Running thingsboard 3.3.2pe behind several proxies (TLS termination, HTTP loadbalancing) requires to set the the server.forward_headers_strategy (see https://docs.spring.io/spring-framework/docs/current/reference/html/web.html#filters-forwarded-headers) 