### PR TITLE
[3.3.3] CASSANDRA_KEYSPACE_NAME ignored during install

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/install/CassandraAbstractDatabaseSchemaService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/CassandraAbstractDatabaseSchemaService.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.service.install;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.thingsboard.server.dao.cassandra.CassandraInstallCluster;
 import org.thingsboard.server.service.install.cql.CQLStatementsParser;
 
@@ -29,6 +30,7 @@ import java.util.List;
 public abstract class CassandraAbstractDatabaseSchemaService implements DatabaseSchemaService {
 
     private static final String CASSANDRA_DIR = "cassandra";
+    private static final String CASSANDRA_STANDARD_KEYSPACE = "thingsboard";
 
     @Autowired
     @Qualifier("CassandraInstallCluster")
@@ -36,6 +38,9 @@ public abstract class CassandraAbstractDatabaseSchemaService implements Database
 
     @Autowired
     private InstallScripts installScripts;
+
+    @Value("${cassandra.keyspace_name}")
+    private String keyspaceName;
 
     private final String schemaCql;
 
@@ -61,6 +66,10 @@ public abstract class CassandraAbstractDatabaseSchemaService implements Database
 
     private void loadCql(Path cql) throws Exception {
         List<String> statements = new CQLStatementsParser(cql).getStatements();
-        statements.forEach(statement -> cluster.getSession().execute(statement));
+        statements.forEach(statement -> cluster.getSession().execute(getCassandraKeyspaceName(statement)));
+    }
+
+    private String getCassandraKeyspaceName(String statement) {
+        return statement.replaceFirst(CASSANDRA_STANDARD_KEYSPACE, keyspaceName);
     }
 }


### PR DESCRIPTION
We can't set up the CASSANDRA_KEYSPACE_NAME name during install. But we say we can do this in the documentation about installing TB.
More about this issue: https://github.com/thingsboard/thingsboard/issues/5603