### PR TITLE
Explicitly upgrade log4j-api, log4j-core, log4j-to-slf4j  to 2.15 on dependency management. NOTE: log4j-core is not used!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <jedis.version>3.3.0</jedis.version>
         <jjwt.version>0.7.0</jjwt.version>
         <slf4j.version>1.7.32</slf4j.version>
+        <log4j.version>2.15.0</log4j.version>
         <logback.version>1.2.6</logback.version>
         <rat.version>0.10</rat.version>
         <cassandra.version>4.10.0</cassandra.version>
@@ -1491,6 +1492,16 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>jul-to-slf4j</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1500,6 +1500,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-to-slf4j</artifactId>
                 <version>${log4j.version}</version>
             </dependency>


### PR DESCRIPTION
This is the improvement to bump log4j-api to 2.15 regarding https://github.com/advisories/GHSA-jfh8-c2jp-5v3q
Note that we don't use log4j-core. We use logback and slf4j instead.

That is why we are **NOT** affected by [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228). See additional comments from [Spring](https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot) and [Slf4j](http://slf4j.org/log4shell.html).
