### PR TITLE
[WIP] Added nofitications to gateway if device created through it was removed or renamed

### DIFF
--- a/common/cluster-api/src/main/proto/queue.proto
+++ b/common/cluster-api/src/main/proto/queue.proto
@@ -405,6 +405,15 @@ message ProvisionDeviceResponseMsg {
   string credentialsValue = 3;
 }
 
+message GatewayDeviceUpdated {
+  string oldDeviceName = 1;
+  string newDeviceName = 2;
+}
+
+message GatewayDeviceDeleted {
+  string deviceName = 1;
+}
+
 enum ResponseStatus {
   UNKNOWN = 0;
   SUCCESS = 1;

--- a/common/data/src/main/java/org/thingsboard/server/common/data/device/profile/MqttTopics.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/device/profile/MqttTopics.java
@@ -30,6 +30,9 @@ public class MqttTopics {
     private static final String CLAIM = "/claim";
     private static final String SUB_TOPIC = "+";
     private static final String PROVISION = "/provision";
+    private static final String DEVICE = "/device";
+    private static final String UPDATED = "/updated";
+    private static final String DELETED = "/deleted";
     private static final String FIRMWARE = "/fw";
     private static final String SOFTWARE = "/sw";
     private static final String CHUNK = "/chunk/";
@@ -75,6 +78,8 @@ public class MqttTopics {
     public static final String GATEWAY_RPC_TOPIC = BASE_GATEWAY_API_TOPIC + RPC;
     public static final String GATEWAY_ATTRIBUTES_REQUEST_TOPIC = BASE_GATEWAY_API_TOPIC + ATTRIBUTES_REQUEST;
     public static final String GATEWAY_ATTRIBUTES_RESPONSE_TOPIC = BASE_GATEWAY_API_TOPIC + ATTRIBUTES_RESPONSE;
+    public static final String GATEWAY_DEVICE_UPDATED_TOPIC = BASE_GATEWAY_API_TOPIC + DEVICE + UPDATED;
+    public static final String GATEWAY_DEVICE_DELETED_TOPIC = BASE_GATEWAY_API_TOPIC + DEVICE + DELETED;
     // v2 topics
     public static final String BASE_DEVICE_API_TOPIC_V2 = "v2";
     public static final String REQUEST_ID_PATTERN = "(?<requestId>\\d+)";

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -647,6 +647,8 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                     case MqttTopics.GATEWAY_ATTRIBUTES_TOPIC:
                     case MqttTopics.GATEWAY_RPC_TOPIC:
                     case MqttTopics.GATEWAY_ATTRIBUTES_RESPONSE_TOPIC:
+                    case MqttTopics.GATEWAY_DEVICE_UPDATED_TOPIC:
+                    case MqttTopics.GATEWAY_DEVICE_DELETED_TOPIC:
                     case MqttTopics.DEVICE_PROVISION_RESPONSE_TOPIC:
                     case MqttTopics.DEVICE_FIRMWARE_RESPONSES_TOPIC:
                     case MqttTopics.DEVICE_FIRMWARE_ERROR_TOPIC:

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/adaptors/BackwardCompatibilityAdaptor.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/adaptors/BackwardCompatibilityAdaptor.java
@@ -23,6 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.server.common.data.ota.OtaPackageType;
 import org.thingsboard.server.common.transport.adaptor.AdaptorException;
 import org.thingsboard.server.gen.transport.TransportProtos;
+import org.thingsboard.server.gen.transport.TransportProtos.GatewayDeviceDeleted;
+import org.thingsboard.server.gen.transport.TransportProtos.GatewayDeviceUpdated;
 import org.thingsboard.server.transport.mqtt.session.MqttDeviceAwareSessionContext;
 
 import java.util.Optional;
@@ -149,5 +151,15 @@ public class BackwardCompatibilityAdaptor implements MqttTransportAdaptor {
     @Override
     public Optional<MqttMessage> convertToPublish(MqttDeviceAwareSessionContext ctx, byte[] firmwareChunk, String requestId, int chunk, OtaPackageType firmwareType) throws AdaptorException {
         return protoAdaptor.convertToPublish(ctx, firmwareChunk, requestId, chunk, firmwareType);
+    }
+
+    @Override
+    public Optional<MqttMessage> convertToPublish(MqttDeviceAwareSessionContext ctx, GatewayDeviceUpdated gatewayDeviceUpdated) throws AdaptorException {
+        return protoAdaptor.convertToPublish(ctx, gatewayDeviceUpdated);
+    }
+
+    @Override
+    public Optional<MqttMessage> convertToPublish(MqttDeviceAwareSessionContext ctx, GatewayDeviceDeleted gatewayDeviceDeleted) throws AdaptorException {
+        return protoAdaptor.convertToPublish(ctx, gatewayDeviceDeleted);
     }
 }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/adaptors/JsonMqttAdaptor.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/adaptors/JsonMqttAdaptor.java
@@ -158,6 +158,16 @@ public class JsonMqttAdaptor implements MqttTransportAdaptor {
     }
 
     @Override
+    public Optional<MqttMessage> convertToPublish(MqttDeviceAwareSessionContext ctx, TransportProtos.GatewayDeviceUpdated gatewayDeviceUpdated) {
+        return Optional.of(createMqttPublishMsg(ctx, MqttTopics.GATEWAY_DEVICE_UPDATED_TOPIC, JsonConverter.toJson(gatewayDeviceUpdated)));
+    }
+
+    @Override
+    public Optional<MqttMessage> convertToPublish(MqttDeviceAwareSessionContext ctx, TransportProtos.GatewayDeviceDeleted gatewayDeviceDeleted) {
+        return Optional.of(createMqttPublishMsg(ctx, MqttTopics.GATEWAY_DEVICE_DELETED_TOPIC, JsonConverter.toJson(gatewayDeviceDeleted)));
+    }
+
+    @Override
     public Optional<MqttMessage> convertToPublish(MqttDeviceAwareSessionContext ctx, byte[] firmwareChunk, String requestId, int chunk, OtaPackageType firmwareType) {
         return Optional.of(createMqttPublishMsg(ctx, String.format(DEVICE_SOFTWARE_FIRMWARE_RESPONSES_TOPIC_FORMAT, firmwareType.getKeyPrefix(), requestId, chunk), firmwareChunk));
     }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/adaptors/MqttTransportAdaptor.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/adaptors/MqttTransportAdaptor.java
@@ -27,6 +27,8 @@ import org.thingsboard.server.common.data.ota.OtaPackageType;
 import org.thingsboard.server.common.transport.adaptor.AdaptorException;
 import org.thingsboard.server.gen.transport.TransportProtos.AttributeUpdateNotificationMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.ClaimDeviceMsg;
+import org.thingsboard.server.gen.transport.TransportProtos.GatewayDeviceDeleted;
+import org.thingsboard.server.gen.transport.TransportProtos.GatewayDeviceUpdated;
 import org.thingsboard.server.gen.transport.TransportProtos.GetAttributeRequestMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.GetAttributeResponseMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.PostAttributeMsg;
@@ -77,6 +79,10 @@ public interface MqttTransportAdaptor {
     ProvisionDeviceRequestMsg convertToProvisionRequestMsg(MqttDeviceAwareSessionContext ctx, MqttPublishMessage inbound) throws AdaptorException;
 
     Optional<MqttMessage> convertToPublish(MqttDeviceAwareSessionContext ctx, ProvisionDeviceResponseMsg provisionResponse) throws AdaptorException;
+
+    Optional<MqttMessage> convertToPublish(MqttDeviceAwareSessionContext ctx, GatewayDeviceUpdated gatewayDeviceUpdated) throws AdaptorException;
+
+    Optional<MqttMessage> convertToPublish(MqttDeviceAwareSessionContext ctx, GatewayDeviceDeleted gatewayDeviceDeleted) throws AdaptorException;
 
     Optional<MqttMessage> convertToPublish(MqttDeviceAwareSessionContext ctx, byte[] firmwareChunk, String requestId, int chunk, OtaPackageType firmwareType) throws AdaptorException;
 

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/adaptor/JsonConverter.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/adaptor/JsonConverter.java
@@ -38,6 +38,8 @@ import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.gen.transport.TransportProtos.AttributeUpdateNotificationMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.ClaimDeviceMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.CredentialsType;
+import org.thingsboard.server.gen.transport.TransportProtos.GatewayDeviceDeleted;
+import org.thingsboard.server.gen.transport.TransportProtos.GatewayDeviceUpdated;
 import org.thingsboard.server.gen.transport.TransportProtos.GetAttributeResponseMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.KeyValueProto;
 import org.thingsboard.server.gen.transport.TransportProtos.KeyValueType;
@@ -430,6 +432,19 @@ public class JsonConverter {
 
     public static JsonObject toJson(ProvisionDeviceResponseMsg payload) {
         return toJson(payload, false, 0);
+    }
+
+    public static JsonObject toJson(GatewayDeviceUpdated payload) {
+        JsonObject result = new JsonObject();
+        result.addProperty("oldDeviceName", payload.getOldDeviceName());
+        result.addProperty("newDeviceName", payload.getNewDeviceName());
+        return result;
+    }
+
+    public static JsonObject toJson(GatewayDeviceDeleted payload) {
+        JsonObject result = new JsonObject();
+        result.addProperty("deviceName", payload.getDeviceName());
+        return result;
     }
 
     public static JsonObject toJson(ProvisionDeviceResponseMsg payload, int requestId) {

--- a/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/AbstractContainerTest.java
+++ b/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/AbstractContainerTest.java
@@ -103,12 +103,12 @@ public abstract class AbstractContainerTest {
         }
     };
 
-    protected Device createGatewayDevice() throws JsonProcessingException {
+    protected Device createGatewayDevice(String deviceName) throws JsonProcessingException {
         String isGateway = "{\"gateway\":true}";
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode additionalInfo = objectMapper.readTree(isGateway);
         Device gatewayDeviceTemplate = new Device();
-        gatewayDeviceTemplate.setName("mqtt_gateway");
+        gatewayDeviceTemplate.setName(deviceName);
         gatewayDeviceTemplate.setType("gateway");
         gatewayDeviceTemplate.setAdditionalInfo(additionalInfo);
         return restClient.saveDevice(gatewayDeviceTemplate);


### PR DESCRIPTION
In order to improve user experience with the ThingsBoard IoT gateway we should notify the gateway about device removal on ThingsBoard or renaming. It is necessary to handle these notifications. 
After device removal on ThingsBoard, the gateway knows nothing about this and continue sending telemetry/attributes etc. But without connect message from the gateway - device won't be created on ThingsBoard again and all this data will be lost.

Possible issues:
1. When the gateway is not connected, but device name on ThingsBoard was changed or device was removed - the gateway doesn't receive an update.
2. When a device is not connected to the gateway, but device name on ThingsBoard was changed or device was removed - the gateway doesn't receive an update.

Possible solutions:
1. These issue may be solved by using persistent RPC's to gateway device, but it looks for me like not the best solution.
2. Creating a hashmap with device id's as keys, the gateway device id as a value in DefaultTransportService and send the notification to the gateway session (in this case possible issue 1 is still not solved)