### PR TITLE
Upgrade log4j artifacts to 2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <jedis.version>3.3.0</jedis.version>
         <jjwt.version>0.7.0</jjwt.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <logback.version>1.2.6</logback.version>
         <rat.version>0.10</rat.version>
         <cassandra.version>4.10.0</cassandra.version>


### PR DESCRIPTION
Just to be sure (even if it is not used, better safe than sorry). 2.15 is flawed because of [CVE-2021-45046](https://logging.apache.org/log4j/2.x/security.html#CVE-2021-45046).