### PR TITLE
[3.3.3] Mqtt rule node update

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/TbMqttNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/TbMqttNode.java
@@ -104,7 +104,8 @@ public class TbMqttNode implements TbNode {
     protected MqttClient initClient(TbContext ctx) throws Exception {
         MqttClientConfig config = new MqttClientConfig(getSslContext());
         if (!StringUtils.isEmpty(this.mqttNodeConfiguration.getClientId())) {
-            config.setClientId(this.mqttNodeConfiguration.getClientId());
+            config.setClientId(this.mqttNodeConfiguration.isAppendClientIdSuffix() ?
+                    this.mqttNodeConfiguration.getClientId() + "_" + ctx.getServiceId() : this.mqttNodeConfiguration.getClientId());
         }
         config.setCleanSession(this.mqttNodeConfiguration.isCleanSession());
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/TbMqttNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/TbMqttNodeConfiguration.java
@@ -28,6 +28,7 @@ public class TbMqttNodeConfiguration implements NodeConfiguration<TbMqttNodeConf
     private int port;
     private int connectTimeoutSec;
     private String clientId;
+    private boolean appendClientIdSuffix;
 
     private boolean cleanSession;
     private boolean ssl;


### PR DESCRIPTION
Added a boolean param to be able to append suffix for "clientId" param in the MQTT rule node.
This is helpful for the cluster mode when the client wants to specify "clientId" (not to have a random id) and does not face the issue with the broker that does not allow client connections with the same clientId.