### PR TITLE
[3.3.3] Edge tests fixes #1

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcSession.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcSession.java
@@ -501,8 +501,9 @@ public final class EdgeGrpcSession implements Closeable {
 
     private ListenableFuture<List<Void>> updateQueueStartTs(Long newStartTs) {
         log.trace("[{}] updating QueueStartTs [{}][{}]", this.sessionId, edge.getId(), newStartTs);
-        newStartTs = ++newStartTs; // increments ts by 1 - next edge event search starts from current offset + 1
-        List<AttributeKvEntry> attributes = Collections.singletonList(new BaseAttributeKvEntry(new LongDataEntry(QUEUE_START_TS_ATTR_KEY, newStartTs), System.currentTimeMillis()));
+        List<AttributeKvEntry> attributes = Collections.singletonList(
+                new BaseAttributeKvEntry(
+                        new LongDataEntry(QUEUE_START_TS_ATTR_KEY, newStartTs), System.currentTimeMillis()));
         return ctx.getAttributesService().save(edge.getTenantId(), edge.getId(), DataConstants.SERVER_SCOPE, attributes);
     }
 

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/fetch/BasePageableEdgeEventFetcher.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/fetch/BasePageableEdgeEventFetcher.java
@@ -31,7 +31,7 @@ public abstract class BasePageableEdgeEventFetcher<T> implements EdgeEventFetche
 
     @Override
     public PageLink getPageLink(int pageSize) {
-        return new PageLink(pageSize, 0, null, new SortOrder("createdTime", SortOrder.Direction.ASC));
+        return new PageLink(pageSize);
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/fetch/BasePageableEdgeEventFetcher.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/fetch/BasePageableEdgeEventFetcher.java
@@ -15,25 +15,13 @@
  */
 package org.thingsboard.server.service.edge.rpc.fetch;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.thingsboard.server.common.data.BaseData;
 import org.thingsboard.server.common.data.edge.Edge;
 import org.thingsboard.server.common.data.edge.EdgeEvent;
-import org.thingsboard.server.common.data.edge.EdgeEventActionType;
-import org.thingsboard.server.common.data.edge.EdgeEventType;
-import org.thingsboard.server.common.data.id.EntityId;
-import org.thingsboard.server.common.data.id.EventId;
-import org.thingsboard.server.common.data.id.HasId;
-import org.thingsboard.server.common.data.id.HasUUID;
-import org.thingsboard.server.common.data.id.IdBased;
-import org.thingsboard.server.common.data.id.RuleChainId;
 import org.thingsboard.server.common.data.id.TenantId;
-import org.thingsboard.server.common.data.id.UUIDBased;
 import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
-import org.thingsboard.server.common.data.rule.RuleChain;
-import org.thingsboard.server.service.edge.rpc.EdgeEventUtils;
+import org.thingsboard.server.common.data.page.SortOrder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +31,7 @@ public abstract class BasePageableEdgeEventFetcher<T> implements EdgeEventFetche
 
     @Override
     public PageLink getPageLink(int pageSize) {
-        return new PageLink(pageSize);
+        return new PageLink(pageSize, 0, null, new SortOrder("createdTime", SortOrder.Direction.ASC));
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/edge/EdgeEventRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/edge/EdgeEventRepository.java
@@ -30,7 +30,7 @@ public interface EdgeEventRepository extends PagingAndSortingRepository<EdgeEven
     @Query("SELECT e FROM EdgeEventEntity e WHERE " +
             "e.tenantId = :tenantId " +
             "AND e.edgeId = :edgeId " +
-            "AND (:startTime IS NULL OR e.createdTime >= :startTime) " +
+            "AND (:startTime IS NULL OR e.createdTime > :startTime) " +
             "AND (:endTime IS NULL OR e.createdTime <= :endTime) " +
             "AND LOWER(e.edgeEventType) LIKE LOWER(CONCAT('%', :textSearch, '%'))"
     )
@@ -44,7 +44,7 @@ public interface EdgeEventRepository extends PagingAndSortingRepository<EdgeEven
     @Query("SELECT e FROM EdgeEventEntity e WHERE " +
             "e.tenantId = :tenantId " +
             "AND e.edgeId = :edgeId " +
-            "AND (:startTime IS NULL OR e.createdTime >= :startTime) " +
+            "AND (:startTime IS NULL OR e.createdTime > :startTime) " +
             "AND (:endTime IS NULL OR e.createdTime <= :endTime) " +
             "AND e.edgeEventAction <> 'TIMESERIES_UPDATED' " +
             "AND LOWER(e.edgeEventType) LIKE LOWER(CONCAT('%', :textSearch, '%'))"

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/edge/JpaBaseEdgeEventDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/edge/JpaBaseEdgeEventDao.java
@@ -100,10 +100,10 @@ public class JpaBaseEdgeEventDao extends JpaAbstractSearchTextDao<EdgeEventEntit
     @Override
     public PageData<EdgeEvent> findEdgeEvents(UUID tenantId, EdgeId edgeId, TimePageLink pageLink, boolean withTsUpdate) {
         List<SortOrder> sortOrders = new ArrayList<>();
-        sortOrders.add(new SortOrder("id", SortOrder.Direction.ASC));
         if (pageLink.getSortOrder() != null) {
             sortOrders.add(pageLink.getSortOrder());
         }
+        sortOrders.add(new SortOrder(DaoUtil.DEFAULT_SORT_PROPERTY, SortOrder.Direction.ASC));
         final Lock readWriteLock = readWriteLocks.computeIfAbsent(edgeId, id -> new ReentrantLock());
         readWriteLock.lock();
         try {

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseEdgeEventServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseEdgeEventServiceTest.java
@@ -106,7 +106,7 @@ public abstract class BaseEdgeEventServiceTest extends AbstractServiceTest {
         EdgeId edgeId = new EdgeId(Uuids.timeBased());
         DeviceId deviceId = new DeviceId(Uuids.timeBased());
         TenantId tenantId = new TenantId(Uuids.timeBased());
-        TimePageLink pageLink = new TimePageLink(1);
+        TimePageLink pageLink = new TimePageLink(1, 0, null, new SortOrder("createdTime", SortOrder.Direction.ASC));
 
         EdgeEvent edgeEventWithTsUpdate = generateEdgeEvent(tenantId, edgeId, deviceId, EdgeEventActionType.TIMESERIES_UPDATED);
         edgeEventService.save(edgeEventWithTsUpdate);

--- a/ui-ngx/src/app/modules/home/components/edge/edge-downlink-table-config.ts
+++ b/ui-ngx/src/app/modules/home/components/edge/edge-downlink-table-config.ts
@@ -98,9 +98,7 @@ export class EdgeDownlinkTableConfig extends EntityTableConfig<EdgeEvent, TimePa
       map[attribute.key] = attribute;
       return map;
     }, {});
-    if (edge.queueStartTs) {
-      this.queueStartTs = edge.queueStartTs.lastUpdateTs;
-    }
+    this.queueStartTs = edge.queueStartTs && edge.queueStartTs.value ? edge.queueStartTs.value : 0;
   }
 
   private updateColumns(updateTableColumns: boolean = false): void {


### PR DESCRIPTION
Edge tests are failing due to incorrect sort order during fetching edge events from the database.
The Issue was fixed by adding an additional sorting field - ID.