### PR TITLE
[WIP][3.4] ensure postgres database is always started in thinsgsboard/tb-postgres

### DIFF
--- a/msa/tb/docker-postgres/start-db.sh
+++ b/msa/tb/docker-postgres/start-db.sh
@@ -22,14 +22,22 @@ PG_CTL=$(find /usr/lib/postgresql/ -name pg_ctl)
 if [ ! -d ${PGDATA} ]; then
     mkdir -p ${PGDATA}
     ${PG_CTL} initdb
+else
+    ${PG_CTL} start
 fi
 
 exec setsid nohup postgres >> ${PGLOG}/postgres.log 2>&1 &
 
 if [ ! -f ${firstlaunch} ]; then
     sleep 2
-    while ! psql -U ${pkg.user} -d postgres -c "CREATE DATABASE thingsboard"
+    while ! psql -U thingsboard -d postgres -c "CREATE DATABASE thingsboard"
     do
       sleep 1
+    done
+else
+    until pg_isready --dbname thingsboard --quiet
+    do
+        sleep 1
+        echo "Waiting for db"
     done
 fi


### PR DESCRIPTION
The Postgres database would only get started on first launch. When starting a second time e.g. after a `docker-compose down` and `docker-compose up`, the database was not started resulting in a failure when ThingsBoard is starting.