### PR TITLE
[3.3.3] upgrade logback version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <jjwt.version>0.7.0</jjwt.version>
         <slf4j.version>1.7.32</slf4j.version>
         <log4j.version>2.17.0</log4j.version>
-        <logback.version>1.2.6</logback.version>
+        <logback.version>1.2.10</logback.version>
         <rat.version>0.10</rat.version>
         <cassandra.version>4.10.0</cassandra.version>
         <metrics.version>4.0.5</metrics.version>


### PR DESCRIPTION
logback 1.2.10 released https://logback.qos.ch/news.html
In response to https://cve.report/CVE-2021-42550

Logback note:
> We note that the vulnerability mentioned in CVE-2021-42550 requires write access to logback's configuration file as a prerequisite. Please understand that log4Shell and CVE-2021-42550 are of different severity levels.

So no worry.