### PR TITLE
[3.3.3] Fix invalid serialization of '=' to \u003d in JsonMqttAdaptor

### DIFF
--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/adaptors/JsonMqttAdaptor.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/adaptors/JsonMqttAdaptor.java
@@ -15,7 +15,6 @@
  */
 package org.thingsboard.server.transport.mqtt.adaptors;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -55,8 +54,6 @@ import static org.thingsboard.server.common.data.device.profile.MqttTopics.DEVIC
 public class JsonMqttAdaptor implements MqttTransportAdaptor {
 
     protected static final Charset UTF8 = StandardCharsets.UTF_8;
-
-    private static final Gson GSON = new Gson();
 
     @Override
     public TransportProtos.PostTelemetryMsg convertToPostTelemetry(MqttDeviceAwareSessionContext ctx, MqttPublishMessage inbound) throws AdaptorException {
@@ -246,7 +243,7 @@ public class JsonMqttAdaptor implements MqttTransportAdaptor {
                 new MqttFixedHeader(MqttMessageType.PUBLISH, false, ctx.getQoSForTopic(topic), false, 0);
         MqttPublishVariableHeader header = new MqttPublishVariableHeader(topic, ctx.nextMsgId());
         ByteBuf payload = ALLOCATOR.buffer();
-        payload.writeBytes(GSON.toJson(json).getBytes(UTF8));
+        payload.writeBytes(json.toString().getBytes(UTF8));
         return new MqttPublishMessage(mqttFixedHeader, header, payload);
     }
 


### PR DESCRIPTION
`Gson` class uses `JsonWriter` with HTML escaping enabled by default, that is causing the issue. When calling `JsonElement.toString` the default JsonWriter with disabled htmlSafe option is used