### PR TITLE
[3.3.3] UI: Disable column sort if enable post-processing function

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/entities-table-widget.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/entities-table-widget.component.html
@@ -41,7 +41,7 @@
       <table mat-table [dataSource]="entityDatasource" [trackBy]="trackByEntityId"
                  matSort [matSortActive]="sortOrderProperty" [matSortDirection]="pageLinkSortDirection()" matSortDisableClear>
         <ng-container [matColumnDef]="column.def" *ngFor="let column of columns; trackBy: trackByColumnDef;">
-          <mat-header-cell [ngStyle]="headerStyle(column)" *matHeaderCellDef mat-sort-header> {{ column.title }} </mat-header-cell>
+          <mat-header-cell [ngStyle]="headerStyle(column)" *matHeaderCellDef mat-sort-header [disabled]="!column.sortable"> {{ column.title }} </mat-header-cell>
           <mat-cell *matCellDef="let entity; let row = index"
                     [innerHTML]="cellContent(entity, column, row)"
                     [ngStyle]="cellStyle(entity, column, row)">

--- a/ui-ngx/src/app/modules/home/components/widget/lib/entities-table-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/entities-table-widget.component.ts
@@ -324,6 +324,7 @@ export class EntitiesTableWidgetComponent extends PageComponent implements OnIni
           label: 'entityName',
           def: 'entityName',
           title: entityNameColumnTitle,
+          sortable: true,
           entityKey: {
             key: 'name',
             type: EntityKeyType.ENTITY_FIELD
@@ -347,6 +348,7 @@ export class EntitiesTableWidgetComponent extends PageComponent implements OnIni
           label: 'entityLabel',
           def: 'entityLabel',
           title: entityLabelColumnTitle,
+          sortable: true,
           entityKey: {
             key: 'label',
             type: EntityKeyType.ENTITY_FIELD
@@ -370,6 +372,7 @@ export class EntitiesTableWidgetComponent extends PageComponent implements OnIni
           label: 'entityType',
           def: 'entityType',
           title: this.translate.instant('entity.entity-type'),
+          sortable: true,
           entityKey: {
             key: 'entityType',
             type: EntityKeyType.ENTITY_FIELD
@@ -403,6 +406,7 @@ export class EntitiesTableWidgetComponent extends PageComponent implements OnIni
         dataKey.label = this.utils.customTranslation(dataKey.label, dataKey.label);
         dataKey.title = dataKey.label;
         dataKey.def = 'def' + this.columns.length;
+        dataKey.sortable = !dataKey.usePostProcessing;
         const keySettings: TableWidgetDataKeySettings = dataKey.settings;
         if (dataKey.type === DataKeyType.entityField &&
           !isDefined(keySettings.columnWidth) || keySettings.columnWidth === '0px') {

--- a/ui-ngx/src/app/modules/home/components/widget/lib/table-widget.models.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/table-widget.models.ts
@@ -73,6 +73,7 @@ export interface EntityData {
 export interface EntityColumn extends DataKey {
   def: string;
   title: string;
+  sortable: boolean;
   entityKey?: EntityKey;
 }
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/timeseries-table-widget.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/timeseries-table-widget.component.html
@@ -52,7 +52,7 @@
                 </mat-cell>
               </ng-container>
               <ng-container [matColumnDef]="h.index + ''" *ngFor="let h of source.header; trackBy: trackByColumnIndex;">
-                <mat-header-cell *matHeaderCellDef mat-sort-header> {{ h.dataKey.label }} </mat-header-cell>
+                <mat-header-cell *matHeaderCellDef mat-sort-header [disabled]="!h.sortable"> {{ h.dataKey.label }} </mat-header-cell>
                 <mat-cell *matCellDef="let row; let rowIndex = index"
                           [innerHTML]="cellContent(source, h.index, row, row[h.index], rowIndex)"
                           [ngStyle]="cellStyle(source, h.index, row, row[h.index], rowIndex)">

--- a/ui-ngx/src/app/modules/home/components/widget/lib/timeseries-table-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/timeseries-table-widget.component.ts
@@ -88,6 +88,7 @@ interface TimeseriesRow {
 interface TimeseriesHeader {
   index: number;
   dataKey: DataKey;
+  sortable: boolean;
 }
 
 interface TimeseriesTableSource {
@@ -308,10 +309,12 @@ export class TimeseriesTableWidgetComponent extends PageComponent implements OnI
         for (let a = 0; a < datasource.dataKeys.length; a++ ) {
           const dataKey = datasource.dataKeys[a];
           const keySettings: TableWidgetDataKeySettings = dataKey.settings;
+          const sortable = !dataKey.usePostProcessing;
           const index = a + 1;
           source.header.push({
             index,
-            dataKey
+            dataKey,
+            sortable
           });
           source.displayedColumns.push(index + '');
           source.rowDataTemplate[dataKey.label] = null;


### PR DESCRIPTION
Disable column sort for that column where the post-processing function is enabled. Only for entities widget table and timeseries widget table.
![Screenshot from 2021-12-29 13-02-19](https://user-images.githubusercontent.com/83352633/147655735-009cc814-f28d-455e-9a9b-6d77221bab45.png)
![Screenshot from 2021-12-29 13-02-54](https://user-images.githubusercontent.com/83352633/147655739-324d87d5-4563-498f-893c-63a646ab9ce5.png)

