### PR TITLE
[3.3.3] UI: Fixed cancel event on color picker

### DIFF
--- a/ui-ngx/src/app/shared/components/dialog/color-picker-dialog.component.ts
+++ b/ui-ngx/src/app/shared/components/dialog/color-picker-dialog.component.ts
@@ -67,7 +67,7 @@ export class ColorPickerDialogComponent extends DialogComponent<ColorPickerDialo
   }
 
   cancel(): void {
-    this.dialogRef.close(null);
+    this.dialogRef.close(this.data.color);
   }
 
   select(): void {

--- a/ui-ngx/src/app/shared/components/dialog/color-picker-dialog.component.ts
+++ b/ui-ngx/src/app/shared/components/dialog/color-picker-dialog.component.ts
@@ -67,7 +67,7 @@ export class ColorPickerDialogComponent extends DialogComponent<ColorPickerDialo
   }
 
   cancel(): void {
-    this.dialogRef.close(this.data.color);
+    this.dialogRef.close(null);
   }
 
   select(): void {

--- a/ui-ngx/src/app/shared/components/json-form/json-form.component.ts
+++ b/ui-ngx/src/app/shared/components/json-form/json-form.component.ts
@@ -217,7 +217,7 @@ export class JsonFormComponent implements OnInit, ControlValueAccessor, Validato
                        val: tinycolor.ColorFormats.RGBA,
                        colorSelectedFn: (color: tinycolor.ColorFormats.RGBA) => void) {
     this.dialogs.colorPicker(tinycolor(val).toRgbString()).subscribe((color) => {
-      if (colorSelectedFn) {
+      if (color && colorSelectedFn) {
         colorSelectedFn(tinycolor(color).toRgb());
       }
     });


### PR DESCRIPTION
Any widget (with color picker in advanced tab) - advanced tab - select color picker - if press the "Cancel" button so sets black color instead of the previous params.
![Screenshot from 2022-01-04 13-05-30](https://user-images.githubusercontent.com/83352633/148050040-cb8708b3-a74c-4dc4-93d2-c06a50b73d42.png)
![Screenshot from 2022-01-04 13-06-04](https://user-images.githubusercontent.com/83352633/148050079-7e42e9de-1e20-4525-ab7b-4df2a16ab887.png)
![Screenshot from 2022-01-04 13-06-23](https://user-images.githubusercontent.com/83352633/148050118-3a8873d0-64c5-4004-929f-4d671535c7bf.png)


