### PR TITLE
[3.3.3] Do not update ws lastActivity in case of general response

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/plugin/TbWebSocketHandler.java
+++ b/application/src/main/java/org/thingsboard/server/controller/plugin/TbWebSocketHandler.java
@@ -290,7 +290,6 @@ public class TbWebSocketHandler extends TextWebSocketHandler implements Telemetr
                 log.trace("[{}] Failed to send msg", session.getId(), result.getException());
                 closeSession(CloseStatus.SESSION_NOT_RELIABLE);
             } else {
-                lastActivityTime = System.currentTimeMillis();
                 String msg = msgQueue.poll();
                 if (msg != null) {
                     sendMsgInternal(msg);

--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbEntityDataSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbEntityDataSubscriptionService.java
@@ -499,6 +499,12 @@ public class DefaultTbEntityDataSubscriptionService implements TbEntityDataSubsc
         if (ctx != null) {
             ctx.cancelTasks();
             ctx.clearSubscriptions();
+            if (ctx.getSessionId() != null) {
+                Map<Integer, TbAbstractSubCtx> sessionSubs = subscriptionsBySessionId.get(ctx.getSessionId());
+                if (sessionSubs != null) {
+                    sessionSubs.remove(ctx.getCmdId());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Do not update ws lastActivity in case of general response - only on pong response. 
Clean up properly subscription map in case canceling subsription