### PR TITLE
fix problematic letters for different lang

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/audit/AuditLogLevelFilter.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/audit/AuditLogLevelFilter.java
@@ -19,6 +19,7 @@ import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.audit.ActionType;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class AuditLogLevelFilter {
@@ -28,7 +29,7 @@ public class AuditLogLevelFilter {
     public AuditLogLevelFilter(Map<String, String> mask) {
         entityTypeMask.clear();
         mask.forEach((entityTypeStr, logLevelMaskStr) -> {
-            EntityType entityType = EntityType.valueOf(entityTypeStr.toUpperCase());
+            EntityType entityType = EntityType.valueOf(entityTypeStr.toUpperCase(Locale.ENGLISH));
             AuditLogLevelMask logLevelMask = AuditLogLevelMask.valueOf(logLevelMaskStr.toUpperCase());
             entityTypeMask.put(entityType, logLevelMask);
         });


### PR DESCRIPTION
The "i / I" characters lead problem in Turkish, toUpperCase method used with Locale.English in order to fix this problem. (Previous code generates "ENTİTY_VİEW" which is incorrect, it is possible to face similar problems in some languages too.)