### PR TITLE
[3.3.3] Device actor session inactivity performance + heap workout

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
@@ -222,7 +222,7 @@ public class AppActor extends ContextAwareActor {
 
         @Override
         public TbActorId createActorId() {
-            return new TbEntityActorId(new TenantId(EntityId.NULL_UUID));
+            return new TbEntityActorId(TenantId.SYS_TENANT_ID);
         }
 
         @Override

--- a/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
@@ -160,7 +160,7 @@ public class AppActor extends ContextAwareActor {
             }
         } else {
             if (EntityType.TENANT.equals(msg.getEntityId().getEntityType())) {
-                TenantId tenantId = new TenantId(msg.getEntityId().getId());
+                TenantId tenantId = TenantId.fromUUID(msg.getEntityId().getId());
                 if (msg.getEvent() == ComponentLifecycleEvent.DELETED) {
                     log.info("[{}] Handling tenant deleted notification: {}", msg.getTenantId(), msg);
                     deletedTenants.add(tenantId);

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -966,21 +966,14 @@ class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcessor {
         final long expTime = System.currentTimeMillis() - systemContext.getSessionInactivityTimeout();
         List<UUID> expiredIds = null;
 
-        try {
-            for (Map.Entry<UUID, SessionInfoMetaData> kv : sessions.entrySet()) { //entry set are cached for stable sessions
-                if (kv.getValue().getLastActivityTime() < expTime) {
-                    final UUID id = kv.getKey();
-                    if (expiredIds == null) {
-                        expiredIds = new ArrayList<>(1); //most of the expired sessions is a single event
-                    }
-                    expiredIds.add(id);
-
+        for (Map.Entry<UUID, SessionInfoMetaData> kv : sessions.entrySet()) { //entry set are cached for stable sessions
+            if (kv.getValue().getLastActivityTime() < expTime) {
+                final UUID id = kv.getKey();
+                if (expiredIds == null) {
+                    expiredIds = new ArrayList<>(1); //most of the expired sessions is a single event
                 }
+                expiredIds.add(id);
             }
-        } catch (ConcurrentModificationException ignored) {
-            //Sessions are not thread safe and possible exceptions
-            //It is an extremely rare event
-            //Complete session check will perform on the next check
         }
 
         if (expiredIds != null) {

--- a/application/src/main/java/org/thingsboard/server/actors/shared/AbstractContextAwareMsgProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/shared/AbstractContextAwareMsgProcessor.java
@@ -22,13 +22,13 @@ import org.thingsboard.server.actors.TbActorCtx;
 import org.thingsboard.server.common.msg.TbActorMsg;
 
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 public abstract class AbstractContextAwareMsgProcessor {
 
+    protected final static ObjectMapper mapper = new ObjectMapper();
+
     protected final ActorSystemContext systemContext;
-    protected final ObjectMapper mapper = new ObjectMapper();
 
     protected AbstractContextAwareMsgProcessor(ActorSystemContext systemContext) {
         super();

--- a/application/src/main/java/org/thingsboard/server/controller/BaseController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/BaseController.java
@@ -482,7 +482,7 @@ public abstract class BaseController {
                     checkCustomerId(new CustomerId(entityId.getId()), operation);
                     return;
                 case TENANT:
-                    checkTenantId(new TenantId(entityId.getId()), operation);
+                    checkTenantId(TenantId.fromUUID(entityId.getId()), operation);
                     return;
                 case TENANT_PROFILE:
                     checkTenantProfileId(new TenantProfileId(entityId.getId()), operation);

--- a/application/src/main/java/org/thingsboard/server/controller/DashboardController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/DashboardController.java
@@ -585,7 +585,7 @@ public class DashboardController extends BaseController {
             @ApiParam(value = SORT_ORDER_DESCRIPTION, allowableValues = SORT_ORDER_ALLOWABLE_VALUES)
             @RequestParam(required = false) String sortOrder) throws ThingsboardException {
         try {
-            TenantId tenantId = new TenantId(toUUID(strTenantId));
+            TenantId tenantId = TenantId.fromUUID(toUUID(strTenantId));
             checkTenantId(tenantId, Operation.READ);
             PageLink pageLink = createPageLink(pageSize, page, textSearch, sortProperty, sortOrder);
             return checkNotNull(dashboardService.findDashboardsByTenantId(tenantId, pageLink));

--- a/application/src/main/java/org/thingsboard/server/controller/DeviceController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/DeviceController.java
@@ -807,7 +807,7 @@ public class DeviceController extends BaseController {
             DeviceId deviceId = new DeviceId(toUUID(strDeviceId));
             Device device = checkDeviceId(deviceId, Operation.ASSIGN_TO_TENANT);
 
-            TenantId newTenantId = new TenantId(toUUID(strTenantId));
+            TenantId newTenantId = TenantId.fromUUID(toUUID(strTenantId));
             Tenant newTenant = tenantService.findTenantById(newTenantId);
             if (newTenant == null) {
                 throw new ThingsboardException("Could not find the specified Tenant!", ThingsboardErrorCode.BAD_REQUEST_PARAMS);

--- a/application/src/main/java/org/thingsboard/server/controller/EventController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/EventController.java
@@ -136,7 +136,7 @@ public class EventController extends BaseController {
         checkParameter("EntityId", strEntityId);
         checkParameter("EntityType", strEntityType);
         try {
-            TenantId tenantId = new TenantId(toUUID(strTenantId));
+            TenantId tenantId = TenantId.fromUUID(toUUID(strTenantId));
 
             EntityId entityId = EntityIdFactory.getByTypeAndId(strEntityType, strEntityId);
             checkEntityId(entityId, Operation.READ);
@@ -177,7 +177,7 @@ public class EventController extends BaseController {
         checkParameter("EntityId", strEntityId);
         checkParameter("EntityType", strEntityType);
         try {
-            TenantId tenantId = new TenantId(toUUID(strTenantId));
+            TenantId tenantId = TenantId.fromUUID(toUUID(strTenantId));
 
             EntityId entityId = EntityIdFactory.getByTypeAndId(strEntityType, strEntityId);
             checkEntityId(entityId, Operation.READ);
@@ -224,7 +224,7 @@ public class EventController extends BaseController {
         checkParameter("EntityId", strEntityId);
         checkParameter("EntityType", strEntityType);
         try {
-            TenantId tenantId = new TenantId(toUUID(strTenantId));
+            TenantId tenantId = TenantId.fromUUID(toUUID(strTenantId));
 
             EntityId entityId = EntityIdFactory.getByTypeAndId(strEntityType, strEntityId);
             checkEntityId(entityId, Operation.READ);

--- a/application/src/main/java/org/thingsboard/server/controller/TenantController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/TenantController.java
@@ -82,7 +82,7 @@ public class TenantController extends BaseController {
             @PathVariable(TENANT_ID) String strTenantId) throws ThingsboardException {
         checkParameter(TENANT_ID, strTenantId);
         try {
-            TenantId tenantId = new TenantId(toUUID(strTenantId));
+            TenantId tenantId = TenantId.fromUUID(toUUID(strTenantId));
             Tenant tenant = checkTenantId(tenantId, Operation.READ);
             if (!tenant.getAdditionalInfo().isNull()) {
                 processDashboardIdFromAdditionalInfo((ObjectNode) tenant.getAdditionalInfo(), HOME_DASHBOARD);
@@ -104,7 +104,7 @@ public class TenantController extends BaseController {
             @PathVariable(TENANT_ID) String strTenantId) throws ThingsboardException {
         checkParameter(TENANT_ID, strTenantId);
         try {
-            TenantId tenantId = new TenantId(toUUID(strTenantId));
+            TenantId tenantId = TenantId.fromUUID(toUUID(strTenantId));
             return checkTenantInfoId(tenantId, Operation.READ);
         } catch (Exception e) {
             throw handleException(e);
@@ -154,7 +154,7 @@ public class TenantController extends BaseController {
             @PathVariable(TENANT_ID) String strTenantId) throws ThingsboardException {
         checkParameter(TENANT_ID, strTenantId);
         try {
-            TenantId tenantId = new TenantId(toUUID(strTenantId));
+            TenantId tenantId = TenantId.fromUUID(toUUID(strTenantId));
             Tenant tenant = checkTenantId(tenantId, Operation.DELETE);
             tenantService.deleteTenant(tenantId);
             tenantProfileCache.evict(tenantId);

--- a/application/src/main/java/org/thingsboard/server/controller/UserController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/UserController.java
@@ -371,7 +371,7 @@ public class UserController extends BaseController {
             @RequestParam(required = false) String sortOrder) throws ThingsboardException {
         checkParameter("tenantId", strTenantId);
         try {
-            TenantId tenantId = new TenantId(toUUID(strTenantId));
+            TenantId tenantId = TenantId.fromUUID(toUUID(strTenantId));
             PageLink pageLink = createPageLink(pageSize, page, textSearch, sortProperty, sortOrder);
             return checkNotNull(userService.findTenantAdmins(tenantId, pageLink));
         } catch (Exception e) {

--- a/application/src/main/java/org/thingsboard/server/controller/WidgetTypeController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/WidgetTypeController.java
@@ -216,7 +216,7 @@ public class WidgetTypeController extends BaseController {
         try {
             TenantId tenantId;
             if (isSystem) {
-                tenantId = new TenantId(ModelConstants.NULL_UUID);
+                tenantId = TenantId.fromUUID(ModelConstants.NULL_UUID);
             } else {
                 tenantId = getCurrentUser().getTenantId();
             }

--- a/application/src/main/java/org/thingsboard/server/service/apiusage/DefaultTbApiUsageStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/apiusage/DefaultTbApiUsageStateService.java
@@ -164,7 +164,7 @@ public class DefaultTbApiUsageStateService extends TbApplicationEventListener<Pa
     public void process(TbProtoQueueMsg<ToUsageStatsServiceMsg> msg, TbCallback callback) {
         ToUsageStatsServiceMsg statsMsg = msg.getValue();
 
-        TenantId tenantId = new TenantId(new UUID(statsMsg.getTenantIdMSB(), statsMsg.getTenantIdLSB()));
+        TenantId tenantId = TenantId.fromUUID(new UUID(statsMsg.getTenantIdMSB(), statsMsg.getTenantIdLSB()));
         EntityId entityId;
         if (statsMsg.getCustomerIdMSB() != 0 && statsMsg.getCustomerIdLSB() != 0) {
             entityId = new CustomerId(new UUID(statsMsg.getCustomerIdMSB(), statsMsg.getCustomerIdLSB()));

--- a/application/src/main/java/org/thingsboard/server/service/edge/DefaultEdgeNotificationService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/DefaultEdgeNotificationService.java
@@ -124,7 +124,7 @@ public class DefaultEdgeNotificationService implements EdgeNotificationService {
     public void pushNotificationToEdge(TransportProtos.EdgeNotificationMsgProto edgeNotificationMsg, TbCallback callback) {
         log.trace("Pushing notification to edge {}", edgeNotificationMsg);
         try {
-            TenantId tenantId = new TenantId(new UUID(edgeNotificationMsg.getTenantIdMSB(), edgeNotificationMsg.getTenantIdLSB()));
+            TenantId tenantId = TenantId.fromUUID(new UUID(edgeNotificationMsg.getTenantIdMSB(), edgeNotificationMsg.getTenantIdLSB()));
             EdgeEventType type = EdgeEventType.valueOf(edgeNotificationMsg.getType());
             switch (type) {
                 case EDGE:

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/TelemetryEdgeProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/TelemetryEdgeProcessor.java
@@ -276,7 +276,7 @@ public class TelemetryEdgeProcessor extends BaseEdgeProcessor {
             case DASHBOARD:
                 return new DashboardId(new UUID(entityData.getEntityIdMSB(), entityData.getEntityIdLSB()));
             case TENANT:
-                return new TenantId(new UUID(entityData.getEntityIdMSB(), entityData.getEntityIdLSB()));
+                return TenantId.fromUUID(new UUID(entityData.getEntityIdMSB(), entityData.getEntityIdLSB()));
             case CUSTOMER:
                 return new CustomerId(new UUID(entityData.getEntityIdMSB(), entityData.getEntityIdLSB()));
             case USER:
@@ -303,7 +303,7 @@ public class TelemetryEdgeProcessor extends BaseEdgeProcessor {
                 entityId = new DashboardId(edgeEvent.getEntityId());
                 break;
             case TENANT:
-                entityId = new TenantId(edgeEvent.getEntityId());
+                entityId = TenantId.fromUUID(edgeEvent.getEntityId());
                 break;
             case CUSTOMER:
                 entityId = new CustomerId(edgeEvent.getEntityId());

--- a/application/src/main/java/org/thingsboard/server/service/install/DatabaseHelper.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/DatabaseHelper.java
@@ -99,7 +99,7 @@ public class DatabaseHelper {
                     }
                 }
                 for (CustomerId customerId : customerIds) {
-                    dashboardService.assignDashboardToCustomer(new TenantId(EntityId.NULL_UUID), dashboardId, customerId);
+                    dashboardService.assignDashboardToCustomer(TenantId.SYS_TENANT_ID, dashboardId, customerId);
                 }
             });
         }

--- a/application/src/main/java/org/thingsboard/server/service/install/InstallScripts.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/InstallScripts.java
@@ -169,7 +169,7 @@ public class InstallScripts {
         ruleChain = ruleChainService.saveRuleChain(ruleChain);
 
         ruleChainMetaData.setRuleChainId(ruleChain.getId());
-        ruleChainService.saveRuleChainMetaData(new TenantId(EntityId.NULL_UUID), ruleChainMetaData);
+        ruleChainService.saveRuleChainMetaData(TenantId.SYS_TENANT_ID, ruleChainMetaData);
 
         return ruleChain;
     }
@@ -217,7 +217,7 @@ public class InstallScripts {
                             dashboard.setTenantId(tenantId);
                             Dashboard savedDashboard = dashboardService.saveDashboard(dashboard);
                             if (customerId != null && !customerId.isNullUid()) {
-                                dashboardService.assignDashboardToCustomer(new TenantId(EntityId.NULL_UUID), savedDashboard.getId(), customerId);
+                                dashboardService.assignDashboardToCustomer(TenantId.SYS_TENANT_ID, savedDashboard.getId(), customerId);
                             }
                         } catch (Exception e) {
                             log.error("Unable to load dashboard from json: [{}]", path.toString());

--- a/application/src/main/java/org/thingsboard/server/service/mail/DefaultMailService.java
+++ b/application/src/main/java/org/thingsboard/server/service/mail/DefaultMailService.java
@@ -95,7 +95,7 @@ public class DefaultMailService implements MailService {
 
     @Override
     public void updateMailConfiguration() {
-        AdminSettings settings = adminSettingsService.findAdminSettingsByKey(new TenantId(EntityId.NULL_UUID), "mail");
+        AdminSettings settings = adminSettingsService.findAdminSettingsByKey(TenantId.SYS_TENANT_ID, "mail");
         if (settings != null) {
             JsonNode jsonConfig = settings.getJsonValue();
             mailSender = createMailSender(jsonConfig);

--- a/application/src/main/java/org/thingsboard/server/service/ota/DefaultOtaPackageStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/ota/DefaultOtaPackageStateService.java
@@ -206,7 +206,7 @@ public class DefaultOtaPackageStateService implements OtaPackageStateService {
         boolean isSuccess = false;
         OtaPackageId targetOtaPackageId = new OtaPackageId(new UUID(msg.getOtaPackageIdMSB(), msg.getOtaPackageIdLSB()));
         DeviceId deviceId = new DeviceId(new UUID(msg.getDeviceIdMSB(), msg.getDeviceIdLSB()));
-        TenantId tenantId = new TenantId(new UUID(msg.getTenantIdMSB(), msg.getTenantIdLSB()));
+        TenantId tenantId = TenantId.fromUUID(new UUID(msg.getTenantIdMSB(), msg.getTenantIdLSB()));
         OtaPackageType firmwareType = OtaPackageType.valueOf(msg.getType());
         long ts = msg.getTs();
 

--- a/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbClusterService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbClusterService.java
@@ -140,7 +140,7 @@ public class DefaultTbClusterService implements TbClusterService {
     public void pushMsgToRuleEngine(TenantId tenantId, EntityId entityId, TbMsg tbMsg, TbQueueCallback callback) {
         if (tenantId.isNullUid()) {
             if (entityId.getEntityType().equals(EntityType.TENANT)) {
-                tenantId = new TenantId(entityId.getId());
+                tenantId = TenantId.fromUUID(entityId.getId());
             } else {
                 log.warn("[{}][{}] Received invalid message: {}", tenantId, entityId, tbMsg);
                 return;

--- a/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbCoreConsumerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbCoreConsumerService.java
@@ -453,37 +453,37 @@ public class DefaultTbCoreConsumerService extends AbstractConsumerService<ToCore
         } else if (msg.hasTsUpdate()) {
             TbTimeSeriesUpdateProto proto = msg.getTsUpdate();
             subscriptionManagerService.onTimeSeriesUpdate(
-                    new TenantId(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
+                    TenantId.fromUUID(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
                     TbSubscriptionUtils.toEntityId(proto.getEntityType(), proto.getEntityIdMSB(), proto.getEntityIdLSB()),
                     TbSubscriptionUtils.toTsKvEntityList(proto.getDataList()), callback);
         } else if (msg.hasAttrUpdate()) {
             TbAttributeUpdateProto proto = msg.getAttrUpdate();
             subscriptionManagerService.onAttributesUpdate(
-                    new TenantId(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
+                    TenantId.fromUUID(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
                     TbSubscriptionUtils.toEntityId(proto.getEntityType(), proto.getEntityIdMSB(), proto.getEntityIdLSB()),
                     proto.getScope(), TbSubscriptionUtils.toAttributeKvList(proto.getDataList()), callback);
         } else if (msg.hasAttrDelete()) {
             TbAttributeDeleteProto proto = msg.getAttrDelete();
             subscriptionManagerService.onAttributesDelete(
-                    new TenantId(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
+                    TenantId.fromUUID(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
                     TbSubscriptionUtils.toEntityId(proto.getEntityType(), proto.getEntityIdMSB(), proto.getEntityIdLSB()),
                     proto.getScope(), proto.getKeysList(), callback);
         } else if (msg.hasTsDelete()) {
             TbTimeSeriesDeleteProto proto = msg.getTsDelete();
             subscriptionManagerService.onTimeSeriesDelete(
-                    new TenantId(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
+                    TenantId.fromUUID(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
                     TbSubscriptionUtils.toEntityId(proto.getEntityType(), proto.getEntityIdMSB(), proto.getEntityIdLSB()),
                     proto.getKeysList(), callback);
         } else if (msg.hasAlarmUpdate()) {
             TbAlarmUpdateProto proto = msg.getAlarmUpdate();
             subscriptionManagerService.onAlarmUpdate(
-                    new TenantId(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
+                    TenantId.fromUUID(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
                     TbSubscriptionUtils.toEntityId(proto.getEntityType(), proto.getEntityIdMSB(), proto.getEntityIdLSB()),
                     JacksonUtil.fromString(proto.getAlarm(), Alarm.class), callback);
         } else if (msg.hasAlarmDelete()) {
             TbAlarmDeleteProto proto = msg.getAlarmDelete();
             subscriptionManagerService.onAlarmDeleted(
-                    new TenantId(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
+                    TenantId.fromUUID(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),
                     TbSubscriptionUtils.toEntityId(proto.getEntityType(), proto.getEntityIdMSB(), proto.getEntityIdLSB()),
                     JacksonUtil.fromString(proto.getAlarm(), Alarm.class), callback);
         } else {

--- a/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbRuleEngineConsumerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbRuleEngineConsumerService.java
@@ -321,7 +321,7 @@ public class DefaultTbRuleEngineConsumerService extends AbstractConsumerService<
     void submitMessage(TbRuleEngineQueueConfiguration configuration, TbRuleEngineConsumerStats stats, TbMsgPackProcessingContext ctx, UUID id, TbProtoQueueMsg<ToRuleEngineMsg> msg) {
         log.trace("[{}] Creating callback for topic {} message: {}", id, configuration.getName(), msg.getValue());
         ToRuleEngineMsg toRuleEngineMsg = msg.getValue();
-        TenantId tenantId = new TenantId(new UUID(toRuleEngineMsg.getTenantIdMSB(), toRuleEngineMsg.getTenantIdLSB()));
+        TenantId tenantId = TenantId.fromUUID(new UUID(toRuleEngineMsg.getTenantIdMSB(), toRuleEngineMsg.getTenantIdLSB()));
         TbMsgCallback callback = prometheusStatsEnabled ?
                 new TbMsgPackCallback(id, tenantId, ctx, stats.getTimer(tenantId, SUCCESSFUL_STATUS), stats.getTimer(tenantId, FAILED_STATUS)) :
                 new TbMsgPackCallback(id, tenantId, ctx);
@@ -344,9 +344,9 @@ public class DefaultTbRuleEngineConsumerService extends AbstractConsumerService<
             TbMsg tmpMsg = TbMsg.fromBytes(configuration.getName(), tmp.getTbMsg().toByteArray(), TbMsgCallback.EMPTY);
             RuleNodeInfo ruleNodeInfo = ctx.getLastVisitedRuleNode(pending.getKey());
             if (printAll) {
-                log.trace("[{}] {} to process message: {}, Last Rule Node: {}", new TenantId(new UUID(tmp.getTenantIdMSB(), tmp.getTenantIdLSB())), prefix, tmpMsg, ruleNodeInfo);
+                log.trace("[{}] {} to process message: {}, Last Rule Node: {}", TenantId.fromUUID(new UUID(tmp.getTenantIdMSB(), tmp.getTenantIdLSB())), prefix, tmpMsg, ruleNodeInfo);
             } else {
-                log.info("[{}] {} to process message: {}, Last Rule Node: {}", new TenantId(new UUID(tmp.getTenantIdMSB(), tmp.getTenantIdLSB())), prefix, tmpMsg, ruleNodeInfo);
+                log.info("[{}] {} to process message: {}, Last Rule Node: {}", TenantId.fromUUID(new UUID(tmp.getTenantIdMSB(), tmp.getTenantIdLSB())), prefix, tmpMsg, ruleNodeInfo);
                 break;
             }
         }

--- a/application/src/main/java/org/thingsboard/server/service/queue/processing/SequentialByTenantIdTbRuleEngineSubmitStrategy.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/processing/SequentialByTenantIdTbRuleEngineSubmitStrategy.java
@@ -29,6 +29,6 @@ public class SequentialByTenantIdTbRuleEngineSubmitStrategy extends SequentialBy
 
     @Override
     protected EntityId getEntityId(TransportProtos.ToRuleEngineMsg msg) {
-        return new TenantId(new UUID(msg.getTenantIdMSB(), msg.getTenantIdLSB()));
+        return TenantId.fromUUID(new UUID(msg.getTenantIdMSB(), msg.getTenantIdLSB()));
     }
 }

--- a/application/src/main/java/org/thingsboard/server/service/security/AccessValidator.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/AccessValidator.java
@@ -450,7 +450,7 @@ public class AccessValidator {
         } else if (currentUser.isSystemAdmin()) {
             callback.onSuccess(ValidationResult.ok(null));
         } else {
-            ListenableFuture<Tenant> tenantFuture = tenantService.findTenantByIdAsync(currentUser.getTenantId(), new TenantId(entityId.getId()));
+            ListenableFuture<Tenant> tenantFuture = tenantService.findTenantByIdAsync(currentUser.getTenantId(), TenantId.fromUUID(entityId.getId()));
             Futures.addCallback(tenantFuture, getCallback(callback, tenant -> {
                 if (tenant == null) {
                     return ValidationResult.entityNotFound("Tenant with requested id wasn't found!");

--- a/application/src/main/java/org/thingsboard/server/service/security/auth/jwt/RefreshTokenAuthenticationProvider.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/auth/jwt/RefreshTokenAuthenticationProvider.java
@@ -75,7 +75,7 @@ public class RefreshTokenAuthenticationProvider implements AuthenticationProvide
     }
 
     private SecurityUser authenticateByUserId(UserId userId) {
-        TenantId systemId = new TenantId(EntityId.NULL_UUID);
+        TenantId systemId = TenantId.SYS_TENANT_ID;
         User user = userService.findUserById(systemId, userId);
         if (user == null) {
             throw new UsernameNotFoundException("User not found by refresh token");
@@ -99,7 +99,7 @@ public class RefreshTokenAuthenticationProvider implements AuthenticationProvide
     }
 
     private SecurityUser authenticateByPublicId(String publicId) {
-        TenantId systemId = new TenantId(EntityId.NULL_UUID);
+        TenantId systemId = TenantId.SYS_TENANT_ID;
         CustomerId customerId;
         try {
             customerId = new CustomerId(UUID.fromString(publicId));

--- a/application/src/main/java/org/thingsboard/server/service/security/model/token/JwtTokenFactory.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/model/token/JwtTokenFactory.java
@@ -126,7 +126,7 @@ public class JwtTokenFactory {
         securityUser.setUserPrincipal(principal);
         String tenantId = claims.get(TENANT_ID, String.class);
         if (tenantId != null) {
-            securityUser.setTenantId(new TenantId(UUID.fromString(tenantId)));
+            securityUser.setTenantId(TenantId.fromUUID(UUID.fromString(tenantId)));
         }
         String customerId = claims.get(CUSTOMER_ID, String.class);
         if (customerId != null) {

--- a/application/src/main/java/org/thingsboard/server/service/sms/DefaultSmsService.java
+++ b/application/src/main/java/org/thingsboard/server/service/sms/DefaultSmsService.java
@@ -71,7 +71,7 @@ public class DefaultSmsService implements SmsService {
 
     @Override
     public void updateSmsConfiguration() {
-        AdminSettings settings = adminSettingsService.findAdminSettingsByKey(new TenantId(EntityId.NULL_UUID), "sms");
+        AdminSettings settings = adminSettingsService.findAdminSettingsByKey(TenantId.SYS_TENANT_ID, "sms");
         if (settings != null) {
             try {
                 JsonNode jsonConfig = settings.getJsonValue();

--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -237,7 +237,7 @@ public class DefaultDeviceStateService extends TbApplicationEventListener<Partit
     @Override
     public void onQueueMsg(TransportProtos.DeviceStateServiceMsgProto proto, TbCallback callback) {
         try {
-            TenantId tenantId = new TenantId(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB()));
+            TenantId tenantId = TenantId.fromUUID(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB()));
             DeviceId deviceId = new DeviceId(new UUID(proto.getDeviceIdMSB(), proto.getDeviceIdLSB()));
             if (proto.getDeleted()) {
                 onDeviceDeleted(tenantId, deviceId);

--- a/application/src/main/java/org/thingsboard/server/service/stats/DefaultRuleEngineStatisticsService.java
+++ b/application/src/main/java/org/thingsboard/server/service/stats/DefaultRuleEngineStatisticsService.java
@@ -77,7 +77,7 @@ public class DefaultRuleEngineStatisticsService implements RuleEngineStatisticsS
     public void reportQueueStats(long ts, TbRuleEngineConsumerStats ruleEngineStats) {
         String queueName = ruleEngineStats.getQueueName();
         ruleEngineStats.getTenantStats().forEach((id, stats) -> {
-            TenantId tenantId = new TenantId(id);
+            TenantId tenantId = TenantId.fromUUID(id);
             try {
                 AssetId serviceAssetId = getServiceAssetId(tenantId, queueName);
                 if (stats.getTotalMsgCounter().get() > 0) {

--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscriptionUtils.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscriptionUtils.java
@@ -125,7 +125,7 @@ public class TbSubscriptionUtils {
                 .sessionId(subProto.getSessionId())
                 .subscriptionId(subProto.getSubscriptionId())
                 .entityId(EntityIdFactory.getByTypeAndUuid(subProto.getEntityType(), new UUID(subProto.getEntityIdMSB(), subProto.getEntityIdLSB())))
-                .tenantId(new TenantId(new UUID(subProto.getTenantIdMSB(), subProto.getTenantIdLSB())));
+                .tenantId(TenantId.fromUUID(new UUID(subProto.getTenantIdMSB(), subProto.getTenantIdLSB())));
 
         builder.scope(TbAttributeSubscriptionScope.valueOf(attributeSub.getScope()));
         builder.allKeys(attributeSub.getAllKeys());
@@ -142,7 +142,7 @@ public class TbSubscriptionUtils {
                 .sessionId(subProto.getSessionId())
                 .subscriptionId(subProto.getSubscriptionId())
                 .entityId(EntityIdFactory.getByTypeAndUuid(subProto.getEntityType(), new UUID(subProto.getEntityIdMSB(), subProto.getEntityIdLSB())))
-                .tenantId(new TenantId(new UUID(subProto.getTenantIdMSB(), subProto.getTenantIdLSB())));
+                .tenantId(TenantId.fromUUID(new UUID(subProto.getTenantIdMSB(), subProto.getTenantIdLSB())));
 
         builder.allKeys(telemetrySub.getAllKeys());
         Map<String, Long> keyStates = new HashMap<>();
@@ -161,7 +161,7 @@ public class TbSubscriptionUtils {
                 .sessionId(subProto.getSessionId())
                 .subscriptionId(subProto.getSubscriptionId())
                 .entityId(EntityIdFactory.getByTypeAndUuid(subProto.getEntityType(), new UUID(subProto.getEntityIdMSB(), subProto.getEntityIdLSB())))
-                .tenantId(new TenantId(new UUID(subProto.getTenantIdMSB(), subProto.getTenantIdLSB())));
+                .tenantId(TenantId.fromUUID(new UUID(subProto.getTenantIdMSB(), subProto.getTenantIdLSB())));
         builder.ts(alarmSub.getTs());
         return builder.build();
     }

--- a/application/src/main/java/org/thingsboard/server/service/transport/DefaultTransportApiService.java
+++ b/application/src/main/java/org/thingsboard/server/service/transport/DefaultTransportApiService.java
@@ -380,7 +380,7 @@ public class DefaultTransportApiService implements TransportApiService {
             DeviceProfile deviceProfile = deviceProfileCache.find(deviceProfileId);
             builder.setData(ByteString.copyFrom(dataDecodingEncodingService.encode(deviceProfile)));
         } else if (entityType.equals(EntityType.TENANT)) {
-            TenantId tenantId = new TenantId(entityUuid);
+            TenantId tenantId = TenantId.fromUUID(entityUuid);
             TenantProfile tenantProfile = tenantProfileCache.get(tenantId);
             ApiUsageState state = apiUsageStateService.getApiUsageState(tenantId);
             builder.setData(ByteString.copyFrom(dataDecodingEncodingService.encode(tenantProfile)));
@@ -425,7 +425,7 @@ public class DefaultTransportApiService implements TransportApiService {
 
 
     private ListenableFuture<TransportApiResponseMsg> handle(GetResourceRequestMsg requestMsg) {
-        TenantId tenantId = new TenantId(new UUID(requestMsg.getTenantIdMSB(), requestMsg.getTenantIdLSB()));
+        TenantId tenantId = TenantId.fromUUID(new UUID(requestMsg.getTenantIdMSB(), requestMsg.getTenantIdLSB()));
         ResourceType resourceType = ResourceType.valueOf(requestMsg.getResourceType());
         String resourceKey = requestMsg.getResourceKey();
         TransportProtos.GetResourceResponseMsg.Builder builder = TransportProtos.GetResourceResponseMsg.newBuilder();
@@ -542,7 +542,7 @@ public class DefaultTransportApiService implements TransportApiService {
     }
 
     private ListenableFuture<TransportApiResponseMsg> handle(TransportProtos.GetOtaPackageRequestMsg requestMsg) {
-        TenantId tenantId = new TenantId(new UUID(requestMsg.getTenantIdMSB(), requestMsg.getTenantIdLSB()));
+        TenantId tenantId = TenantId.fromUUID(new UUID(requestMsg.getTenantIdMSB(), requestMsg.getTenantIdLSB()));
         DeviceId deviceId = new DeviceId(new UUID(requestMsg.getDeviceIdMSB(), requestMsg.getDeviceIdLSB()));
         OtaPackageType otaPackageType = OtaPackageType.valueOf(requestMsg.getType());
         Device device = deviceService.findDeviceById(tenantId, deviceId);
@@ -592,7 +592,7 @@ public class DefaultTransportApiService implements TransportApiService {
     }
 
     private ListenableFuture<TransportApiResponseMsg> handleRegistration(TransportProtos.LwM2MRegistrationRequestMsg msg) {
-        TenantId tenantId = new TenantId(UUID.fromString(msg.getTenantId()));
+        TenantId tenantId = TenantId.fromUUID(UUID.fromString(msg.getTenantId()));
         String deviceName = msg.getEndpoint();
         Lock deviceCreationLock = deviceCreationLocks.computeIfAbsent(deviceName, id -> new ReentrantLock());
         deviceCreationLock.lock();

--- a/application/src/main/java/org/thingsboard/server/service/transport/msg/TransportToDeviceActorMsgWrapper.java
+++ b/application/src/main/java/org/thingsboard/server/service/transport/msg/TransportToDeviceActorMsgWrapper.java
@@ -44,7 +44,7 @@ public class TransportToDeviceActorMsgWrapper implements TbActorMsg, DeviceAware
     public TransportToDeviceActorMsgWrapper(TransportToDeviceActorMsg msg, TbCallback callback) {
         this.msg = msg;
         this.callback = callback;
-        this.tenantId = new TenantId(new UUID(msg.getSessionInfo().getTenantIdMSB(), msg.getSessionInfo().getTenantIdLSB()));
+        this.tenantId = TenantId.fromUUID(new UUID(msg.getSessionInfo().getTenantIdMSB(), msg.getSessionInfo().getTenantIdLSB()));
         this.deviceId = new DeviceId(new UUID(msg.getSessionInfo().getDeviceIdMSB(), msg.getSessionInfo().getDeviceIdLSB()));
     }
 

--- a/application/src/test/java/org/thingsboard/server/service/resource/sql/BaseTbResourceServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/resource/sql/BaseTbResourceServiceTest.java
@@ -277,7 +277,7 @@ public class BaseTbResourceServiceTest extends AbstractControllerTest {
     @Test(expected = DataValidationException.class)
     public void testSaveTbResourceWithInvalidTenant() throws Exception {
         TbResource resource = new TbResource();
-        resource.setTenantId(new TenantId(Uuids.timeBased()));
+        resource.setTenantId(TenantId.fromUUID(Uuids.timeBased()));
         resource.setResourceType(ResourceType.JKS);
         resource.setTitle("My resource");
         resource.setFileName(DEFAULT_FILE_NAME);

--- a/common/data/src/main/java/org/thingsboard/server/common/data/id/EntityIdFactory.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/id/EntityIdFactory.java
@@ -40,7 +40,7 @@ public class EntityIdFactory {
     public static EntityId getByTypeAndUuid(EntityType type, UUID uuid) {
         switch (type) {
             case TENANT:
-                return new TenantId(uuid);
+                return TenantId.fromUUID(uuid);
             case CUSTOMER:
                 return new CustomerId(uuid);
             case USER:

--- a/common/data/src/main/java/org/thingsboard/server/common/data/id/TenantId.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/id/TenantId.java
@@ -28,9 +28,13 @@ import java.util.UUID;
 public final class TenantId extends UUIDBased implements EntityId {
 
     @JsonIgnore
-    public static final TenantId SYS_TENANT_ID = TenantId.fromUUID(EntityId.NULL_UUID);
+    public static final TenantId SYS_TENANT_ID = new TenantId(EntityId.NULL_UUID);
 
     static final ConcurrentReferenceHashMap<UUID, TenantId> tenants = new ConcurrentReferenceHashMap<>(16, ReferenceType.SOFT);
+
+    static {
+        tenants.put(SYS_TENANT_ID.getId(), SYS_TENANT_ID);
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/id/TenantId.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/id/TenantId.java
@@ -28,13 +28,10 @@ import java.util.UUID;
 public final class TenantId extends UUIDBased implements EntityId {
 
     @JsonIgnore
-    public static final TenantId SYS_TENANT_ID = new TenantId(EntityId.NULL_UUID);
-
     static final ConcurrentReferenceHashMap<UUID, TenantId> tenants = new ConcurrentReferenceHashMap<>(16, ReferenceType.SOFT);
 
-    static {
-        tenants.put(SYS_TENANT_ID.getId(), SYS_TENANT_ID);
-    }
+    @JsonIgnore
+    public static final TenantId SYS_TENANT_ID = TenantId.fromUUID(EntityId.NULL_UUID);
 
     private static final long serialVersionUID = 1L;
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/id/TenantId.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/id/TenantId.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 public final class TenantId extends UUIDBased implements EntityId {
 
     @JsonIgnore
-    public static final TenantId SYS_TENANT_ID = new TenantId(EntityId.NULL_UUID);
+    public static final TenantId SYS_TENANT_ID = TenantId.fromUUID(EntityId.NULL_UUID);
 
     static final ConcurrentReferenceHashMap<UUID, TenantId> tenants = new ConcurrentReferenceHashMap<>(16, ReferenceType.SOFT);
 
@@ -39,6 +39,7 @@ public final class TenantId extends UUIDBased implements EntityId {
         return tenants.computeIfAbsent(id, TenantId::new);
     }
 
+    //default constructor is still available due to possible usage in extensions
     public TenantId(UUID id) {
         super(id);
     }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/id/TenantId.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/id/TenantId.java
@@ -15,23 +15,31 @@
  */
 package org.thingsboard.server.common.data.id;
 
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
+import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.ConcurrentReferenceHashMap.ReferenceType;
 import org.thingsboard.server.common.data.EntityType;
+
+import java.util.UUID;
 
 public final class TenantId extends UUIDBased implements EntityId {
 
     @JsonIgnore
     public static final TenantId SYS_TENANT_ID = new TenantId(EntityId.NULL_UUID);
 
+    static final ConcurrentReferenceHashMap<UUID, TenantId> tenants = new ConcurrentReferenceHashMap<>(16, ReferenceType.SOFT);
+
     private static final long serialVersionUID = 1L;
 
     @JsonCreator
-    public TenantId(@JsonProperty("id") UUID id) {
+    public static TenantId fromUUID(@JsonProperty("id") UUID id) {
+        return tenants.computeIfAbsent(id, TenantId::new);
+    }
+
+    public TenantId(UUID id) {
         super(id);
     }
 

--- a/common/message/src/main/java/org/thingsboard/server/common/msg/TbMsgMetaData.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/TbMsgMetaData.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Data
 public final class TbMsgMetaData implements Serializable {
 
-    public static final TbMsgMetaData EMPTY = new TbMsgMetaData(Collections.emptyMap());
+    public static final TbMsgMetaData EMPTY = new TbMsgMetaData(0);
 
     private final Map<String, String> data;
 
@@ -39,6 +39,13 @@ public final class TbMsgMetaData implements Serializable {
 
     public TbMsgMetaData(Map<String, String> data) {
         this.data = new ConcurrentHashMap<>(data);
+    }
+
+    /**
+     * Internal constructor to create immutable TbMsgMetaData.EMPTY
+     * */
+    private TbMsgMetaData(int ignored) {
+        this.data = Collections.emptyMap();
     }
 
     public String getValue(String key) {

--- a/common/message/src/main/java/org/thingsboard/server/common/msg/TbMsgMetaData.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/TbMsgMetaData.java
@@ -15,9 +15,7 @@
  */
 package org.thingsboard.server.common.msg;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -29,15 +27,18 @@ import java.util.concurrent.ConcurrentHashMap;
  * Created by ashvayka on 13.01.18.
  */
 @Data
-@NoArgsConstructor
 public final class TbMsgMetaData implements Serializable {
 
     public static final TbMsgMetaData EMPTY = new TbMsgMetaData(Collections.emptyMap());
 
-    private final Map<String, String> data = new ConcurrentHashMap<>();
+    private final Map<String, String> data;
+
+    public TbMsgMetaData() {
+        this.data = new ConcurrentHashMap<>();
+    }
 
     public TbMsgMetaData(Map<String, String> data) {
-        data.forEach((key, val) -> putValue(key, val));
+        this.data = new ConcurrentHashMap<>(data);
     }
 
     public String getValue(String key) {
@@ -55,6 +56,6 @@ public final class TbMsgMetaData implements Serializable {
     }
 
     public TbMsgMetaData copy() {
-        return new TbMsgMetaData(new ConcurrentHashMap<>(data));
+        return new TbMsgMetaData(data);
     }
 }

--- a/common/queue/src/main/java/org/thingsboard/server/queue/common/DefaultTbQueueRequestTemplate.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/common/DefaultTbQueueRequestTemplate.java
@@ -210,7 +210,7 @@ public class DefaultTbQueueRequestTemplate<Request extends TbQueueMsg, Response 
     @Override
     public ListenableFuture<Response> send(Request request, long requestTimeoutNs) {
         if (pendingRequests.mappingCount() >= maxPendingRequests) {
-            log.warn("Pending request map is full [{}]! Consider to increase maxPendingRequests or increase processing performance", maxPendingRequests);
+            log.warn("Pending request map is full [{}]! Consider to increase maxPendingRequests or increase processing performance. Request is {}", maxPendingRequests, request);
             return Futures.immediateFailedFuture(new RuntimeException("Pending request map is full!"));
         }
         UUID requestId = UUID.randomUUID();

--- a/common/queue/src/main/java/org/thingsboard/server/queue/discovery/DefaultTbServiceInfoProvider.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/discovery/DefaultTbServiceInfoProvider.java
@@ -88,7 +88,7 @@ public class DefaultTbServiceInfoProvider implements TbServiceInfoProvider {
         UUID tenantId;
         if (!StringUtils.isEmpty(tenantIdStr)) {
             tenantId = UUID.fromString(tenantIdStr);
-            isolatedTenant = new TenantId(tenantId);
+            isolatedTenant = TenantId.fromUUID(tenantId);
         } else {
             tenantId = TenantId.NULL_UUID;
         }

--- a/common/queue/src/main/java/org/thingsboard/server/queue/discovery/HashPartitionService.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/discovery/HashPartitionService.java
@@ -327,7 +327,7 @@ public class HashPartitionService implements PartitionService {
     }
 
     private TenantId getSystemOrIsolatedTenantId(TransportProtos.ServiceInfo serviceInfo) {
-        return new TenantId(new UUID(serviceInfo.getTenantIdMSB(), serviceInfo.getTenantIdLSB()));
+        return TenantId.fromUUID(new UUID(serviceInfo.getTenantIdMSB(), serviceInfo.getTenantIdLSB()));
     }
 
     private void addNode(Map<ServiceQueueKey, List<ServiceInfo>> queueServiceList, ServiceInfo instance) {

--- a/common/queue/src/main/java/org/thingsboard/server/queue/discovery/HashPartitionService.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/discovery/HashPartitionService.java
@@ -279,7 +279,7 @@ public class HashPartitionService implements PartitionService {
             tpi.tenantId(tenantId);
             myPartitionsSearchKey = new ServiceQueueKey(serviceQueue, tenantId);
         } else {
-            myPartitionsSearchKey = new ServiceQueueKey(serviceQueue, new TenantId(TenantId.NULL_UUID));
+            myPartitionsSearchKey = new ServiceQueueKey(serviceQueue, TenantId.SYS_TENANT_ID);
         }
         List<Integer> partitions = myPartitions.get(myPartitionsSearchKey);
         if (partitions != null) {

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClient.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClient.java
@@ -148,7 +148,7 @@ public class LwM2mClient implements Serializable {
 
     public void init(ValidateDeviceCredentialsResponse credentials, UUID sessionId) {
         this.session = createSession(nodeId, sessionId, credentials);
-        this.tenantId = new TenantId(new UUID(session.getTenantIdMSB(), session.getTenantIdLSB()));
+        this.tenantId = TenantId.fromUUID(new UUID(session.getTenantIdMSB(), session.getTenantIdLSB()));
         this.deviceId = new UUID(session.getDeviceIdMSB(), session.getDeviceIdLSB());
         this.profileId = new UUID(session.getDeviceProfileIdMSB(), session.getDeviceProfileIdLSB());
         this.powerMode = credentials.getDeviceInfo().getPowerMode();

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/session/DefaultLwM2MSessionManager.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/session/DefaultLwM2MSessionManager.java
@@ -19,13 +19,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.thingsboard.server.common.transport.TransportService;
-import org.thingsboard.server.common.transport.service.DefaultTransportService;
 import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.queue.util.TbLwM2mTransportComponent;
 import org.thingsboard.server.transport.lwm2m.server.LwM2mSessionMsgListener;
 import org.thingsboard.server.transport.lwm2m.server.attributes.LwM2MAttributesService;
 import org.thingsboard.server.transport.lwm2m.server.rpc.LwM2MRpcRequestHandler;
 import org.thingsboard.server.transport.lwm2m.server.uplink.LwM2mUplinkMsgHandler;
+
+import static org.thingsboard.server.common.transport.service.DefaultTransportService.SESSION_EVENT_MSG_CLOSED;
+import static org.thingsboard.server.common.transport.service.DefaultTransportService.SESSION_EVENT_MSG_OPEN;
+import static org.thingsboard.server.common.transport.service.DefaultTransportService.SUBSCRIBE_TO_ATTRIBUTE_UPDATES_ASYNC_MSG;
+import static org.thingsboard.server.common.transport.service.DefaultTransportService.SUBSCRIBE_TO_RPC_ASYNC_MSG;
 
 @Slf4j
 @Service
@@ -52,16 +56,16 @@ public class DefaultLwM2MSessionManager implements LwM2MSessionManager {
         transportService.registerAsyncSession(sessionInfo, new LwM2mSessionMsgListener(uplinkHandler, attributesService, rpcHandler, sessionInfo, transportService));
         TransportProtos.TransportToDeviceActorMsg msg = TransportProtos.TransportToDeviceActorMsg.newBuilder()
                 .setSessionInfo(sessionInfo)
-                .setSessionEvent(DefaultTransportService.getSessionEventMsg(TransportProtos.SessionEvent.OPEN))
-                .setSubscribeToAttributes(TransportProtos.SubscribeToAttributeUpdatesMsg.newBuilder().setSessionType(TransportProtos.SessionType.ASYNC).build())
-                .setSubscribeToRPC(TransportProtos.SubscribeToRPCMsg.newBuilder().setSessionType(TransportProtos.SessionType.ASYNC).build())
+                .setSessionEvent(SESSION_EVENT_MSG_OPEN)
+                .setSubscribeToAttributes(SUBSCRIBE_TO_ATTRIBUTE_UPDATES_ASYNC_MSG)
+                .setSubscribeToRPC(SUBSCRIBE_TO_RPC_ASYNC_MSG)
                 .build();
         transportService.process(msg, null);
     }
 
     @Override
     public void deregister(TransportProtos.SessionInfoProto sessionInfo) {
-        transportService.process(sessionInfo, DefaultTransportService.getSessionEventMsg(TransportProtos.SessionEvent.CLOSED), null);
+        transportService.process(sessionInfo, SESSION_EVENT_MSG_CLOSED, null);
         transportService.deregisterSession(sessionInfo);
     }
 }

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/DefaultLwM2mUplinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/DefaultLwM2mUplinkMsgHandler.java
@@ -428,7 +428,7 @@ public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService impl
     @Override
     public void onResourceUpdate(TransportProtos.ResourceUpdateMsg resourceUpdateMsgOpt) {
         String idVer = resourceUpdateMsgOpt.getResourceKey();
-        TenantId tenantId = new TenantId(new UUID(resourceUpdateMsgOpt.getTenantIdMSB(), resourceUpdateMsgOpt.getTenantIdLSB()));
+        TenantId tenantId = TenantId.fromUUID(new UUID(resourceUpdateMsgOpt.getTenantIdMSB(), resourceUpdateMsgOpt.getTenantIdLSB()));
         modelProvider.evict(tenantId, idVer);
         clientContext.getLwM2mClients().forEach(e -> e.updateResourceModel(idVer, modelProvider));
     }
@@ -436,7 +436,7 @@ public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService impl
     @Override
     public void onResourceDelete(TransportProtos.ResourceDeleteMsg resourceDeleteMsgOpt) {
         String pathIdVer = resourceDeleteMsgOpt.getResourceKey();
-        TenantId tenantId = new TenantId(new UUID(resourceDeleteMsgOpt.getTenantIdMSB(), resourceDeleteMsgOpt.getTenantIdLSB()));
+        TenantId tenantId = TenantId.fromUUID(new UUID(resourceDeleteMsgOpt.getTenantIdMSB(), resourceDeleteMsgOpt.getTenantIdLSB()));
         modelProvider.evict(tenantId, pathIdVer);
         clientContext.getLwM2mClients().forEach(e -> e.deleteResources(pathIdVer, modelProvider));
     }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -65,7 +65,6 @@ import org.thingsboard.server.common.transport.service.SessionMetaData;
 import org.thingsboard.server.common.transport.util.SslUtil;
 import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.gen.transport.TransportProtos.ProvisionDeviceResponseMsg;
-import org.thingsboard.server.gen.transport.TransportProtos.SessionEvent;
 import org.thingsboard.server.gen.transport.TransportProtos.ValidateDeviceX509CertRequestMsg;
 import org.thingsboard.server.queue.scheduler.SchedulerComponent;
 import org.thingsboard.server.transport.mqtt.adaptors.MqttTransportAdaptor;
@@ -102,6 +101,8 @@ import static io.netty.handler.codec.mqtt.MqttMessageType.UNSUBACK;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_LEAST_ONCE;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
 import static io.netty.handler.codec.mqtt.MqttQoS.FAILURE;
+import static org.thingsboard.server.common.transport.service.DefaultTransportService.SESSION_EVENT_MSG_CLOSED;
+import static org.thingsboard.server.common.transport.service.DefaultTransportService.SESSION_EVENT_MSG_OPEN;
 
 /**
  * @author Andrew Shvayka
@@ -929,7 +930,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     public void doDisconnect() {
         if (deviceSessionCtx.isConnected()) {
             log.debug("[{}] Client disconnected!", sessionId);
-            transportService.process(deviceSessionCtx.getSessionInfo(), DefaultTransportService.getSessionEventMsg(SessionEvent.CLOSED), null);
+            transportService.process(deviceSessionCtx.getSessionInfo(), SESSION_EVENT_MSG_CLOSED, null);
             transportService.deregisterSession(deviceSessionCtx.getSessionInfo());
             if (gatewaySessionHandler != null) {
                 gatewaySessionHandler.onGatewayDisconnect();
@@ -948,7 +949,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
             deviceSessionCtx.setDeviceInfo(msg.getDeviceInfo());
             deviceSessionCtx.setDeviceProfile(msg.getDeviceProfile());
             deviceSessionCtx.setSessionInfo(SessionInfoCreator.create(msg, context, sessionId));
-            transportService.process(deviceSessionCtx.getSessionInfo(), DefaultTransportService.getSessionEventMsg(SessionEvent.OPEN), new TransportServiceCallback<Void>() {
+            transportService.process(deviceSessionCtx.getSessionInfo(), SESSION_EVENT_MSG_OPEN, new TransportServiceCallback<Void>() {
                 @Override
                 public void onSuccess(Void msg) {
                     SessionMetaData sessionMetaData = transportService.registerAsyncSession(deviceSessionCtx.getSessionInfo(), MqttTransportHandler.this);

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -75,7 +75,6 @@ import org.thingsboard.server.transport.mqtt.session.MqttTopicMatcher;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.nio.ByteBuffer;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -113,6 +112,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     private static final Pattern FW_REQUEST_PATTERN = Pattern.compile(MqttTopics.DEVICE_FIRMWARE_REQUEST_TOPIC_PATTERN);
     private static final Pattern SW_REQUEST_PATTERN = Pattern.compile(MqttTopics.DEVICE_SOFTWARE_REQUEST_TOPIC_PATTERN);
 
+
     private static final String PAYLOAD_TOO_LARGE = "PAYLOAD_TOO_LARGE";
 
     private static final MqttQoS MAX_SUPPORTED_QOS_LVL = AT_LEAST_ONCE;
@@ -125,8 +125,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     private final ConcurrentMap<MqttTopicMatcher, Integer> mqttQoSMap;
 
     final DeviceSessionCtx deviceSessionCtx;
-    volatile int ip = 0;
-    volatile int port = 0;
+    volatile InetSocketAddress address;
     volatile GatewaySessionHandler gatewaySessionHandler;
 
     private final ConcurrentHashMap<String, String> otaPackSessions;
@@ -185,14 +184,9 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     }
 
     void processMqttMsg(ChannelHandlerContext ctx, MqttMessage msg) {
-        if (port == 0) {
-            InetSocketAddress address = getAddress(ctx);
-            ip = getIpv4(address); //ipv6 will not appear in logs
-            port = address.getPort();
-        }
-
+        address = getAddress(ctx);
         if (msg.fixedHeader() == null) {
-            log.info("[{}:{}] Invalid message received", ip, port);
+            log.info("[{}:{}] Invalid message received", address.getHostName(), address.getPort());
             ctx.close();
             return;
         }
@@ -204,11 +198,6 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         } else {
             enqueueRegularSessionMsg(ctx, msg);
         }
-    }
-
-    int getIpv4(InetSocketAddress address) {
-        byte[] ipBytes = address.getAddress().getAddress();
-        return ipBytes.length == 4 ? ByteBuffer.wrap(ipBytes).getInt() : -1;
     }
 
     InetSocketAddress getAddress(ChannelHandlerContext ctx) {
@@ -803,7 +792,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
 
                     @Override
                     public void onError(Throwable e) {
-                        log.trace("[{}] Failed to process credentials: {}", ip, userName, e);
+                        log.trace("[{}] Failed to process credentials: {}", address, userName, e);
                         ctx.writeAndFlush(createMqttConnAckMsg(MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE, connectMessage));
                         ctx.close();
                     }
@@ -826,14 +815,14 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
 
                         @Override
                         public void onError(Throwable e) {
-                            log.trace("[{}] Failed to process credentials: {}", ip, sha3Hash, e);
+                            log.trace("[{}] Failed to process credentials: {}", address, sha3Hash, e);
                             ctx.writeAndFlush(createMqttConnAckMsg(MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE, connectMessage));
                             ctx.close();
                         }
                     });
         } catch (Exception e) {
             ctx.writeAndFlush(createMqttConnAckMsg(CONNECTION_REFUSED_NOT_AUTHORIZED, connectMessage));
-            log.trace("[{}] X509 auth failure: {}", sessionId, ip, e);
+            log.trace("[{}] X509 auth failure: {}", sessionId, address, e);
             ctx.close();
         }
     }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/DeviceSessionCtx.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/DeviceSessionCtx.java
@@ -238,7 +238,7 @@ public class DeviceSessionCtx extends MqttDeviceAwareSessionContext {
 
     public void release() {
         if (!msgQueue.isEmpty()) {
-            log.warn("doDisconnect for device {} but unprocessed messages {} left in the msg queue", getDeviceId(), msgQueue.size());
+            log.warn("doDisconnect for device {} but unprocessed messages {} left in the msg queue. cleared", getDeviceId(), getMsgQueueSize());
             msgQueue.forEach(ReferenceCountUtil::safeRelease);
             msgQueue.clear();
         }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/DeviceSessionCtx.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/DeviceSessionCtx.java
@@ -238,7 +238,7 @@ public class DeviceSessionCtx extends MqttDeviceAwareSessionContext {
 
     public void release() {
         if (!msgQueue.isEmpty()) {
-            log.warn("doDisconnect for device {} but unprocessed messages {} left in the msg queue. cleared", getDeviceId(), getMsgQueueSize());
+            log.warn("doDisconnect for device {} but unprocessed messages {} left in the msg queue", getDeviceId(), msgQueue.size());
             msgQueue.forEach(ReferenceCountUtil::safeRelease);
             msgQueue.clear();
         }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandler.java
@@ -44,7 +44,6 @@ import org.thingsboard.server.common.transport.adaptor.JsonConverter;
 import org.thingsboard.server.common.transport.adaptor.ProtoConverter;
 import org.thingsboard.server.common.transport.auth.GetOrCreateDeviceFromGatewayResponse;
 import org.thingsboard.server.common.transport.auth.TransportDeviceInfo;
-import org.thingsboard.server.common.transport.service.DefaultTransportService;
 import org.thingsboard.server.gen.transport.TransportApiProtos;
 import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.gen.transport.TransportProtos.GetOrCreateDeviceFromGatewayRequestMsg;
@@ -68,6 +67,10 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.springframework.util.ConcurrentReferenceHashMap.ReferenceType;
+import static org.thingsboard.server.common.transport.service.DefaultTransportService.SESSION_EVENT_MSG_CLOSED;
+import static org.thingsboard.server.common.transport.service.DefaultTransportService.SESSION_EVENT_MSG_OPEN;
+import static org.thingsboard.server.common.transport.service.DefaultTransportService.SUBSCRIBE_TO_ATTRIBUTE_UPDATES_ASYNC_MSG;
+import static org.thingsboard.server.common.transport.service.DefaultTransportService.SUBSCRIBE_TO_RPC_ASYNC_MSG;
 
 /**
  * Created by ashvayka on 19.01.17.
@@ -267,11 +270,9 @@ public class GatewaySessionHandler {
                                     transportService.registerAsyncSession(deviceSessionInfo, deviceSessionCtx);
                                     transportService.process(TransportProtos.TransportToDeviceActorMsg.newBuilder()
                                             .setSessionInfo(deviceSessionInfo)
-                                            .setSessionEvent(DefaultTransportService.getSessionEventMsg(TransportProtos.SessionEvent.OPEN))
-                                            .setSubscribeToAttributes(TransportProtos.SubscribeToAttributeUpdatesMsg.newBuilder()
-                                                    .setSessionType(TransportProtos.SessionType.ASYNC).build())
-                                            .setSubscribeToRPC(TransportProtos.SubscribeToRPCMsg.newBuilder()
-                                                    .setSessionType(TransportProtos.SessionType.ASYNC).build())
+                                            .setSessionEvent(SESSION_EVENT_MSG_OPEN)
+                                            .setSubscribeToAttributes(SUBSCRIBE_TO_ATTRIBUTE_UPDATES_ASYNC_MSG)
+                                            .setSubscribeToRPC(SUBSCRIBE_TO_RPC_ASYNC_MSG)
                                             .build(), null);
                                 }
                                 futureToSet.set(devices.get(deviceName));
@@ -720,7 +721,7 @@ public class GatewaySessionHandler {
 
     private void deregisterSession(String deviceName, GatewayDeviceSessionCtx deviceSessionCtx) {
         transportService.deregisterSession(deviceSessionCtx.getSessionInfo());
-        transportService.process(deviceSessionCtx.getSessionInfo(), DefaultTransportService.getSessionEventMsg(TransportProtos.SessionEvent.CLOSED), null);
+        transportService.process(deviceSessionCtx.getSessionInfo(), SESSION_EVENT_MSG_CLOSED, null);
         log.debug("[{}] Removed device [{}] from the gateway session", sessionId, deviceName);
     }
 

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
@@ -23,7 +23,6 @@ import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttConnectPayload;
 import io.netty.handler.codec.mqtt.MqttConnectVariableHeader;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
-import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
@@ -118,7 +117,8 @@ public class MqttTransportHandlerTest {
 
         handler.processMqttMsg(ctx, msg);
 
-        assertThat(handler.address, is(IP_ADDR));
+        assertThat(handler.ip, is(handler.getIpv4(IP_ADDR)));
+        assertThat(handler.port, is(IP_ADDR.getPort()));
         assertThat(handler.deviceSessionCtx.getChannel(), is(ctx));
         verify(handler, never()).doDisconnect();
         verify(handler, times(1)).processConnect(ctx, msg);
@@ -154,7 +154,7 @@ public class MqttTransportHandlerTest {
 
         messages.forEach((msg) -> handler.processMqttMsg(ctx, msg));
 
-        assertThat(handler.address, is(IP_ADDR));
+        assertThat(handler.ip, is(handler.getIpv4(IP_ADDR)));
         assertThat(handler.deviceSessionCtx.getChannel(), is(ctx));
         assertThat(handler.deviceSessionCtx.isConnected(), is(false));
         assertThat(handler.deviceSessionCtx.getMsgQueueSize(), is(MSG_QUEUE_LIMIT));

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttConnectPayload;
 import io.netty.handler.codec.mqtt.MqttConnectVariableHeader;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
 import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
@@ -117,8 +118,7 @@ public class MqttTransportHandlerTest {
 
         handler.processMqttMsg(ctx, msg);
 
-        assertThat(handler.ip, is(handler.getIpv4(IP_ADDR)));
-        assertThat(handler.port, is(IP_ADDR.getPort()));
+        assertThat(handler.address, is(IP_ADDR));
         assertThat(handler.deviceSessionCtx.getChannel(), is(ctx));
         verify(handler, never()).doDisconnect();
         verify(handler, times(1)).processConnect(ctx, msg);
@@ -154,7 +154,7 @@ public class MqttTransportHandlerTest {
 
         messages.forEach((msg) -> handler.processMqttMsg(ctx, msg));
 
-        assertThat(handler.ip, is(handler.getIpv4(IP_ADDR)));
+        assertThat(handler.address, is(IP_ADDR));
         assertThat(handler.deviceSessionCtx.getChannel(), is(ctx));
         assertThat(handler.deviceSessionCtx.isConnected(), is(false));
         assertThat(handler.deviceSessionCtx.getMsgQueueSize(), is(MSG_QUEUE_LIMIT));

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
@@ -451,7 +451,7 @@ public class DefaultTransportService implements TransportService {
 
     private TransportDeviceInfo getTransportDeviceInfo(TransportProtos.DeviceInfoProto di) {
         TransportDeviceInfo tdi = new TransportDeviceInfo();
-        tdi.setTenantId(new TenantId(new UUID(di.getTenantIdMSB(), di.getTenantIdLSB())));
+        tdi.setTenantId(TenantId.fromUUID(new UUID(di.getTenantIdMSB(), di.getTenantIdLSB())));
         tdi.setCustomerId(new CustomerId(new UUID(di.getCustomerIdMSB(), di.getCustomerIdLSB())));
         tdi.setDeviceId(new DeviceId(new UUID(di.getDeviceIdMSB(), di.getDeviceIdLSB())));
         tdi.setDeviceProfileId(new DeviceProfileId(new UUID(di.getDeviceProfileIdMSB(), di.getDeviceProfileIdLSB())));
@@ -805,7 +805,7 @@ public class DefaultTransportService implements TransportService {
         if (log.isTraceEnabled()) {
             log.trace("[{}] Processing msg: {}", toSessionId(sessionInfo), msg);
         }
-        TenantId tenantId = new TenantId(new UUID(sessionInfo.getTenantIdMSB(), sessionInfo.getTenantIdLSB()));
+        TenantId tenantId = TenantId.fromUUID(new UUID(sessionInfo.getTenantIdMSB(), sessionInfo.getTenantIdLSB()));
         DeviceId deviceId = new DeviceId(new UUID(sessionInfo.getDeviceIdMSB(), sessionInfo.getDeviceIdLSB()));
 
         EntityType rateLimitedEntityType = rateLimitService.checkLimits(tenantId, deviceId, dataPoints);
@@ -895,14 +895,14 @@ public class DefaultTransportService implements TransportService {
                 } else if (EntityType.TENANT_PROFILE.equals(entityType)) {
                     tenantProfileCache.remove(new TenantProfileId(entityUuid));
                 } else if (EntityType.TENANT.equals(entityType)) {
-                    rateLimitService.remove(new TenantId(entityUuid));
+                    rateLimitService.remove(TenantId.fromUUID(entityUuid));
                 } else if (EntityType.DEVICE.equals(entityType)) {
                     rateLimitService.remove(new DeviceId(entityUuid));
                     onDeviceDeleted(new DeviceId(entityUuid));
                 }
             } else if (toSessionMsg.hasResourceUpdateMsg()) {
                 TransportProtos.ResourceUpdateMsg msg = toSessionMsg.getResourceUpdateMsg();
-                TenantId tenantId = new TenantId(new UUID(msg.getTenantIdMSB(), msg.getTenantIdLSB()));
+                TenantId tenantId = TenantId.fromUUID(new UUID(msg.getTenantIdMSB(), msg.getTenantIdLSB()));
                 ResourceType resourceType = ResourceType.valueOf(msg.getResourceType());
                 String resourceId = msg.getResourceKey();
                 transportResourceCache.update(tenantId, resourceType, resourceId);
@@ -913,7 +913,7 @@ public class DefaultTransportService implements TransportService {
 
             } else if (toSessionMsg.hasResourceDeleteMsg()) {
                 TransportProtos.ResourceDeleteMsg msg = toSessionMsg.getResourceDeleteMsg();
-                TenantId tenantId = new TenantId(new UUID(msg.getTenantIdMSB(), msg.getTenantIdLSB()));
+                TenantId tenantId = TenantId.fromUUID(new UUID(msg.getTenantIdMSB(), msg.getTenantIdLSB()));
                 ResourceType resourceType = ResourceType.valueOf(msg.getResourceType());
                 String resourceId = msg.getResourceKey();
                 transportResourceCache.evict(tenantId, resourceType, resourceId);
@@ -1001,7 +1001,7 @@ public class DefaultTransportService implements TransportService {
     }
 
     protected TenantId getTenantId(TransportProtos.SessionInfoProto sessionInfo) {
-        return new TenantId(new UUID(sessionInfo.getTenantIdMSB(), sessionInfo.getTenantIdLSB()));
+        return TenantId.fromUUID(new UUID(sessionInfo.getTenantIdMSB(), sessionInfo.getTenantIdLSB()));
     }
 
     protected CustomerId getCustomerId(TransportProtos.SessionInfoProto sessionInfo) {

--- a/dao/src/main/java/org/thingsboard/server/dao/component/BaseComponentDescriptorService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/component/BaseComponentDescriptorService.java
@@ -51,7 +51,7 @@ public class BaseComponentDescriptorService implements ComponentDescriptorServic
 
     @Override
     public ComponentDescriptor saveComponent(TenantId tenantId, ComponentDescriptor component) {
-        componentValidator.validate(component, data -> new TenantId(EntityId.NULL_UUID));
+        componentValidator.validate(component, data -> TenantId.SYS_TENANT_ID);
         Optional<ComponentDescriptor> result = componentDescriptorDao.saveIfNotExist(tenantId, component);
         return result.orElseGet(() -> componentDescriptorDao.findByClazz(tenantId, component.getClazz()));
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceCredentialsServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceCredentialsServiceImpl.java
@@ -73,7 +73,7 @@ public class DeviceCredentialsServiceImpl extends AbstractEntityService implemen
     public DeviceCredentials findDeviceCredentialsByCredentialsId(String credentialsId) {
         log.trace("Executing findDeviceCredentialsByCredentialsId [{}]", credentialsId);
         validateString(credentialsId, "Incorrect credentialsId " + credentialsId);
-        return deviceCredentialsDao.findByCredentialsId(new TenantId(EntityId.NULL_UUID), credentialsId);
+        return deviceCredentialsDao.findByCredentialsId(TenantId.SYS_TENANT_ID, credentialsId);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/BaseEntityService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/BaseEntityService.java
@@ -139,7 +139,7 @@ public class BaseEntityService extends AbstractEntityService implements EntitySe
                 hasName = entityViewService.findEntityViewByIdAsync(tenantId, new EntityViewId(entityId.getId()));
                 break;
             case TENANT:
-                hasName = tenantService.findTenantByIdAsync(tenantId, new TenantId(entityId.getId()));
+                hasName = tenantService.findTenantByIdAsync(tenantId, TenantId.fromUUID(entityId.getId()));
                 break;
             case CUSTOMER:
                 hasName = customerService.findCustomerByIdAsync(tenantId, new CustomerId(entityId.getId()));

--- a/dao/src/main/java/org/thingsboard/server/dao/model/ModelConstants.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/ModelConstants.java
@@ -28,7 +28,7 @@ public class ModelConstants {
     }
 
     public static final UUID NULL_UUID = Uuids.startOf(0);
-    public static final TenantId SYSTEM_TENANT = new TenantId(ModelConstants.NULL_UUID);
+    public static final TenantId SYSTEM_TENANT = TenantId.fromUUID(ModelConstants.NULL_UUID);
 
     // this is the difference between midnight October 15, 1582 UTC and midnight January 1, 1970 UTC as 100 nanosecond units
     public static final long EPOCH_DIFF = 122192928000000000L;

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractAlarmEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractAlarmEntity.java
@@ -166,7 +166,7 @@ public abstract class AbstractAlarmEntity<T extends Alarm> extends BaseSqlEntity
         Alarm alarm = new Alarm(new AlarmId(id));
         alarm.setCreatedTime(createdTime);
         if (tenantId != null) {
-            alarm.setTenantId(new TenantId(tenantId));
+            alarm.setTenantId(TenantId.fromUUID(tenantId));
         }
         if (customerId != null) {
             alarm.setCustomerId(new CustomerId(customerId));

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractAssetEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractAssetEntity.java
@@ -119,7 +119,7 @@ public abstract class AbstractAssetEntity<T extends Asset> extends BaseSqlEntity
         Asset asset = new Asset(new AssetId(id));
         asset.setCreatedTime(createdTime);
         if (tenantId != null) {
-            asset.setTenantId(new TenantId(tenantId));
+            asset.setTenantId(TenantId.fromUUID(tenantId));
         }
         if (customerId != null) {
             asset.setCustomerId(new CustomerId(customerId));

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractDeviceEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractDeviceEntity.java
@@ -145,7 +145,7 @@ public abstract class AbstractDeviceEntity<T extends Device> extends BaseSqlEnti
         Device device = new Device(new DeviceId(getUuid()));
         device.setCreatedTime(createdTime);
         if (tenantId != null) {
-            device.setTenantId(new TenantId(tenantId));
+            device.setTenantId(TenantId.fromUUID(tenantId));
         }
         if (customerId != null) {
             device.setCustomerId(new CustomerId(customerId));

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractEdgeEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractEdgeEntity.java
@@ -153,7 +153,7 @@ public abstract class AbstractEdgeEntity<T extends Edge> extends BaseSqlEntity<T
         Edge edge = new Edge(new EdgeId(getUuid()));
         edge.setCreatedTime(createdTime);
         if (tenantId != null) {
-            edge.setTenantId(new TenantId(tenantId));
+            edge.setTenantId(TenantId.fromUUID(tenantId));
         }
         if (customerId != null) {
             edge.setCustomerId(new CustomerId(customerId));

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractEntityViewEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractEntityViewEntity.java
@@ -158,7 +158,7 @@ public abstract class AbstractEntityViewEntity<T extends EntityView> extends Bas
             entityView.setEntityId(EntityIdFactory.getByTypeAndUuid(entityType.name(), entityId));
         }
         if (tenantId != null) {
-            entityView.setTenantId(new TenantId(tenantId));
+            entityView.setTenantId(TenantId.fromUUID(tenantId));
         }
         if (customerId != null) {
             entityView.setCustomerId(new CustomerId(customerId));

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractTenantEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractTenantEntity.java
@@ -138,7 +138,7 @@ public abstract class AbstractTenantEntity<T extends Tenant> extends BaseSqlEnti
     }
 
     protected Tenant toTenant() {
-        Tenant tenant = new Tenant(new TenantId(this.getUuid()));
+        Tenant tenant = new Tenant(TenantId.fromUUID(this.getUuid()));
         tenant.setCreatedTime(createdTime);
         tenant.setTitle(title);
         tenant.setRegion(region);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractWidgetTypeEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AbstractWidgetTypeEntity.java
@@ -75,7 +75,7 @@ public abstract class AbstractWidgetTypeEntity<T extends BaseWidgetType> extends
         BaseWidgetType widgetType = new BaseWidgetType(new WidgetTypeId(getUuid()));
         widgetType.setCreatedTime(createdTime);
         if (tenantId != null) {
-            widgetType.setTenantId(new TenantId(tenantId));
+            widgetType.setTenantId(TenantId.fromUUID(tenantId));
         }
         widgetType.setBundleAlias(bundleAlias);
         widgetType.setAlias(alias);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/ApiUsageStateEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/ApiUsageStateEntity.java
@@ -102,7 +102,7 @@ public class ApiUsageStateEntity extends BaseSqlEntity<ApiUsageState> implements
         ApiUsageState ur = new ApiUsageState(new ApiUsageStateId(this.getUuid()));
         ur.setCreatedTime(createdTime);
         if (tenantId != null) {
-            ur.setTenantId(new TenantId(tenantId));
+            ur.setTenantId(TenantId.fromUUID(tenantId));
         }
         if (entityId != null) {
             ur.setEntityId(EntityIdFactory.getByTypeAndUuid(entityType, entityId));

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AuditLogEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AuditLogEntity.java
@@ -132,7 +132,7 @@ public class AuditLogEntity extends BaseSqlEntity<AuditLog> implements BaseEntit
         AuditLog auditLog = new AuditLog(new AuditLogId(this.getUuid()));
         auditLog.setCreatedTime(createdTime);
         if (tenantId != null) {
-            auditLog.setTenantId(new TenantId(tenantId));
+            auditLog.setTenantId(TenantId.fromUUID(tenantId));
         }
         if (customerId != null) {
             auditLog.setCustomerId(new CustomerId(customerId));

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/CustomerEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/CustomerEntity.java
@@ -113,7 +113,7 @@ public final class CustomerEntity extends BaseSqlEntity<Customer> implements Sea
     public Customer toData() {
         Customer customer = new Customer(new CustomerId(this.getUuid()));
         customer.setCreatedTime(createdTime);
-        customer.setTenantId(new TenantId(tenantId));
+        customer.setTenantId(TenantId.fromUUID(tenantId));
         customer.setTitle(title);
         customer.setCountry(country);
         customer.setState(state);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/DashboardEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/DashboardEntity.java
@@ -119,7 +119,7 @@ public final class DashboardEntity extends BaseSqlEntity<Dashboard> implements S
         Dashboard dashboard = new Dashboard(new DashboardId(this.getUuid()));
         dashboard.setCreatedTime(this.getCreatedTime());
         if (tenantId != null) {
-            dashboard.setTenantId(new TenantId(tenantId));
+            dashboard.setTenantId(TenantId.fromUUID(tenantId));
         }
         dashboard.setTitle(title);
         dashboard.setImage(image);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/DashboardInfoEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/DashboardInfoEntity.java
@@ -113,7 +113,7 @@ public class DashboardInfoEntity extends BaseSqlEntity<DashboardInfo> implements
         DashboardInfo dashboardInfo = new DashboardInfo(new DashboardId(this.getUuid()));
         dashboardInfo.setCreatedTime(createdTime);
         if (tenantId != null) {
-            dashboardInfo.setTenantId(new TenantId(tenantId));
+            dashboardInfo.setTenantId(TenantId.fromUUID(tenantId));
         }
         dashboardInfo.setTitle(title);
         dashboardInfo.setImage(image);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/DeviceProfileEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/DeviceProfileEntity.java
@@ -158,7 +158,7 @@ public final class DeviceProfileEntity extends BaseSqlEntity<DeviceProfile> impl
         DeviceProfile deviceProfile = new DeviceProfile(new DeviceProfileId(this.getUuid()));
         deviceProfile.setCreatedTime(createdTime);
         if (tenantId != null) {
-            deviceProfile.setTenantId(new TenantId(tenantId));
+            deviceProfile.setTenantId(TenantId.fromUUID(tenantId));
         }
         deviceProfile.setName(name);
         deviceProfile.setType(type);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/EdgeEventEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/EdgeEventEntity.java
@@ -111,7 +111,7 @@ public class EdgeEventEntity extends BaseSqlEntity<EdgeEvent> implements BaseEnt
     public EdgeEvent toData() {
         EdgeEvent edgeEvent = new EdgeEvent(new EdgeEventId(this.getUuid()));
         edgeEvent.setCreatedTime(createdTime);
-        edgeEvent.setTenantId(new TenantId(tenantId));
+        edgeEvent.setTenantId(TenantId.fromUUID(tenantId));
         edgeEvent.setEdgeId(new EdgeId(edgeId));
         if (entityId != null) {
             edgeEvent.setEntityId(entityId);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/EntityAlarmEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/EntityAlarmEntity.java
@@ -85,7 +85,7 @@ public final class EntityAlarmEntity implements ToData<EntityAlarm> {
     @Override
     public EntityAlarm toData() {
         EntityAlarm result = new EntityAlarm();
-        result.setTenantId(new TenantId(tenantId));
+        result.setTenantId(TenantId.fromUUID(tenantId));
         result.setEntityId(EntityIdFactory.getByTypeAndUuid(entityType, entityId));
         result.setAlarmId(new AlarmId(alarmId));
         result.setAlarmType(alarmType);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/EventEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/EventEntity.java
@@ -103,7 +103,7 @@ public class EventEntity extends BaseSqlEntity<Event> implements BaseEntity<Even
     public Event toData() {
         Event event = new Event(new EventId(this.getUuid()));
         event.setCreatedTime(createdTime);
-        event.setTenantId(new TenantId(tenantId));
+        event.setTenantId(TenantId.fromUUID(tenantId));
         event.setEntityId(EntityIdFactory.getByTypeAndUuid(entityType, entityId));
         event.setBody(body);
         event.setType(eventType);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/OAuth2ParamsEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/OAuth2ParamsEntity.java
@@ -58,7 +58,7 @@ public class OAuth2ParamsEntity extends BaseSqlEntity<OAuth2Params> {
         OAuth2Params oauth2Params = new OAuth2Params();
         oauth2Params.setId(new OAuth2ParamsId(id));
         oauth2Params.setCreatedTime(createdTime);
-        oauth2Params.setTenantId(new TenantId(tenantId));
+        oauth2Params.setTenantId(TenantId.fromUUID(tenantId));
         oauth2Params.setEnabled(enabled);
         return oauth2Params;
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/OtaPackageEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/OtaPackageEntity.java
@@ -151,7 +151,7 @@ public class OtaPackageEntity extends BaseSqlEntity<OtaPackage> implements Searc
     public OtaPackage toData() {
         OtaPackage otaPackage = new OtaPackage(new OtaPackageId(id));
         otaPackage.setCreatedTime(createdTime);
-        otaPackage.setTenantId(new TenantId(tenantId));
+        otaPackage.setTenantId(TenantId.fromUUID(tenantId));
         if (deviceProfileId != null) {
             otaPackage.setDeviceProfileId(new DeviceProfileId(deviceProfileId));
         }

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/OtaPackageInfoEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/OtaPackageInfoEntity.java
@@ -170,7 +170,7 @@ public class OtaPackageInfoEntity extends BaseSqlEntity<OtaPackageInfo> implemen
     public OtaPackageInfo toData() {
         OtaPackageInfo otaPackageInfo = new OtaPackageInfo(new OtaPackageId(id));
         otaPackageInfo.setCreatedTime(createdTime);
-        otaPackageInfo.setTenantId(new TenantId(tenantId));
+        otaPackageInfo.setTenantId(TenantId.fromUUID(tenantId));
         if (deviceProfileId != null) {
             otaPackageInfo.setDeviceProfileId(new DeviceProfileId(deviceProfileId));
         }

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/RpcEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/RpcEntity.java
@@ -97,7 +97,7 @@ public class RpcEntity extends BaseSqlEntity<Rpc> implements BaseEntity<Rpc> {
     public Rpc toData() {
         Rpc rpc = new Rpc(new RpcId(id));
         rpc.setCreatedTime(createdTime);
-        rpc.setTenantId(new TenantId(tenantId));
+        rpc.setTenantId(TenantId.fromUUID(tenantId));
         rpc.setDeviceId(new DeviceId(deviceId));
         rpc.setExpirationTime(expirationTime);
         rpc.setRequest(request);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/RuleChainEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/RuleChainEntity.java
@@ -110,7 +110,7 @@ public class RuleChainEntity extends BaseSqlEntity<RuleChain> implements SearchT
     public RuleChain toData() {
         RuleChain ruleChain = new RuleChain(new RuleChainId(this.getUuid()));
         ruleChain.setCreatedTime(createdTime);
-        ruleChain.setTenantId(new TenantId(tenantId));
+        ruleChain.setTenantId(TenantId.fromUUID(tenantId));
         ruleChain.setName(name);
         ruleChain.setType(type);
         if (firstRuleNodeId != null) {

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/TbResourceEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/TbResourceEntity.java
@@ -88,7 +88,7 @@ public class TbResourceEntity extends BaseSqlEntity<TbResource> implements Searc
     public TbResource toData() {
         TbResource resource = new TbResource(new TbResourceId(id));
         resource.setCreatedTime(createdTime);
-        resource.setTenantId(new TenantId(tenantId));
+        resource.setTenantId(TenantId.fromUUID(tenantId));
         resource.setTitle(title);
         resource.setResourceType(ResourceType.valueOf(resourceType));
         resource.setResourceKey(resourceKey);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/TbResourceInfoEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/TbResourceInfoEntity.java
@@ -76,7 +76,7 @@ public class TbResourceInfoEntity extends BaseSqlEntity<TbResourceInfo> implemen
     public TbResourceInfo toData() {
         TbResourceInfo resource = new TbResourceInfo(new TbResourceId(id));
         resource.setCreatedTime(createdTime);
-        resource.setTenantId(new TenantId(tenantId));
+        resource.setTenantId(TenantId.fromUUID(tenantId));
         resource.setTitle(title);
         resource.setResourceType(ResourceType.valueOf(resourceType));
         resource.setResourceKey(resourceKey);

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/UserEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/UserEntity.java
@@ -110,7 +110,7 @@ public class UserEntity extends BaseSqlEntity<User> implements SearchTextEntity<
         user.setCreatedTime(createdTime);
         user.setAuthority(authority);
         if (tenantId != null) {
-            user.setTenantId(new TenantId(tenantId));
+            user.setTenantId(TenantId.fromUUID(tenantId));
         }
         if (customerId != null) {
             user.setCustomerId(new CustomerId(customerId));

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/WidgetsBundleEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/WidgetsBundleEntity.java
@@ -87,7 +87,7 @@ public final class WidgetsBundleEntity extends BaseSqlEntity<WidgetsBundle> impl
         WidgetsBundle widgetsBundle = new WidgetsBundle(new WidgetsBundleId(id));
         widgetsBundle.setCreatedTime(createdTime);
         if (tenantId != null) {
-            widgetsBundle.setTenantId(new TenantId(tenantId));
+            widgetsBundle.setTenantId(TenantId.fromUUID(tenantId));
         }
         widgetsBundle.setAlias(alias);
         widgetsBundle.setTitle(title);

--- a/dao/src/main/java/org/thingsboard/server/dao/resource/BaseResourceService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/resource/BaseResourceService.java
@@ -180,7 +180,7 @@ public class BaseResourceService implements ResourceService {
                 throw new DataValidationException("Resource key should be specified!");
             }
             if (resource.getTenantId() == null) {
-                resource.setTenantId(new TenantId(ModelConstants.NULL_UUID));
+                resource.setTenantId(TenantId.fromUUID(ModelConstants.NULL_UUID));
             }
             if (!resource.getTenantId().getId().equals(ModelConstants.NULL_UUID)) {
                 Tenant tenant = tenantDao.findById(tenantId, resource.getTenantId().getId());

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/asset/JpaAssetDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/asset/JpaAssetDao.java
@@ -182,7 +182,7 @@ public class JpaAssetDao extends JpaAbstractSearchTextDao<AssetEntity, Asset> im
         if (types != null && !types.isEmpty()) {
             list = new ArrayList<>();
             for (String type : types) {
-                list.add(new EntitySubtype(new TenantId(tenantId), EntityType.ASSET, type));
+                list.add(new EntitySubtype(TenantId.fromUUID(tenantId), EntityType.ASSET, type));
             }
         }
         return list;

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/device/JpaDeviceDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/device/JpaDeviceDao.java
@@ -274,7 +274,7 @@ public class JpaDeviceDao extends JpaAbstractSearchTextDao<DeviceEntity, Device>
         if (types != null && !types.isEmpty()) {
             list = new ArrayList<>();
             for (String type : types) {
-                list.add(new EntitySubtype(new TenantId(tenantId), EntityType.DEVICE, type));
+                list.add(new EntitySubtype(TenantId.fromUUID(tenantId), EntityType.DEVICE, type));
             }
         }
         return list;

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/edge/JpaEdgeDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/edge/JpaEdgeDao.java
@@ -187,7 +187,7 @@ public class JpaEdgeDao extends JpaAbstractSearchTextDao<EdgeEntity, Edge> imple
         if (types != null && !types.isEmpty()) {
             list = new ArrayList<>();
             for (String type : types) {
-                list.add(new EntitySubtype(new TenantId(tenantId), EntityType.EDGE, type));
+                list.add(new EntitySubtype(TenantId.fromUUID(tenantId), EntityType.EDGE, type));
             }
         }
         return list;

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/entityview/JpaEntityViewDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/entityview/JpaEntityViewDao.java
@@ -172,7 +172,7 @@ public class JpaEntityViewDao extends JpaAbstractSearchTextDao<EntityViewEntity,
         if (types != null && !types.isEmpty()) {
             list = new ArrayList<>();
             for (String type : types) {
-                list.add(new EntitySubtype(new TenantId(tenantId), EntityType.ENTITY_VIEW, type));
+                list.add(new EntitySubtype(TenantId.fromUUID(tenantId), EntityType.ENTITY_VIEW, type));
             }
         }
         return list;

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/AlarmDataAdapter.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/AlarmDataAdapter.java
@@ -86,7 +86,7 @@ public class AlarmDataAdapter {
         alarm.setType(row.get(ModelConstants.ALARM_TYPE_PROPERTY).toString());
         alarm.setSeverity(AlarmSeverity.valueOf(row.get(ModelConstants.ALARM_SEVERITY_PROPERTY).toString()));
         alarm.setStatus(AlarmStatus.valueOf(row.get(ModelConstants.ALARM_STATUS_PROPERTY).toString()));
-        alarm.setTenantId(new TenantId((UUID) row.get(ModelConstants.TENANT_ID_PROPERTY)));
+        alarm.setTenantId(TenantId.fromUUID((UUID) row.get(ModelConstants.TENANT_ID_PROPERTY)));
         Object customerIdObj = row.get(ModelConstants.CUSTOMER_ID_PROPERTY);
         CustomerId customerId = customerIdObj != null ? new CustomerId((UUID) customerIdObj) : null;
         alarm.setCustomerId(customerId);

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/tenant/JpaTenantDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/tenant/JpaTenantDao.java
@@ -77,7 +77,7 @@ public class JpaTenantDao extends JpaAbstractSearchTextDao<TenantEntity, Tenant>
 
     @Override
     public PageData<TenantId> findTenantsIds(PageLink pageLink) {
-        return DaoUtil.pageToPageData(tenantRepository.findTenantsIds(DaoUtil.toPageable(pageLink))).mapData(TenantId::new);
+        return DaoUtil.pageToPageData(tenantRepository.findTenantsIds(DaoUtil.toPageable(pageLink))).mapData(TenantId::fromUUID);
     }
 
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
@@ -168,20 +168,20 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
     public PageData<Tenant> findTenants(PageLink pageLink) {
         log.trace("Executing findTenants pageLink [{}]", pageLink);
         Validator.validatePageLink(pageLink);
-        return tenantDao.findTenantsByRegion(new TenantId(EntityId.NULL_UUID), DEFAULT_TENANT_REGION, pageLink);
+        return tenantDao.findTenantsByRegion(TenantId.SYS_TENANT_ID, DEFAULT_TENANT_REGION, pageLink);
     }
 
     @Override
     public PageData<TenantInfo> findTenantInfos(PageLink pageLink) {
         log.trace("Executing findTenantInfos pageLink [{}]", pageLink);
         Validator.validatePageLink(pageLink);
-        return tenantDao.findTenantInfosByRegion(new TenantId(EntityId.NULL_UUID), DEFAULT_TENANT_REGION, pageLink);
+        return tenantDao.findTenantInfosByRegion(TenantId.SYS_TENANT_ID, DEFAULT_TENANT_REGION, pageLink);
     }
 
     @Override
     public void deleteTenants() {
         log.trace("Executing deleteTenants");
-        tenantsRemover.removeEntities(new TenantId(EntityId.NULL_UUID), DEFAULT_TENANT_REGION);
+        tenantsRemover.removeEntities(TenantId.SYS_TENANT_ID, DEFAULT_TENANT_REGION);
     }
 
     private DataValidator<Tenant> tenantValidator =

--- a/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
@@ -224,7 +224,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
 
                 @Override
                 protected void removeEntity(TenantId tenantId, Tenant entity) {
-                    deleteTenant(new TenantId(entity.getUuidId()));
+                    deleteTenant(TenantId.fromUUID(entity.getUuidId()));
                 }
             };
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/user/UserServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/user/UserServiceImpl.java
@@ -409,7 +409,7 @@ public class UserServiceImpl extends AbstractEntityService implements UserServic
                     }
                     TenantId tenantId = user.getTenantId();
                     if (tenantId == null) {
-                        tenantId = new TenantId(ModelConstants.NULL_UUID);
+                        tenantId = TenantId.fromUUID(ModelConstants.NULL_UUID);
                         user.setTenantId(tenantId);
                     }
                     CustomerId customerId = user.getCustomerId();

--- a/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetTypeServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetTypeServiceImpl.java
@@ -135,7 +135,7 @@ public class WidgetTypeServiceImpl implements WidgetTypeService {
                         throw new DataValidationException("Widgets type descriptor can't be empty!");
                     }
                     if (widgetTypeDetails.getTenantId() == null) {
-                        widgetTypeDetails.setTenantId(new TenantId(ModelConstants.NULL_UUID));
+                        widgetTypeDetails.setTenantId(TenantId.fromUUID(ModelConstants.NULL_UUID));
                     }
                     if (!widgetTypeDetails.getTenantId().getId().equals(ModelConstants.NULL_UUID)) {
                         Tenant tenant = tenantDao.findById(tenantId, widgetTypeDetails.getTenantId().getId());

--- a/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetsBundleServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetsBundleServiceImpl.java
@@ -159,7 +159,7 @@ public class WidgetsBundleServiceImpl implements WidgetsBundleService {
                         throw new DataValidationException("Widgets bundle title should be specified!");
                     }
                     if (widgetsBundle.getTenantId() == null) {
-                        widgetsBundle.setTenantId(new TenantId(ModelConstants.NULL_UUID));
+                        widgetsBundle.setTenantId(TenantId.fromUUID(ModelConstants.NULL_UUID));
                     }
                     if (!widgetsBundle.getTenantId().getId().equals(ModelConstants.NULL_UUID)) {
                         Tenant tenant = tenantDao.findById(tenantId, widgetsBundle.getTenantId().getId());

--- a/dao/src/test/java/org/thingsboard/server/dao/nosql/CassandraPartitionsCacheTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/nosql/CassandraPartitionsCacheTest.java
@@ -96,7 +96,7 @@ public class CassandraPartitionsCacheTest {
         cassandraBaseTimeseriesDao.init();
 
         UUID id = UUID.randomUUID();
-        TenantId tenantId = new TenantId(id);
+        TenantId tenantId = TenantId.fromUUID(id);
         long tsKvEntryTs = System.currentTimeMillis();
 
         for (int i = 0; i < 50000; i++) {

--- a/dao/src/test/java/org/thingsboard/server/dao/service/AbstractServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/AbstractServiceTest.java
@@ -173,7 +173,7 @@ public abstract class AbstractServiceTest {
 
     protected Event generateEvent(TenantId tenantId, EntityId entityId, String eventType, String eventUid) throws IOException {
         if (tenantId == null) {
-            tenantId = new TenantId(Uuids.timeBased());
+            tenantId = TenantId.fromUUID(Uuids.timeBased());
         }
         Event event = new Event();
         event.setTenantId(tenantId);

--- a/dao/src/test/java/org/thingsboard/server/dao/service/AbstractServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/AbstractServiceTest.java
@@ -86,7 +86,7 @@ public abstract class AbstractServiceTest {
 
     protected ObjectMapper mapper = new ObjectMapper();
 
-    public static final TenantId SYSTEM_TENANT_ID = new TenantId(EntityId.NULL_UUID);
+    public static final TenantId SYSTEM_TENANT_ID = TenantId.SYS_TENANT_ID;
 
     @Autowired
     protected UserService userService;

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseAssetServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseAssetServiceTest.java
@@ -104,7 +104,7 @@ public abstract class BaseAssetServiceTest extends AbstractServiceTest {
         Asset asset = new Asset();
         asset.setName("My asset");
         asset.setType("default");
-        asset.setTenantId(new TenantId(Uuids.timeBased()));
+        asset.setTenantId(TenantId.fromUUID(Uuids.timeBased()));
         assetService.saveAsset(asset);
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseCustomerServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseCustomerServiceTest.java
@@ -105,7 +105,7 @@ public abstract class BaseCustomerServiceTest extends AbstractServiceTest {
     public void testSaveCustomerWithInvalidTenant() {
         Customer customer = new Customer();
         customer.setTitle("My customer");
-        customer.setTenantId(new TenantId(Uuids.timeBased()));
+        customer.setTenantId(TenantId.fromUUID(Uuids.timeBased()));
         customerService.saveCustomer(customer);
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseDashboardServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseDashboardServiceTest.java
@@ -102,7 +102,7 @@ public abstract class BaseDashboardServiceTest extends AbstractServiceTest {
     public void testSaveDashboardWithInvalidTenant() {
         Dashboard dashboard = new Dashboard();
         dashboard.setTitle("My dashboard");
-        dashboard.setTenantId(new TenantId(Uuids.timeBased()));
+        dashboard.setTenantId(TenantId.fromUUID(Uuids.timeBased()));
         dashboardService.saveDashboard(dashboard);
     }
     

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseDeviceServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseDeviceServiceTest.java
@@ -267,7 +267,7 @@ public abstract class BaseDeviceServiceTest extends AbstractServiceTest {
         Device device = new Device();
         device.setName("My device");
         device.setType("default");
-        device.setTenantId(new TenantId(Uuids.timeBased()));
+        device.setTenantId(TenantId.fromUUID(Uuids.timeBased()));
         deviceService.saveDevice(device);
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseEdgeEventServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseEdgeEventServiceTest.java
@@ -53,7 +53,7 @@ public abstract class BaseEdgeEventServiceTest extends AbstractServiceTest {
 
     protected EdgeEvent generateEdgeEvent(TenantId tenantId, EdgeId edgeId, EntityId entityId, EdgeEventActionType edgeEventAction) throws IOException {
         if (tenantId == null) {
-            tenantId = new TenantId(Uuids.timeBased());
+            tenantId = TenantId.fromUUID(Uuids.timeBased());
         }
         EdgeEvent edgeEvent = new EdgeEvent();
         edgeEvent.setTenantId(tenantId);
@@ -76,7 +76,7 @@ public abstract class BaseEdgeEventServiceTest extends AbstractServiceTest {
 
         EdgeId edgeId = new EdgeId(Uuids.timeBased());
         DeviceId deviceId = new DeviceId(Uuids.timeBased());
-        TenantId tenantId = new TenantId(Uuids.timeBased());
+        TenantId tenantId = TenantId.fromUUID(Uuids.timeBased());
         saveEdgeEventWithProvidedTime(timeBeforeStartTime, edgeId, deviceId, tenantId);
         EdgeEvent savedEdgeEvent = saveEdgeEventWithProvidedTime(eventTime, edgeId, deviceId, tenantId);
         EdgeEvent savedEdgeEvent2 = saveEdgeEventWithProvidedTime(eventTime + 1, edgeId, deviceId, tenantId);
@@ -105,7 +105,7 @@ public abstract class BaseEdgeEventServiceTest extends AbstractServiceTest {
     public void findEdgeEventsWithTsUpdateAndWithout() throws Exception {
         EdgeId edgeId = new EdgeId(Uuids.timeBased());
         DeviceId deviceId = new DeviceId(Uuids.timeBased());
-        TenantId tenantId = new TenantId(Uuids.timeBased());
+        TenantId tenantId = TenantId.fromUUID(Uuids.timeBased());
         TimePageLink pageLink = new TimePageLink(1, 0, null, new SortOrder("createdTime", SortOrder.Direction.ASC));
 
         EdgeEvent edgeEventWithTsUpdate = generateEdgeEvent(tenantId, edgeId, deviceId, EdgeEventActionType.TIMESERIES_UPDATED);

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseEdgeServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseEdgeServiceTest.java
@@ -100,7 +100,7 @@ public abstract class BaseEdgeServiceTest extends AbstractServiceTest {
         Edge edge = new Edge();
         edge.setName("My edge");
         edge.setType("default");
-        edge.setTenantId(new TenantId(Uuids.timeBased()));
+        edge.setTenantId(TenantId.fromUUID(Uuids.timeBased()));
         edgeService.saveEdge(edge, true);
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseOtaPackageServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseOtaPackageServiceTest.java
@@ -342,7 +342,7 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
     @Test
     public void testSaveFirmwareWithInvalidTenant() {
         OtaPackage firmware = new OtaPackage();
-        firmware.setTenantId(new TenantId(Uuids.timeBased()));
+        firmware.setTenantId(TenantId.fromUUID(Uuids.timeBased()));
         firmware.setDeviceProfileId(deviceProfileId);
         firmware.setType(FIRMWARE);
         firmware.setTitle(TITLE);

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseRuleChainServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseRuleChainServiceTest.java
@@ -97,7 +97,7 @@ public abstract class BaseRuleChainServiceTest extends AbstractServiceTest {
     public void testSaveRuleChainWithInvalidTenant() {
         RuleChain ruleChain = new RuleChain();
         ruleChain.setName("My RuleChain");
-        ruleChain.setTenantId(new TenantId(Uuids.timeBased()));
+        ruleChain.setTenantId(TenantId.fromUUID(Uuids.timeBased()));
         ruleChainService.saveRuleChain(ruleChain);
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseWidgetTypeServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseWidgetTypeServiceTest.java
@@ -142,7 +142,7 @@ public abstract class BaseWidgetTypeServiceTest extends AbstractServiceTest {
         WidgetsBundle savedWidgetsBundle = widgetsBundleService.saveWidgetsBundle(widgetsBundle);
 
         WidgetTypeDetails widgetType = new WidgetTypeDetails();
-        widgetType.setTenantId(new TenantId(Uuids.timeBased()));
+        widgetType.setTenantId(TenantId.fromUUID(Uuids.timeBased()));
         widgetType.setBundleAlias(savedWidgetsBundle.getAlias());
         widgetType.setName("Widget Type");
         widgetType.setDescriptor(new ObjectMapper().readValue("{ \"someKey\": \"someValue\" }", JsonNode.class));
@@ -176,7 +176,7 @@ public abstract class BaseWidgetTypeServiceTest extends AbstractServiceTest {
         widgetType.setName("Widget Type");
         widgetType.setDescriptor(new ObjectMapper().readValue("{ \"someKey\": \"someValue\" }", JsonNode.class));
         WidgetTypeDetails savedWidgetType = widgetTypeService.saveWidgetType(widgetType);
-        savedWidgetType.setTenantId(new TenantId(ModelConstants.NULL_UUID));
+        savedWidgetType.setTenantId(TenantId.fromUUID(ModelConstants.NULL_UUID));
         try {
             widgetTypeService.saveWidgetType(savedWidgetType);
         } finally {

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseWidgetsBundleServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseWidgetsBundleServiceTest.java
@@ -88,7 +88,7 @@ public abstract class BaseWidgetsBundleServiceTest extends AbstractServiceTest {
     public void testSaveWidgetsBundleWithInvalidTenant() {
         WidgetsBundle widgetsBundle = new WidgetsBundle();
         widgetsBundle.setTitle("My widgets bundle");
-        widgetsBundle.setTenantId(new TenantId(Uuids.timeBased()));
+        widgetsBundle.setTenantId(TenantId.fromUUID(Uuids.timeBased()));
         widgetsBundleService.saveWidgetsBundle(widgetsBundle);
     }
 
@@ -98,7 +98,7 @@ public abstract class BaseWidgetsBundleServiceTest extends AbstractServiceTest {
         widgetsBundle.setTitle("My widgets bundle");
         widgetsBundle.setTenantId(tenantId);
         WidgetsBundle savedWidgetsBundle = widgetsBundleService.saveWidgetsBundle(widgetsBundle);
-        savedWidgetsBundle.setTenantId(new TenantId(ModelConstants.NULL_UUID));
+        savedWidgetsBundle.setTenantId(TenantId.fromUUID(ModelConstants.NULL_UUID));
         try {
             widgetsBundleService.saveWidgetsBundle(savedWidgetsBundle);
         } finally {
@@ -160,7 +160,7 @@ public abstract class BaseWidgetsBundleServiceTest extends AbstractServiceTest {
     @Test
     public void testFindSystemWidgetsBundlesByPageLink() {
 
-        TenantId tenantId = new TenantId(ModelConstants.NULL_UUID);
+        TenantId tenantId = TenantId.fromUUID(ModelConstants.NULL_UUID);
 
         List<WidgetsBundle> systemWidgetsBundles = widgetsBundleService.findSystemWidgetsBundles(tenantId);
         List<WidgetsBundle> createdWidgetsBundles = new ArrayList<>();
@@ -204,7 +204,7 @@ public abstract class BaseWidgetsBundleServiceTest extends AbstractServiceTest {
 
     @Test
     public void testFindSystemWidgetsBundles() {
-        TenantId tenantId = new TenantId(ModelConstants.NULL_UUID);
+        TenantId tenantId = TenantId.fromUUID(ModelConstants.NULL_UUID);
 
         List<WidgetsBundle> systemWidgetsBundles = widgetsBundleService.findSystemWidgetsBundles(tenantId);
 
@@ -290,7 +290,7 @@ public abstract class BaseWidgetsBundleServiceTest extends AbstractServiceTest {
         tenant = tenantService.saveTenant(tenant);
 
         TenantId tenantId = tenant.getId();
-        TenantId systemTenantId = new TenantId(ModelConstants.NULL_UUID);
+        TenantId systemTenantId = TenantId.fromUUID(ModelConstants.NULL_UUID);
 
         List<WidgetsBundle> createdWidgetsBundles = new ArrayList<>();
         List<WidgetsBundle> createdSystemWidgetsBundles = new ArrayList<>();
@@ -376,7 +376,7 @@ public abstract class BaseWidgetsBundleServiceTest extends AbstractServiceTest {
         tenant = tenantService.saveTenant(tenant);
 
         TenantId tenantId = tenant.getId();
-        TenantId systemTenantId = new TenantId(ModelConstants.NULL_UUID);
+        TenantId systemTenantId = TenantId.fromUUID(ModelConstants.NULL_UUID);
 
         List<WidgetsBundle> createdWidgetsBundles = new ArrayList<>();
         List<WidgetsBundle> createdSystemWidgetsBundles = new ArrayList<>();

--- a/dao/src/test/java/org/thingsboard/server/dao/service/event/BaseEventServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/event/BaseEventServiceTest.java
@@ -68,7 +68,7 @@ public abstract class BaseEventServiceTest extends AbstractServiceTest {
         long timeAfterEndTime = LocalDateTime.of(2016, Month.NOVEMBER, 1, 13, 30).toEpochSecond(ZoneOffset.UTC);
 
         CustomerId customerId = new CustomerId(Uuids.timeBased());
-        TenantId tenantId = new TenantId(Uuids.timeBased());
+        TenantId tenantId = TenantId.fromUUID(Uuids.timeBased());
         saveEventWithProvidedTime(timeBeforeStartTime, customerId, tenantId);
         Event savedEvent = saveEventWithProvidedTime(eventTime, customerId, tenantId);
         Event savedEvent2 = saveEventWithProvidedTime(eventTime+1, customerId, tenantId);
@@ -103,7 +103,7 @@ public abstract class BaseEventServiceTest extends AbstractServiceTest {
         long timeAfterEndTime = LocalDateTime.of(2016, Month.NOVEMBER, 1, 13, 30).toEpochSecond(ZoneOffset.UTC);
 
         CustomerId customerId = new CustomerId(Uuids.timeBased());
-        TenantId tenantId = new TenantId(Uuids.timeBased());
+        TenantId tenantId = TenantId.fromUUID(Uuids.timeBased());
         saveEventWithProvidedTime(timeBeforeStartTime, customerId, tenantId);
         Event savedEvent = saveEventWithProvidedTime(eventTime, customerId, tenantId);
         Event savedEvent2 = saveEventWithProvidedTime(eventTime+1, customerId, tenantId);

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/alarm/JpaAlarmDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/alarm/JpaAlarmDaoTest.java
@@ -53,9 +53,9 @@ public class JpaAlarmDaoTest extends AbstractJpaDaoTest {
         saveAlarm(alarm1Id, tenantId, originator1Id, "TEST_ALARM");
         saveAlarm(alarm2Id, tenantId, originator1Id, "TEST_ALARM");
         saveAlarm(alarm3Id, tenantId, originator2Id, "TEST_ALARM");
-        assertEquals(3, alarmDao.find(new TenantId(tenantId)).size());
+        assertEquals(3, alarmDao.find(TenantId.fromUUID(tenantId)).size());
         ListenableFuture<Alarm> future = alarmDao
-                .findLatestByOriginatorAndType(new TenantId(tenantId), new DeviceId(originator1Id), "TEST_ALARM");
+                .findLatestByOriginatorAndType(TenantId.fromUUID(tenantId), new DeviceId(originator1Id), "TEST_ALARM");
         Alarm alarm = future.get();
         assertNotNull(alarm);
         assertEquals(alarm2Id, alarm.getId().getId());
@@ -64,13 +64,13 @@ public class JpaAlarmDaoTest extends AbstractJpaDaoTest {
     private void saveAlarm(UUID id, UUID tenantId, UUID deviceId, String type) {
         Alarm alarm = new Alarm();
         alarm.setId(new AlarmId(id));
-        alarm.setTenantId(new TenantId(tenantId));
+        alarm.setTenantId(TenantId.fromUUID(tenantId));
         alarm.setOriginator(new DeviceId(deviceId));
         alarm.setType(type);
         alarm.setPropagate(true);
         alarm.setStartTs(System.currentTimeMillis());
         alarm.setEndTs(System.currentTimeMillis());
         alarm.setStatus(AlarmStatus.ACTIVE_UNACK);
-        alarmDao.save(new TenantId(tenantId), alarm);
+        alarmDao.save(TenantId.fromUUID(tenantId), alarm);
     }
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/asset/JpaAssetDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/asset/JpaAssetDaoTest.java
@@ -60,7 +60,7 @@ public class JpaAssetDaoTest extends AbstractJpaDaoTest {
             UUID customerId = i % 2 == 0 ? customerId1 : customerId2;
             saveAsset(assetId, tenantId, customerId, "ASSET_" + i, "TYPE_1");
         }
-        assertEquals(60, assetDao.find(new TenantId(tenantId1)).size());
+        assertEquals(60, assetDao.find(TenantId.fromUUID(tenantId1)).size());
 
         PageLink pageLink = new PageLink(20, 0, "ASSET_");
         PageData<Asset> assets1 = assetDao.findAssetsByTenantId(tenantId1, pageLink);
@@ -213,10 +213,10 @@ public class JpaAssetDaoTest extends AbstractJpaDaoTest {
     private void saveAsset(UUID id, UUID tenantId, UUID customerId, String name, String type) {
         Asset asset = new Asset();
         asset.setId(new AssetId(id));
-        asset.setTenantId(new TenantId(tenantId));
+        asset.setTenantId(TenantId.fromUUID(tenantId));
         asset.setCustomerId(new CustomerId(customerId));
         asset.setName(name);
         asset.setType(type);
-        assetDao.save(new TenantId(tenantId), asset);
+        assetDao.save(TenantId.fromUUID(tenantId), asset);
     }
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/customer/JpaCustomerDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/customer/JpaCustomerDaoTest.java
@@ -76,8 +76,8 @@ public class JpaCustomerDaoTest extends AbstractJpaDaoTest {
     private void createCustomer(UUID tenantId, int index) {
         Customer customer = new Customer();
         customer.setId(new CustomerId(Uuids.timeBased()));
-        customer.setTenantId(new TenantId(tenantId));
+        customer.setTenantId(TenantId.fromUUID(tenantId));
         customer.setTitle("CUSTOMER_" + index);
-        customerDao.save(new TenantId(tenantId), customer);
+        customerDao.save(TenantId.fromUUID(tenantId), customer);
     }
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/dashboard/JpaDashboardInfoDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/dashboard/JpaDashboardInfoDaoTest.java
@@ -60,7 +60,7 @@ public class JpaDashboardInfoDaoTest extends AbstractJpaDaoTest {
     private void createDashboard(UUID tenantId, int index) {
         DashboardInfo dashboardInfo = new DashboardInfo();
         dashboardInfo.setId(new DashboardId(Uuids.timeBased()));
-        dashboardInfo.setTenantId(new TenantId(tenantId));
+        dashboardInfo.setTenantId(TenantId.fromUUID(tenantId));
         dashboardInfo.setTitle("DASHBOARD_" + index);
         dashboardInfoDao.save(AbstractServiceTest.SYSTEM_TENANT_ID, dashboardInfo);
     }

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/device/JpaDeviceDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/device/JpaDeviceDaoTest.java
@@ -81,15 +81,15 @@ public class JpaDeviceDaoTest extends AbstractJpaDaoTest {
         UUID tenantId = Uuids.timeBased();
         UUID customerId = Uuids.timeBased();
         Device device = getDevice(tenantId, customerId);
-        deviceDao.save(new TenantId(tenantId), device);
+        deviceDao.save(TenantId.fromUUID(tenantId), device);
 
         UUID uuid = device.getId().getId();
-        Device entity = deviceDao.findById(new TenantId(tenantId), uuid);
+        Device entity = deviceDao.findById(TenantId.fromUUID(tenantId), uuid);
         assertNotNull(entity);
         assertEquals(uuid, entity.getId().getId());
 
         executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(10, ThingsBoardThreadFactory.forName(getClass().getSimpleName() + "-test-scope")));
-        ListenableFuture<Device> future = executor.submit(() -> deviceDao.findById(new TenantId(tenantId), uuid));
+        ListenableFuture<Device> future = executor.submit(() -> deviceDao.findById(TenantId.fromUUID(tenantId), uuid));
         Device asyncDevice = future.get();
         assertNotNull("Async device expected to be not null", asyncDevice);
     }
@@ -106,8 +106,8 @@ public class JpaDeviceDaoTest extends AbstractJpaDaoTest {
         for(int i = 0; i < 5; i++) {
             UUID deviceId1 = Uuids.timeBased();
             UUID deviceId2 = Uuids.timeBased();
-            deviceDao.save(new TenantId(tenantId1), getDevice(tenantId1, customerId1, deviceId1));
-            deviceDao.save(new TenantId(tenantId2), getDevice(tenantId2, customerId2, deviceId2));
+            deviceDao.save(TenantId.fromUUID(tenantId1), getDevice(tenantId1, customerId1, deviceId1));
+            deviceDao.save(TenantId.fromUUID(tenantId2), getDevice(tenantId2, customerId2, deviceId2));
             deviceIds.add(deviceId1);
             deviceIds.add(deviceId2);
         }
@@ -129,8 +129,8 @@ public class JpaDeviceDaoTest extends AbstractJpaDaoTest {
         for(int i = 0; i < 20; i++) {
             UUID deviceId1 = Uuids.timeBased();
             UUID deviceId2 = Uuids.timeBased();
-            deviceDao.save(new TenantId(tenantId1), getDevice(tenantId1, customerId1, deviceId1));
-            deviceDao.save(new TenantId(tenantId2), getDevice(tenantId2, customerId2, deviceId2));
+            deviceDao.save(TenantId.fromUUID(tenantId1), getDevice(tenantId1, customerId1, deviceId1));
+            deviceDao.save(TenantId.fromUUID(tenantId2), getDevice(tenantId2, customerId2, deviceId2));
             deviceIds.add(deviceId1);
             deviceIds.add(deviceId2);
         }
@@ -142,8 +142,8 @@ public class JpaDeviceDaoTest extends AbstractJpaDaoTest {
 
     private void createDevices(UUID tenantId1, UUID tenantId2, UUID customerId1, UUID customerId2, int count) {
         for (int i = 0; i < count / 2; i++) {
-            deviceDao.save(new TenantId(tenantId1), getDevice(tenantId1, customerId1));
-            deviceDao.save(new TenantId(tenantId2), getDevice(tenantId2, customerId2));
+            deviceDao.save(TenantId.fromUUID(tenantId1), getDevice(tenantId1, customerId1));
+            deviceDao.save(TenantId.fromUUID(tenantId2), getDevice(tenantId2, customerId2));
         }
     }
 
@@ -154,7 +154,7 @@ public class JpaDeviceDaoTest extends AbstractJpaDaoTest {
     private Device getDevice(UUID tenantId, UUID customerID, UUID deviceId) {
         Device device = new Device();
         device.setId(new DeviceId(deviceId));
-        device.setTenantId(new TenantId(tenantId));
+        device.setTenantId(TenantId.fromUUID(tenantId));
         device.setCustomerId(new CustomerId(customerID));
         device.setName("SEARCH_TEXT");
         return device;

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/event/JpaBaseEventDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/event/JpaBaseEventDaoTest.java
@@ -149,10 +149,10 @@ public class JpaBaseEventDaoTest extends AbstractJpaDaoTest {
             String type = i % 2 == 0 ? STATS : ALARM;
             UUID eventId1 = Uuids.timeBased();
             Event event1 = getEvent(eventId1, tenantId, entityId1, type);
-            eventDao.save(new TenantId(tenantId), event1);
+            eventDao.save(TenantId.fromUUID(tenantId), event1);
             UUID eventId2 = Uuids.timeBased();
             Event event2 = getEvent(eventId2, tenantId, entityId2, type);
-            eventDao.save(new TenantId(tenantId), event2);
+            eventDao.save(TenantId.fromUUID(tenantId), event2);
         }
         return System.currentTimeMillis();
     }
@@ -161,10 +161,10 @@ public class JpaBaseEventDaoTest extends AbstractJpaDaoTest {
         for (int i = 0; i < count / 2; i++) {
             UUID eventId1 = Uuids.timeBased();
             Event event1 = getEvent(eventId1, tenantId, entityId1);
-            eventDao.save(new TenantId(tenantId), event1);
+            eventDao.save(TenantId.fromUUID(tenantId), event1);
             UUID eventId2 = Uuids.timeBased();
             Event event2 = getEvent(eventId2, tenantId, entityId2);
-            eventDao.save(new TenantId(tenantId), event2);
+            eventDao.save(TenantId.fromUUID(tenantId), event2);
         }
         return System.currentTimeMillis();
     }
@@ -178,7 +178,7 @@ public class JpaBaseEventDaoTest extends AbstractJpaDaoTest {
     private Event getEvent(UUID eventId, UUID tenantId, UUID entityId) {
         Event event = new Event();
         event.setId(new EventId(eventId));
-        event.setTenantId(new TenantId(tenantId));
+        event.setTenantId(TenantId.fromUUID(tenantId));
         EntityId deviceId = new DeviceId(entityId);
         event.setEntityId(deviceId);
         event.setUid(event.getId().getId().toString());

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/tenant/JpaTenantDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/tenant/JpaTenantDaoTest.java
@@ -69,7 +69,7 @@ public class JpaTenantDaoTest extends AbstractJpaDaoTest {
 
     private void createTenant(String region, String title, int index) {
         Tenant tenant = new Tenant();
-        tenant.setId(new TenantId(Uuids.timeBased()));
+        tenant.setId(TenantId.fromUUID(Uuids.timeBased()));
         tenant.setRegion(region);
         tenant.setTitle(title + "_" + index);
         tenantDao.save(AbstractServiceTest.SYSTEM_TENANT_ID, tenant);

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/user/JpaUserDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/user/JpaUserDaoTest.java
@@ -111,7 +111,7 @@ public class JpaUserDaoTest extends AbstractJpaDaoTest {
     public void testSave() throws IOException {
         User user = new User();
         user.setId(new UserId(UUID.fromString("cd481534-27cc-11e7-93ae-92361f002671")));
-        user.setTenantId(new TenantId(UUID.fromString("1edcb2c6-27cb-11e7-93ae-92361f002671")));
+        user.setTenantId(TenantId.fromUUID(UUID.fromString("1edcb2c6-27cb-11e7-93ae-92361f002671")));
         user.setCustomerId(new CustomerId(UUID.fromString("51477cb4-27cb-11e7-93ae-92361f002671")));
         user.setEmail("user@thingsboard.org");
         user.setFirstName("Jackson");
@@ -140,7 +140,7 @@ public class JpaUserDaoTest extends AbstractJpaDaoTest {
         User user = new User();
         UUID id = Uuids.timeBased();
         user.setId(new UserId(id));
-        user.setTenantId(new TenantId(tenantId));
+        user.setTenantId(TenantId.fromUUID(tenantId));
         user.setCustomerId(new CustomerId(customerId));
         if (customerId == NULL_UUID) {
             user.setAuthority(Authority.TENANT_ADMIN);

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/widget/JpaWidgetsBundleDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/widget/JpaWidgetsBundleDaoTest.java
@@ -149,7 +149,7 @@ public class JpaWidgetsBundleDaoTest extends AbstractJpaDaoTest {
             widgetsBundle.setAlias(prefix + i);
             widgetsBundle.setTitle(prefix + i);
             widgetsBundle.setId(new WidgetsBundleId(Uuids.timeBased()));
-            widgetsBundle.setTenantId(new TenantId(tenantId));
+            widgetsBundle.setTenantId(TenantId.fromUUID(tenantId));
             widgetsBundleDao.save(AbstractServiceTest.SYSTEM_TENANT_ID, widgetsBundle);
         }
     }

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/widget/JpaWidgetsBundleDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/widget/JpaWidgetsBundleDaoTest.java
@@ -158,7 +158,7 @@ public class JpaWidgetsBundleDaoTest extends AbstractJpaDaoTest {
             WidgetsBundle widgetsBundle = new WidgetsBundle();
             widgetsBundle.setAlias(prefix + i);
             widgetsBundle.setTitle(prefix + i);
-            widgetsBundle.setTenantId(new TenantId(NULL_UUID));
+            widgetsBundle.setTenantId(TenantId.SYS_TENANT_ID);
             widgetsBundle.setId(new WidgetsBundleId(Uuids.timeBased()));
             widgetsBundleDao.save(AbstractServiceTest.SYSTEM_TENANT_ID, widgetsBundle);
         }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateRelationNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateRelationNode.java
@@ -208,7 +208,7 @@ public class TbCreateRelationNode extends TbAbstractRelationActionNode<TbCreateR
     }
 
     private ListenableFuture<Boolean> processTenant(TbContext ctx, EntityContainer entityContainer, SearchDirectionIds sdId, String relationType) {
-        return Futures.transformAsync(ctx.getTenantService().findTenantByIdAsync(ctx.getTenantId(), new TenantId(entityContainer.getEntityId().getId())), tenant -> {
+        return Futures.transformAsync(ctx.getTenantService().findTenantByIdAsync(ctx.getTenantId(), TenantId.fromUUID(entityContainer.getEntityId().getId())), tenant -> {
             if (tenant != null) {
                 return processSave(ctx, sdId, relationType);
             } else {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbAlarmNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbAlarmNodeTest.java
@@ -98,7 +98,7 @@ public class TbAlarmNodeTest {
 
     private EntityId originator = new DeviceId(Uuids.timeBased());
     private EntityId alarmOriginator = new AlarmId(Uuids.timeBased());
-    private TenantId tenantId = new TenantId(Uuids.timeBased());
+    private TenantId tenantId = TenantId.fromUUID(Uuids.timeBased());
     private TbMsgMetaData metaData = new TbMsgMetaData();
     private String rawJson = "{\"name\": \"Vit\", \"passed\": 5}";
 

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/AbstractAttributeNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/AbstractAttributeNodeTest.java
@@ -68,7 +68,7 @@ import static org.thingsboard.server.common.data.DataConstants.SERVER_SCOPE;
 @RunWith(MockitoJUnitRunner.class)
 public abstract class AbstractAttributeNodeTest {
     final CustomerId customerId = new CustomerId(Uuids.timeBased());
-    final TenantId tenantId = new TenantId(Uuids.timeBased());
+    final TenantId tenantId = TenantId.fromUUID(Uuids.timeBased());
     final RuleChainId ruleChainId = new RuleChainId(Uuids.timeBased());
     final RuleNodeId ruleNodeId = new RuleNodeId(Uuids.timeBased());
     final String keyAttrConf = "${word}";

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/profile/TbDeviceProfileNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/profile/TbDeviceProfileNodeTest.java
@@ -99,7 +99,7 @@ public class TbDeviceProfileNodeTest {
     @Mock
     private AttributesService attributesService;
 
-    private final TenantId tenantId = new TenantId(UUID.randomUUID());
+    private final TenantId tenantId = TenantId.fromUUID(UUID.randomUUID());
     private final DeviceId deviceId = new DeviceId(UUID.randomUUID());
     private final CustomerId customerId = new CustomerId(UUID.randomUUID());
     private final DeviceProfileId deviceProfileId = new DeviceProfileId(UUID.randomUUID());


### PR DESCRIPTION
Based on heap dump analysis when 1M devices are connected by MQTT to a single Thingsboard node

device check session inactivity refactored to reduce memory usage.

TenantId - factory + weap map
![image](https://user-images.githubusercontent.com/79898499/148775627-d8b8d0e5-f167-4b1d-b629-9f4bb6fd2c14.png)

MqttTransportHandler stored an InetSocketAddress instances that is quite heavy for the heap for 1M connection
![image](https://user-images.githubusercontent.com/79898499/148776029-05e8eddd-9ddc-4218-a9b7-21549e30f448.png)

Live instance count reduced with a static ObjectMapper on DeviceActorMessageProcessor(AbstractContextAwareMsgProcessor)
![image](https://user-images.githubusercontent.com/79898499/148812109-e5cbae77-8720-4e59-b7c4-7aea5dd06daf.png)




