### PR TITLE
[3.3.3] fixed sending shared attributes after sleeping

### DIFF
--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/attributes/DefaultLwM2MAttributesService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/attributes/DefaultLwM2MAttributesService.java
@@ -198,7 +198,7 @@ public class DefaultLwM2MAttributesService implements LwM2MAttributesService {
                 if (pathIdVer != null) {
                     // #1.1
                     if (lwM2MClient.getSharedAttributes().containsKey(pathIdVer)) {
-                        if (tsKvProto.getTs() >= lwM2MClient.getSharedAttributes().get(pathIdVer).getTs()) {
+                        if (tsKvProto.getTs() > lwM2MClient.getSharedAttributes().get(pathIdVer).getTs()) {
                             lwM2MClient.getSharedAttributes().put(pathIdVer, tsKvProto);
                             attributesUpdate.put(pathIdVer, tsKvProto);
                         }


### PR DESCRIPTION
We do not have to send attributes that have already been sent.