### PR TITLE
[WIP][3.4] Add caching to TenantService and replace usages of TenantDao to TenantService in other services

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/sync/DefaultEdgeRequestsService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/sync/DefaultEdgeRequestsService.java
@@ -348,7 +348,7 @@ public class DefaultEdgeRequestsService implements EdgeRequestsService {
                     if (entityViews != null && !entityViews.isEmpty()) {
                         List<ListenableFuture<Boolean>> futures = new ArrayList<>();
                         for (EntityView entityView : entityViews) {
-                            ListenableFuture<Boolean> future = relationService.checkRelation(tenantId, edge.getId(), entityView.getId(),
+                            ListenableFuture<Boolean> future = relationService.checkRelationAsync(tenantId, edge.getId(), entityView.getId(),
                                     EntityRelation.CONTAINS_TYPE, RelationTypeGroup.EDGE);
                             futures.add(future);
                             Futures.addCallback(future, new FutureCallback<>() {

--- a/application/src/main/java/org/thingsboard/server/service/ttl/AlarmsCleanUpService.java
+++ b/application/src/main/java/org/thingsboard/server/service/ttl/AlarmsCleanUpService.java
@@ -32,7 +32,7 @@ import org.thingsboard.server.dao.alarm.AlarmDao;
 import org.thingsboard.server.dao.alarm.AlarmService;
 import org.thingsboard.server.dao.relation.RelationService;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 import org.thingsboard.server.queue.discovery.PartitionService;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 import org.thingsboard.server.service.action.EntityActionService;
@@ -50,7 +50,7 @@ public class AlarmsCleanUpService {
     @Value("${sql.ttl.alarms.removal_batch_size}")
     private Integer removalBatchSize;
 
-    private final TenantDao tenantDao;
+    private final TenantService tenantService;
     private final AlarmDao alarmDao;
     private final AlarmService alarmService;
     private final RelationService relationService;
@@ -64,7 +64,7 @@ public class AlarmsCleanUpService {
         PageLink removalBatchRequest = new PageLink(removalBatchSize, 0 );
         PageData<TenantId> tenantsIds;
         do {
-            tenantsIds = tenantDao.findTenantsIds(tenantsBatchRequest);
+            tenantsIds = tenantService.findTenantsIds(tenantsBatchRequest);
             for (TenantId tenantId : tenantsIds.getData()) {
                 if (!partitionService.resolve(ServiceType.TB_CORE, tenantId, tenantId).isMyPartition()) {
                     continue;

--- a/application/src/main/java/org/thingsboard/server/service/ttl/rpc/RpcCleanUpService.java
+++ b/application/src/main/java/org/thingsboard/server/service/ttl/rpc/RpcCleanUpService.java
@@ -27,7 +27,7 @@ import org.thingsboard.server.common.data.tenant.profile.DefaultTenantProfileCon
 import org.thingsboard.server.common.msg.queue.ServiceType;
 import org.thingsboard.server.dao.rpc.RpcDao;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 import org.thingsboard.server.queue.discovery.PartitionService;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 
@@ -43,7 +43,7 @@ public class RpcCleanUpService {
     @Value("${sql.ttl.rpc.enabled}")
     private boolean ttlTaskExecutionEnabled;
 
-    private final TenantDao tenantDao;
+    private final TenantService tenantService;
     private final PartitionService partitionService;
     private final TbTenantProfileCache tenantProfileCache;
     private final RpcDao rpcDao;
@@ -54,7 +54,7 @@ public class RpcCleanUpService {
             PageLink tenantsBatchRequest = new PageLink(10_000, 0);
             PageData<TenantId> tenantsIds;
             do {
-                tenantsIds = tenantDao.findTenantsIds(tenantsBatchRequest);
+                tenantsIds = tenantService.findTenantsIds(tenantsBatchRequest);
                 for (TenantId tenantId : tenantsIds.getData()) {
                     if (!partitionService.resolve(ServiceType.TB_CORE, tenantId, tenantId).isMyPartition()) {
                         continue;

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -407,6 +407,9 @@ caffeine:
     tenantProfiles:
       timeToLiveInMinutes: "${CACHE_SPECS_TENANT_PROFILES_TTL:1440}"
       maxSize: "${CACHE_SPECS_TENANT_PROFILES_MAX_SIZE:10000}"
+    tenants:
+      timeToLiveInMinutes: "${CACHE_SPECS_TENANTS_TTL:1440}"
+      maxSize: "${CACHE_SPECS_TENANTS_MAX_SIZE:10000}"
     deviceProfiles:
       timeToLiveInMinutes: "${CACHE_SPECS_DEVICE_PROFILES_TTL:1440}"
       maxSize: "${CACHE_SPECS_DEVICE_PROFILES_MAX_SIZE:10000}"

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/entityview/EntityViewService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/entityview/EntityViewService.java
@@ -72,6 +72,8 @@ public interface EntityViewService {
 
     ListenableFuture<List<EntityView>> findEntityViewsByTenantIdAndEntityIdAsync(TenantId tenantId, EntityId entityId);
 
+    List<EntityView> findEntityViewsByTenantIdAndEntityId(TenantId tenantId, EntityId entityId);
+
     void deleteEntityView(TenantId tenantId, EntityViewId entityViewId);
 
     void deleteEntityViewsByTenantId(TenantId tenantId);

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/relation/RelationService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/relation/RelationService.java
@@ -34,7 +34,9 @@ import java.util.List;
  */
 public interface RelationService {
 
-    ListenableFuture<Boolean> checkRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup);
+    ListenableFuture<Boolean> checkRelationAsync(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup);
+
+    Boolean checkRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup);
 
     EntityRelation getRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup);
 

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/tenant/TenantService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/tenant/TenantService.java
@@ -39,4 +39,6 @@ public interface TenantService {
     PageData<TenantInfo> findTenantInfos(PageLink pageLink);
     
     void deleteTenants();
+
+    PageData<TenantId> findTenantsIds(PageLink pageLink);
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/CacheConstants.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/CacheConstants.java
@@ -26,6 +26,7 @@ public class CacheConstants {
     public static final String CLAIM_DEVICES_CACHE = "claimDevices";
     public static final String SECURITY_SETTINGS_CACHE = "securitySettings";
     public static final String TENANT_PROFILE_CACHE = "tenantProfiles";
+    public static final String TENANTS_CACHE = "tenants";
     public static final String DEVICE_PROFILE_CACHE = "deviceProfiles";
     public static final String ATTRIBUTES_CACHE = "attributes";
     public static final String TOKEN_OUTDATAGE_TIME_CACHE = "tokensOutdatageTime";

--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
@@ -431,7 +431,6 @@ public class BaseAlarmService extends AbstractEntityService implements AlarmServ
                         throw new DataValidationException("Alarm should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(alarm.getTenantId());
-                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Alarm is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
@@ -431,6 +431,7 @@ public class BaseAlarmService extends AbstractEntityService implements AlarmServ
                         throw new DataValidationException("Alarm should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(alarm.getTenantId());
+                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Alarm is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
@@ -51,7 +51,7 @@ import org.thingsboard.server.dao.entity.AbstractEntityService;
 import org.thingsboard.server.dao.entity.EntityService;
 import org.thingsboard.server.dao.exception.DataValidationException;
 import org.thingsboard.server.dao.service.DataValidator;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
@@ -81,7 +81,7 @@ public class BaseAlarmService extends AbstractEntityService implements AlarmServ
     private AlarmDao alarmDao;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     private EntityService entityService;
@@ -430,7 +430,7 @@ public class BaseAlarmService extends AbstractEntityService implements AlarmServ
                     if (alarm.getTenantId() == null) {
                         throw new DataValidationException("Alarm should be assigned to tenant!");
                     } else {
-                        Tenant tenant = tenantDao.findById(alarm.getTenantId(), alarm.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(alarm.getTenantId());
                         if (tenant == null) {
                             throw new DataValidationException("Alarm is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
@@ -55,7 +55,7 @@ import org.thingsboard.server.dao.exception.DataValidationException;
 import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -86,7 +86,7 @@ public class BaseAssetService extends AbstractEntityService implements AssetServ
     private AssetDao assetDao;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     private CustomerDao customerDao;
@@ -416,7 +416,8 @@ public class BaseAssetService extends AbstractEntityService implements AssetServ
                     if (asset.getTenantId() == null) {
                         throw new DataValidationException("Asset should be assigned to tenant!");
                     } else {
-                        Tenant tenant = tenantDao.findById(tenantId, asset.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(asset.getTenantId());
+                        // FIXME: 12.01.22
                         if (tenant == null) {
                             throw new DataValidationException("Asset is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
@@ -412,7 +412,6 @@ public class BaseAssetService extends AbstractEntityService implements AssetServ
                         throw new DataValidationException("Asset should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(asset.getTenantId());
-                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Asset is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
@@ -417,7 +417,7 @@ public class BaseAssetService extends AbstractEntityService implements AssetServ
                         throw new DataValidationException("Asset should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(asset.getTenantId());
-                        // FIXME: 12.01.22
+                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Asset is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
@@ -168,14 +168,9 @@ public class BaseAssetService extends AbstractEntityService implements AssetServ
         deleteEntityRelations(tenantId, assetId);
 
         Asset asset = assetDao.findById(tenantId, assetId.getId());
-        try {
-            List<EntityView> entityViews = entityViewService.findEntityViewsByTenantIdAndEntityIdAsync(asset.getTenantId(), assetId).get();
-            if (entityViews != null && !entityViews.isEmpty()) {
-                throw new DataValidationException("Can't delete asset that has entity views!");
-            }
-        } catch (ExecutionException | InterruptedException e) {
-            log.error("Exception while finding entity views for assetId [{}]", assetId, e);
-            throw new RuntimeException("Exception while finding entity views for assetId [" + assetId + "]", e);
+        List<EntityView> entityViews = entityViewService.findEntityViewsByTenantIdAndEntityId(asset.getTenantId(), assetId);
+        if (entityViews != null && !entityViews.isEmpty()) {
+            throw new DataValidationException("Can't delete asset that has entity views!");
         }
 
         removeAssetFromCacheByName(asset.getTenantId(), asset.getName());

--- a/dao/src/main/java/org/thingsboard/server/dao/customer/CustomerServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/customer/CustomerServiceImpl.java
@@ -211,7 +211,6 @@ public class CustomerServiceImpl extends AbstractEntityService implements Custom
                         throw new DataValidationException("Customer should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(customer.getTenantId());
-                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Customer is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/customer/CustomerServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/customer/CustomerServiceImpl.java
@@ -211,6 +211,7 @@ public class CustomerServiceImpl extends AbstractEntityService implements Custom
                         throw new DataValidationException("Customer should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(customer.getTenantId());
+                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Customer is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/customer/CustomerServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/customer/CustomerServiceImpl.java
@@ -42,7 +42,7 @@ import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.service.Validator;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 import org.thingsboard.server.dao.usagerecord.ApiUsageStateService;
 import org.thingsboard.server.dao.user.UserService;
 
@@ -66,16 +66,13 @@ public class CustomerServiceImpl extends AbstractEntityService implements Custom
     private UserService userService;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     private AssetService assetService;
 
     @Autowired
     private DeviceService deviceService;
-
-    @Autowired
-    private EntityViewService entityViewService;
 
     @Autowired
     private DashboardService dashboardService;
@@ -213,7 +210,7 @@ public class CustomerServiceImpl extends AbstractEntityService implements Custom
                     if (customer.getTenantId() == null) {
                         throw new DataValidationException("Customer should be assigned to tenant!");
                     } else {
-                        Tenant tenant = tenantDao.findById(tenantId, customer.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(customer.getTenantId());
                         if (tenant == null) {
                             throw new DataValidationException("Customer is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/dashboard/DashboardServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/dashboard/DashboardServiceImpl.java
@@ -309,7 +309,7 @@ public class DashboardServiceImpl extends AbstractEntityService implements Dashb
                         throw new DataValidationException("Dashboard should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(dashboard.getTenantId());
-                        // FIXME: 12.01.22
+                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Dashboard is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/dashboard/DashboardServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/dashboard/DashboardServiceImpl.java
@@ -309,7 +309,6 @@ public class DashboardServiceImpl extends AbstractEntityService implements Dashb
                         throw new DataValidationException("Dashboard should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(dashboard.getTenantId());
-                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Dashboard is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/dashboard/DashboardServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/dashboard/DashboardServiceImpl.java
@@ -45,7 +45,7 @@ import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.service.Validator;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import static org.thingsboard.server.dao.service.Validator.validateId;
 
@@ -62,7 +62,7 @@ public class DashboardServiceImpl extends AbstractEntityService implements Dashb
     private DashboardInfoDao dashboardInfoDao;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     private CustomerDao customerDao;
@@ -308,7 +308,8 @@ public class DashboardServiceImpl extends AbstractEntityService implements Dashb
                     if (dashboard.getTenantId() == null) {
                         throw new DataValidationException("Dashboard should be assigned to tenant!");
                     } else {
-                        Tenant tenant = tenantDao.findById(tenantId, dashboard.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(dashboard.getTenantId());
+                        // FIXME: 12.01.22
                         if (tenant == null) {
                             throw new DataValidationException("Dashboard is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceProfileServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceProfileServiceImpl.java
@@ -81,7 +81,7 @@ import org.thingsboard.server.dao.rule.RuleChainService;
 import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.service.Validator;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 import org.thingsboard.server.queue.QueueService;
 
 import java.util.Arrays;
@@ -127,7 +127,7 @@ public class DeviceProfileServiceImpl extends AbstractEntityService implements D
     private DeviceService deviceService;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     private CacheManager cacheManager;
@@ -375,7 +375,7 @@ public class DeviceProfileServiceImpl extends AbstractEntityService implements D
                     if (deviceProfile.getTenantId() == null) {
                         throw new DataValidationException("Device profile should be assigned to tenant!");
                     } else {
-                        Tenant tenant = tenantDao.findById(deviceProfile.getTenantId(), deviceProfile.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(deviceProfile.getTenantId());
                         if (tenant == null) {
                             throw new DataValidationException("Device profile is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceProfileServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceProfileServiceImpl.java
@@ -376,7 +376,6 @@ public class DeviceProfileServiceImpl extends AbstractEntityService implements D
                         throw new DataValidationException("Device profile should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(deviceProfile.getTenantId());
-                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Device profile is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceProfileServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceProfileServiceImpl.java
@@ -376,6 +376,7 @@ public class DeviceProfileServiceImpl extends AbstractEntityService implements D
                         throw new DataValidationException("Device profile should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(deviceProfile.getTenantId());
+                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Device profile is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
@@ -742,6 +742,7 @@ public class DeviceServiceImpl extends AbstractEntityService implements DeviceSe
                         throw new DataValidationException("Device should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(device.getTenantId());
+                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Device is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
@@ -81,7 +81,7 @@ import org.thingsboard.server.dao.ota.OtaPackageService;
 import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -117,7 +117,7 @@ public class DeviceServiceImpl extends AbstractEntityService implements DeviceSe
     private DeviceDao deviceDao;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     private CustomerDao customerDao;
@@ -741,7 +741,7 @@ public class DeviceServiceImpl extends AbstractEntityService implements DeviceSe
                     if (device.getTenantId() == null) {
                         throw new DataValidationException("Device should be assigned to tenant!");
                     } else {
-                        Tenant tenant = tenantDao.findById(device.getTenantId(), device.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(device.getTenantId());
                         if (tenant == null) {
                             throw new DataValidationException("Device is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
@@ -732,7 +732,6 @@ public class DeviceServiceImpl extends AbstractEntityService implements DeviceSe
                         throw new DataValidationException("Device should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(device.getTenantId());
-                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Device is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
@@ -344,14 +344,9 @@ public class DeviceServiceImpl extends AbstractEntityService implements DeviceSe
 
         Device device = deviceDao.findById(tenantId, deviceId.getId());
         final String deviceName = device.getName();
-        try {
-            List<EntityView> entityViews = entityViewService.findEntityViewsByTenantIdAndEntityIdAsync(device.getTenantId(), deviceId).get();
-            if (entityViews != null && !entityViews.isEmpty()) {
-                throw new DataValidationException("Can't delete device that has entity views!");
-            }
-        } catch (ExecutionException | InterruptedException e) {
-            log.error("Exception while finding entity views for deviceId [{}]", deviceId, e);
-            throw new RuntimeException("Exception while finding entity views for deviceId [" + deviceId + "]", e);
+        List<EntityView> entityViews = entityViewService.findEntityViewsByTenantIdAndEntityId(device.getTenantId(), deviceId);
+        if (entityViews != null && !entityViews.isEmpty()) {
+            throw new DataValidationException("Can't delete device that has entity views!");
         }
 
         DeviceCredentials deviceCredentials = deviceCredentialsService.findDeviceCredentialsByDeviceId(tenantId, deviceId);
@@ -568,14 +563,9 @@ public class DeviceServiceImpl extends AbstractEntityService implements DeviceSe
     public Device assignDeviceToTenant(TenantId tenantId, Device device) {
         log.trace("Executing assignDeviceToTenant [{}][{}]", tenantId, device);
 
-        try {
-            List<EntityView> entityViews = entityViewService.findEntityViewsByTenantIdAndEntityIdAsync(device.getTenantId(), device.getId()).get();
-            if (!CollectionUtils.isEmpty(entityViews)) {
-                throw new DataValidationException("Can't assign device that has entity views to another tenant!");
-            }
-        } catch (ExecutionException | InterruptedException e) {
-            log.error("Exception while finding entity views for deviceId [{}]", device.getId(), e);
-            throw new RuntimeException("Exception while finding entity views for deviceId [" + device.getId() + "]", e);
+        List<EntityView> entityViews = entityViewService.findEntityViewsByTenantIdAndEntityId(device.getTenantId(), device.getId());
+        if (!CollectionUtils.isEmpty(entityViews)) {
+            throw new DataValidationException("Can't assign device that has entity views to another tenant!");
         }
 
         eventService.removeEvents(device.getTenantId(), device.getId());

--- a/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
@@ -414,6 +414,7 @@ public class EdgeServiceImpl extends AbstractEntityService implements EdgeServic
                         throw new DataValidationException("Edge should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(edge.getTenantId());
+                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Edge is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
@@ -60,7 +60,7 @@ import org.thingsboard.server.dao.rule.RuleChainService;
 import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.service.Validator;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 import org.thingsboard.server.dao.user.UserService;
 
 import javax.annotation.Nullable;
@@ -96,7 +96,7 @@ public class EdgeServiceImpl extends AbstractEntityService implements EdgeServic
     private EdgeDao edgeDao;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     private CustomerDao customerDao;
@@ -413,7 +413,7 @@ public class EdgeServiceImpl extends AbstractEntityService implements EdgeServic
                     if (edge.getTenantId() == null) {
                         throw new DataValidationException("Edge should be assigned to tenant!");
                     } else {
-                        Tenant tenant = tenantDao.findById(edge.getTenantId(), edge.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(edge.getTenantId());
                         if (tenant == null) {
                             throw new DataValidationException("Edge is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
@@ -414,7 +414,6 @@ public class EdgeServiceImpl extends AbstractEntityService implements EdgeServic
                         throw new DataValidationException("Edge should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(edge.getTenantId());
-                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Edge is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
@@ -82,20 +82,16 @@ public abstract class AbstractEntityService {
     }
 
     protected void checkAssignedEntityViewsToEdge(TenantId tenantId, EntityId entityId, EdgeId edgeId) {
-        try {
-            List<EntityView> entityViews = entityViewService.findEntityViewsByTenantIdAndEntityId(tenantId, entityId);
-            if (entityViews != null && !entityViews.isEmpty()) {
-                EntityView entityView = entityViews.get(0);
-                // TODO: @voba - refactor this blocking operation
-                Boolean relationExists = relationService.checkRelation(tenantId, edgeId, entityView.getId(),
-                        EntityRelation.CONTAINS_TYPE, RelationTypeGroup.EDGE).get();
-                if (relationExists) {
-                    throw new DataValidationException("Can't unassign device/asset from edge that is related to entity view and entity view is assigned to edge!");
-                }
+        List<EntityView> entityViews = entityViewService.findEntityViewsByTenantIdAndEntityId(tenantId, entityId);
+        if (entityViews != null && !entityViews.isEmpty()) {
+            EntityView entityView = entityViews.get(0);
+            Boolean relationExists = relationService.checkRelation(
+                    tenantId, edgeId, entityView.getId(),
+                    EntityRelation.CONTAINS_TYPE, RelationTypeGroup.EDGE
+            );
+            if (relationExists) {
+                throw new DataValidationException("Can't unassign device/asset from edge that is related to entity view and entity view is assigned to edge!");
             }
-        } catch (Exception e) {
-            log.error("[{}] Exception while finding entity views for entityId [{}]", tenantId, entityId, e);
-            throw new RuntimeException("Exception while finding entity views for entityId [" + entityId + "]", e);
         }
     }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
@@ -40,6 +40,7 @@ public abstract class AbstractEntityService {
     public static final String INCORRECT_EDGE_ID = "Incorrect edgeId ";
     public static final String INCORRECT_PAGE_LINK = "Incorrect page link ";
 
+    @Lazy
     @Autowired
     protected RelationService relationService;
 

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
@@ -83,7 +83,7 @@ public abstract class AbstractEntityService {
 
     protected void checkAssignedEntityViewsToEdge(TenantId tenantId, EntityId entityId, EdgeId edgeId) {
         try {
-            List<EntityView> entityViews = entityViewService.findEntityViewsByTenantIdAndEntityIdAsync(tenantId, entityId).get();
+            List<EntityView> entityViews = entityViewService.findEntityViewsByTenantIdAndEntityId(tenantId, entityId);
             if (entityViews != null && !entityViews.isEmpty()) {
                 EntityView entityView = entityViews.get(0);
                 // TODO: @voba - refactor this blocking operation

--- a/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewDao.java
@@ -179,4 +179,5 @@ public interface EntityViewDao extends Dao<EntityView> {
                                                             String type,
                                                             PageLink pageLink);
 
+    List<EntityView> findEntityViewsByTenantIdAndEntityId(UUID tenantId, UUID entityId);
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
@@ -447,7 +447,6 @@ public class EntityViewServiceImpl extends AbstractEntityService implements Enti
                         throw new DataValidationException("Entity view should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(entityView.getTenantId());
-                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Entity view is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
@@ -52,7 +52,7 @@ import org.thingsboard.server.dao.entity.AbstractEntityService;
 import org.thingsboard.server.dao.exception.DataValidationException;
 import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -87,7 +87,7 @@ public class EntityViewServiceImpl extends AbstractEntityService implements Enti
     private EntityViewDao entityViewDao;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     private CustomerDao customerDao;
@@ -432,7 +432,7 @@ public class EntityViewServiceImpl extends AbstractEntityService implements Enti
                     if (entityView.getTenantId() == null) {
                         throw new DataValidationException("Entity view should be assigned to tenant!");
                     } else {
-                        Tenant tenant = tenantDao.findById(tenantId, entityView.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(entityView.getTenantId());
                         if (tenant == null) {
                             throw new DataValidationException("Entity view is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
@@ -433,6 +433,7 @@ public class EntityViewServiceImpl extends AbstractEntityService implements Enti
                         throw new DataValidationException("Entity view should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(entityView.getTenantId());
+                        // TODO: 13.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Entity view is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
@@ -308,9 +308,7 @@ public class EntityViewServiceImpl extends AbstractEntityService implements Enti
         validateId(tenantId, INCORRECT_TENANT_ID + tenantId);
         validateId(entityId.getId(), "Incorrect entityId" + entityId);
 
-        List<Object> tenantIdAndEntityId = new ArrayList<>();
-        tenantIdAndEntityId.add(tenantId);
-        tenantIdAndEntityId.add(entityId);
+        List<Object> tenantIdAndEntityId = List.of(tenantId, entityId);
 
         Cache cache = cacheManager.getCache(ENTITY_VIEW_CACHE);
         List<EntityView> fromCache = cache.get(tenantIdAndEntityId, List.class);
@@ -366,15 +364,10 @@ public class EntityViewServiceImpl extends AbstractEntityService implements Enti
             throw new DataValidationException("Can't assign entityView to edge from different tenant!");
         }
 
-        try {
-            Boolean relationExists = relationService.checkRelation(tenantId, edgeId, entityView.getEntityId(),
-                    EntityRelation.CONTAINS_TYPE, RelationTypeGroup.EDGE).get();
-            if (!relationExists) {
-                throw new DataValidationException("Can't assign entity view to edge because related device/asset doesn't assigned to edge!");
-            }
-        } catch (ExecutionException | InterruptedException e) {
-            log.error("Exception during relation check", e);
-            throw new RuntimeException("Exception during relation check", e);
+        Boolean relationExists = relationService.checkRelation(tenantId, edgeId, entityView.getEntityId(),
+                EntityRelation.CONTAINS_TYPE, RelationTypeGroup.EDGE);
+        if (!relationExists) {
+            throw new DataValidationException("Can't assign entity view to edge because related device/asset doesn't assigned to edge!");
         }
 
         try {

--- a/dao/src/main/java/org/thingsboard/server/dao/ota/BaseOtaPackageService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/ota/BaseOtaPackageService.java
@@ -46,7 +46,7 @@ import org.thingsboard.server.dao.exception.DataValidationException;
 import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -66,7 +66,7 @@ public class BaseOtaPackageService implements OtaPackageService {
     public static final String INCORRECT_OTA_PACKAGE_ID = "Incorrect otaPackageId ";
     public static final String INCORRECT_TENANT_ID = "Incorrect tenantId ";
 
-    private final TenantDao tenantDao;
+    private final TenantService tenantService;
     private final DeviceProfileDao deviceProfileDao;
     private final OtaPackageDao otaPackageDao;
     private final OtaPackageInfoDao otaPackageInfoDao;
@@ -357,7 +357,8 @@ public class BaseOtaPackageService implements OtaPackageService {
         if (otaPackageInfo.getTenantId() == null) {
             throw new DataValidationException("OtaPackage should be assigned to tenant!");
         } else {
-            Tenant tenant = tenantDao.findById(otaPackageInfo.getTenantId(), otaPackageInfo.getTenantId().getId());
+            Tenant tenant = tenantService.findTenantById(otaPackageInfo.getTenantId());
+            // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
             if (tenant == null) {
                 throw new DataValidationException("OtaPackage is referencing to non-existent tenant!");
             }

--- a/dao/src/main/java/org/thingsboard/server/dao/relation/BaseRelationService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/relation/BaseRelationService.java
@@ -30,11 +30,8 @@ import org.springframework.cache.annotation.Caching;
 import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
-import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
-import org.thingsboard.server.common.data.page.PageData;
-import org.thingsboard.server.common.data.page.PageLink;
 import org.thingsboard.server.common.data.relation.EntityRelation;
 import org.thingsboard.server.common.data.relation.EntityRelationInfo;
 import org.thingsboard.server.common.data.relation.EntityRelationsQuery;
@@ -77,10 +74,15 @@ public class BaseRelationService implements RelationService {
     private CacheManager cacheManager;
 
     @Override
-    public ListenableFuture<Boolean> checkRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup) {
+    public ListenableFuture<Boolean> checkRelationAsync(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup) {
         log.trace("Executing checkRelation [{}][{}][{}][{}]", from, to, relationType, typeGroup);
         validate(from, to, relationType, typeGroup);
-        return relationDao.checkRelation(tenantId, from, to, relationType, typeGroup);
+        return relationDao.checkRelationAsync(tenantId, from, to, relationType, typeGroup);
+    }
+
+    @Override
+    public Boolean checkRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup) {
+        return null;
     }
 
     @Cacheable(cacheNames = RELATIONS_CACHE, key = "{#from, #to, #relationType, #typeGroup}")

--- a/dao/src/main/java/org/thingsboard/server/dao/relation/BaseRelationService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/relation/BaseRelationService.java
@@ -75,14 +75,16 @@ public class BaseRelationService implements RelationService {
 
     @Override
     public ListenableFuture<Boolean> checkRelationAsync(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup) {
-        log.trace("Executing checkRelation [{}][{}][{}][{}]", from, to, relationType, typeGroup);
+        log.trace("Executing checkRelationAsync [{}][{}][{}][{}]", from, to, relationType, typeGroup);
         validate(from, to, relationType, typeGroup);
         return relationDao.checkRelationAsync(tenantId, from, to, relationType, typeGroup);
     }
 
     @Override
     public Boolean checkRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup) {
-        return null;
+        log.trace("Executing checkRelation [{}][{}][{}][{}]", from, to, relationType, typeGroup);
+        validate(from, to, relationType, typeGroup);
+        return relationDao.checkRelation(tenantId, from, to, relationType, typeGroup);
     }
 
     @Cacheable(cacheNames = RELATIONS_CACHE, key = "{#from, #to, #relationType, #typeGroup}")

--- a/dao/src/main/java/org/thingsboard/server/dao/relation/RelationDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/relation/RelationDao.java
@@ -41,7 +41,9 @@ public interface RelationDao {
 
     ListenableFuture<List<EntityRelation>> findAllByToAndType(TenantId tenantId, EntityId to, String relationType, RelationTypeGroup typeGroup);
 
-    ListenableFuture<Boolean> checkRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup);
+    ListenableFuture<Boolean> checkRelationAsync(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup);
+
+    Boolean checkRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup);
 
     ListenableFuture<EntityRelation> getRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/resource/BaseResourceService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/resource/BaseResourceService.java
@@ -184,7 +184,6 @@ public class BaseResourceService implements ResourceService {
             }
             if (!resource.getTenantId().getId().equals(ModelConstants.NULL_UUID)) {
                 Tenant tenant = tenantService.findTenantById(resource.getTenantId());
-                // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                 if (tenant == null) {
                     throw new DataValidationException("Resource is referencing to non-existent tenant!");
                 }

--- a/dao/src/main/java/org/thingsboard/server/dao/resource/BaseResourceService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/resource/BaseResourceService.java
@@ -36,7 +36,7 @@ import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.service.Validator;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import java.util.List;
 import java.util.Optional;
@@ -52,13 +52,13 @@ public class BaseResourceService implements ResourceService {
     public static final String INCORRECT_RESOURCE_ID = "Incorrect resourceId ";
     private final TbResourceDao resourceDao;
     private final TbResourceInfoDao resourceInfoDao;
-    private final TenantDao tenantDao;
+    private final TenantService tenantService;
     private final TbTenantProfileCache tenantProfileCache;
 
-    public BaseResourceService(TbResourceDao resourceDao, TbResourceInfoDao resourceInfoDao, TenantDao tenantDao, @Lazy TbTenantProfileCache tenantProfileCache) {
+    public BaseResourceService(TbResourceDao resourceDao, TbResourceInfoDao resourceInfoDao, TenantService tenantService, @Lazy TbTenantProfileCache tenantProfileCache) {
         this.resourceDao = resourceDao;
         this.resourceInfoDao = resourceInfoDao;
-        this.tenantDao = tenantDao;
+        this.tenantService = tenantService;
         this.tenantProfileCache = tenantProfileCache;
     }
 
@@ -183,7 +183,8 @@ public class BaseResourceService implements ResourceService {
                 resource.setTenantId(new TenantId(ModelConstants.NULL_UUID));
             }
             if (!resource.getTenantId().getId().equals(ModelConstants.NULL_UUID)) {
-                Tenant tenant = tenantDao.findById(tenantId, resource.getTenantId().getId());
+                Tenant tenant = tenantService.findTenantById(resource.getTenantId());
+                // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                 if (tenant == null) {
                     throw new DataValidationException("Resource is referencing to non-existent tenant!");
                 }

--- a/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
@@ -59,7 +59,7 @@ import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.service.Validator;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -94,7 +94,7 @@ public class BaseRuleChainService extends AbstractEntityService implements RuleC
     private RuleNodeDao ruleNodeDao;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     @Lazy
@@ -726,7 +726,8 @@ public class BaseRuleChainService extends AbstractEntityService implements RuleC
                     if (ruleChain.getTenantId() == null || ruleChain.getTenantId().isNullUid()) {
                         throw new DataValidationException("Rule chain should be assigned to tenant!");
                     }
-                    Tenant tenant = tenantDao.findById(tenantId, ruleChain.getTenantId().getId());
+                    Tenant tenant = tenantService.findTenantById(ruleChain.getTenantId());
+                    // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                     if (tenant == null) {
                         throw new DataValidationException("Rule chain is referencing to non-existent tenant!");
                     }

--- a/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
@@ -727,7 +727,6 @@ public class BaseRuleChainService extends AbstractEntityService implements RuleC
                         throw new DataValidationException("Rule chain should be assigned to tenant!");
                     }
                     Tenant tenant = tenantService.findTenantById(ruleChain.getTenantId());
-                    // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                     if (tenant == null) {
                         throw new DataValidationException("Rule chain is referencing to non-existent tenant!");
                     }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/entityview/EntityViewRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/entityview/EntityViewRepository.java
@@ -20,7 +20,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
-import org.thingsboard.server.dao.model.sql.DeviceEntity;
 import org.thingsboard.server.dao.model.sql.EntityViewEntity;
 import org.thingsboard.server.dao.model.sql.EntityViewInfoEntity;
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/entityview/JpaEntityViewDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/entityview/JpaEntityViewDao.java
@@ -200,4 +200,12 @@ public class JpaEntityViewDao extends JpaAbstractSearchTextDao<EntityViewEntity,
                         Objects.toString(pageLink.getTextSearch(), ""),
                         DaoUtil.toPageable(pageLink)));
     }
+
+    @Override
+    public List<EntityView> findEntityViewsByTenantIdAndEntityId(UUID tenantId, UUID entityId) {
+        return DaoUtil.convertDataList(
+                entityViewRepository.findAllByTenantIdAndEntityId(
+                        tenantId, entityId)
+        );
+    }
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/relation/JpaRelationDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/relation/JpaRelationDao.java
@@ -101,9 +101,15 @@ public class JpaRelationDao extends JpaAbstractDaoListeningExecutorService imple
     }
 
     @Override
-    public ListenableFuture<Boolean> checkRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup) {
+    public ListenableFuture<Boolean> checkRelationAsync(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup) {
         RelationCompositeKey key = getRelationCompositeKey(from, to, relationType, typeGroup);
         return service.submit(() -> relationRepository.existsById(key));
+    }
+
+    @Override
+    public Boolean checkRelation(TenantId tenantId, EntityId from, EntityId to, String relationType, RelationTypeGroup typeGroup) {
+        RelationCompositeKey key = getRelationCompositeKey(from, to, relationType, typeGroup);
+        return relationRepository.existsById(key);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
@@ -107,7 +107,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
     private RpcService rpcService;
 
     @Override
-    @Cacheable(cacheNames = TENANTS_CACHE, key = "#tenantId", condition = "#tenantId!=null")
+    @Cacheable(cacheNames = TENANTS_CACHE, key = "#tenantId")
     public Tenant findTenantById(TenantId tenantId) {
         log.trace("Executing findTenantById [{}]", tenantId);
         Validator.validateId(tenantId, INCORRECT_TENANT_ID + tenantId);
@@ -148,8 +148,8 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
     }
 
     @Override
-    @Transactional
-    @CacheEvict(cacheNames = TENANTS_CACHE, key = "#tenantId", condition = "#tenantId!=null")
+    @Transactional(timeout = 60 * 60)
+    @CacheEvict(cacheNames = TENANTS_CACHE, key = "#tenantId")
     public void deleteTenant(TenantId tenantId) {
         log.trace("Executing deleteTenant [{}]", tenantId);
         Validator.validateId(tenantId, INCORRECT_TENANT_ID + tenantId);

--- a/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
@@ -191,6 +191,13 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
         tenantsRemover.removeEntities(new TenantId(EntityId.NULL_UUID), DEFAULT_TENANT_REGION);
     }
 
+    @Override
+    public PageData<TenantId> findTenantsIds(PageLink pageLink) {
+        log.trace("Executing deleteTenants");
+        Validator.validatePageLink(pageLink);
+        return tenantDao.findTenantsIds(pageLink);
+    }
+
     private DataValidator<Tenant> tenantValidator =
             new DataValidator<Tenant>() {
                 @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
@@ -123,7 +123,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
 
     @Override
     public ListenableFuture<Tenant> findTenantByIdAsync(TenantId callerId, TenantId tenantId) {
-        log.trace("Executing TenantIdAsync [{}]", tenantId);
+        log.trace("Executing findTenantByIdAsync [{}]", tenantId);
         validateId(tenantId, INCORRECT_TENANT_ID + tenantId);
         return tenantDao.findByIdAsync(callerId, tenantId.getId());
     }
@@ -193,7 +193,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
 
     @Override
     public PageData<TenantId> findTenantsIds(PageLink pageLink) {
-        log.trace("Executing deleteTenants");
+        log.trace("Executing findTenantsIds");
         Validator.validatePageLink(pageLink);
         return tenantDao.findTenantsIds(pageLink);
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
@@ -21,6 +21,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.transaction.annotation.Transactional;
 import org.thingsboard.server.common.data.Tenant;
 import org.thingsboard.server.common.data.TenantInfo;
 import org.thingsboard.server.common.data.TenantProfile;
@@ -34,7 +36,6 @@ import org.thingsboard.server.dao.dashboard.DashboardService;
 import org.thingsboard.server.dao.device.DeviceProfileService;
 import org.thingsboard.server.dao.device.DeviceService;
 import org.thingsboard.server.dao.entity.AbstractEntityService;
-import org.thingsboard.server.dao.entityview.EntityViewService;
 import org.thingsboard.server.dao.exception.DataValidationException;
 import org.thingsboard.server.dao.ota.OtaPackageService;
 import org.thingsboard.server.dao.resource.ResourceService;
@@ -66,6 +67,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
     private TenantProfileService tenantProfileService;
 
     @Autowired
+    @Lazy
     private UserService userService;
 
     @Autowired
@@ -82,9 +84,6 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
 
     @Autowired
     private ApiUsageStateService apiUsageStateService;
-
-    @Autowired
-    private EntityViewService entityViewService;
 
     @Autowired
     private WidgetsBundleService widgetsBundleService;
@@ -126,6 +125,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
     }
 
     @Override
+    @Transactional
     public Tenant saveTenant(Tenant tenant) {
         log.trace("Executing saveTenant [{}]", tenant);
         tenant.setRegion(DEFAULT_TENANT_REGION);
@@ -143,6 +143,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
     }
 
     @Override
+    @Transactional
     public void deleteTenant(TenantId tenantId) {
         log.trace("Executing deleteTenant [{}]", tenantId);
         Validator.validateId(tenantId, INCORRECT_TENANT_ID + tenantId);

--- a/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
@@ -20,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,6 +50,7 @@ import org.thingsboard.server.dao.usagerecord.ApiUsageStateService;
 import org.thingsboard.server.dao.user.UserService;
 import org.thingsboard.server.dao.widget.WidgetsBundleService;
 
+import static org.thingsboard.server.common.data.CacheConstants.TENANTS_CACHE;
 import static org.thingsboard.server.dao.service.Validator.validateId;
 
 @Service
@@ -104,6 +107,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
     private RpcService rpcService;
 
     @Override
+    @Cacheable(cacheNames = TENANTS_CACHE, key = "#tenantId", condition = "#tenantId!=null")
     public Tenant findTenantById(TenantId tenantId) {
         log.trace("Executing findTenantById [{}]", tenantId);
         Validator.validateId(tenantId, INCORRECT_TENANT_ID + tenantId);
@@ -126,6 +130,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = TENANTS_CACHE, key = "#tenant.id", condition = "#tenant.id!=null")
     public Tenant saveTenant(Tenant tenant) {
         log.trace("Executing saveTenant [{}]", tenant);
         tenant.setRegion(DEFAULT_TENANT_REGION);
@@ -144,6 +149,7 @@ public class TenantServiceImpl extends AbstractEntityService implements TenantSe
 
     @Override
     @Transactional
+    @CacheEvict(cacheNames = TENANTS_CACHE, key = "#tenantId", condition = "#tenantId!=null")
     public void deleteTenant(TenantId tenantId) {
         log.trace("Executing deleteTenant [{}]", tenantId);
         Validator.validateId(tenantId, INCORRECT_TENANT_ID + tenantId);

--- a/dao/src/main/java/org/thingsboard/server/dao/usagerecord/ApiUsageStateServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/usagerecord/ApiUsageStateServiceImpl.java
@@ -35,7 +35,7 @@ import org.thingsboard.server.common.data.tenant.profile.TenantProfileConfigurat
 import org.thingsboard.server.dao.entity.AbstractEntityService;
 import org.thingsboard.server.dao.exception.DataValidationException;
 import org.thingsboard.server.dao.service.DataValidator;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 import org.thingsboard.server.dao.tenant.TenantProfileDao;
 import org.thingsboard.server.dao.timeseries.TimeseriesService;
 
@@ -52,11 +52,11 @@ public class ApiUsageStateServiceImpl extends AbstractEntityService implements A
 
     private final ApiUsageStateDao apiUsageStateDao;
     private final TenantProfileDao tenantProfileDao;
-    private final TenantDao tenantDao;
+    private final TenantService tenantService;
     private final TimeseriesService tsService;
 
-    public ApiUsageStateServiceImpl(TenantDao tenantDao, ApiUsageStateDao apiUsageStateDao, TenantProfileDao tenantProfileDao, TimeseriesService tsService) {
-        this.tenantDao = tenantDao;
+    public ApiUsageStateServiceImpl(TenantService tenantService, ApiUsageStateDao apiUsageStateDao, TenantProfileDao tenantProfileDao, TimeseriesService tsService) {
+        this.tenantService = tenantService;
         this.apiUsageStateDao = apiUsageStateDao;
         this.tenantProfileDao = tenantProfileDao;
         this.tsService = tsService;
@@ -114,7 +114,7 @@ public class ApiUsageStateServiceImpl extends AbstractEntityService implements A
 
         if (entityId.getEntityType() == EntityType.TENANT && !entityId.equals(TenantId.SYS_TENANT_ID)) {
             tenantId = (TenantId) entityId;
-            Tenant tenant = tenantDao.findById(tenantId, tenantId.getId());
+            Tenant tenant = tenantService.findTenantById(tenantId);
             TenantProfile tenantProfile = tenantProfileDao.findById(tenantId, tenant.getTenantProfileId().getId());
             TenantProfileConfiguration configuration = tenantProfile.getProfileData().getConfiguration();
 
@@ -164,7 +164,8 @@ public class ApiUsageStateServiceImpl extends AbstractEntityService implements A
                     if (apiUsageState.getTenantId() == null) {
                         throw new DataValidationException("ApiUsageState should be assigned to tenant!");
                     } else {
-                        Tenant tenant = tenantDao.findById(requestTenantId, apiUsageState.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(apiUsageState.getTenantId());
+                        // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null && !requestTenantId.equals(TenantId.SYS_TENANT_ID)) {
                             throw new DataValidationException("ApiUsageState is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/usagerecord/ApiUsageStateServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/usagerecord/ApiUsageStateServiceImpl.java
@@ -165,7 +165,6 @@ public class ApiUsageStateServiceImpl extends AbstractEntityService implements A
                         throw new DataValidationException("ApiUsageState should be assigned to tenant!");
                     } else {
                         Tenant tenant = tenantService.findTenantById(apiUsageState.getTenantId());
-                        // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null && !requestTenantId.equals(TenantId.SYS_TENANT_ID)) {
                             throw new DataValidationException("ApiUsageState is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/user/UserServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/user/UserServiceImpl.java
@@ -51,7 +51,7 @@ import org.thingsboard.server.dao.model.ModelConstants;
 import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -80,20 +80,20 @@ public class UserServiceImpl extends AbstractEntityService implements UserServic
 
     private final UserDao userDao;
     private final UserCredentialsDao userCredentialsDao;
-    private final TenantDao tenantDao;
+    private final TenantService tenantService;
     private final CustomerDao customerDao;
     private final TbTenantProfileCache tenantProfileCache;
     private final ApplicationEventPublisher eventPublisher;
 
     public UserServiceImpl(UserDao userDao,
                            UserCredentialsDao userCredentialsDao,
-                           TenantDao tenantDao,
+                           @Lazy TenantService tenantService,
                            CustomerDao customerDao,
                            @Lazy TbTenantProfileCache tenantProfileCache,
                            ApplicationEventPublisher eventPublisher) {
         this.userDao = userDao;
         this.userCredentialsDao = userCredentialsDao;
-        this.tenantDao = tenantDao;
+        this.tenantService = tenantService;
         this.customerDao = customerDao;
         this.tenantProfileCache = tenantProfileCache;
         this.eventPublisher = eventPublisher;
@@ -448,7 +448,8 @@ public class UserServiceImpl extends AbstractEntityService implements UserServic
                                 + " already present in database!");
                     }
                     if (!tenantId.getId().equals(ModelConstants.NULL_UUID)) {
-                        Tenant tenant = tenantDao.findById(tenantId, user.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(user.getTenantId());
+                        // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("User is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetTypeServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetTypeServiceImpl.java
@@ -139,7 +139,6 @@ public class WidgetTypeServiceImpl implements WidgetTypeService {
                     }
                     if (!widgetTypeDetails.getTenantId().getId().equals(ModelConstants.NULL_UUID)) {
                         Tenant tenant = tenantService.findTenantById(widgetTypeDetails.getTenantId());
-                        // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Widget type is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetTypeServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetTypeServiceImpl.java
@@ -30,7 +30,7 @@ import org.thingsboard.server.dao.exception.DataValidationException;
 import org.thingsboard.server.dao.model.ModelConstants;
 import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.Validator;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import java.util.List;
 
@@ -44,7 +44,7 @@ public class WidgetTypeServiceImpl implements WidgetTypeService {
     private WidgetTypeDao widgetTypeDao;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     private WidgetsBundleDao widgetsBundleService;
@@ -138,7 +138,8 @@ public class WidgetTypeServiceImpl implements WidgetTypeService {
                         widgetTypeDetails.setTenantId(new TenantId(ModelConstants.NULL_UUID));
                     }
                     if (!widgetTypeDetails.getTenantId().getId().equals(ModelConstants.NULL_UUID)) {
-                        Tenant tenant = tenantDao.findById(tenantId, widgetTypeDetails.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(widgetTypeDetails.getTenantId());
+                        // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Widget type is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetsBundleServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetsBundleServiceImpl.java
@@ -31,7 +31,7 @@ import org.thingsboard.server.dao.model.ModelConstants;
 import org.thingsboard.server.dao.service.DataValidator;
 import org.thingsboard.server.dao.service.PaginatedRemover;
 import org.thingsboard.server.dao.service.Validator;
-import org.thingsboard.server.dao.tenant.TenantDao;
+import org.thingsboard.server.dao.tenant.TenantService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,7 +48,7 @@ public class WidgetsBundleServiceImpl implements WidgetsBundleService {
     private WidgetsBundleDao widgetsBundleDao;
 
     @Autowired
-    private TenantDao tenantDao;
+    private TenantService tenantService;
 
     @Autowired
     private WidgetTypeService widgetTypeService;
@@ -162,7 +162,8 @@ public class WidgetsBundleServiceImpl implements WidgetsBundleService {
                         widgetsBundle.setTenantId(new TenantId(ModelConstants.NULL_UUID));
                     }
                     if (!widgetsBundle.getTenantId().getId().equals(ModelConstants.NULL_UUID)) {
-                        Tenant tenant = tenantDao.findById(tenantId, widgetsBundle.getTenantId().getId());
+                        Tenant tenant = tenantService.findTenantById(widgetsBundle.getTenantId());
+                        // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Widgets bundle is referencing to non-existent tenant!");
                         }

--- a/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetsBundleServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/widget/WidgetsBundleServiceImpl.java
@@ -163,7 +163,6 @@ public class WidgetsBundleServiceImpl implements WidgetsBundleService {
                     }
                     if (!widgetsBundle.getTenantId().getId().equals(ModelConstants.NULL_UUID)) {
                         Tenant tenant = tenantService.findTenantById(widgetsBundle.getTenantId());
-                        // TODO: 12.01.22 Instead of finding and checking for null need to create and use tenantService.exists()
                         if (tenant == null) {
                             throw new DataValidationException("Widgets bundle is referencing to non-existent tenant!");
                         }

--- a/dao/src/test/java/org/thingsboard/server/dao/service/AbstractServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/AbstractServiceTest.java
@@ -59,6 +59,7 @@ import org.thingsboard.server.dao.event.EventService;
 import org.thingsboard.server.dao.ota.OtaPackageService;
 import org.thingsboard.server.dao.relation.RelationService;
 import org.thingsboard.server.dao.resource.ResourceService;
+import org.thingsboard.server.dao.rpc.RpcService;
 import org.thingsboard.server.dao.rule.RuleChainService;
 import org.thingsboard.server.dao.settings.AdminSettingsService;
 import org.thingsboard.server.dao.tenant.TenantProfileService;
@@ -162,6 +163,9 @@ public abstract class AbstractServiceTest {
 
     @Autowired
     protected OtaPackageService otaPackageService;
+
+    @Autowired
+    protected RpcService rpcService;
 
     public class IdComparator<D extends HasId> implements Comparator<D> {
         @Override

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseOtaPackageServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseOtaPackageServiceTest.java
@@ -97,26 +97,26 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
 
         Assert.assertEquals(0, otaPackageService.sumDataSizeByTenantId(tenantId));
 
-        createFirmware(tenantId, "1");
+        createAndSaveFirmware(tenantId, "1");
         Assert.assertEquals(1, otaPackageService.sumDataSizeByTenantId(tenantId));
 
         thrown.expect(DataValidationException.class);
         thrown.expectMessage(String.format("Failed to create the ota package, files size limit is exhausted %d bytes!", DATA_SIZE));
-        createFirmware(tenantId, "2");
+        createAndSaveFirmware(tenantId, "2");
     }
 
     @Test
     public void sumDataSizeByTenantId() {
         Assert.assertEquals(0, otaPackageService.sumDataSizeByTenantId(tenantId));
 
-        createFirmware(tenantId, "0.1");
+        createAndSaveFirmware(tenantId, "0.1");
         Assert.assertEquals(1, otaPackageService.sumDataSizeByTenantId(tenantId));
 
         int maxSumDataSize = 8;
         List<OtaPackage> packages = new ArrayList<>(maxSumDataSize);
 
         for (int i = 2; i <= maxSumDataSize; i++) {
-            packages.add(createFirmware(tenantId, "0." + i));
+            packages.add(createAndSaveFirmware(tenantId, "0." + i));
             Assert.assertEquals(i, otaPackageService.sumDataSizeByTenantId(tenantId));
         }
 
@@ -419,15 +419,15 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
 
     @Test
     public void testSaveFirmwareWithExistingTitleAndVersion() {
-        createFirmware(tenantId, VERSION);
+        createAndSaveFirmware(tenantId, VERSION);
         thrown.expect(DataValidationException.class);
         thrown.expectMessage("OtaPackage with such title and version already exists!");
-        createFirmware(tenantId, VERSION);
+        createAndSaveFirmware(tenantId, VERSION);
     }
 
     @Test
     public void testDeleteFirmwareWithReferenceByDevice() {
-        OtaPackage savedFirmware = createFirmware(tenantId, VERSION);
+        OtaPackage savedFirmware = createAndSaveFirmware(tenantId, VERSION);
 
         Device device = new Device();
         device.setTenantId(tenantId);
@@ -448,7 +448,7 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
 
     @Test
     public void testUpdateDeviceProfileId() {
-        OtaPackage savedFirmware = createFirmware(tenantId, VERSION);
+        OtaPackage savedFirmware = createAndSaveFirmware(tenantId, VERSION);
 
         try {
             thrown.expect(DataValidationException.class);
@@ -494,7 +494,7 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
 
     @Test
     public void testFindFirmwareById() {
-        OtaPackage savedFirmware = createFirmware(tenantId, VERSION);
+        OtaPackage savedFirmware = createAndSaveFirmware(tenantId, VERSION);
 
         OtaPackage foundFirmware = otaPackageService.findOtaPackageById(tenantId, savedFirmware.getId());
         Assert.assertNotNull(foundFirmware);
@@ -520,7 +520,7 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
 
     @Test
     public void testDeleteFirmware() {
-        OtaPackage savedFirmware = createFirmware(tenantId, VERSION);
+        OtaPackage savedFirmware = createAndSaveFirmware(tenantId, VERSION);
 
         OtaPackage foundFirmware = otaPackageService.findOtaPackageById(tenantId, savedFirmware.getId());
         Assert.assertNotNull(foundFirmware);
@@ -533,7 +533,7 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
     public void testFindTenantFirmwaresByTenantId() {
         List<OtaPackageInfo> firmwares = new ArrayList<>();
         for (int i = 0; i < 165; i++) {
-            OtaPackageInfo info = new OtaPackageInfo(createFirmware(tenantId, VERSION + i));
+            OtaPackageInfo info = new OtaPackageInfo(createAndSaveFirmware(tenantId, VERSION + i));
             info.setHasData(true);
             firmwares.add(info);
         }
@@ -580,7 +580,7 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
     public void testFindTenantFirmwaresByTenantIdAndHasData() {
         List<OtaPackageInfo> firmwares = new ArrayList<>();
         for (int i = 0; i < 165; i++) {
-            firmwares.add(new OtaPackageInfo(otaPackageService.saveOtaPackage(createFirmware(tenantId, VERSION + i))));
+            firmwares.add(new OtaPackageInfo(otaPackageService.saveOtaPackage(createAndSaveFirmware(tenantId, VERSION + i))));
         }
 
         OtaPackageInfo firmwareWithUrl = new OtaPackageInfo();
@@ -696,7 +696,15 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         otaPackageService.saveOtaPackageInfo(firmwareInfo, true);
     }
 
-    private OtaPackage createFirmware(TenantId tenantId, String version) {
+    private OtaPackage createAndSaveFirmware(TenantId tenantId, String version) {
+        return otaPackageService.saveOtaPackage(createFirmware(tenantId, version, deviceProfileId));
+    }
+
+    public static OtaPackage createFirmware(
+            TenantId tenantId,
+            String version,
+            DeviceProfileId deviceProfileId
+    ) {
         OtaPackage firmware = new OtaPackage();
         firmware.setTenantId(tenantId);
         firmware.setDeviceProfileId(deviceProfileId);
@@ -709,6 +717,6 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmware.setChecksum(CHECKSUM);
         firmware.setData(DATA);
         firmware.setDataSize(DATA_SIZE);
-        return otaPackageService.saveOtaPackage(firmware);
+        return firmware;
     }
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseRelationServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseRelationServiceTest.java
@@ -57,13 +57,13 @@ public abstract class BaseRelationServiceTest extends AbstractServiceTest {
 
         Assert.assertTrue(saveRelation(relation));
 
-        Assert.assertTrue(relationService.checkRelation(SYSTEM_TENANT_ID, parentId, childId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON).get());
+        Assert.assertTrue(relationService.checkRelation(SYSTEM_TENANT_ID, parentId, childId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON));
 
-        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, parentId, childId, "NOT_EXISTING_TYPE", RelationTypeGroup.COMMON).get());
+        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, parentId, childId, "NOT_EXISTING_TYPE", RelationTypeGroup.COMMON));
 
-        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, childId, parentId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON).get());
+        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, childId, parentId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON));
 
-        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, childId, parentId, "NOT_EXISTING_TYPE", RelationTypeGroup.COMMON).get());
+        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, childId, parentId, "NOT_EXISTING_TYPE", RelationTypeGroup.COMMON));
     }
 
     @Test
@@ -80,9 +80,9 @@ public abstract class BaseRelationServiceTest extends AbstractServiceTest {
 
         Assert.assertTrue(relationService.deleteRelationAsync(SYSTEM_TENANT_ID, relationA).get());
 
-        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, parentId, childId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON).get());
+         Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, parentId, childId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON));
 
-        Assert.assertTrue(relationService.checkRelation(SYSTEM_TENANT_ID, childId, subChildId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON).get());
+        Assert.assertTrue(relationService.checkRelation(SYSTEM_TENANT_ID, childId, subChildId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON));
 
         Assert.assertTrue(relationService.deleteRelationAsync(SYSTEM_TENANT_ID, childId, subChildId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON).get());
     }
@@ -118,9 +118,9 @@ public abstract class BaseRelationServiceTest extends AbstractServiceTest {
 
         Assert.assertNull(relationService.deleteEntityRelationsAsync(SYSTEM_TENANT_ID, childId).get());
 
-        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, parentId, childId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON).get());
+        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, parentId, childId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON));
 
-        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, childId, subChildId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON).get());
+        Assert.assertFalse(relationService.checkRelation(SYSTEM_TENANT_ID, childId, subChildId, EntityRelation.CONTAINS_TYPE, RelationTypeGroup.COMMON));
     }
 
     @Test

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseTenantServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseTenantServiceTest.java
@@ -329,7 +329,7 @@ public abstract class BaseTenantServiceTest extends AbstractServiceTest {
     }
 
     @Test
-    public void testGettingTenantAddItToCache() {
+    public void testGettingTenantAddingItToCache() {
         Tenant tenant = new Tenant();
         tenant.setTitle("My tenant");
         Tenant savedTenant = tenantService.saveTenant(tenant);

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseTenantServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseTenantServiceTest.java
@@ -423,6 +423,8 @@ public abstract class BaseTenantServiceTest extends AbstractServiceTest {
         assertResourceIsDeleted(savedTenant, savedResource);
         assertOtaPackageIsDeleted(savedTenant, savedOtaPackage);
         Assert.assertNull(rpcService.findById(savedTenant.getId(), savedRpc.getId()));
+
+        tenantProfileService.deleteTenantProfile(TenantId.SYS_TENANT_ID, savedProfile.getId());
     }
 
     private void assertOtaPackageIsDeleted(Tenant savedTenant, OtaPackage savedOtaPackage) {

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseTenantServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseTenantServiceTest.java
@@ -71,6 +71,8 @@ import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.thingsboard.server.common.data.ota.OtaPackageType.FIRMWARE;
 
 public abstract class BaseTenantServiceTest extends AbstractServiceTest {
@@ -328,12 +330,12 @@ public abstract class BaseTenantServiceTest extends AbstractServiceTest {
         tenant.setTitle("My tenant");
         Tenant savedTenant = tenantService.saveTenant(tenant);
 
-        Mockito.reset(tenantDao);
+        reset(tenantDao);
         Objects.requireNonNull(cacheManager.getCache(CacheConstants.TENANTS_CACHE), "Tenant cache manager is null").evict(savedTenant.getId());
 
-        Mockito.verify(tenantDao, Mockito.times(0)).findById(any(), any());
+        verify(tenantDao, Mockito.times(0)).findById(any(), any());
         tenantService.findTenantById(savedTenant.getId());
-        Mockito.verify(tenantDao, Mockito.times(1)).findById(eq(savedTenant.getId()), eq(savedTenant.getId().getId()));
+        verify(tenantDao, Mockito.times(1)).findById(eq(savedTenant.getId()), eq(savedTenant.getId().getId()));
 
         Cache.ValueWrapper cachedTenant =
                 Objects.requireNonNull(cacheManager.getCache(CacheConstants.TENANTS_CACHE), "Cache manager is null!").get(savedTenant.getId());
@@ -342,7 +344,7 @@ public abstract class BaseTenantServiceTest extends AbstractServiceTest {
         for (int i = 0; i < 100; i++) {
             tenantService.findTenantById(savedTenant.getId());
         }
-        Mockito.verify(tenantDao, Mockito.times(1)).findById(eq(savedTenant.getId()), eq(savedTenant.getId().getId()));
+        verify(tenantDao, Mockito.times(1)).findById(eq(savedTenant.getId()), eq(savedTenant.getId().getId()));
 
         tenantService.deleteTenant(savedTenant.getId());
     }
@@ -360,14 +362,14 @@ public abstract class BaseTenantServiceTest extends AbstractServiceTest {
         savedTenant.setTitle("My new tenant");
         savedTenant = tenantService.saveTenant(savedTenant);
 
-        Mockito.reset(tenantDao);
+        reset(tenantDao);
 
         cachedTenant = Objects.requireNonNull(cacheManager.getCache(CacheConstants.TENANTS_CACHE), "Cache manager is null!").get(savedTenant.getId());
         Assert.assertNull("Updating a Tenant doesn't evict the cache!", cachedTenant);
 
-        Mockito.verify(tenantDao, Mockito.times(0)).findById(any(), any());
+        verify(tenantDao, Mockito.times(0)).findById(any(), any());
         tenantService.findTenantById(savedTenant.getId());
-        Mockito.verify(tenantDao, Mockito.times(1)).findById(eq(savedTenant.getId()), eq(savedTenant.getId().getId()));
+        verify(tenantDao, Mockito.times(1)).findById(eq(savedTenant.getId()), eq(savedTenant.getId().getId()));
 
         tenantService.deleteTenant(savedTenant.getId());
     }

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseTenantServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseTenantServiceTest.java
@@ -415,17 +415,17 @@ public abstract class BaseTenantServiceTest extends AbstractServiceTest {
         assertDeviceIsDeleted(savedTenant, savedDevice);
         assertDeviceProfileIsDeleted(savedTenant, savedDeviceProfile);
         assertDashboardIsDeleted(savedTenant, savedDashboard);
-        assertEdgeIsDeletd(savedTenant, savedEdge);
+        assertEdgeIsDeleted(savedTenant, savedEdge);
         assertTenantAdminIsDeleted(savedTenant);
         assertUserIsDeleted(savedTenant, savedUser);
         Assert.assertNull(ruleChainService.findRuleChainById(savedTenant.getId(), savedRuleChain.getId()));
         Assert.assertNull(apiUsageStateService.findTenantApiUsageState(savedTenant.getId()));
         assertResourceIsDeleted(savedTenant, savedResource);
-        assertOtaPAckageIsDeleted(savedTenant, savedOtaPackage);
+        assertOtaPackageIsDeleted(savedTenant, savedOtaPackage);
         Assert.assertNull(rpcService.findById(savedTenant.getId(), savedRpc.getId()));
     }
 
-    private void assertOtaPAckageIsDeleted(Tenant savedTenant, OtaPackage savedOtaPackage) {
+    private void assertOtaPackageIsDeleted(Tenant savedTenant, OtaPackage savedOtaPackage) {
         Assert.assertNull(
                 otaPackageService.findOtaPackageById(
                         savedTenant.getId(), savedOtaPackage.getId()
@@ -463,7 +463,7 @@ public abstract class BaseTenantServiceTest extends AbstractServiceTest {
         Assert.assertEquals(0, tenantAdmins.getTotalElements());
     }
 
-    private void assertEdgeIsDeletd(Tenant savedTenant, Edge savedEdge) {
+    private void assertEdgeIsDeleted(Tenant savedTenant, Edge savedEdge) {
         Assert.assertNull(edgeService.findEdgeById(savedTenant.getId(), savedEdge.getId()));
         PageLink pageLinkEdges = new PageLink(1000);
         PageData<Edge> edges = edgeService.findEdgesByTenantId(savedTenant.getId(), pageLinkEdges);

--- a/dao/src/test/resources/application-test.properties
+++ b/dao/src/test/resources/application-test.properties
@@ -34,6 +34,9 @@ caffeine.specs.claimDevices.maxSize=100000
 caffeine.specs.tenantProfiles.timeToLiveInMinutes=1440
 caffeine.specs.tenantProfiles.maxSize=100000
 
+caffeine.specs.tenants.timeToLiveInMinutes=1440
+caffeine.specs.tenants.maxSize=100000
+
 caffeine.specs.deviceProfiles.timeToLiveInMinutes=1440
 caffeine.specs.deviceProfiles.maxSize=100000
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateRelationNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateRelationNode.java
@@ -124,7 +124,7 @@ public class TbCreateRelationNode extends TbAbstractRelationActionNode<TbCreateR
     }
 
     private ListenableFuture<Boolean> checkRelation(TbContext ctx, SearchDirectionIds sdId, String relationType) {
-        return ctx.getRelationService().checkRelation(ctx.getTenantId(), sdId.getFromId(), sdId.getToId(), relationType, RelationTypeGroup.COMMON);
+        return ctx.getRelationService().checkRelationAsync(ctx.getTenantId(), sdId.getFromId(), sdId.getToId(), relationType, RelationTypeGroup.COMMON);
     }
 
     private ListenableFuture<Boolean> processCreateRelation(TbContext ctx, EntityContainer entityContainer, SearchDirectionIds sdId, String relationType) {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbDeleteRelationNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbDeleteRelationNode.java
@@ -98,7 +98,7 @@ public class TbDeleteRelationNode extends TbAbstractRelationActionNode<TbDeleteR
 
     private ListenableFuture<Boolean> processSingle(TbContext ctx, TbMsg msg, EntityContainer entityContainer, String relationType) {
         SearchDirectionIds sdId = processSingleSearchDirection(msg, entityContainer);
-        return Futures.transformAsync(ctx.getRelationService().checkRelation(ctx.getTenantId(), sdId.getFromId(), sdId.getToId(), relationType, RelationTypeGroup.COMMON),
+        return Futures.transformAsync(ctx.getRelationService().checkRelationAsync(ctx.getTenantId(), sdId.getFromId(), sdId.getToId(), relationType, RelationTypeGroup.COMMON),
                 result -> {
                     if (result) {
                         return processSingleDeleteRelation(ctx, sdId, relationType);

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbCheckRelationNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbCheckRelationNode.java
@@ -82,7 +82,7 @@ public class TbCheckRelationNode implements TbNode {
             to = EntityIdFactory.getByTypeAndId(config.getEntityType(), config.getEntityId());
             from = msg.getOriginator();
         }
-        return ctx.getRelationService().checkRelation(ctx.getTenantId(), from, to, config.getRelationType(), RelationTypeGroup.COMMON);
+        return ctx.getRelationService().checkRelationAsync(ctx.getTenantId(), from, to, config.getRelationType(), RelationTypeGroup.COMMON);
     }
 
     private ListenableFuture<Boolean> processList(TbContext ctx, TbMsg msg) {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateRelationNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateRelationNodeTest.java
@@ -113,7 +113,7 @@ public class TbCreateRelationNodeTest {
         metaData.putValue("type", "AssetType");
         msg = TbMsg.newMsg(DataConstants.ENTITY_CREATED, deviceId, metaData, TbMsgDataType.JSON, "{}", ruleChainId, ruleNodeId);
 
-        when(ctx.getRelationService().checkRelation(any(), eq(assetId), eq(deviceId), eq(RELATION_TYPE_CONTAINS), eq(RelationTypeGroup.COMMON)))
+        when(ctx.getRelationService().checkRelationAsync(any(), eq(assetId), eq(deviceId), eq(RELATION_TYPE_CONTAINS), eq(RelationTypeGroup.COMMON)))
                 .thenReturn(Futures.immediateFuture(false));
         when(ctx.getRelationService().saveRelationAsync(any(), eq(new EntityRelation(assetId, deviceId, RELATION_TYPE_CONTAINS, RelationTypeGroup.COMMON))))
                 .thenReturn(Futures.immediateFuture(true));
@@ -144,7 +144,7 @@ public class TbCreateRelationNodeTest {
         when(ctx.getRelationService().findByToAndTypeAsync(any(), eq(msg.getOriginator()), eq(RELATION_TYPE_CONTAINS), eq(RelationTypeGroup.COMMON)))
                 .thenReturn(Futures.immediateFuture(Collections.singletonList(relation)));
         when(ctx.getRelationService().deleteRelationAsync(any(), eq(relation))).thenReturn(Futures.immediateFuture(true));
-        when(ctx.getRelationService().checkRelation(any(), eq(assetId), eq(deviceId), eq(RELATION_TYPE_CONTAINS), eq(RelationTypeGroup.COMMON)))
+        when(ctx.getRelationService().checkRelationAsync(any(), eq(assetId), eq(deviceId), eq(RELATION_TYPE_CONTAINS), eq(RelationTypeGroup.COMMON)))
                 .thenReturn(Futures.immediateFuture(false));
         when(ctx.getRelationService().saveRelationAsync(any(), eq(new EntityRelation(assetId, deviceId, RELATION_TYPE_CONTAINS, RelationTypeGroup.COMMON))))
                 .thenReturn(Futures.immediateFuture(true));
@@ -171,7 +171,7 @@ public class TbCreateRelationNodeTest {
         metaData.putValue("type", "AssetType");
         msg = TbMsg.newMsg(DataConstants.ENTITY_CREATED, deviceId, metaData, TbMsgDataType.JSON, "{}", ruleChainId, ruleNodeId);
 
-        when(ctx.getRelationService().checkRelation(any(), eq(assetId), eq(deviceId), eq(RELATION_TYPE_CONTAINS), eq(RelationTypeGroup.COMMON)))
+        when(ctx.getRelationService().checkRelationAsync(any(), eq(assetId), eq(deviceId), eq(RELATION_TYPE_CONTAINS), eq(RelationTypeGroup.COMMON)))
                 .thenReturn(Futures.immediateFuture(false));
         when(ctx.getRelationService().saveRelationAsync(any(), eq(new EntityRelation(assetId, deviceId, RELATION_TYPE_CONTAINS, RelationTypeGroup.COMMON))))
                 .thenReturn(Futures.immediateFuture(true));


### PR DESCRIPTION
In the other services, TenantDao is often used to retrieve an tenant entity by id. Direct tenantDao usages:
![image](https://user-images.githubusercontent.com/95230703/150547130-28f89847-c773-4b0c-b02f-869bbaba0cfc.png)


It causes many calls to DB. And many SELECT requests affecting the performance.
![image](https://user-images.githubusercontent.com/95230703/150547616-d117972a-c9d1-456d-b3ca-d90d0166ce57.png)
![image](https://user-images.githubusercontent.com/95230703/150547646-638086bd-937c-4836-9422-d28054d82abf.png)


Replacing usages of TenantDao to TenantService with cacheable find tenant by id method will significantly increase performance.