### PR TITLE
[3.3.3] Reduce number of scheduled messages for session timeout

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
@@ -18,9 +18,12 @@ package org.thingsboard.server.actors.app;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.server.actors.ActorSystemContext;
 import org.thingsboard.server.actors.TbActor;
+import org.thingsboard.server.actors.TbActorCtx;
+import org.thingsboard.server.actors.TbActorException;
 import org.thingsboard.server.actors.TbActorId;
 import org.thingsboard.server.actors.TbActorRef;
 import org.thingsboard.server.actors.TbEntityActorId;
+import org.thingsboard.server.actors.device.SessionTimeoutCheckMsg;
 import org.thingsboard.server.actors.service.ContextAwareActor;
 import org.thingsboard.server.actors.service.ContextBasedCreator;
 import org.thingsboard.server.actors.service.DefaultActorService;
@@ -65,6 +68,15 @@ public class AppActor extends ContextAwareActor {
     }
 
     @Override
+    public void init(TbActorCtx ctx) throws TbActorException {
+        super.init(ctx);
+        if (systemContext.getServiceInfoProvider().isService(ServiceType.TB_CORE)) {
+            systemContext.schedulePeriodicMsgWithDelay(ctx, SessionTimeoutCheckMsg.instance(),
+                    systemContext.getSessionReportTimeout(), systemContext.getSessionReportTimeout());
+        }
+    }
+
+    @Override
     protected boolean doProcess(TbActorMsg msg) {
         if (!ruleChainsInitialized) {
             initTenantActors();
@@ -100,6 +112,9 @@ public class AppActor extends ContextAwareActor {
                 break;
             case EDGE_EVENT_UPDATE_TO_EDGE_SESSION_MSG:
                 onToTenantActorMsg((EdgeEventUpdateMsg) msg);
+                break;
+            case SESSION_TIMEOUT_MSG:
+                ctx.broadcastToChildrenByType(msg, EntityType.TENANT);
                 break;
             default:
                 return false;

--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -939,7 +939,6 @@ class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcessor {
     }
 
     void init(TbActorCtx ctx) {
-        schedulePeriodicMsgWithDelay(ctx, SessionTimeoutCheckMsg.instance(), systemContext.getSessionReportTimeout(), systemContext.getSessionReportTimeout());
         PageLink pageLink = new PageLink(1024, 0, null, new SortOrder("createdTime"));
         PageData<Rpc> pageData;
         do {

--- a/application/src/main/java/org/thingsboard/server/actors/tenant/TenantActor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/tenant/TenantActor.java
@@ -85,8 +85,6 @@ public class TenantActor extends RuleChainManagerActor {
                 cantFindTenant = true;
                 log.info("[{}] Started tenant actor for missing tenant.", tenantId);
             } else {
-                systemContext.schedulePeriodicMsgWithDelay(ctx, SessionTimeoutCheckMsg.instance(), systemContext.getSessionReportTimeout(), systemContext.getSessionReportTimeout());
-
                 apiUsageState = new ApiUsageState(systemContext.getApiUsageStateService().getApiUsageState(tenant.getId()));
 
                 // This Service may be started for specific tenant only.
@@ -174,7 +172,7 @@ public class TenantActor extends RuleChainManagerActor {
                 onToDeviceActorMsg((DeviceAwareMsg) msg, true);
                 break;
             case SESSION_TIMEOUT_MSG:
-                broadcastToAllDeviceActors(msg);
+                ctx.broadcastToChildrenByType(msg, EntityType.DEVICE);
                 break;
             case RULE_CHAIN_INPUT_MSG:
             case RULE_CHAIN_OUTPUT_MSG:
@@ -188,11 +186,6 @@ public class TenantActor extends RuleChainManagerActor {
                 return false;
         }
         return true;
-    }
-
-    private void broadcastToAllDeviceActors(TbActorMsg msg) {
-        ctx.broadcastToChildren(msg, actorId -> actorId instanceof TbEntityActorId
-                && EntityType.DEVICE.equals(((TbEntityActorId) actorId).getEntityId().getEntityType()));
     }
 
     private boolean isMyPartition(EntityId entityId) {

--- a/common/actor/src/main/java/org/thingsboard/server/actors/TbActorCtx.java
+++ b/common/actor/src/main/java/org/thingsboard/server/actors/TbActorCtx.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.actors;
 
+import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.msg.TbActorMsg;
 
 import java.util.List;
@@ -34,6 +35,8 @@ public interface TbActorCtx extends TbActorRef {
     TbActorRef getOrCreateChildActor(TbActorId actorId, Supplier<String> dispatcher, Supplier<TbActorCreator> creator);
 
     void broadcastToChildren(TbActorMsg msg);
+
+    void broadcastToChildrenByType(TbActorMsg msg, EntityType entityType);
 
     void broadcastToChildren(TbActorMsg msg, Predicate<TbActorId> childFilter);
 

--- a/common/actor/src/main/java/org/thingsboard/server/actors/TbActorId.java
+++ b/common/actor/src/main/java/org/thingsboard/server/actors/TbActorId.java
@@ -15,6 +15,16 @@
  */
 package org.thingsboard.server.actors;
 
+import org.thingsboard.server.common.data.EntityType;
+
 public interface TbActorId {
+
+    /**
+     * Returns entity type of the actor.
+     * May return null if the actor does not belong to any entity.
+     * This method is added for performance optimization.
+     *
+     */
+    EntityType getEntityType();
 
 }

--- a/common/actor/src/main/java/org/thingsboard/server/actors/TbActorMailbox.java
+++ b/common/actor/src/main/java/org/thingsboard/server/actors/TbActorMailbox.java
@@ -17,6 +17,7 @@ package org.thingsboard.server.actors;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.msg.MsgType;
 import org.thingsboard.server.common.msg.TbActorMsg;
 import org.thingsboard.server.common.msg.TbActorStopReason;
@@ -139,7 +140,7 @@ public final class TbActorMailbox implements TbActorCtx {
                 try {
                     log.debug("[{}] Going to process message: {}", selfId, msg);
                     actor.process(msg);
-                } catch (TbRuleNodeUpdateException updateException){
+                } catch (TbRuleNodeUpdateException updateException) {
                     stopReason = TbActorStopReason.INIT_FAILED;
                     destroy();
                 } catch (Throwable t) {
@@ -175,6 +176,11 @@ public final class TbActorMailbox implements TbActorCtx {
     @Override
     public void broadcastToChildren(TbActorMsg msg) {
         system.broadcastToChildren(selfId, msg);
+    }
+
+    @Override
+    public void broadcastToChildrenByType(TbActorMsg msg, EntityType entityType) {
+        broadcastToChildren(msg, actorId -> entityType.equals(actorId.getEntityType()));
     }
 
     @Override

--- a/common/actor/src/main/java/org/thingsboard/server/actors/TbEntityActorId.java
+++ b/common/actor/src/main/java/org/thingsboard/server/actors/TbEntityActorId.java
@@ -16,6 +16,7 @@
 package org.thingsboard.server.actors;
 
 import lombok.Getter;
+import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.id.EntityId;
 
 import java.util.Objects;
@@ -45,5 +46,10 @@ public class TbEntityActorId implements TbActorId {
     @Override
     public int hashCode() {
         return Objects.hash(entityId);
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return entityId.getEntityType();
     }
 }

--- a/common/actor/src/main/java/org/thingsboard/server/actors/TbStringActorId.java
+++ b/common/actor/src/main/java/org/thingsboard/server/actors/TbStringActorId.java
@@ -15,6 +15,8 @@
  */
 package org.thingsboard.server.actors;
 
+import org.thingsboard.server.common.data.EntityType;
+
 import java.util.Objects;
 
 public class TbStringActorId implements TbActorId {
@@ -41,5 +43,10 @@ public class TbStringActorId implements TbActorId {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    @Override
+    public EntityType getEntityType() {
+        return null;
     }
 }


### PR DESCRIPTION
Now we have one scheduled message per tenant and not one per device.