### PR TITLE
[3.3.3]improved removing timeseries/attributes

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
@@ -331,7 +331,7 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
                             if (subscriptionUpdate == null) {
                                 subscriptionUpdate = new ArrayList<>();
                             }
-                            subscriptionUpdate.add(new BasicTsKvEntry(0, new StringDataEntry(key, null)));
+                            subscriptionUpdate.add(new BasicTsKvEntry(0, new StringDataEntry(key, "")));
                         }
                     }
                     return subscriptionUpdate;
@@ -355,7 +355,7 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
                             if (subscriptionUpdate == null) {
                                 subscriptionUpdate = new ArrayList<>();
                             }
-                            subscriptionUpdate.add(new BasicTsKvEntry(0, new StringDataEntry(key, null)));
+                            subscriptionUpdate.add(new BasicTsKvEntry(0, new StringDataEntry(key, "")));
                         }
                     }
                     return subscriptionUpdate;

--- a/ui-ngx/src/app/modules/home/models/datasource/attribute-datasource.ts
+++ b/ui-ngx/src/app/modules/home/models/datasource/attribute-datasource.ts
@@ -89,7 +89,7 @@ export class AttributeDatasource implements DataSource<AttributeData> {
                   pageLink: PageLink): Observable<PageData<AttributeData>> {
     return this.getAllAttributes(entityId, attributesScope).pipe(
       map((data) => {
-        const filteredData = data.filter(attrData => attrData.lastUpdateTs !== 0 && attrData.value !== null);
+        const filteredData = data.filter(attrData => attrData.lastUpdateTs !== 0 && attrData.value !== '');
         return pageLink.filterData(filteredData);
       })
     );


### PR DESCRIPTION
The value when getting timeseries or attributes which is absent and deleting the timeseries or attributes by WS should be the same.
get: coordinates: {ts: 0, value: ""}
delete: coordinates: {ts: 0, value: null}