### PR TITLE
[3.3.3] Fix events deletion

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/event/BaseEventService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/event/BaseEventService.java
@@ -137,10 +137,6 @@ public class BaseEventService implements EventService {
             eventDao.removeAllByIds(eventsPageData.getData().stream()
                     .map(IdBased::getUuidId)
                     .collect(Collectors.toList()));
-
-            if (eventsPageData.hasNext()) {
-                eventsPageLink = eventsPageLink.nextPageLink();
-            }
         } while (eventsPageData.hasNext());
     }
 


### PR DESCRIPTION
We must not change page number of a deletion page link. If amount of events to delete is larger then 1000 (batch size) in a couple of times, only some part of events would be deleted (because after we delete a page, we increase the page number, and then events that are now on the previous page are left untouched, and so on). 
P.s. It was like that before, didn't notice when developed the events clearing api