### PR TITLE
[3.x] Caffeine cache stats 

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -379,6 +379,9 @@ cache:
   attributes:
     # make sure that if cache.type is 'redis' and cache.attributes.enabled is 'true' that you change 'maxmemory-policy' Redis config property to 'allkeys-lru', 'allkeys-lfu' or 'allkeys-random'
     enabled: "${CACHE_ATTRIBUTES_ENABLED:true}"
+  stats:
+    enabled: "${CACHE_STATS_ENABLED:true}"
+    interval: "${CACHE_STATS_INTERVAL:60}"
 
 caffeine:
   specs:

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -239,6 +239,8 @@ cassandra:
     # Specify partitioning size for timestamp key-value storage. Example: MINUTES, HOURS, DAYS, MONTHS, INDEFINITE
     ts_key_value_partitioning: "${TS_KV_PARTITIONING:MONTHS}"
     ts_key_value_partitions_max_cache_size: "${TS_KV_PARTITIONS_MAX_CACHE_SIZE:100000}"
+    ts_key_value_partitions_cache_stats_enabled: "${TS_KV_PARTITIONS_CACHE_STATS_ENABLED:true}"
+    ts_key_value_partitions_cache_stats_interval: "${TS_KV_PARTITIONS_CACHE_STATS_INTERVAL:60}"
     ts_key_value_ttl: "${TS_KV_TTL:0}"
     events_ttl: "${TS_EVENTS_TTL:0}"
     # Specify TTL of debug log in seconds. The current value corresponds to one week

--- a/common/cache/pom.xml
+++ b/common/cache/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>data</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.thingsboard.common</groupId>
+            <artifactId>util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>


### PR DESCRIPTION
Caffeine cache stats for general and Cassandra ts partition cache

This feature is intended to able tune-up caches based on the hit ratio.

![image](https://user-images.githubusercontent.com/79898499/150360047-de5244ea-d09d-4e7d-9fb2-36e7967eacda.png)

for the Cassandra

![image](https://user-images.githubusercontent.com/79898499/150378215-bf11ab39-9eaf-4eea-be09-fcde5370c998.png)

more about Caffeine stats - https://github.com/ben-manes/caffeine/wiki/Statistics
