### PR TITLE
[3.3.3] added updating session metadata if attributes/rpc subscription was sent by this way

### DIFF
--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
@@ -510,6 +510,16 @@ public class DefaultTransportService implements TransportService {
     public void process(TransportToDeviceActorMsg msg, TransportServiceCallback<Void> callback) {
         TransportProtos.SessionInfoProto sessionInfo = msg.getSessionInfo();
         if (checkLimits(sessionInfo, msg, callback)) {
+            SessionMetaData sessionMetaData = sessions.get(toSessionId(sessionInfo));
+            if (sessionMetaData != null) {
+                if (msg.hasSubscribeToAttributes()) {
+                    sessionMetaData.setSubscribedToAttributes(true);
+                }
+                if (msg.hasSubscribeToRPC()) {
+                    sessionMetaData.setSubscribedToRPC(true);
+                }
+            }
+
             reportActivityInternal(sessionInfo);
             sendToDeviceActor(sessionInfo, msg, callback);
         }


### PR DESCRIPTION
If we send attributes/rpc subscription by `public void process(TransportToDeviceActorMsg msg, TransportServiceCallback<Void> callback)` then `SubscriptionInfo :{attributeSubscription: false, rpcSubscription: false}`