### PR TITLE
[3.4] Prohibit deletion of device profiles that are referenced by OTA update packages

### DIFF
--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/ota/OtaPackageService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/ota/OtaPackageService.java
@@ -51,4 +51,7 @@ public interface OtaPackageService {
     void deleteOtaPackagesByTenantId(TenantId tenantId);
 
     long sumDataSizeByTenantId(TenantId tenantId);
+
+    boolean existsByDeviceProfileId(DeviceProfileId deviceProfileId);
+
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceProfileServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceProfileServiceImpl.java
@@ -218,6 +218,9 @@ public class DeviceProfileServiceImpl extends AbstractEntityService implements D
         if (deviceProfile != null && deviceProfile.isDefault()) {
             throw new DataValidationException("Deletion of Default Device Profile is prohibited!");
         }
+        if (otaPackageService.existsByDeviceProfileId(deviceProfileId)) {
+            throw new DataValidationException("The device profile is referenced by OTA update package");
+        }
         this.removeDeviceProfile(tenantId, deviceProfile);
     }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/ota/BaseOtaPackageService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/ota/BaseOtaPackageService.java
@@ -224,6 +224,11 @@ public class BaseOtaPackageService implements OtaPackageService {
     }
 
     @Override
+    public boolean existsByDeviceProfileId(DeviceProfileId deviceProfileId) {
+        return otaPackageDao.existsByDeviceProfileId(deviceProfileId);
+    }
+
+    @Override
     public void deleteOtaPackagesByTenantId(TenantId tenantId) {
         log.trace("Executing deleteOtaPackagesByTenantId, tenantId [{}]", tenantId);
         validateId(tenantId, INCORRECT_TENANT_ID + tenantId);

--- a/dao/src/main/java/org/thingsboard/server/dao/ota/OtaPackageDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/ota/OtaPackageDao.java
@@ -16,11 +16,14 @@
 package org.thingsboard.server.dao.ota;
 
 import org.thingsboard.server.common.data.OtaPackage;
+import org.thingsboard.server.common.data.id.DeviceProfileId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.dao.Dao;
-import org.thingsboard.server.dao.TenantEntityDao;
 import org.thingsboard.server.dao.TenantEntityWithDataDao;
 
 public interface OtaPackageDao extends Dao<OtaPackage>, TenantEntityWithDataDao {
     Long sumDataSizeByTenantId(TenantId tenantId);
+
+    boolean existsByDeviceProfileId(DeviceProfileId deviceProfileId);
+
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/ota/JpaOtaPackageDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/ota/JpaOtaPackageDao.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Component;
 import org.thingsboard.server.common.data.OtaPackage;
+import org.thingsboard.server.common.data.id.DeviceProfileId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.dao.ota.OtaPackageDao;
 import org.thingsboard.server.dao.model.sql.OtaPackageEntity;
@@ -48,4 +49,10 @@ public class JpaOtaPackageDao extends JpaAbstractSearchTextDao<OtaPackageEntity,
     public Long sumDataSizeByTenantId(TenantId tenantId) {
         return otaPackageRepository.sumDataSizeByTenantId(tenantId.getId());
     }
+
+    @Override
+    public boolean existsByDeviceProfileId(DeviceProfileId deviceProfileId) {
+        return otaPackageRepository.existsByDeviceProfileId(deviceProfileId.getId());
+    }
+
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/ota/OtaPackageRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/ota/OtaPackageRepository.java
@@ -19,11 +19,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.thingsboard.server.dao.model.sql.OtaPackageEntity;
-import org.thingsboard.server.dao.model.sql.OtaPackageInfoEntity;
 
 import java.util.UUID;
 
 public interface OtaPackageRepository extends CrudRepository<OtaPackageEntity, UUID> {
     @Query(value = "SELECT COALESCE(SUM(ota.data_size), 0) FROM ota_package ota WHERE ota.tenant_id = :tenantId AND ota.data IS NOT NULL", nativeQuery = true)
     Long sumDataSizeByTenantId(@Param("tenantId") UUID tenantId);
+
+    boolean existsByDeviceProfileId(UUID deviceProfileId);
+
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseOtaPackageServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseOtaPackageServiceTest.java
@@ -487,8 +487,10 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
             thrown.expectMessage("The otaPackage referenced by the device profile cannot be deleted!");
             otaPackageService.deleteOtaPackage(tenantId, savedFirmware.getId());
         } finally {
-            deviceProfileService.deleteDeviceProfile(tenantId, savedDeviceProfile.getId());
+            savedDeviceProfile.setFirmwareId(null);
+            deviceProfileService.saveDeviceProfile(savedDeviceProfile);
             otaPackageService.deleteOtaPackage(tenantId, savedFirmware.getId());
+            deviceProfileService.deleteDeviceProfile(tenantId, savedDeviceProfile.getId());
         }
     }
 


### PR DESCRIPTION
Before, after deleting device profile that is used by OTA update package, the following error was occurring when opening OTA update details:
![image](https://user-images.githubusercontent.com/56742475/151144790-e1e5c6f7-33d1-45ca-87d0-ee14d489d6d5.png)

The deletion was being allowed due to no foreign key constraint in table ota_package for device_profile_id field in DB.