### PR TITLE
[3.3.3] Fix RPC call from cloud to edge

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/DeviceController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/DeviceController.java
@@ -875,9 +875,6 @@ public class DeviceController extends BaseController {
 
             Device savedDevice = checkNotNull(deviceService.assignDeviceToEdge(getCurrentUser().getTenantId(), deviceId, edgeId));
 
-            tbClusterService.pushMsgToCore(new DeviceEdgeUpdateMsg(savedDevice.getTenantId(),
-                    savedDevice.getId(), edgeId), null);
-
             logEntityAction(deviceId, savedDevice,
                     savedDevice.getCustomerId(),
                     ActionType.ASSIGNED_TO_EDGE, null, strDeviceId, strEdgeId, edge.getName());
@@ -917,9 +914,6 @@ public class DeviceController extends BaseController {
             Device device = checkDeviceId(deviceId, Operation.READ);
 
             Device savedDevice = checkNotNull(deviceService.unassignDeviceFromEdge(getCurrentUser().getTenantId(), deviceId, edgeId));
-
-            tbClusterService.pushMsgToCore(new DeviceEdgeUpdateMsg(savedDevice.getTenantId(),
-                    savedDevice.getId(), null), null);
 
             logEntityAction(deviceId, device,
                     device.getCustomerId(),

--- a/application/src/main/java/org/thingsboard/server/controller/DeviceController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/DeviceController.java
@@ -38,7 +38,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.thingsboard.rule.engine.api.msg.DeviceCredentialsUpdateNotificationMsg;
-import org.thingsboard.rule.engine.api.msg.DeviceEdgeUpdateMsg;
 import org.thingsboard.server.common.data.ClaimRequest;
 import org.thingsboard.server.common.data.Customer;
 import org.thingsboard.server.common.data.DataConstants;

--- a/common/data/src/main/java/org/thingsboard/server/common/data/id/EdgeId.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/id/EdgeId.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
+import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.ConcurrentReferenceHashMap.ReferenceType;
 import org.thingsboard.server.common.data.EntityType;
 
 import java.util.UUID;
@@ -26,6 +28,9 @@ import java.util.UUID;
 public class EdgeId extends UUIDBased implements EntityId {
 
     private static final long serialVersionUID = 1L;
+
+    @JsonIgnore
+    static final ConcurrentReferenceHashMap<UUID, EdgeId> edges = new ConcurrentReferenceHashMap<>(16, ReferenceType.SOFT);
 
     @JsonCreator
     public EdgeId(@JsonProperty("id") UUID id) {
@@ -40,5 +45,10 @@ public class EdgeId extends UUIDBased implements EntityId {
     @Override
     public EntityType getEntityType() {
         return EntityType.EDGE;
+    }
+
+    @JsonCreator
+    public static EdgeId fromUUID(@JsonProperty("id") UUID id) {
+        return edges.computeIfAbsent(id, EdgeId::new);
     }
 }


### PR DESCRIPTION
At the moment to be able to send RPC requests from cloud to edge, TB service must be restarted, once device is provisioned to edge. 