### PR TITLE
[3.3.4] UI: Alarms table widget allows alarms to be cleared when "Allow alarms clear" is disabled

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/alarms-table-widget.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/alarms-table-widget.component.html
@@ -51,7 +51,7 @@
                 (click)="ackAlarms($event)">
           <mat-icon>done</mat-icon>
         </button>
-        <button mat-button mat-icon-button
+        <button *ngIf="ctx.settings.allowClear" mat-button mat-icon-button
                 [disabled]="isLoading$ | async"
                 matTooltip="{{ 'alarm.clear' | translate }}"
                 matTooltipPosition="above"


### PR DESCRIPTION
## Pull Request description
Issue: https://github.com/thingsboard/thingsboard/issues/6022

I fix bug with clear alarm. When we disable "Allow alarms clear" but enable "Enable alarms selection", the users can't clear an alarm. They can select an alarm, and in the top right corner, they haven't a "clear" button. 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conficts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)
