### PR TITLE
[3.3.4] Fix SNMP transport initialization error

### DIFF
--- a/common/transport/snmp/src/main/java/org/thingsboard/server/transport/snmp/SnmpTransportContext.java
+++ b/common/transport/snmp/src/main/java/org/thingsboard/server/transport/snmp/SnmpTransportContext.java
@@ -73,7 +73,7 @@ public class SnmpTransportContext extends TransportContext {
     private final Map<DeviceId, DeviceSessionContext> sessions = new ConcurrentHashMap<>();
     private final Collection<DeviceId> allSnmpDevicesIds = new ConcurrentLinkedDeque<>();
 
-    @AfterStartUp(order = 2)
+    @AfterStartUp(order = Integer.MAX_VALUE)
     public void fetchDevicesAndEstablishSessions() {
         log.info("Initializing SNMP devices sessions");
 


### PR DESCRIPTION
## Pull Request description

This fixes the issue https://github.com/thingsboard/thingsboard/issues/6025 

The problem was occurring because of an improper SNMP transport context startup order: it had the order value equal to 2, the same as transport API template (that is needed for the transport context to get the list of SNMP devices and process initialization), and due to Spring performing an arbitrary ordering when order values are same, the SNMP transport context sometimes was being started before the necessary transport API template. 
This problem only affects a monolith TB setup.
Tested locally with docker-compose.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



