### PR TITLE
[3.3.4] UI: Decode base64 and return normal value

### DIFF
--- a/ui-ngx/src/app/core/utils.ts
+++ b/ui-ngx/src/app/core/utils.ts
@@ -185,6 +185,12 @@ export function objToBase64(obj: any): string {
     }));
 }
 
+export function base64toString(b64Encoded: string): string {
+  return decodeURIComponent(atob(b64Encoded).split('').map((c) => {
+    return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+  }).join(''));
+}
+
 export function objToBase64URI(obj: any): string {
   return encodeURIComponent(objToBase64(obj));
 }

--- a/ui-ngx/src/app/modules/home/components/event/event-content-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/event/event-content-dialog.component.ts
@@ -27,6 +27,7 @@ import { getAce } from '@shared/models/ace/ace.models';
 import { Observable } from 'rxjs/internal/Observable';
 import { beautifyJs } from '@shared/models/beautify.models';
 import { of } from 'rxjs';
+import { base64toString, isLiteralObject } from '@core/utils';
 
 export interface EventContentDialogData {
   content: string;
@@ -64,6 +65,14 @@ export class EventContentDialogComponent extends DialogComponent<EventContentDia
     this.createEditor(this.eventContentEditorElmRef, this.content);
   }
 
+  isJson(str) {
+    try {
+      return isLiteralObject(JSON.parse(str));
+    } catch (e) {
+      return false;
+    }
+  }
+
   createEditor(editorElementRef: ElementRef, content: string) {
     const editorElement = editorElementRef.nativeElement;
     let mode = 'java';
@@ -72,6 +81,16 @@ export class EventContentDialogComponent extends DialogComponent<EventContentDia
       mode = contentTypesMap.get(this.contentType).code;
       if (this.contentType === ContentType.JSON && content) {
         content$ = beautifyJs(content, {indent_size: 4});
+      } else if (this.contentType === ContentType.BINARY && content) {
+        try {
+          const decodedData = base64toString(content);
+          if (this.isJson(decodedData)) {
+            mode = 'json';
+            content$ = beautifyJs(decodedData, {indent_size: 4});
+          } else {
+            content$ = of(decodedData);
+          }
+        } catch (e) {}
       }
     }
     if (!content$) {


### PR DESCRIPTION
## Pull Request description

This PR added the ability to decode base64 income information of  Events to normal view and fixed the issue [#5697](https://github.com/thingsboard/thingsboard/issues/5697).

Before fix:
![Screenshot from 2022-01-21 13-32-15](https://user-images.githubusercontent.com/83352633/150522706-e6ce5904-1b63-4359-917b-61a638898e9f.png)
After:
![Screenshot from 2022-01-21 13-34-25](https://user-images.githubusercontent.com/83352633/150522732-540ed860-e6a9-4432-bc04-8a3c065e3091.png)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




