### PR TITLE
[3.3.4] UI: Fixed image map widget not updated image after firt load empty data

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/maps/common-maps-utils.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/maps/common-maps-utils.ts
@@ -123,6 +123,7 @@ export function aspectCache(imageUrl: string): Observable<number> {
       return aspect;
     }));
   }
+  return of(0);
 }
 
 export type TranslateFunc = (key: string, defaultTranslation?: string) => string;

--- a/ui-ngx/src/app/modules/home/components/widget/lib/maps/providers/image-map.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/maps/providers/image-map.ts
@@ -94,8 +94,10 @@ export class ImageMap extends LeafletMap {
         type: widgetType.latest,
         callbacks: {
           onDataUpdated: (subscription) => {
-            result.next([subscription.data[0]?.data, isUpdate]);
-            isUpdate = true;
+            if (subscription.data[0]?.data[0]?.length > 0) {
+              result.next([subscription.data[0].data, isUpdate]);
+              isUpdate = true;
+            }
           }
         }
       };
@@ -126,7 +128,6 @@ export class ImageMap extends LeafletMap {
 
     private imageFromAlias(alias: Observable<[DataSet, boolean]>): Observable<MapImage> {
       return alias.pipe(
-        filter(result => result[0].length > 0),
         mergeMap(res => {
           const mapImage: MapImage = {
             imageUrl: res[0][0][1],


### PR DESCRIPTION
## Pull Request description

When the image card widget is set to load images from the entity attribute and when loading the default entity does not have this attribute, the data will no longer be loaded, even when there is a switch on the entity that has this attribute. Fixed #6092 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



