### PR TITLE
 [3.6] lwm2m: Observe Composite

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
@@ -303,7 +303,7 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractWebsocketTest
         lwM2MTestClient = new LwM2MTestClient(this.executor, endpoint);
         int clientPort = SocketUtils.findAvailableUdpPort();
         lwM2MTestClient.init(security, coapConfig, clientPort, isRpc, isBootstrap, this.shortServerId, this.shortServerIdBs,
-                securityBs, this.defaultLwM2mUplinkMsgHandlerTest, this.clientContextTest);
+                securityBs, this.defaultLwM2mUplinkMsgHandlerTest, this.clientContextTest, this.resources);
     }
 
     private void clientDestroy() {

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/Lwm2mTestHelper.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/Lwm2mTestHelper.java
@@ -17,8 +17,6 @@ package org.thingsboard.server.transport.lwm2m;
 
 public class Lwm2mTestHelper {
 
-    // Models
-    public static final String[] resources = new String[]{"0.xml", "1.xml", "2.xml", "3.xml", "5.xml", "6.xml", "9.xml", "19.xml", "3303.xml"};
     public static final int BINARY_APP_DATA_CONTAINER = 19;
     public static final int TEMPERATURE_SENSOR = 3303;
 
@@ -34,12 +32,14 @@ public class Lwm2mTestHelper {
     public static final int RESOURCE_ID_2 = 2;
     public static final int RESOURCE_ID_3 = 3;
     public static final int RESOURCE_ID_4 = 4;
+    public static final int RESOURCE_ID_5 = 5;
     public static final int RESOURCE_ID_7 = 7;
     public static final int RESOURCE_ID_8 = 8;
     public static final int RESOURCE_ID_9 = 9;
     public static final int RESOURCE_ID_11 = 11;
     public static final int RESOURCE_ID_14 = 14;
     public static final int RESOURCE_ID_15 = 15;
+    public static final int RESOURCE_INSTANCE_ID_0 = 0;
     public static final int RESOURCE_INSTANCE_ID_2 = 2;
 
     public static final String RESOURCE_ID_NAME_3_9 = "batteryLevel";

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/AbstractOtaLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/AbstractOtaLwM2MIntegrationTest.java
@@ -29,7 +29,7 @@ import static org.thingsboard.server.common.data.ota.OtaPackageType.SOFTWARE;
 @DaoSqlTest
 public abstract class AbstractOtaLwM2MIntegrationTest extends AbstractLwM2MIntegrationTest {
 
-    private final  String[] RESOURCES_OTA = new String[]{"3.xml", "5.xml", "9.xml"};
+    private final  String[] RESOURCES_OTA = new String[]{"0.xml", "1.xml", "2.xml", "3.xml", "5.xml", "6.xml", "9.xml", "19.xml", "3303.xml"};
     protected static final String CLIENT_ENDPOINT_WITHOUT_FW_INFO = "WithoutFirmwareInfoDevice";
     protected static final String CLIENT_ENDPOINT_OTA5 = "Ota5_Device";
     protected static final String CLIENT_ENDPOINT_OTA9 = "Ota9_Device";

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcLwM2MIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package org.thingsboard.server.transport.lwm2m.rpc;
 
-import org.junit.Before;
 import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MDeviceCredentials;
 import org.thingsboard.server.common.data.device.profile.Lwm2mDeviceProfileTransportConfiguration;
@@ -44,7 +43,6 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_0;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_14;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_9;
-import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.resources;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
 
 @DaoSqlTest
@@ -74,15 +72,9 @@ public abstract class AbstractRpcLwM2MIntegrationTest extends AbstractLwM2MInteg
     protected String idVer_19_0_0;
 
     public AbstractRpcLwM2MIntegrationTest() {
-        setResources(resources);
     }
 
-    @Before
-    public void startInitRPC() throws Exception {
-        initRpc();
-    }
-
-    private void initRpc () throws Exception {
+    public void initRpc () throws Exception {
         String endpoint = DEVICE_ENDPOINT_RPC_PREF + endpointSequence.incrementAndGet();
         createNewClient(SECURITY_NO_SEC, COAP_CONFIG, true, endpoint, false, null);
         expectedObjects = ConcurrentHashMap.newKeySet();

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.rpc;
+
+import org.junit.Before;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+
+@DaoSqlTest
+public abstract class AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest extends AbstractRpcLwM2MIntegrationTest{
+    private final String[] RESOURCES_RPC_MULTIPLE_19 = new String[]{"0.xml", "1.xml", "2.xml", "3.xml", "5.xml", "6.xml", "9.xml", "19.xml", "3303.xml"};
+
+    @Before
+    public void startInitRPC() throws Exception {
+        initRpc();
+    }
+
+    public AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest () {
+        setResources(this.RESOURCES_RPC_MULTIPLE_19);
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcWithObjectId19_SingleResourceLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcWithObjectId19_SingleResourceLwM2MIntegrationTest.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.rpc;
+
+import org.junit.Before;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+
+@DaoSqlTest
+public abstract class AbstractRpcWithObjectId19_SingleResourceLwM2MIntegrationTest extends AbstractRpcLwM2MIntegrationTest{
+
+    private final String[] RESOURCES_RPC_SINGLE_19 = new String[]{"0.xml", "1.xml", "2.xml", "3.xml", "5.xml", "6.xml", "9.xml", "19_1_0.xml", "3303.xml"};
+
+    @Before
+    public void startInitRPC() throws Exception {
+        initRpc();
+    }
+
+    public AbstractRpcWithObjectId19_SingleResourceLwM2MIntegrationTest() {
+        setResources(this.RESOURCES_RPC_SINGLE_19);
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationCreateTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationCreateTest.java
@@ -20,7 +20,7 @@ import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.Test;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcLwM2MIntegrationTest;
+import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -30,8 +30,7 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INST
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_12;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_0;
 
-
-public class RpcLwm2mIntegrationCreateTest extends AbstractRpcLwM2MIntegrationTest {
+public class RpcLwm2mIntegrationCreateTest extends AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest {
 
     /**
      * Create  {"id":"/19_1.1","value":{"0":{"0":"00AC"}, "1":1}}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationDeleteTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationDeleteTest.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.leshan.core.ResponseCode;
 import org.junit.Test;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcLwM2MIntegrationTest;
+import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -28,8 +28,7 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INST
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_12;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_7;
 
-
-public class RpcLwm2mIntegrationDeleteTest extends AbstractRpcLwM2MIntegrationTest {
+public class RpcLwm2mIntegrationDeleteTest extends AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest {
 
     /**
      * if there is such an instance

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationDiscoverTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationDiscoverTest.java
@@ -21,7 +21,7 @@ import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.Test;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcLwM2MIntegrationTest;
+import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -34,8 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_0;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_2;
 
-
-public class RpcLwm2mIntegrationDiscoverTest extends AbstractRpcLwM2MIntegrationTest {
+public class RpcLwm2mIntegrationDiscoverTest extends AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest {
 
     /**
      * DiscoverAll

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationExecuteTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationExecuteTest.java
@@ -20,7 +20,7 @@ import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.Test;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcLwM2MIntegrationTest;
+import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -32,8 +32,7 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_8;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_9;
 
-
-public class RpcLwm2mIntegrationExecuteTest extends AbstractRpcLwM2MIntegrationTest {
+public class RpcLwm2mIntegrationExecuteTest extends AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest {
 
 
     /**

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationObserveComposite_ObjectId19_MultipleResourceTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationObserveComposite_ObjectId19_MultipleResourceTest.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.rpc.sql;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.eclipse.leshan.core.ResponseCode;
+import org.junit.Test;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_1;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_14;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_3;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_5;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_7;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_19_0_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_19_1_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_3_14;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_3_9;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_INSTANCE_ID_0;
+import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.fromVersionedIdToObjectId;
+
+public class RpcLwm2mIntegrationObserveComposite_ObjectId19_MultipleResourceTest extends AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest {
+
+    /**
+     *  ObserveComposite {"ids":["5/0/7", "5/0/5", "5/0/3", "3/0/9"]} - BAD_REQUEST
+     * @throws Exception
+     */
+    @Test
+    public void testObserveCompositeThereAreObservationOneResource_Result_BAD_REQUEST_Value_ObservationAlreadyRegistered() throws Exception {
+        String expectedIdVer5_0_7 = objectInstanceIdVer_5 + "/" + RESOURCE_ID_7;
+        String expectedIdVer5_0_5= objectInstanceIdVer_5 + "/" + RESOURCE_ID_5;
+        String expectedIdVer5_0_3 = objectInstanceIdVer_5 + "/" + RESOURCE_ID_3;
+        String expectedIds = "[\"" + expectedIdVer5_0_7 + "\", \"" + expectedIdVer5_0_5 + "\", \"" + expectedIdVer5_0_3 + "\", \"" + idVer_3_0_9 + "\"]";
+        String actualResult =  sendCompositeRPCByIds("ObserveComposite", expectedIds);
+        ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
+        assertEquals(ResponseCode.BAD_REQUEST.getName(), rpcActualResult.get("result").asText());
+        String expectedResult = "Observation one or all of this list is already registered!";
+        assertEquals(expectedResult, rpcActualResult.get("error").asText());
+    }
+
+    /**
+     *  ObserveComposite {"ids":["5/0/7", "5/0/5", "5/0/3", "3/0/9", "19/1/0/0"]} - Ok
+     * @throws Exception
+     */
+    @Test
+    public void testObserveCompositeAnyResources_Result_CONTENT_Value_LwM2mSingleResource_LwM2mResourceInstance() throws Exception {
+        String actualResultCancelAll = sendObserve("ObserveCancelAll", null);
+        ObjectNode rpcActualResultCancelAll = JacksonUtil.fromString(actualResultCancelAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultCancelAll.get("result").asText());
+        String expectedIdVer5_0_7 = objectInstanceIdVer_5 + "/" + RESOURCE_ID_7;
+        String expectedIdVer5_0_5= objectInstanceIdVer_5 + "/" + RESOURCE_ID_5;
+        String expectedIdVer5_0_3 = objectInstanceIdVer_5 + "/" + RESOURCE_ID_3;
+        String expectedIdVer19_1_0_0 = objectIdVer_19 + "/" + OBJECT_INSTANCE_ID_1 + "/" + RESOURCE_ID_0 + "/" + RESOURCE_INSTANCE_ID_0;
+        String expectedIds = "[\"" + expectedIdVer5_0_7 + "\", \"" + expectedIdVer5_0_5 + "\", \"" + expectedIdVer5_0_3 + "\", \"" + idVer_3_0_9 + "\", \"" + expectedIdVer19_1_0_0 + "\"]";
+        String actualResult =  sendCompositeRPCByIds("ObserveComposite", expectedIds);
+        ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult.get("result").asText());
+        String actualValues = rpcActualResult.get("value").asText();
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer5_0_7) + "=LwM2mSingleResource"));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer5_0_3) + "=LwM2mSingleResource"));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer5_0_5 + "=LwM2mSingleResource")));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(idVer_3_0_9) + "=LwM2mSingleResource"));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer19_1_0_0) + "=LwM2mResourceInstance"));
+    }
+
+    /**
+     *  ObserveComposite {"ids":["5/0/7", "5/0/5", "5/0/3", "3/0/9", "19/1/0"]} - Ok
+     * @throws Exception
+     */
+    @Test
+    public void testObserveCompositeAnyResources_Result_CONTENT_Value_LwM2mSingleResource_LwM2mMultipleResource() throws Exception {
+        String actualResultCancelAll = sendObserve("ObserveCancelAll", null);
+        ObjectNode rpcActualResultCancelAll = JacksonUtil.fromString(actualResultCancelAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultCancelAll.get("result").asText());
+        String expectedIdVer5_0_7 = objectInstanceIdVer_5 + "/" + RESOURCE_ID_7;
+        String expectedIdVer5_0_5= objectInstanceIdVer_5 + "/" + RESOURCE_ID_5;
+        String expectedIdVer5_0_3 = objectInstanceIdVer_5 + "/" + RESOURCE_ID_3;
+        String expectedIdVer19_1_0 = objectIdVer_19 + "/" + OBJECT_INSTANCE_ID_1 + "/" + RESOURCE_ID_0;
+        String expectedIds = "[\"" + expectedIdVer5_0_7 + "\", \"" + expectedIdVer5_0_5 + "\", \"" + expectedIdVer5_0_3 + "\", \"" + idVer_3_0_9 + "\", \"" + expectedIdVer19_1_0 + "\"]";
+        String actualResult =  sendCompositeRPCByIds("ObserveComposite", expectedIds);
+        ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult.get("result").asText());
+        String actualValues = rpcActualResult.get("value").asText();
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer5_0_7) + "=LwM2mSingleResource"));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer5_0_3) + "=LwM2mSingleResource"));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer5_0_5 + "=LwM2mSingleResource")));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(idVer_3_0_9) + "=LwM2mSingleResource"));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer19_1_0) + "=LwM2mMultipleResource"));
+    }
+
+    /**
+     *  ObserveComposite with keyName {"keys":["batteryLevel", "UtfOffset", "dataRead", "dataWrite"]} - Ok
+     * @throws Exception
+     */
+    @Test
+    public void testObserveCompositeWithKeyName_Result_CONTENT_Value_SingleResources() throws Exception {
+        String actualResultCancelAll = sendObserve("ObserveCancelAll", null);
+        ObjectNode rpcActualResultCancelAll = JacksonUtil.fromString(actualResultCancelAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultCancelAll.get("result").asText());
+        String expectedKey3_0_9 = RESOURCE_ID_NAME_3_9;
+        String expectedKey3_0_14 = RESOURCE_ID_NAME_3_14;
+        String expectedKey19_0_0 = RESOURCE_ID_NAME_19_0_0;
+        String expectedKey19_1_0 = RESOURCE_ID_NAME_19_1_0;
+        String expectedKeys = "[\"" + expectedKey3_0_9 + "\", \"" + expectedKey3_0_14 + "\", \"" + expectedKey19_0_0 + "\", \"" + expectedKey19_1_0 + "\"]";
+        String actualResult = sendCompositeRPCByKeys("ObserveComposite", expectedKeys);
+        ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult.get("result").asText());
+        String actualValues = rpcActualResult.get("value").asText();
+        String expectedIdVer3_0_14 = objectInstanceIdVer_3 + "/" + RESOURCE_ID_14;
+        String expectedIdVer19_0_0 = objectIdVer_19 + "/" + OBJECT_INSTANCE_ID_0 + "/" + RESOURCE_ID_0;
+        String expectedIdVer19_1_0 = objectIdVer_19 + "/" + OBJECT_INSTANCE_ID_1 + "/" + RESOURCE_ID_0;
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer3_0_14)));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer19_0_0)));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer19_1_0)));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(idVer_3_0_9)));
+    }
+
+    /**
+     *  ObserveComposite with keyName {"keys":["batteryLevel", "UtfOffset", "dataRead", "dataWrite"]} - - BAD_REQUEST
+     * @throws Exception
+     */
+    @Test
+    public void testObserveCompositeWithKeyNameThereAreObservationOneResource_Result_BAD_REQUEST_Value_ObservationAlreadyRegistered() throws Exception {
+        String expectedKey3_0_9 = RESOURCE_ID_NAME_3_9;
+        String expectedKey3_0_14 = RESOURCE_ID_NAME_3_14;
+        String expectedKey19_0_0 = RESOURCE_ID_NAME_19_0_0;
+        String expectedKey19_1_0 = RESOURCE_ID_NAME_19_1_0;
+        String expectedKeys = "[\"" + expectedKey3_0_9 + "\", \"" + expectedKey3_0_14 + "\", \"" + expectedKey19_0_0 + "\", \"" + expectedKey19_1_0 + "\"]";
+        String actualResult = sendCompositeRPCByKeys("ObserveComposite", expectedKeys);
+        ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
+        assertEquals(ResponseCode.BAD_REQUEST.getName(), rpcActualResult.get("result").asText());
+        String expectedResult = "Observation one or all of this list is already registered!";
+        assertEquals(expectedResult, rpcActualResult.get("error").asText());
+    }
+
+    /**
+     *  ObserveReadAll
+     * {"result":"CONTENT","value":"[\"CompositeObservation: [/19/1/0\",\"/19/0/0\",\"/3/0/14\",\"/3/0/9]\"]"} - Ok
+     * @throws Exception
+     */
+    @Test
+    public void testObserveReadAll_Result_CONTENT_Value_CompositeObservation_Only() throws Exception {
+        String actualResultCancelAll = sendObserve("ObserveCancelAll", null);
+        ObjectNode rpcActualResultCancelAll = JacksonUtil.fromString(actualResultCancelAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultCancelAll.get("result").asText());
+        String expectedKey3_0_9 = RESOURCE_ID_NAME_3_9;
+        String expectedKey3_0_14 = RESOURCE_ID_NAME_3_14;
+        String expectedKey19_0_0 = RESOURCE_ID_NAME_19_0_0;
+        String expectedKey19_1_0 = RESOURCE_ID_NAME_19_1_0;
+        String expectedKeys = "[\"" + expectedKey3_0_9 + "\", \"" + expectedKey3_0_14 + "\", \"" + expectedKey19_0_0 + "\", \"" + expectedKey19_1_0 + "\"]";
+        String actualResult = sendCompositeRPCByKeys("ObserveComposite", expectedKeys);
+        ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult.get("result").asText());
+        String actualResultReadAll = sendCompositeRPCByKeys("ObserveReadAll", null);
+        ObjectNode rpcActualResultReadAll = JacksonUtil.fromString(actualResultReadAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultReadAll.get("result").asText());
+        String actualValues =  rpcActualResultReadAll.get("value").asText();
+        String expectedIdVer3_0_14 = objectInstanceIdVer_3 + "/" + RESOURCE_ID_14;
+        String expectedIdVer19_1_0 = objectIdVer_19 + "/" + OBJECT_INSTANCE_ID_1 + "/" + RESOURCE_ID_0;
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer3_0_14)));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(idVer_19_0_0)));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer19_1_0)));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(idVer_3_0_9)));
+        assertTrue(actualValues.contains("CompositeObservation: ["));
+    }
+
+    /**
+     *  ObserveReadAll
+     * {"result":"CONTENT","value":"{"result":"CONTENT","value":"["SingleObservation:/3/0/9","SingleObservation:/3/0/14","SingleObservation:/19/1/0/0","SingleObservation:/19/0/0"]"} - Ok
+     * @throws Exception
+     */
+    @Test
+    public void testObserveReadAll_Result_CONTENT_Value_SingleObservation_Only() throws Exception {
+        String actualResultCancelAll = sendObserve("ObserveCancelAll", null);
+        ObjectNode rpcActualResultCancelAll = JacksonUtil.fromString(actualResultCancelAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultCancelAll.get("result").asText());
+        String expectedIdVer3_0_14 = objectInstanceIdVer_3 + "/" + RESOURCE_ID_14;
+        String expectedIdVer19_1_0_0 = objectIdVer_19 + "/" + OBJECT_INSTANCE_ID_1 + "/" + RESOURCE_ID_0 + "/" + RESOURCE_INSTANCE_ID_0;
+        String actualResult3_0_9 = sendObserve("Observe", idVer_3_0_9);
+        ObjectNode rpcActualResult3_0_9 = JacksonUtil.fromString(actualResult3_0_9, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult3_0_9.get("result").asText());
+        String actualResult3_0_14 = sendObserve("Observe", expectedIdVer3_0_14);
+        ObjectNode rpcActualResult3_0_14 = JacksonUtil.fromString(actualResult3_0_14, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult3_0_14.get("result").asText());
+        String actualResult19_1_0_0 = sendObserve("Observe", expectedIdVer19_1_0_0);
+        ObjectNode rpcActualResult19_1_0_0 = JacksonUtil.fromString(actualResult19_1_0_0, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult19_1_0_0.get("result").asText());
+        String actualResult19_0_0 = sendObserve("Observe", idVer_19_0_0);
+        ObjectNode rpcActualResult19_0_0 = JacksonUtil.fromString(actualResult19_0_0, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult19_0_0.get("result").asText());
+        String actualResultReadAll = sendCompositeRPCByKeys("ObserveReadAll", null);
+        ObjectNode rpcActualResultReadAll = JacksonUtil.fromString(actualResultReadAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultReadAll.get("result").asText());
+        String actualValues =  rpcActualResultReadAll.get("value").asText();
+        assertTrue(actualValues.contains("SingleObservation:" + fromVersionedIdToObjectId(idVer_3_0_9)));
+        assertTrue(actualValues.contains("SingleObservation:" + fromVersionedIdToObjectId(expectedIdVer3_0_14)));
+        assertTrue(actualValues.contains("SingleObservation:" + fromVersionedIdToObjectId(expectedIdVer19_1_0_0)));
+        assertTrue(actualValues.contains("SingleObservation:" + fromVersionedIdToObjectId(idVer_19_0_0)));
+    }
+
+    private String sendObserve(String method, String params) throws Exception {
+        String sendRpcRequest;
+        if (params == null) {
+            sendRpcRequest = "{\"method\": \"" + method + "\"}";
+        }
+        else {
+            sendRpcRequest = "{\"method\": \"" + method + "\", \"params\": {\"id\": \"" + params + "\"}}";
+        }
+        return doPostAsync("/api/plugins/rpc/twoway/" + deviceId, sendRpcRequest, String.class, status().isOk());
+    }
+
+    private String sendCompositeRPCByIds(String method, String paths) throws Exception {
+        String setRpcRequest = "{\"method\": \"" + method + "\", \"params\": {\"ids\":" + paths + "}}";
+        return doPostAsync("/api/plugins/rpc/twoway/" + deviceId, setRpcRequest, String.class, status().isOk());
+    }
+
+    private String sendCompositeRPCByKeys(String method, String keys) throws Exception {
+        String setRpcRequest = "{\"method\": \"" + method + "\", \"params\": {\"keys\":" + keys + "}}";
+        return doPostAsync("/api/plugins/rpc/twoway/" + deviceId, setRpcRequest, String.class, status().isOk());
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationObserveTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationObserveTest.java
@@ -20,7 +20,7 @@ import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.Test;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcLwM2MIntegrationTest;
+import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest;
 
 import static org.eclipse.leshan.core.LwM2mId.ACCESS_CONTROL;
 import static org.junit.Assert.assertEquals;
@@ -32,7 +32,7 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_3;
 import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.fromVersionedIdToObjectId;
 
-public class RpcLwm2mIntegrationObserveTest extends AbstractRpcLwM2MIntegrationTest {
+public class RpcLwm2mIntegrationObserveTest extends AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest {
 
     /**
      * ObserveReadAll

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationObserveWriteRead_ObjectId19_SingleResourceTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationObserveWriteRead_ObjectId19_SingleResourceTest.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.rpc.sql;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.eclipse.leshan.core.ResponseCode;
+import org.junit.Test;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcWithObjectId19_SingleResourceLwM2MIntegrationTest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_1;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_14;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_3;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_5;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_7;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_19_0_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_19_1_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_3_14;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_3_9;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_INSTANCE_ID_0;
+import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.fromVersionedIdToObjectId;
+
+public class RpcLwm2mIntegrationObserveWriteRead_ObjectId19_SingleResourceTest extends AbstractRpcWithObjectId19_SingleResourceLwM2MIntegrationTest {
+
+    /**
+     *  ObserveComposite {"ids":["5/0/7", "5/0/5", "5/0/3", "3/0/9", "19/0/0/0"]} - Ok
+     *  Return: "... 19/0/0/0=null"
+     *  Observe {"id":"19/0/0"} - Ok
+     * @throws Exception
+     */
+    @Test
+    public void testObserveCompositeAnyResources_Result_CONTENT_Value_LwM2mSingleResource_LwM2mResourceInstanceNull_AfterRepeatOnlyObserve_Result_Ok() throws Exception {
+        String actualResultCancelAll = sendObserve("ObserveCancelAll", null);
+        ObjectNode rpcActualResultCancelAll = JacksonUtil.fromString(actualResultCancelAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultCancelAll.get("result").asText());
+        String expectedIdVer5_0_7 = objectInstanceIdVer_5 + "/" + RESOURCE_ID_7;
+        String expectedIdVer5_0_5= objectInstanceIdVer_5 + "/" + RESOURCE_ID_5;
+        String expectedIdVer5_0_3 = objectInstanceIdVer_5 + "/" + RESOURCE_ID_3;
+        String expectedIdVer19_0_0_0 = idVer_19_0_0 + "/" + RESOURCE_INSTANCE_ID_0;
+        String expectedIds = "[\"" + expectedIdVer5_0_7 + "\", \"" + expectedIdVer5_0_5 + "\", \"" + expectedIdVer5_0_3 + "\", \"" + idVer_3_0_9 + "\", \"" + expectedIdVer19_0_0_0 + "\"]";
+        String actualResult =  sendCompositeRPCByIds("ObserveComposite", expectedIds);
+        ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult.get("result").asText());
+        String actualValues = rpcActualResult.get("value").asText();
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer5_0_7) + "=LwM2mSingleResource"));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer5_0_3) + "=LwM2mSingleResource"));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer5_0_5 + "=LwM2mSingleResource")));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(idVer_3_0_9) + "=LwM2mSingleResource"));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer19_0_0_0) + "=null"));
+        String actualResultReadAll = sendCompositeRPCByKeys("ObserveReadAll", null);
+        ObjectNode rpcActualResultReadAll = JacksonUtil.fromString(actualResultReadAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultReadAll.get("result").asText());
+        String actualReadAllValues =  rpcActualResultReadAll.get("value").asText();
+        assertTrue(actualReadAllValues.contains(fromVersionedIdToObjectId(expectedIdVer19_0_0_0)));
+        String actualResultObserve = sendObserve("Observe", idVer_19_0_0);
+        ObjectNode rpcActualResultObserve = JacksonUtil.fromString(actualResultObserve, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultObserve.get("result").asText());
+        String actualObserveValue =  rpcActualResultObserve.get("value").asText();
+        String expected = String.format("LwM2mSingleResource id=%d", RESOURCE_ID_0);
+        assertTrue(actualObserveValue.contains(expected));
+    }
+
+    /**
+     *  ObserveComposite with keyName {"keys":["batteryLevel", "UtfOffset", "dataRead", "dataWrite"]} - Ok
+     * @throws Exception
+     */
+    @Test
+    public void testObserveCompositeWithKeyName_Result_CONTENT_Value_SingleResources() throws Exception {
+        String actualResultCancelAll = sendObserve("ObserveCancelAll", null);
+        ObjectNode rpcActualResultCancelAll = JacksonUtil.fromString(actualResultCancelAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultCancelAll.get("result").asText());
+        String expectedKey3_0_9 = RESOURCE_ID_NAME_3_9;
+        String expectedKey3_0_14 = RESOURCE_ID_NAME_3_14;
+        String expectedKey19_0_0 = RESOURCE_ID_NAME_19_0_0;
+        String expectedKey19_1_0 = RESOURCE_ID_NAME_19_1_0;
+        String expectedKeys = "[\"" + expectedKey3_0_9 + "\", \"" + expectedKey3_0_14 + "\", \"" + expectedKey19_0_0 + "\", \"" + expectedKey19_1_0 + "\"]";
+        String actualResult = sendCompositeRPCByKeys("ObserveComposite", expectedKeys);
+        ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult.get("result").asText());
+        String actualValues = rpcActualResult.get("value").asText();
+        String expectedIdVer3_0_14 = objectInstanceIdVer_3 + "/" + RESOURCE_ID_14;
+        String expectedIdVer19_1_0 = objectIdVer_19 + "/" + OBJECT_INSTANCE_ID_1 + "/" + RESOURCE_ID_0;
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer3_0_14)));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(idVer_19_0_0)));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(expectedIdVer19_1_0)));
+        assertTrue(actualValues.contains(fromVersionedIdToObjectId(idVer_3_0_9)));
+    }
+
+    /**
+     *  ObserveReadAll
+     * {"result":"CONTENT","value":"{"result":"CONTENT","value":"["SingleObservation:/3/0/9","SingleObservation:/3/0/14","SingleObservation:/19/1/0/0","SingleObservation:/19/0/0"]"} - Ok
+     * @throws Exception
+     */
+    @Test
+    public void testObserveReadAll_Result_CONTENT_Value_SingleObservation_Only() throws Exception {
+        String actualResultCancelAll = sendObserve("ObserveCancelAll", null);
+        ObjectNode rpcActualResultCancelAll = JacksonUtil.fromString(actualResultCancelAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultCancelAll.get("result").asText());
+        String expectedIdVer3_0_14 = objectInstanceIdVer_3 + "/" + RESOURCE_ID_14;
+        String expectedIdVer19_1_0 = objectIdVer_19 + "/" + OBJECT_INSTANCE_ID_1 + "/" + RESOURCE_ID_0 ;
+        String actualResult3_0_9 = sendObserve("Observe", idVer_3_0_9);
+        ObjectNode rpcActualResult3_0_9 = JacksonUtil.fromString(actualResult3_0_9, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult3_0_9.get("result").asText());
+        String actualResult3_0_14 = sendObserve("Observe", expectedIdVer3_0_14);
+        ObjectNode rpcActualResult3_0_14 = JacksonUtil.fromString(actualResult3_0_14, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult3_0_14.get("result").asText());
+        String actualResult19_1_0 = sendObserve("Observe", expectedIdVer19_1_0);
+        ObjectNode rpcActualResult19_1_0 = JacksonUtil.fromString(actualResult19_1_0, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult19_1_0.get("result").asText());
+        String actualResult19_0_0 = sendObserve("Observe", idVer_19_0_0);
+        ObjectNode rpcActualResult19_0_0 = JacksonUtil.fromString(actualResult19_0_0, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult19_0_0.get("result").asText());
+        String actualResultReadAll = sendCompositeRPCByKeys("ObserveReadAll", null);
+        ObjectNode rpcActualResultReadAll = JacksonUtil.fromString(actualResultReadAll, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResultReadAll.get("result").asText());
+        String actualValues =  rpcActualResultReadAll.get("value").asText();
+        assertTrue(actualValues.contains("SingleObservation:" + fromVersionedIdToObjectId(idVer_3_0_9)));
+        assertTrue(actualValues.contains("SingleObservation:" + fromVersionedIdToObjectId(expectedIdVer3_0_14)));
+        assertTrue(actualValues.contains("SingleObservation:" + fromVersionedIdToObjectId(expectedIdVer19_1_0)));
+        assertTrue(actualValues.contains("SingleObservation:" + fromVersionedIdToObjectId(idVer_19_0_0)));
+    }
+
+    /**
+     * SingleResource
+     * WriteReplace {"id": "/19_1.1/0/0","value": {"0":"0000ad45675600", "15":"1525ad45675600cdef"}}
+     * {"result":"BAD_REQUEST"}
+     */
+    @Test
+    public void testWriteReplaceMultipleResourceValueToSingleResource_Result_BAD_REQUEST_ValueSingleResourceMustBeOPAQUE() throws Exception {
+        String expectedPath = objectIdVer_19 + "/" + OBJECT_INSTANCE_ID_0 + "/" + RESOURCE_ID_0;
+        int resourceInstanceId0 = 0;
+        int resourceInstanceId15 = 15;
+        String expectedValue0 = "0000ad45675600";
+        String expectedValue15 = "1525ad45675600cdef";
+        String expectedValue = "{\"" + resourceInstanceId0 + "\":\"" + expectedValue0 + "\", \"" + resourceInstanceId15 + "\":\"" + expectedValue15 + "\"}";
+        String actualResult = sendRPCWriteObjectById("WriteReplace", expectedPath, expectedValue);
+        ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
+        assertEquals(ResponseCode.BAD_REQUEST.getName(), rpcActualResult.get("result").asText());
+        String expected = String.format("Resource id=%s, value = {%s=%s, %s=%s}, class = LinkedHashMap. Format value is bad. " +
+                        "Value for this Single Resource must be OPAQUE!",
+                fromVersionedIdToObjectId(expectedPath), resourceInstanceId0, expectedValue0, resourceInstanceId15, expectedValue15);
+        assertEquals(expected, rpcActualResult.get("error").asText());
+    }
+
+    private String sendObserve(String method, String params) throws Exception {
+        String sendRpcRequest;
+        if (params == null) {
+            sendRpcRequest = "{\"method\": \"" + method + "\"}";
+        }
+        else {
+            sendRpcRequest = "{\"method\": \"" + method + "\", \"params\": {\"id\": \"" + params + "\"}}";
+        }
+        return doPostAsync("/api/plugins/rpc/twoway/" + deviceId, sendRpcRequest, String.class, status().isOk());
+    }
+
+    private String sendCompositeRPCByIds(String method, String paths) throws Exception {
+        String setRpcRequest = "{\"method\": \"" + method + "\", \"params\": {\"ids\":" + paths + "}}";
+        return doPostAsync("/api/plugins/rpc/twoway/" + deviceId, setRpcRequest, String.class, status().isOk());
+    }
+
+    private String sendCompositeRPCByKeys(String method, String keys) throws Exception {
+        String setRpcRequest = "{\"method\": \"" + method + "\", \"params\": {\"keys\":" + keys + "}}";
+        return doPostAsync("/api/plugins/rpc/twoway/" + deviceId, setRpcRequest, String.class, status().isOk());
+    }
+
+    private String sendRPCWriteObjectById(String method, String path, Object value) throws Exception {
+        String setRpcRequest = "{\"method\": \"" + method + "\", \"params\": {\"id\": \"" + path + "\", \"value\": " + value + " }}";
+        return doPostAsync("/api/plugins/rpc/twoway/" + deviceId, setRpcRequest, String.class, status().isOk());
+    }
+
+    private String sendRPCReadById(String id) throws Exception {
+        String setRpcRequest = "{\"method\": \"Read\", \"params\": {\"id\": \"" + id + "\"}}";
+        return doPostAsync("/api/plugins/rpc/twoway/" + deviceId, setRpcRequest, String.class, status().isOk());
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationReadTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationReadTest.java
@@ -20,7 +20,7 @@ import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.Test;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcLwM2MIntegrationTest;
+import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest;
 
 import static org.eclipse.leshan.core.LwM2mId.SERVER;
 import static org.junit.Assert.assertEquals;
@@ -41,8 +41,7 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_2;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_9;
 
-
-public class RpcLwm2mIntegrationReadTest extends AbstractRpcLwM2MIntegrationTest {
+public class RpcLwm2mIntegrationReadTest extends AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest {
 
     /**
      * Read {"id":"/3"}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationWriteAttributesTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationWriteAttributesTest.java
@@ -19,15 +19,14 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.leshan.core.ResponseCode;
 import org.junit.Test;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcLwM2MIntegrationTest;
+import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_14;
 
-
-public class RpcLwm2mIntegrationWriteAttributesTest extends AbstractRpcLwM2MIntegrationTest {
+public class RpcLwm2mIntegrationWriteAttributesTest extends AbstractRpcWithObjectId19_MultipleResourceLwM2MIntegrationTest {
 
     /**
      * WriteAttributes {"id":"/3/0/14","attributes":{"pmax":100, "pmin":10}}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/AbstractSecurityLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/AbstractSecurityLwM2MIntegrationTest.java
@@ -109,7 +109,7 @@ public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2M
     protected final PrivateKey clientPrivateKeyFromCertTrust;                                   // client private key used for X509 and RPK
     protected final X509Certificate clientX509CertTrustNo;                                      // client certificate signed by intermediate, rootCA with a good CN ("host name")
     protected final PrivateKey clientPrivateKeyFromCertTrustNo;                                 // client private key used for X509 and RPK
-    private final String[] RESOURCES_SECURITY = new String[]{"1.xml", "2.xml", "3.xml", "5.xml", "9.xml"};
+    private final String[] RESOURCES_SECURITY = new String[]{"0.xml", "1.xml", "2.xml", "3.xml", "5.xml", "6.xml", "9.xml", "19.xml", "3303.xml"};
 
 
     private final LwM2MBootstrapClientCredentials defaultBootstrapCredentials;

--- a/application/src/test/resources/lwm2m/19_1_0.xml
+++ b/application/src/test/resources/lwm2m/19_1_0.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2016-2018 The Thingsboard Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<LWM2M xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.openmobilealliance.org/tech/profiles/LWM2M.xsd">
+	<Object ObjectType="MODefinition">
+		<Name>BinaryAppDataContainer</Name>
+		<Description1><![CDATA[This LwM2M Objects provides the application service data related to a LwM2M Server, eg. Water meter data.
+There are several methods to create instance to indicate the message direction based on the negotiation between Application and LwM2M. The Client and Server should negotiate the instance(s) used to exchange the data. For example:
+ - Using a single instance for both directions communication, from Client to Server and from Server to Client.
+ - Using an instance for communication from Client to Server and another one for communication from Server to Client
+ - Using several instances
+]]></Description1>
+		<ObjectID>19</ObjectID>
+		<ObjectURN>urn:oma:lwm2m:oma:19</ObjectURN>
+		<LWM2MVersion>1.0</LWM2MVersion>
+		<ObjectVersion>1.0</ObjectVersion>
+		<MultipleInstances>Multiple</MultipleInstances>
+		<Mandatory>Optional</Mandatory>
+		<Resources>
+			<Item ID="0"><Name>Data</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Opaque</Type>
+				<RangeEnumeration />
+				<Units />
+				<Description><![CDATA[Indicates the application data content.]]></Description>
+			</Item>
+			<Item ID="1"><Name>Data Priority</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>1 bytes</RangeEnumeration>
+				<Units />
+				<Description><![CDATA[Indicates the Application data priority:
+0:Immediate
+1:BestEffort
+2:Latest
+3-100: Reserved for future use.
+101-254: Proprietary mode.]]></Description>
+			</Item>
+			<Item ID="2"><Name>Data Creation Time</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Time</Type>
+				<RangeEnumeration />
+				<Units />
+				<Description><![CDATA[Indicates the Data instance creation timestamp.]]></Description>
+			</Item>
+			<Item ID="3"><Name>Data Description</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>String</Type>
+				<RangeEnumeration>32 bytes</RangeEnumeration>
+				<Units />
+				<Description><![CDATA[Indicates the data description.
+e.g. "meter reading".]]></Description>
+			</Item>
+			<Item ID="4"><Name>Data Format</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>String</Type>
+				<RangeEnumeration>32 bytes</RangeEnumeration>
+				<Units />
+				<Description><![CDATA[Indicates the format of the Application Data.
+e.g. YG-Meter-Water-Reading
+UTF8-string
+]]></Description>
+			</Item>
+			<Item ID="5"><Name>App ID</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>2 bytes</RangeEnumeration>
+				<Units />
+				<Description><![CDATA[Indicates the destination Application ID.]]></Description>
+			</Item></Resources>
+		<Description2><![CDATA[]]></Description2>
+	</Object>
+</LWM2M>

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mServerListener.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mServerListener.java
@@ -89,34 +89,40 @@ public class LwM2mServerListener {
 
         @Override
         public void cancelled(Observation observation) {
-            //TODO: should be able to use CompositeObservation
-            log.trace("Canceled Observation {}.", ((SingleObservation)observation).getPath());
+            log.trace("Canceled Observation [RegistrationId:{}: {}].", observation.getRegistrationId(), observation instanceof SingleObservation ?
+                    "Single: " + ((SingleObservation) observation).getPath() :
+                    "Composite: " + ((CompositeObservation) observation).getPaths());
         }
 
         @Override
         public void onResponse(SingleObservation observation, Registration registration, ObserveResponse response) {
             if (registration != null) {
+                log.trace("Update Single Observation [RegistrationId:{}: {}].", observation.getRegistrationId(), observation.getPath());
                 service.onUpdateValueAfterReadResponse(registration, convertObjectIdToVersionedId(observation.getPath().toString(), registration), response);
             }
         }
 
         @Override
         public void onResponse(CompositeObservation observation, Registration registration, ObserveCompositeResponse response) {
-            throw new RuntimeException("Not implemented yet!");
+            log.trace("Update Composite Observation [{}: {}].", observation.getRegistrationId(), observation.getPaths());
+            service.onUpdateValueAfterReadCompositeResponse(registration, response);
         }
 
         @Override
         public void onError(Observation observation, Registration registration, Exception error) {
             if (error != null) {
-                //TODO: should be able to use CompositeObservation
-                log.debug("Unable to handle notification of [{}:{}] [{}]", observation.getRegistrationId(), ((SingleObservation)observation).getPath(), error.getMessage());
+                var path = observation instanceof SingleObservation ? "Single Observation Cancel: " + ((SingleObservation) observation).getPath() : "Composite Observation Cancel: " + ((CompositeObservation) observation).getPaths();
+                var msgError = path + ": " + error.getMessage();
+                log.trace("Unable to handle notification [RegistrationId:{}]: [{}].", observation.getRegistrationId(), msgError);
+                service.onErrorObservation(registration, msgError);
             }
         }
 
         @Override
         public void newObservation(Observation observation, Registration registration) {
-            //TODO: should be able to use CompositeObservation
-            log.trace("Successful start newObservation {}.", ((SingleObservation)observation).getPath());
+            log.trace("Successful start newObservation  [RegistrationId:{}: {}].", observation.getRegistrationId(), observation instanceof SingleObservation ?
+                    "Single: " + ((SingleObservation) observation).getPath() :
+                    "Composite: " + ((CompositeObservation) observation).getPaths());
         }
     };
 }

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/DefaultLwM2mDownlinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/DefaultLwM2mDownlinkMsgHandler.java
@@ -171,15 +171,8 @@ public class DefaultLwM2mDownlinkMsgHandler extends LwM2MExecutorAwareService im
             Set<Observation> observations = context.getServer().getObservationService().getObservations(client.getRegistration());
             if (observations.stream().noneMatch(observation -> (observation instanceof SingleObservation ? ((SingleObservation) observation).getPath().equals(resultId) :
                     ((CompositeObservation) observation).getPaths().contains(resultId)))) {
-                ObserveRequest downlink;
                 ContentFormat contentFormat = getReadRequestContentFormat(client, request, modelProvider);
-                if (resultId.isResource()) {
-                    downlink = new ObserveRequest(contentFormat, resultId.getObjectId(), resultId.getObjectInstanceId(), resultId.getResourceId());
-                } else if (resultId.isObjectInstance()) {
-                    downlink = new ObserveRequest(contentFormat, resultId.getObjectId(), resultId.getObjectInstanceId());
-                } else {
-                    downlink = new ObserveRequest(contentFormat, resultId.getObjectId());
-                }
+                ObserveRequest downlink = new ObserveRequest(contentFormat, resultId.toString());
                 log.info("[{}] Send observation: {}.", client.getEndpoint(), request.getVersionedId());
                 sendSimpleRequest(client, downlink, request.getTimeout(), callback);
             } else {

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/LwM2mDownlinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/LwM2mDownlinkMsgHandler.java
@@ -21,6 +21,7 @@ import org.eclipse.leshan.core.request.CreateRequest;
 import org.eclipse.leshan.core.request.DeleteRequest;
 import org.eclipse.leshan.core.request.DiscoverRequest;
 import org.eclipse.leshan.core.request.ExecuteRequest;
+import org.eclipse.leshan.core.request.ObserveCompositeRequest;
 import org.eclipse.leshan.core.request.ObserveRequest;
 import org.eclipse.leshan.core.request.ReadCompositeRequest;
 import org.eclipse.leshan.core.request.ReadRequest;
@@ -31,6 +32,7 @@ import org.eclipse.leshan.core.response.CreateResponse;
 import org.eclipse.leshan.core.response.DeleteResponse;
 import org.eclipse.leshan.core.response.DiscoverResponse;
 import org.eclipse.leshan.core.response.ExecuteResponse;
+import org.eclipse.leshan.core.response.ObserveCompositeResponse;
 import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.ReadCompositeResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
@@ -38,6 +40,8 @@ import org.eclipse.leshan.core.response.WriteAttributesResponse;
 import org.eclipse.leshan.core.response.WriteCompositeResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
 import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
+import org.thingsboard.server.transport.lwm2m.server.downlink.composite.TbLwM2MObserveCompositeCancelRequest;
+import org.thingsboard.server.transport.lwm2m.server.downlink.composite.TbLwM2MObserveCompositeRequest;
 import org.thingsboard.server.transport.lwm2m.server.downlink.composite.TbLwM2MReadCompositeRequest;
 import org.thingsboard.server.transport.lwm2m.server.rpc.composite.RpcWriteCompositeRequest;
 
@@ -52,15 +56,19 @@ public interface LwM2mDownlinkMsgHandler {
 
     void sendObserveRequest(LwM2mClient client, TbLwM2MObserveRequest request, DownlinkRequestCallback<ObserveRequest, ObserveResponse> callback);
 
-    void sendObserveAllRequest(LwM2mClient client, TbLwM2MObserveAllRequest request, DownlinkRequestCallback<TbLwM2MObserveAllRequest, Set<String>> callback);
+    void sendObserveCancelRequest(LwM2mClient client, TbLwM2MObserveCancelRequest request, DownlinkRequestCallback<TbLwM2MObserveCancelRequest, Integer> callback);
+
+    void sendObserveCompositeRequest(LwM2mClient client, TbLwM2MObserveCompositeRequest request, DownlinkRequestCallback<ObserveCompositeRequest, ObserveCompositeResponse> callback, ContentFormat contentFormatComposite);
+
+    void sendObserveCompositeCancelRequest(LwM2mClient client, TbLwM2MObserveCompositeCancelRequest request, DownlinkRequestCallback<TbLwM2MObserveCompositeCancelRequest, Integer> callback);
+
+    void sendObserveReadAllRequest(LwM2mClient client, TbLwM2MObserveReadAllRequest request, DownlinkRequestCallback<TbLwM2MObserveReadAllRequest, Set<String>> callback);
+
+    void sendObserveCancelAllRequest(LwM2mClient client, TbLwM2MObserveCancelAllRequest request, DownlinkRequestCallback<TbLwM2MObserveCancelAllRequest, Integer> callback);
 
     void sendExecuteRequest(LwM2mClient client, TbLwM2MExecuteRequest request, DownlinkRequestCallback<ExecuteRequest, ExecuteResponse> callback);
 
     void sendDeleteRequest(LwM2mClient client, TbLwM2MDeleteRequest request, DownlinkRequestCallback<DeleteRequest, DeleteResponse> callback);
-
-    void sendCancelObserveRequest(LwM2mClient client, TbLwM2MCancelObserveRequest request, DownlinkRequestCallback<TbLwM2MCancelObserveRequest, Integer> callback);
-
-    void sendCancelAllRequest(LwM2mClient client, TbLwM2MCancelAllRequest request, DownlinkRequestCallback<TbLwM2MCancelAllRequest, Integer> callback);
 
     void sendDiscoverRequest(LwM2mClient client, TbLwM2MDiscoverRequest request, DownlinkRequestCallback<DiscoverRequest, DiscoverResponse> callback);
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/TbLwM2MObserveCancelAllCallback.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/TbLwM2MObserveCancelAllCallback.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.server.downlink;
+
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
+import org.thingsboard.server.transport.lwm2m.server.log.LwM2MTelemetryLogService;
+
+import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.LOG_LWM2M_INFO;
+
+@Slf4j
+public class TbLwM2MObserveCancelAllCallback extends AbstractTbLwM2MRequestCallback<TbLwM2MObserveCancelAllRequest, Integer> {
+
+    public TbLwM2MObserveCancelAllCallback(LwM2MTelemetryLogService logService, LwM2mClient client) {
+        super(logService, client);
+    }
+
+    @Override
+    public void onSuccess(TbLwM2MObserveCancelAllRequest request, Integer canceledSubscriptionsCount) {
+        log.trace("[{}] Cancel of all observations was successful: {}", client.getEndpoint(),  canceledSubscriptionsCount);
+        logService.log(client, String.format("[%s]: Cancel of all observations was successful. Result: [%s]", LOG_LWM2M_INFO, canceledSubscriptionsCount));
+    }
+
+}

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/TbLwM2MObserveCancelAllRequest.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/TbLwM2MObserveCancelAllRequest.java
@@ -19,13 +19,13 @@ import lombok.Builder;
 import lombok.Getter;
 import org.thingsboard.server.transport.lwm2m.server.LwM2MOperationType;
 
-public class TbLwM2MCancelAllRequest implements TbLwM2MDownlinkRequest<Integer> {
+public class TbLwM2MObserveCancelAllRequest implements TbLwM2MDownlinkRequest<Integer> {
 
     @Getter
     private final long timeout;
 
     @Builder
-    private TbLwM2MCancelAllRequest(long timeout) {
+    private TbLwM2MObserveCancelAllRequest(long timeout) {
         this.timeout = timeout;
     }
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/TbLwM2MObserveCancelCallback.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/TbLwM2MObserveCancelCallback.java
@@ -22,16 +22,19 @@ import org.thingsboard.server.transport.lwm2m.server.log.LwM2MTelemetryLogServic
 import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.LOG_LWM2M_INFO;
 
 @Slf4j
-public class TbLwM2MCancelAllObserveCallback extends AbstractTbLwM2MRequestCallback<TbLwM2MCancelAllRequest, Integer> {
+public class TbLwM2MObserveCancelCallback extends AbstractTbLwM2MRequestCallback<TbLwM2MObserveCancelRequest, Integer> {
 
-    public TbLwM2MCancelAllObserveCallback(LwM2MTelemetryLogService logService, LwM2mClient client) {
+    private final String versionedId;
+
+    public TbLwM2MObserveCancelCallback(LwM2MTelemetryLogService logService, LwM2mClient client, String versionedId) {
         super(logService, client);
+        this.versionedId = versionedId;
     }
 
     @Override
-    public void onSuccess(TbLwM2MCancelAllRequest request, Integer canceledSubscriptionsCount) {
-        log.trace("[{}] Cancel of all observations was successful: {}", client.getEndpoint(),  canceledSubscriptionsCount);
-        logService.log(client, String.format("[%s]: Cancel of all observations was successful. Result: [%s]", LOG_LWM2M_INFO, canceledSubscriptionsCount));
+    public void onSuccess(TbLwM2MObserveCancelRequest request, Integer canceledSubscriptionsCount) {
+        log.trace("[{}] Cancel observation of [{}] successful: {}", client.getEndpoint(),  versionedId, canceledSubscriptionsCount);
+        logService.log(client, String.format("[%s]: Cancel Observe for [%s] successful. Result: [%s]", LOG_LWM2M_INFO, versionedId, canceledSubscriptionsCount));
     }
 
 }

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/TbLwM2MObserveCancelRequest.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/TbLwM2MObserveCancelRequest.java
@@ -16,24 +16,18 @@
 package org.thingsboard.server.transport.lwm2m.server.downlink;
 
 import lombok.Builder;
-import lombok.Getter;
 import org.thingsboard.server.transport.lwm2m.server.LwM2MOperationType;
 
-import java.util.Set;
-
-public class TbLwM2MObserveAllRequest implements TbLwM2MDownlinkRequest<Set<String>> {
-
-    @Getter
-    private final long timeout;
+public class TbLwM2MObserveCancelRequest extends AbstractTbLwM2MTargetedDownlinkRequest<Integer> {
 
     @Builder
-    private TbLwM2MObserveAllRequest(long timeout) {
-        this.timeout = timeout;
+    private TbLwM2MObserveCancelRequest(String versionedId, long timeout) {
+        super(versionedId, timeout);
     }
 
     @Override
     public LwM2MOperationType getType() {
-        return LwM2MOperationType.OBSERVE_READ_ALL;
+        return LwM2MOperationType.OBSERVE_CANCEL;
     }
 
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/TbLwM2MObserveReadAllRequest.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/TbLwM2MObserveReadAllRequest.java
@@ -16,18 +16,24 @@
 package org.thingsboard.server.transport.lwm2m.server.downlink;
 
 import lombok.Builder;
+import lombok.Getter;
 import org.thingsboard.server.transport.lwm2m.server.LwM2MOperationType;
 
-public class TbLwM2MCancelObserveRequest extends AbstractTbLwM2MTargetedDownlinkRequest<Integer> {
+import java.util.Set;
+
+public class TbLwM2MObserveReadAllRequest implements TbLwM2MDownlinkRequest<Set<String>> {
+
+    @Getter
+    private final long timeout;
 
     @Builder
-    private TbLwM2MCancelObserveRequest(String versionedId, long timeout) {
-        super(versionedId, timeout);
+    private TbLwM2MObserveReadAllRequest(long timeout) {
+        this.timeout = timeout;
     }
 
     @Override
     public LwM2MOperationType getType() {
-        return LwM2MOperationType.OBSERVE_CANCEL;
+        return LwM2MOperationType.OBSERVE_READ_ALL;
     }
 
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/composite/TbLwM2MObserveCompositeCallback.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/composite/TbLwM2MObserveCompositeCallback.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.server.downlink.composite;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.leshan.core.request.ObserveCompositeRequest;
+import org.eclipse.leshan.core.response.ObserveCompositeResponse;
+import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
+import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MUplinkTargetedCallback;
+import org.thingsboard.server.transport.lwm2m.server.log.LwM2MTelemetryLogService;
+import org.thingsboard.server.transport.lwm2m.server.uplink.LwM2mUplinkMsgHandler;
+
+@Slf4j
+public class TbLwM2MObserveCompositeCallback extends TbLwM2MUplinkTargetedCallback<ObserveCompositeRequest, ObserveCompositeResponse> {
+
+    public TbLwM2MObserveCompositeCallback(LwM2mUplinkMsgHandler handler, LwM2MTelemetryLogService logService, LwM2mClient client, String[] versionedIds) {
+        super(handler, logService, client, versionedIds);
+    }
+
+    @Override
+    public void onSuccess(ObserveCompositeRequest request, ObserveCompositeResponse response) {
+        super.onSuccess(request, response);
+        handler.onUpdateValueAfterReadCompositeResponse(client.getRegistration(), response);
+    }
+
+}

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/composite/TbLwM2MObserveCompositeCancelCallback.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/composite/TbLwM2MObserveCompositeCancelCallback.java
@@ -13,28 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.transport.lwm2m.server.downlink;
+package org.thingsboard.server.transport.lwm2m.server.downlink.composite;
 
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
+import org.thingsboard.server.transport.lwm2m.server.downlink.AbstractTbLwM2MRequestCallback;
 import org.thingsboard.server.transport.lwm2m.server.log.LwM2MTelemetryLogService;
 
 import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.LOG_LWM2M_INFO;
 
 @Slf4j
-public class TbLwM2MCancelObserveCallback extends AbstractTbLwM2MRequestCallback<TbLwM2MCancelObserveRequest, Integer> {
+public class TbLwM2MObserveCompositeCancelCallback extends AbstractTbLwM2MRequestCallback<TbLwM2MObserveCompositeCancelRequest, Integer> {
 
-    private final String versionedId;
+    private final String [] versionedIds;
 
-    public TbLwM2MCancelObserveCallback(LwM2MTelemetryLogService logService, LwM2mClient client, String versionedId) {
+    public TbLwM2MObserveCompositeCancelCallback(LwM2MTelemetryLogService logService, LwM2mClient client, String [] versionedIds) {
         super(logService, client);
-        this.versionedId = versionedId;
+        this.versionedIds = versionedIds;
     }
 
     @Override
-    public void onSuccess(TbLwM2MCancelObserveRequest request, Integer canceledSubscriptionsCount) {
-        log.trace("[{}] Cancel observation of [{}] successful: {}", client.getEndpoint(),  versionedId, canceledSubscriptionsCount);
-        logService.log(client, String.format("[%s]: Cancel Observe for [%s] successful. Result: [%s]", LOG_LWM2M_INFO, versionedId, canceledSubscriptionsCount));
+    public void onSuccess(TbLwM2MObserveCompositeCancelRequest request, Integer canceledSubscriptionsCount) {
+        log.trace("[{}] Cancel composite observation of [{}] successful: {}", client.getEndpoint(),  this.versionedIds, canceledSubscriptionsCount);
+        logService.log(client, String.format("[%s]: Cancel Composite Observe for [%s] successful. Result: [%s]", LOG_LWM2M_INFO, this.versionedIds, canceledSubscriptionsCount));
     }
-
 }

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/composite/TbLwM2MObserveCompositeCancelRequest.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/composite/TbLwM2MObserveCompositeCancelRequest.java
@@ -13,32 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.transport.lwm2m.server.downlink;
+package org.thingsboard.server.transport.lwm2m.server.downlink.composite;
 
 import lombok.Builder;
-import org.eclipse.leshan.core.request.ContentFormat;
-import org.eclipse.leshan.core.response.ObserveResponse;
 import org.thingsboard.server.transport.lwm2m.server.LwM2MOperationType;
 
-import java.util.Optional;
-
-public class TbLwM2MObserveRequest extends AbstractTbLwM2MTargetedDownlinkRequest<ObserveResponse> implements HasContentFormat {
-
-    private final Optional<ContentFormat> requestContentFormat;
+public class TbLwM2MObserveCompositeCancelRequest extends AbstractTbLwM2MTargetedDownlinkCompositeRequest {
 
     @Builder
-    private TbLwM2MObserveRequest(String versionedId, long timeout, ContentFormat requestContentFormat) {
-        super(versionedId, timeout);
-        this.requestContentFormat = Optional.ofNullable(requestContentFormat);
+    private TbLwM2MObserveCompositeCancelRequest(String [] versionedIds, long timeout) {
+        super(versionedIds, timeout);
     }
 
     @Override
     public LwM2MOperationType getType() {
-        return LwM2MOperationType.OBSERVE;
-    }
-
-    @Override
-    public Optional<ContentFormat> getRequestContentFormat() {
-        return this.requestContentFormat;
+        return LwM2MOperationType.OBSERVE_COMPOSITE_CANCEL;
     }
 }

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/composite/TbLwM2MObserveCompositeRequest.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/composite/TbLwM2MObserveCompositeRequest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.server.downlink.composite;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.eclipse.leshan.core.request.ContentFormat;
+import org.eclipse.leshan.core.response.ObserveCompositeResponse;
+import org.thingsboard.server.transport.lwm2m.server.LwM2MOperationType;
+import org.thingsboard.server.transport.lwm2m.server.downlink.HasContentFormat;
+
+import java.util.Optional;
+
+public class TbLwM2MObserveCompositeRequest extends AbstractTbLwM2MTargetedDownlinkCompositeRequest<ObserveCompositeResponse> implements HasContentFormat {
+
+
+    private final Optional<ContentFormat> requestContentFormatOpt;
+
+    @Getter
+    private final ContentFormat responseContentFormat;
+
+    @Builder
+    private TbLwM2MObserveCompositeRequest(String [] versionedIds, long timeout, ContentFormat requestContentFormat, ContentFormat responseContentFormat) {
+        super(versionedIds, timeout);
+        this.requestContentFormatOpt = Optional.ofNullable(requestContentFormat);
+        this.responseContentFormat = responseContentFormat;
+    }
+
+    @Override
+    public LwM2MOperationType getType() {
+        return LwM2MOperationType.OBSERVE_COMPOSITE;
+    }
+
+    @Override
+    public Optional<ContentFormat> getRequestContentFormat() {
+        return this.requestContentFormatOpt;
+    }
+}

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/model/LwM2MModelConfigServiceImpl.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/model/LwM2MModelConfigServiceImpl.java
@@ -26,8 +26,8 @@ import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
 import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClientContext;
 import org.thingsboard.server.transport.lwm2m.server.downlink.DownlinkRequestCallback;
 import org.thingsboard.server.transport.lwm2m.server.downlink.LwM2mDownlinkMsgHandler;
-import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MCancelObserveCallback;
-import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MCancelObserveRequest;
+import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MObserveCancelCallback;
+import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MObserveCancelRequest;
 import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MObserveCallback;
 import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MObserveRequest;
 import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MReadCallback;
@@ -169,15 +169,15 @@ public class LwM2MModelConfigServiceImpl implements LwM2MModelConfigService {
 
         Set<String> toCancelObserve = modelConfig.getToCancelObserve();
         toCancelObserve.forEach(id -> {
-            TbLwM2MCancelObserveRequest request = TbLwM2MCancelObserveRequest.builder().versionedId(id)
+            TbLwM2MObserveCancelRequest request = TbLwM2MObserveCancelRequest.builder().versionedId(id)
                     .timeout(clientContext.getRequestTimeout(lwM2mClient)).build();
-            downlinkMsgHandler.sendCancelObserveRequest(lwM2mClient, request,
+            downlinkMsgHandler.sendObserveCancelRequest(lwM2mClient, request,
                     createDownlinkProxyCallback(() -> {
                         toCancelObserve.remove(id);
                         if (modelConfig.isEmpty()) {
                             modelStore.remove(endpoint);
                         }
-                    }, new TbLwM2MCancelObserveCallback(logService, lwM2mClient, id))
+                    }, new TbLwM2MObserveCancelCallback(logService, lwM2mClient, id))
             );
         });
     }

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/rpc/RpcObserveCancelAllCallback.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/rpc/RpcObserveCancelAllCallback.java
@@ -20,11 +20,11 @@ import org.thingsboard.server.common.transport.TransportService;
 import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
 import org.thingsboard.server.transport.lwm2m.server.downlink.DownlinkRequestCallback;
-import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MCancelObserveRequest;
+import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MObserveCancelAllRequest;
 
-public class RpcCancelObserveCallback extends RpcDownlinkRequestCallbackProxy<TbLwM2MCancelObserveRequest, Integer> {
+public class RpcObserveCancelAllCallback extends RpcDownlinkRequestCallbackProxy<TbLwM2MObserveCancelAllRequest, Integer> {
 
-    public RpcCancelObserveCallback(TransportService transportService, LwM2mClient client, TransportProtos.ToDeviceRpcRequestMsg requestMsg, DownlinkRequestCallback<TbLwM2MCancelObserveRequest, Integer> callback) {
+    public RpcObserveCancelAllCallback(TransportService transportService, LwM2mClient client, TransportProtos.ToDeviceRpcRequestMsg requestMsg, DownlinkRequestCallback<TbLwM2MObserveCancelAllRequest, Integer> callback) {
         super(transportService, client, requestMsg, callback);
     }
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/rpc/RpcObserveCancelCallback.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/rpc/RpcObserveCancelCallback.java
@@ -20,11 +20,11 @@ import org.thingsboard.server.common.transport.TransportService;
 import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
 import org.thingsboard.server.transport.lwm2m.server.downlink.DownlinkRequestCallback;
-import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MCancelAllRequest;
+import org.thingsboard.server.transport.lwm2m.server.downlink.TbLwM2MObserveCancelRequest;
 
-public class RpcCancelAllObserveCallback extends RpcDownlinkRequestCallbackProxy<TbLwM2MCancelAllRequest, Integer> {
+public class RpcObserveCancelCallback extends RpcDownlinkRequestCallbackProxy<TbLwM2MObserveCancelRequest, Integer> {
 
-    public RpcCancelAllObserveCallback(TransportService transportService, LwM2mClient client, TransportProtos.ToDeviceRpcRequestMsg requestMsg, DownlinkRequestCallback<TbLwM2MCancelAllRequest, Integer> callback) {
+    public RpcObserveCancelCallback(TransportService transportService, LwM2mClient client, TransportProtos.ToDeviceRpcRequestMsg requestMsg, DownlinkRequestCallback<TbLwM2MObserveCancelRequest, Integer> callback) {
         super(transportService, client, requestMsg, callback);
     }
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/rpc/composite/RpcObserveCompositeCancelCallback.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/rpc/composite/RpcObserveCompositeCancelCallback.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.server.rpc.composite;
+
+import org.eclipse.leshan.core.ResponseCode;
+import org.thingsboard.server.common.transport.TransportService;
+import org.thingsboard.server.gen.transport.TransportProtos;
+import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
+import org.thingsboard.server.transport.lwm2m.server.downlink.DownlinkRequestCallback;
+import org.thingsboard.server.transport.lwm2m.server.downlink.composite.TbLwM2MObserveCompositeCancelRequest;
+import org.thingsboard.server.transport.lwm2m.server.rpc.LwM2MRpcResponseBody;
+import org.thingsboard.server.transport.lwm2m.server.rpc.RpcDownlinkRequestCallbackProxy;
+
+public class RpcObserveCompositeCancelCallback extends RpcDownlinkRequestCallbackProxy<TbLwM2MObserveCompositeCancelRequest, Integer> {
+
+    public RpcObserveCompositeCancelCallback(TransportService transportService, LwM2mClient client, TransportProtos.ToDeviceRpcRequestMsg requestMsg, DownlinkRequestCallback<TbLwM2MObserveCompositeCancelRequest, Integer> callback) {
+        super(transportService, client, requestMsg, callback);
+    }
+
+    @Override
+    protected void sendRpcReplyOnSuccess(Integer response) {
+        reply(LwM2MRpcResponseBody.builder().result(ResponseCode.CONTENT.getName()).value(response.toString()).build());
+    }
+}

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/rpc/composite/RpcObserveResponseCompositeCallback.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/rpc/composite/RpcObserveResponseCompositeCallback.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.server.rpc.composite;
+
+import org.eclipse.leshan.core.request.LwM2mRequest;
+import org.eclipse.leshan.core.response.ObserveCompositeResponse;
+import org.thingsboard.server.common.transport.TransportService;
+import org.thingsboard.server.gen.transport.TransportProtos;
+import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
+import org.thingsboard.server.transport.lwm2m.server.downlink.DownlinkRequestCallback;
+import org.thingsboard.server.transport.lwm2m.server.rpc.RpcLwM2MDownlinkCallback;
+
+import java.util.Optional;
+
+import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.contentToString;
+
+public class RpcObserveResponseCompositeCallback<R extends LwM2mRequest<T>, T extends ObserveCompositeResponse> extends RpcLwM2MDownlinkCallback<R, T> {
+
+    public RpcObserveResponseCompositeCallback(TransportService transportService, LwM2mClient client, TransportProtos.ToDeviceRpcRequestMsg requestMsg, DownlinkRequestCallback<R, T> callback) {
+        super(transportService, client, requestMsg, callback);
+    }
+
+    @Override
+    protected Optional<String> serializeSuccessfulResponse(T response) {
+        return contentToString(response.getContent());
+    }
+}

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/LwM2mUplinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/LwM2mUplinkMsgHandler.java
@@ -44,6 +44,8 @@ public interface LwM2mUplinkMsgHandler {
 
     void onUpdateValueAfterReadResponse(Registration registration, String path, ReadResponse response);
 
+    void onErrorObservation(Registration registration, String errorMsg);
+
     void onUpdateValueAfterReadCompositeResponse(Registration registration, ReadCompositeResponse response);
 
     void onDeviceProfileUpdate(TransportProtos.SessionInfoProto sessionInfo, DeviceProfile deviceProfile);


### PR DESCRIPTION
## Pull Request description

This fixes the issue https://github.com/thingsboard/thingsboard/issues/6040

###    add new Operation (used from RPC terminal):
- **OBSERVE_COMPOSITE**
- - success:
`ObserveComposite {"ids":["5/0/5", "5/0/3", "3/0/9"]}`
`{"result":"CONTENT","_value_":"{/5/0/5=LwM2mSingleResource [id=5, value=0, type=INTEGER], /5/0/3=LwM2mSingleResource [id=3, value=0, type=INTEGER], /3/0/9=LwM2
mSingleResource [id=9, value=60, type=INTEGER]}"}`
- - error (if the request includes a resource that is already observing):
`ObserveComposite {"ids":["3/0/15", "3/0/14", "5/0/3"]}`
`{"result":"BAD_REQUEST","error":"Observation one or all of this list is already registered!"}`

- **OBSERVE_COMPOSITE_CANCEL** (must include copying all resources of one of the "ObserveComposite" operations):
-  - success:
`ObserveCompositeCancel {"ids":["5/0/5", "5/0/3", "3/0/9"]}
{"result":"CONTENT","value":"1"}`
- - error (if the request includes resources that are not equal to the resource list of one of the Observe Composite operations):
`ObserveCompositeCancel {"ids":["3/0/1", "5/0/2", "5/0/9", "5/0/12"]}
{"result":"CONTENT","value":"0"}`
 
###    edit Operation:
- **OBSERVE**
- - error
`if resource (SingleObservation or in CompositeObservation) is already registered - return BAD REQUEST  message: Observation is already registered!`

- **OBSERVE_READ_ALL**
- - success:
`ObserveReadAll`
`{"result":"CONTENT","value":"[\"SingleObservation:/5/0/7\",\"CompositeObservation: [\"5/0/5\", \"5/0/3\", \"3/0/9\"]"}`

### add Tests: Observe-Composite" operation to the L2M2M

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.