### PR TITLE
[WIP][3.4] UI: Vertical resize in Knob Control widget

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/rpc/knob.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/rpc/knob.component.html
@@ -16,7 +16,10 @@
 
 -->
 <div class="tb-knob" fxLayout="column" [ngStyle]="{'pointerEvents': ctx.isEdit ? 'none' : 'all'}">
-  <div #knobContainer id="knob-container" fxFlex fxLayout="column" fxLayoutAlign="center center">
+  <div fxFlex="20" #knobTitleContainer class="title-container" fxLayout="row" fxLayoutAlign="center center" [fxShow]="showTitle">
+    <span #knobTitle class="knob-title">{{ title }}</span>
+  </div>
+  <div #knobContainer fxFlex="{{showTitle ? 80 : 100}}" id="knob-container" fxFlex fxLayout="column" fxLayoutAlign="center center">
     <div #knob class="knob">
       <div #knobValueContainer class="value-container" fxLayout="row" fxLayoutAlign="center center">
         <span #knobValue class="knob-value">{{ value }}</span>
@@ -30,9 +33,6 @@
       <div #knobErrorContainer class="error-container" [ngStyle]="{'background': error?.length ? 'rgba(255,255,255,0.25)' : 'none'}"
            fxLayout="row" fxLayoutAlign="center center">
         <span #knobError class="knob-error" [innerHTML]="error"></span>
-      </div>
-      <div #knobTitleContainer class="title-container" fxLayout="row" fxLayoutAlign="center center">
-        <span #knobTitle class="knob-title">{{ title }}</span>
       </div>
       <div #knobMinmaxContainer class="minmax-container" fxLayout="row" fxLayoutAlign="start center">
         <span class="minmax-label">min</span>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/rpc/knob.component.scss
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/rpc/knob.component.scss
@@ -31,6 +31,14 @@ $minmax-container-margin-bottom-pct: percentage(.12) !default;
     width: 100%;
     height: 100%;
 
+    .title-container {
+      .knob-title {
+        font-weight: 500;
+        color: #757575;
+        white-space: nowrap;
+      }
+    }
+
     .knob {
       position: relative;
 
@@ -83,21 +91,6 @@ $minmax-container-margin-bottom-pct: percentage(.12) !default;
 
         .knob-error {
           color: #ff3315;
-          white-space: nowrap;
-        }
-      }
-
-      .title-container {
-        position: absolute;
-        right: $title-container-margin-pct;
-        bottom: $title-container-margin-bottom-pct;
-        left: $title-container-margin-pct;
-        z-index: 4;
-        height: $title-height;
-
-        .knob-title {
-          font-weight: 500;
-          color: #757575;
           white-space: nowrap;
         }
       }

--- a/ui-ngx/src/app/modules/home/components/widget/lib/rpc/knob.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/rpc/knob.component.ts
@@ -70,6 +70,7 @@ export class KnobComponent extends PageComponent implements OnInit, OnDestroy {
   minValue: number;
   maxValue: number;
   newValue = 0;
+  showTitle = false;
 
   private startDeg = -1;
   private currentDeg = 0;
@@ -151,6 +152,7 @@ export class KnobComponent extends PageComponent implements OnInit, OnDestroy {
     this.minValue = isDefined(settings.minValue) ? settings.minValue : 0;
     this.maxValue = isDefined(settings.maxValue) ? settings.maxValue : 100;
     this.title = isDefined(settings.title) ? settings.title : '';
+    this.showTitle = !!(this.title && this.title.length);
 
     const levelColors = ['#19ff4b', '#ffff19', '#ff3232'];
 
@@ -169,7 +171,6 @@ export class KnobComponent extends PageComponent implements OnInit, OnDestroy {
       donutEndAngle: 9 / 4 * Math.PI,
       animation: false
     };
-
 
     this.knob.on('click', (e) => {
       if (this.moving) {
@@ -206,8 +207,6 @@ export class KnobComponent extends PageComponent implements OnInit, OnDestroy {
       this.startDeg = -1;
       this.rpcUpdateValue(this.newValue);
     });
-
-
 
     this.knob.on('mousedown touchstart', (e) => {
       this.moving  = false;
@@ -344,14 +343,18 @@ export class KnobComponent extends PageComponent implements OnInit, OnDestroy {
     const width = this.knobContainer.width();
     const height = this.knobContainer.height();
     const size = Math.min(width, height);
+
     this.knob.css({width: size, height: size});
+    
     if (this.canvasBar) {
       this.canvasBar.update({width: size, height: size} as GenericOptions);
     }
-    this.setFontSize(this.knobTitle, this.title, this.knobTitleContainer.height(), this.knobTitleContainer.width());
+    
+    if (this.ctx.widgetConfig.showTitle) {
+      this.setFontSize(this.knobTitle, this.title, this.knobTitleContainer.height() * 2 / 3, this.knobTitleContainer.width());
+    }
+    
     this.setFontSize(this.knobError, this.error, this.knobErrorContainer.height(), this.knobErrorContainer.width());
-    const minmaxHeight = this.knobMinmaxContainer.height();
-    this.minmaxLabel.css({fontSize: minmaxHeight + 'px', lineHeight: minmaxHeight + 'px'});
     this.checkValueSize();
   }
 


### PR DESCRIPTION
## Pull Request description

Issue: https://github.com/thingsboard/thingsboard/issues/#6141
Knob Control widget can be resize aslo by vertical.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help).