### PR TITLE
[3.4] Create Alarm node update the alarm acknowledge status fix

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
@@ -166,6 +166,7 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
             }
             if (msgAlarm != null) {
                 existingAlarm.setSeverity(msgAlarm.getSeverity());
+                updateStatus(existingAlarm, msgAlarm);
                 existingAlarm.setPropagate(msgAlarm.isPropagate());
                 existingAlarm.setPropagateToOwner(msgAlarm.isPropagateToOwner());
                 existingAlarm.setPropagateToTenant(msgAlarm.isPropagateToTenant());
@@ -188,6 +189,24 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         }, ctx.getDbCallbackExecutor());
 
         return Futures.transform(asyncUpdated, a -> new TbAlarmResult(false, true, false, a), MoreExecutors.directExecutor());
+    }
+
+    private void updateStatus(Alarm existingAlarm, Alarm msgAlarm) {
+        boolean isActive = existingAlarm.getStatus() == AlarmStatus.ACTIVE_ACK
+                || existingAlarm.getStatus() == AlarmStatus.ACTIVE_UNACK;
+
+        boolean acknowledged = existingAlarm.getStatus() == AlarmStatus.ACTIVE_ACK
+                || existingAlarm.getStatus() == AlarmStatus.CLEARED_ACK;
+        boolean shouldBeAcknowledged = msgAlarm.getStatus() == AlarmStatus.ACTIVE_ACK
+                || msgAlarm.getStatus() == AlarmStatus.CLEARED_ACK;
+
+        if (!acknowledged && shouldBeAcknowledged) {
+            if (isActive) {
+                existingAlarm.setStatus(AlarmStatus.ACTIVE_ACK);
+            } else {
+                existingAlarm.setStatus(AlarmStatus.CLEARED_ACK);
+            }
+        }
     }
 
     private Alarm buildAlarm(TbMsg msg, JsonNode details, TenantId tenantId) {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
@@ -198,8 +198,10 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         if (existingAlarm.getStatus().isAck() && !msgAlarm.getStatus().isAck()) {
             throw new RuntimeException("An already acknowledged alarm cannot be made unacknowledged!");
         }
-        existingAlarm.setStatus(msgAlarm.getStatus());
-        existingAlarm.setAckTs(System.currentTimeMillis());
+        if (existingAlarm.getStatus() != msgAlarm.getStatus()) {
+            existingAlarm.setStatus(msgAlarm.getStatus());
+            existingAlarm.setAckTs(System.currentTimeMillis());
+        }
     }
 
     private Alarm buildAlarm(TbMsg msg, JsonNode details, TenantId tenantId) {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
@@ -198,12 +198,7 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         if (existingAlarm.getStatus().isAck() && !msgAlarm.getStatus().isAck()) {
             throw new RuntimeException("An already acknowledged alarm cannot be made unacknowledged!");
         }
-
-        if (existingAlarm.getStatus().isCleared()) {
-            existingAlarm.setStatus(AlarmStatus.CLEARED_ACK);
-        } else {
-            existingAlarm.setStatus(AlarmStatus.ACTIVE_ACK);
-        }
+        existingAlarm.setStatus(msgAlarm.getStatus());
         existingAlarm.setAckTs(System.currentTimeMillis());
     }
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
@@ -192,9 +192,6 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
     }
 
     private void updateStatus(Alarm existingAlarm, Alarm msgAlarm) {
-        if (!existingAlarm.getStatus().isCleared() && msgAlarm.getStatus().isCleared()) {
-            throw new RuntimeException("The 'Alarm Create' node cannot clear the alarm!");
-        }
         if (existingAlarm.getStatus().isAck() && !msgAlarm.getStatus().isAck()) {
             throw new RuntimeException("An already acknowledged alarm cannot be made unacknowledged!");
         }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
@@ -195,9 +195,6 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         if (!existingAlarm.getStatus().isCleared() && msgAlarm.getStatus().isCleared()) {
             throw new RuntimeException("The 'Alarm Create' node cannot clear the alarm!");
         }
-        if (existingAlarm.getStatus().isCleared() && !msgAlarm.getStatus().isCleared()) {
-            throw new RuntimeException("An already cleared alarm cannot be made active!");
-        }
         if (existingAlarm.getStatus().isAck() && !msgAlarm.getStatus().isAck()) {
             throw new RuntimeException("An already acknowledged alarm cannot be made unacknowledged!");
         }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbAlarmNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbAlarmNodeTest.java
@@ -678,6 +678,7 @@ public class TbAlarmNodeTest {
         actualAlarm = new ObjectMapper().readValue(dataCaptor.getValue().getBytes(), Alarm.class);
         expectedAlarm.setStatus(ACTIVE_ACK);
         expectedAlarm.setEndTs(actualAlarm.getEndTs());
+        expectedAlarm.setAckTs(actualAlarm.getAckTs());
 
         assertEquals(expectedAlarm, actualAlarm);
     }


### PR DESCRIPTION
## Pull Request description

Issue: [#6221](https://github.com/thingsboard/thingsboard/issues/6221)

On alarm update, `Create Alarm` node does not change the alarm status

Was added the `updateStatus` method, which is checking whether the alarm should be acknowledged basing on message data
Was added the corresponding test

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.