### PR TITLE
[3.4] fixed entity view caching

### DIFF
--- a/application/src/test/java/org/thingsboard/server/controller/BaseAssetControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/BaseAssetControllerTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.thingsboard.server.common.data.Customer;
 import org.thingsboard.server.common.data.EntitySubtype;
+import org.thingsboard.server.common.data.EntityView;
 import org.thingsboard.server.common.data.Tenant;
 import org.thingsboard.server.common.data.User;
 import org.thingsboard.server.common.data.asset.Asset;
@@ -179,6 +180,39 @@ public abstract class BaseAssetControllerTest extends AbstractControllerTest {
                 .andExpect(status().isOk());
 
         doGet("/api/asset/" + savedAsset.getId().getId().toString())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testDeleteAssetAssignedToEntityView() throws Exception {
+        Asset asset1 = new Asset();
+        asset1.setName("My asset 1");
+        asset1.setType("default");
+        Asset savedAsset1 = doPost("/api/asset", asset1, Asset.class);
+
+        Asset asset2 = new Asset();
+        asset2.setName("My asset 2");
+        asset2.setType("default");
+        Asset savedAsset2 = doPost("/api/asset", asset2, Asset.class);
+
+        EntityView view = new EntityView();
+        view.setEntityId(savedAsset1.getId());
+        view.setTenantId(savedTenant.getId());
+        view.setName("My entity view");
+        view.setType("default");
+        EntityView savedView = doPost("/api/entityView", view, EntityView.class);
+
+        doDelete("/api/asset/" + savedAsset1.getId().getId().toString())
+                .andExpect(status().isBadRequest());
+
+        savedView.setEntityId(savedAsset2.getId());
+
+        doPost("/api/entityView", savedView, EntityView.class);
+
+        doDelete("/api/asset/" + savedAsset1.getId().getId().toString())
+                .andExpect(status().isOk());
+
+        doGet("/api/asset/" + savedAsset1.getId().getId().toString())
                 .andExpect(status().isNotFound());
     }
 

--- a/application/src/test/java/org/thingsboard/server/controller/BaseEntityViewControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/BaseEntityViewControllerTest.java
@@ -27,6 +27,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.test.web.servlet.ResultMatcher;
 import org.thingsboard.server.common.data.Customer;
 import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.EntityView;
@@ -115,7 +116,8 @@ public abstract class BaseEntityViewControllerTest extends AbstractControllerTes
 
     @Test
     public void testSaveEntityView() throws Exception {
-        EntityView savedView = getNewSavedEntityView("Test entity view");
+        String name = "Test entity view";
+        EntityView savedView = getNewSavedEntityView(name);
 
         Assert.assertNotNull(savedView);
         Assert.assertNotNull(savedView.getId());
@@ -123,14 +125,20 @@ public abstract class BaseEntityViewControllerTest extends AbstractControllerTes
         assertEquals(savedTenant.getId(), savedView.getTenantId());
         Assert.assertNotNull(savedView.getCustomerId());
         assertEquals(NULL_UUID, savedView.getCustomerId().getId());
-        assertEquals(savedView.getName(), savedView.getName());
+        assertEquals(name, savedView.getName());
 
-        savedView.setName("New test entity view");
-        doPost("/api/entityView", savedView, EntityView.class);
         EntityView foundEntityView = doGet("/api/entityView/" + savedView.getId().getId().toString(), EntityView.class);
 
-        assertEquals(foundEntityView.getName(), savedView.getName());
-        assertEquals(foundEntityView.getKeys(), telemetry);
+        assertEquals(savedView, foundEntityView);
+
+        savedView.setName("New test entity view");
+
+        doPost("/api/entityView", savedView, EntityView.class);
+        foundEntityView = doGet("/api/entityView/" + savedView.getId().getId().toString(), EntityView.class);
+
+        assertEquals(savedView, foundEntityView);
+
+        doGet("/api/tenant/entityViews?entityViewName=" + name, EntityView.class, status().isNotFound());
     }
 
     @Test

--- a/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
@@ -24,9 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.thingsboard.server.common.data.EntitySubtype;
 import org.thingsboard.server.common.data.EntityType;
@@ -86,29 +84,31 @@ public class EntityViewServiceImpl extends AbstractEntityService implements Enti
     @Autowired
     private DataValidator<EntityView> entityViewValidator;
 
-    @Caching(evict = {
-            @CacheEvict(cacheNames = ENTITY_VIEW_CACHE, key = "{#entityView.tenantId, #entityView.entityId}"),
-            @CacheEvict(cacheNames = ENTITY_VIEW_CACHE, key = "{#entityView.tenantId, #entityView.name}"),
-            @CacheEvict(cacheNames = ENTITY_VIEW_CACHE, key = "{#entityView.id}")})
     @Override
     public EntityView saveEntityView(EntityView entityView) {
         log.trace("Executing save entity view [{}]", entityView);
         entityViewValidator.validate(entityView, EntityView::getTenantId);
+
+        if (entityView.getId() != null) {
+            EntityView oldEntityView = entityViewDao.findById(entityView.getTenantId(), entityView.getUuidId());
+            evictCache(oldEntityView);
+        }
+
         return entityViewDao.save(entityView.getTenantId(), entityView);
     }
 
-    @CacheEvict(cacheNames = ENTITY_VIEW_CACHE, key = "{#entityViewId}")
     @Override
     public EntityView assignEntityViewToCustomer(TenantId tenantId, EntityViewId entityViewId, CustomerId customerId) {
         EntityView entityView = findEntityViewById(tenantId, entityViewId);
+        evictCache(entityView);
         entityView.setCustomerId(customerId);
         return saveEntityView(entityView);
     }
 
-    @CacheEvict(cacheNames = ENTITY_VIEW_CACHE, key = "{#entityViewId}")
     @Override
     public EntityView unassignEntityViewFromCustomer(TenantId tenantId, EntityViewId entityViewId) {
         EntityView entityView = findEntityViewById(tenantId, entityViewId);
+        evictCache(entityView);
         entityView.setCustomerId(null);
         return saveEntityView(entityView);
     }
@@ -292,15 +292,13 @@ public class EntityViewServiceImpl extends AbstractEntityService implements Enti
         }
     }
 
-    @CacheEvict(cacheNames = ENTITY_VIEW_CACHE, key = "{#entityViewId}")
     @Override
     public void deleteEntityView(TenantId tenantId, EntityViewId entityViewId) {
         log.trace("Executing deleteEntityView [{}]", entityViewId);
         validateId(entityViewId, INCORRECT_ENTITY_VIEW_ID + entityViewId);
         deleteEntityRelations(tenantId, entityViewId);
         EntityView entityView = entityViewDao.findById(tenantId, entityViewId.getId());
-        cacheManager.getCache(ENTITY_VIEW_CACHE).evict(Arrays.asList(entityView.getTenantId(), entityView.getEntityId()));
-        cacheManager.getCache(ENTITY_VIEW_CACHE).evict(Arrays.asList(entityView.getTenantId(), entityView.getName()));
+        evictCache(entityView);
         entityViewDao.removeById(tenantId, entityViewId.getId());
     }
 
@@ -323,7 +321,6 @@ public class EntityViewServiceImpl extends AbstractEntityService implements Enti
                 }, MoreExecutors.directExecutor());
     }
 
-    @CacheEvict(cacheNames = ENTITY_VIEW_CACHE, key = "{#entityViewId}")
     @Override
     public EntityView assignEntityViewToEdge(TenantId tenantId, EntityViewId entityViewId, EdgeId edgeId) {
         EntityView entityView = findEntityViewById(tenantId, entityViewId);
@@ -413,4 +410,11 @@ public class EntityViewServiceImpl extends AbstractEntityService implements Enti
             unassignEntityViewFromCustomer(tenantId, new EntityViewId(entity.getUuidId()));
         }
     };
+
+    private void evictCache(EntityView entityView) {
+        Cache cache = cacheManager.getCache(ENTITY_VIEW_CACHE);
+        cache.evict(Arrays.asList(entityView.getTenantId(), entityView.getEntityId()));
+        cache.evict(Arrays.asList(entityView.getTenantId(), entityView.getName()));
+        cache.evict(Arrays.asList(entityView.getId()));
+    }
 }


### PR DESCRIPTION
## Pull Request description

Issue: https://github.com/thingsboard/thingsboard/issues/6323

For fixing this issue we evict cache for old entity view.
If we evict cache for new entity view caches by name and entityId won't evict.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



