### PR TITLE
[3.4] Fix SQL error on reinstall

### DIFF
--- a/dao/src/main/resources/sql/schema-entities.sql
+++ b/dao/src/main/resources/sql/schema-entities.sql
@@ -242,10 +242,17 @@ CREATE TABLE IF NOT EXISTS device_profile (
     CONSTRAINT fk_software_device_profile FOREIGN KEY (software_id) REFERENCES ota_package(id)
 );
 
-ALTER TABLE ota_package
-    ADD CONSTRAINT fk_device_profile_ota_package
-        FOREIGN KEY (device_profile_id) REFERENCES device_profile (id)
-            ON DELETE CASCADE;
+DO
+$$
+    BEGIN
+        IF NOT EXISTS(SELECT 1 FROM pg_constraint WHERE conname = 'fk_device_profile_ota_package') THEN
+            ALTER TABLE ota_package
+                ADD CONSTRAINT fk_device_profile_ota_package
+                    FOREIGN KEY (device_profile_id) REFERENCES device_profile (id)
+                        ON DELETE CASCADE;
+        END IF;
+    END;
+$$;
 
 -- We will use one-to-many relation in the first release and extend this feature in case of user requests
 -- CREATE TABLE IF NOT EXISTS device_profile_firmware (

--- a/dao/src/test/java/org/thingsboard/server/dao/SqlDaoServiceTestSuite.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/SqlDaoServiceTestSuite.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
         "org.thingsboard.server.dao.service.event.sql.*SqlTest",
         "org.thingsboard.server.dao.service.sql.*SqlTest",
         "org.thingsboard.server.dao.service.timeseries.sql.*SqlTest",
+        "org.thingsboard.server.dao.service.install.sql.*SqlTest"
 })
 public class SqlDaoServiceTestSuite {
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/service/install/sql/EntitiesSchemaSqlTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/install/sql/EntitiesSchemaSqlTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.service.install.sql;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.thingsboard.server.dao.service.AbstractServiceTest;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@DaoSqlTest
+public class EntitiesSchemaSqlTest extends AbstractServiceTest {
+
+    @Value("${spring.datasource.url}")
+    private String dbUrl;
+    @Value("${spring.datasource.username}")
+    private String dbUserName;
+    @Value("${spring.datasource.password}")
+    private String dbPassword;
+
+    @Value("${classpath:sql/schema-entities.sql}")
+    private Path installScriptPath;
+
+    @Test
+    public void testRepeatedInstall() throws IOException {
+        String installScript = Files.readString(installScriptPath);
+        try (Connection connection = getConnection()) {
+            for (int i = 1; i <= 2; i++) {
+                connection.createStatement().execute(installScript);
+            }
+        } catch (SQLException e) {
+            Assertions.fail("Failed to execute reinstall", e);
+        }
+    }
+
+    @Test
+    public void testRepeatedInstall_badScript() throws SQLException {
+        String illegalInstallScript = "CREATE TABLE IF NOT EXISTS qwerty ();\n" +
+                "ALTER TABLE qwerty ADD COLUMN first VARCHAR(10);";
+
+        Connection connection = getConnection();
+        try {
+            assertDoesNotThrow(() -> {
+                connection.createStatement().execute(illegalInstallScript);
+            });
+
+            assertThatThrownBy(() -> {
+                connection.createStatement().execute(illegalInstallScript);
+            }).hasMessageContaining("column").hasMessageContaining("already exists");
+        } finally {
+            connection.createStatement().execute("DROP TABLE qwerty;");
+            connection.close();
+        }
+    }
+
+    private Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(dbUrl, dbUserName, dbPassword);
+    }
+
+}


### PR DESCRIPTION
## Pull Request description

Fixed `fk_device_profile_ota_package` constraint creation in the install script, so that it works during repeated install. 
The upgrade script associated with this constraint is fine.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



