### PR TITLE
[3.4] Lwm2m coap from client post1

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/Lwm2mTestHelper.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/Lwm2mTestHelper.java
@@ -38,12 +38,14 @@ public class Lwm2mTestHelper {
     public static final int RESOURCE_ID_8 = 8;
     public static final int RESOURCE_ID_9 = 9;
     public static final int RESOURCE_ID_11 = 11;
+    public static final int RESOURCE_ID_13 = 13;
     public static final int RESOURCE_ID_14 = 14;
     public static final int RESOURCE_ID_15 = 15;
     public static final int RESOURCE_INSTANCE_ID_2 = 2;
 
     public static final String RESOURCE_ID_NAME_3_9 = "batteryLevel";
-    public static final String RESOURCE_ID_NAME_3_14 = "UtfOffset";
+    public static final String RESOURCE_ID_NAME_3_13 = "currentTime";
+    public static final String RESOURCE_ID_NAME_3_14 = "utfOffset";
     public static final String RESOURCE_ID_NAME_19_0_0 = "dataRead";
     public static final String RESOURCE_ID_NAME_19_1_0 = "dataWrite";
     public static final String RESOURCE_ID_NAME_19_0_3 = "dataDescription";

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/SimpleLwM2MDevice.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/SimpleLwM2MDevice.java
@@ -25,10 +25,10 @@ import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
-
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +47,7 @@ public class SimpleLwM2MDevice extends BaseInstanceEnabler implements Destroyabl
     private static final int max = 50;
     private static final  PrimitiveIterator.OfInt randomIterator = new Random().ints(min,max + 1).iterator();
     private static final List<Integer> supportedResources = Arrays.asList(0, 1, 2, 3, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 20, 21);
+    private Date currentTime;
 
 
     public SimpleLwM2MDevice() {
@@ -86,6 +87,8 @@ public class SimpleLwM2MDevice extends BaseInstanceEnabler implements Destroyabl
                 Map<Integer, Long> errorCodes = new HashMap<>();
                 errorCodes.put(0, getErrorCode());
                 return ReadResponse.success(resourceId, errorCodes, ResourceModel.Type.INTEGER);
+            case 13:
+                return ReadResponse.success(resourceId, getCurrentTime());
             case 14:
                 return ReadResponse.success(resourceId, getUtcOffset());
             case 15:
@@ -123,7 +126,9 @@ public class SimpleLwM2MDevice extends BaseInstanceEnabler implements Destroyabl
 
         switch (resourceId) {
             case 13:
-                return WriteResponse.notFound();
+                setCurrentTime((Date) value.getValue());
+                fireResourceChange(resourceId);
+                return WriteResponse.success();
             case 14:
                 setUtcOffset((String) value.getValue());
                 fireResourceChange(resourceId);
@@ -167,6 +172,19 @@ public class SimpleLwM2MDevice extends BaseInstanceEnabler implements Destroyabl
     }
 
     private String utcOffset = new SimpleDateFormat("X").format(Calendar.getInstance().getTime());
+
+    private Date getCurrentTime() {
+        try {
+            this.currentTime = currentTime == null ? currentTime = new Date() : currentTime;
+         } catch (Exception e) {
+            log.error("", e);
+        }
+        return currentTime;
+    }
+
+    private Date setCurrentTime(Date date) {
+        return currentTime = date;
+    }
 
     private String getUtcOffset() {
         return utcOffset;

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/coapresources/AbstractCoapResourcesLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/coapresources/AbstractCoapResourcesLwM2MIntegrationTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.coapresources;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MDeviceCredentials;
+import org.thingsboard.server.common.data.device.profile.Lwm2mDeviceProfileTransportConfiguration;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+import org.thingsboard.server.transport.lwm2m.AbstractLwM2MIntegrationTest;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import static org.eclipse.leshan.core.LwM2mId.DEVICE;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.BINARY_APP_DATA_CONTAINER;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_1;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_13;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_9;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_14;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_19_1_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_3_13;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_3_14;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_3_9;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.TEMPERATURE_SENSOR;
+import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.LWM2M_POST_COAP_RESOURCE;
+
+@Slf4j
+@DaoSqlTest
+public abstract class AbstractCoapResourcesLwM2MIntegrationTest extends AbstractLwM2MIntegrationTest {
+
+    protected String OBSERVE_ATTRIBUTES_WITH_PARAMS_RPC;
+    protected String deviceId;
+    public Set expectedObjects;
+    public Set expectedObjectIdVers;
+    public Set expectedInstances;
+    public Set expectedObjectIdVerInstances;
+
+    private static final Predicate PREDICATE_3 = path -> (!((String) path).startsWith("/" + TEMPERATURE_SENSOR) && ((String) path).startsWith("/" + DEVICE));
+    protected String objectIdVer_3;
+    protected String objectIdVer_19;
+    protected static AtomicInteger endpointSequence = new AtomicInteger();
+    protected static String DEVICE_ENDPOINT_COAP_RESOURCES_PREF = "deviceEndpointCoapResource";
+    protected String idVer_3_0_9;
+    protected String idVer_3_0_13;
+    protected String idVer_3_0_14;
+    protected String idVer_19_1_0;
+    protected String serverURI = "coap://localhost:5685/" + LWM2M_POST_COAP_RESOURCE;
+    protected static final Random RANDOM = new Random();
+
+    private static final String[] resources = new String[]{"3.xml","19.xml"};
+
+    public AbstractCoapResourcesLwM2MIntegrationTest() {
+        setResources(this.resources);
+    }
+
+    @Before
+    public void startInitRPC() throws Exception {
+        initRpc();
+    }
+
+    private void initRpc () throws Exception {
+        String endpoint = DEVICE_ENDPOINT_COAP_RESOURCES_PREF + endpointSequence.incrementAndGet();
+        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, true, endpoint, false, null);
+        expectedObjects = ConcurrentHashMap.newKeySet();
+        expectedObjectIdVers = ConcurrentHashMap.newKeySet();
+        expectedInstances = ConcurrentHashMap.newKeySet();
+        expectedObjectIdVerInstances = ConcurrentHashMap.newKeySet();
+        lwM2MTestClient.getLeshanClient().getObjectTree().getObjectEnablers().forEach((key, val) -> {
+            if (key > 0) {
+                String objectVerId = "/" + key;
+                objectVerId += ("_" + val.getObjectModel().version);
+                expectedObjects.add("/" + key);
+                expectedObjectIdVers.add(objectVerId);
+                String finalObjectVerId = objectVerId;
+                val.getAvailableInstanceIds().forEach(inststanceId -> {
+                    expectedInstances.add("/" + key + "/" + inststanceId);
+                    expectedObjectIdVerInstances.add(finalObjectVerId + "/" + inststanceId);
+                });
+            }
+        });
+        objectIdVer_3 = (String) expectedObjectIdVers.stream().filter(PREDICATE_3).findFirst().get();
+        objectIdVer_19 = (String) expectedObjectIdVers.stream().filter(path -> ((String) path).startsWith("/" + BINARY_APP_DATA_CONTAINER)).findFirst().get();
+        idVer_3_0_9 = objectIdVer_3 + "/" + OBJECT_INSTANCE_ID_0 + "/" + RESOURCE_ID_9;
+        idVer_3_0_13 = objectIdVer_3 + "/" + OBJECT_INSTANCE_ID_0 + "/" + RESOURCE_ID_13;
+        idVer_3_0_14 = objectIdVer_3 + "/" + OBJECT_INSTANCE_ID_0 + "/" + RESOURCE_ID_14;
+        idVer_19_1_0 = objectIdVer_19 + "/" + OBJECT_INSTANCE_ID_1 + "/" + RESOURCE_ID_0;
+
+        OBSERVE_ATTRIBUTES_WITH_PARAMS_RPC =
+                "    {\n" +
+                        "    \"keyName\": {\n" +
+                        "      \"" + idVer_3_0_9 + "\": \"" + RESOURCE_ID_NAME_3_9 + "\",\n" +
+                        "      \"" + idVer_3_0_13 + "\": \"" + RESOURCE_ID_NAME_3_13 + "\",\n" +
+                        "      \"" + idVer_3_0_14 + "\": \"" + RESOURCE_ID_NAME_3_14 + "\",\n" +
+                        "      \"" + idVer_19_1_0 + "\": \"" + RESOURCE_ID_NAME_19_1_0 + "\"\n" +
+                        "    },\n" +
+                        "    \"observe\": [],\n" +
+                        "    \"attribute\": [\n" +
+                        "      \"" + idVer_3_0_14 + "\"\n" +
+                        "    ],\n" +
+                        "    \"telemetry\": [\n" +
+                        "      \"" + idVer_3_0_9 + "\",\n" +
+                        "      \"" + idVer_3_0_13 + "\",\n" +
+                        "      \"" + idVer_19_1_0 + "\"\n" +
+                        "    ],\n" +
+                        "    \"attributeLwm2m\": {}\n" +
+                        "  }";
+
+        Lwm2mDeviceProfileTransportConfiguration transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITH_PARAMS_RPC, getBootstrapServerCredentialsNoSec(NONE));
+        createDeviceProfile(transportConfiguration);
+
+        LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(endpoint));
+        final Device device = createDevice(deviceCredentials, endpoint);
+        deviceId = device.getId().getId().toString();
+
+        lwM2MTestClient.start(true);
+    }
+
+    protected String pathIdVerToObjectId(String pathIdVer) {
+        if (pathIdVer.contains("_")) {
+            String[] objVer = pathIdVer.split("/");
+            objVer[1] = objVer[1].split("_")[0];
+            return String.join("/", objVer);
+        }
+        return pathIdVer;
+    }
+}
+

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/coapresources/sql/CoapResourcesLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/coapresources/sql/CoapResourcesLwM2MIntegrationTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.coapresources.sql;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.californium.core.CoapClient;
+import org.eclipse.californium.core.CoapResponse;
+import org.eclipse.californium.core.coap.CoAP;
+import org.eclipse.californium.core.coap.OptionSet;
+import org.eclipse.californium.core.coap.Request;
+import org.eclipse.californium.elements.exception.ConnectorException;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.request.ContentFormat;
+import org.eclipse.leshan.core.util.Hex;
+import org.junit.Test;
+import org.locationtech.jts.util.Assert;
+import org.thingsboard.server.transport.lwm2m.coapresources.AbstractCoapResourcesLwM2MIntegrationTest;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import static org.eclipse.californium.core.config.CoapConfig.MAX_RESOURCE_BODY_SIZE;
+import static org.eclipse.leshan.core.LwM2mId.DEVICE;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.BINARY_APP_DATA_CONTAINER;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_1;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_0;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_13;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_14;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_9;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_INSTANCE_ID_2;
+import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.LWM2M_POST_COAP_RESOURCE;
+import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.VALUE_SUB_LWM2M_POST_COAP_RESPONSE;
+
+@Slf4j
+public class CoapResourcesLwM2MIntegrationTest extends AbstractCoapResourcesLwM2MIntegrationTest {
+
+    private String dataHexDec = "5b7b226e223a222f31392f302f30222c227664223a22494f55644141433554414141525234414145556541414246486741415252344141455565414141414141414141414141414141414141423948414141525234414141414141414141414141416d557741414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c3064414143394851414176523041414c306441414339485141417652304141464f3553726b414b51695f4143676376305f775f7a4650385038774150427775613378434178743651544f415041472d4e3334424f44643651496a424c427752793370384563496e6731474245614b526741726639474b5168644751646d792d6f4c79537248433853414242666f43383564416c4541672d67487851656f44436b5f71463068503668524d485f71482d6272372d5034492d78366a4476734a38557a7141304f5a5167625a2d78674330706c434150496b675137785f7a355a47714f797366763438416a37454245412d776e35512d6f42524b464642646b3847514c536f555541386736424154696b36776b45514f6f4f51414168487248555141416a78756b415137336f3849634375665f6573767143386741715439484c47305f71463034662d6f66344153456c444c50375f76774f2d7877774b3059492d777a3552656f4152616c4643746c394753795f41534d4149366c4641746b414b7744773259414d386638387065734a42614f797466762d38413737454655492d774434512d6f46524b424642646b3847514c536f45554138736d414154696b36776745514f6f4d514c336e6930494932514175415043786741416878756b414251684776656a7768375036675f45414b55625271304c41384b6541676b4a4138715341434559414c71725178756b415371666e77764567414a644141666f4338305f714630374251435436415055662d6f66346c454164513748375f76417244413737454245412d776a38512d6f425135784643646e374743795f41534541495a784641746b414b5144776c5941424f4b507244414f74737250375f76454f2d78457a416673495f455871413057735251585a66526b433071784641504b4a674145357065734d4130487141454636353848784941534c51414c36416663462d674838346b41672d675434355541412d67482d45304e4936677743542d6f5453455f71456b77662d6f5035746676";
+
+
+    /**
+     * ContentFormat = ContentFormat.CBOR_CODE
+     * request.code = POST
+     * url = coap://localhost:5685/tbpost/{endpoint}/{lwm2mPath.toString()}
+     * url = coap://localhost:5685/tbpost/deviceEndpointCoapResource1//3/0/9
+     * payload = (byte[]) value
+     * @return response
+     * @throws Exception
+     */
+    @Test
+    public void testRequestPostValueInteger_Result_CONTENT() throws Exception {
+        String path3_0_9 =  DEVICE + "/" + OBJECT_INSTANCE_ID_0 + "/" + RESOURCE_ID_9;
+        LwM2mPath lwM2mPath = new LwM2mPath(path3_0_9);
+        int batteryLevel = RANDOM.nextInt(101);
+        String url = this.serverURI + "/" + lwM2MTestClient.getEndpoint() + "/" + lwM2mPath.toString().trim();
+        CoapResponse  response = requestPost(url, ByteBuffer.allocate(4).putInt(batteryLevel).array());
+        Assert.equals( CoAP.ResponseCode.CONTENT, response.getCode());
+        String payload = new String (response.getPayload());
+        String expectValueStr = Integer.toString(batteryLevel);
+        String actualValueStr = payload.substring(payload.indexOf(VALUE_SUB_LWM2M_POST_COAP_RESPONSE) + VALUE_SUB_LWM2M_POST_COAP_RESPONSE.length());
+        Assert.equals(expectValueStr, actualValueStr);
+    }
+
+    /**
+     * value: Date -> long seconds -> byte[]
+     * @throws Exception
+     */
+    @Test
+    public void testRequestPostValueDate_Result_CONTENT() throws Exception {
+        String path3_0_13 =  DEVICE + "/" + OBJECT_INSTANCE_ID_0 + "/" + RESOURCE_ID_13;
+        LwM2mPath lwM2mPath = new LwM2mPath(path3_0_13);
+        Date expectDate = new Date();
+        long currentTime = expectDate.getTime()/1000L;
+        String url = this.serverURI + "/" + lwM2MTestClient.getEndpoint() + "/" + lwM2mPath.toString().trim();
+        CoapResponse  response = requestPost(url, ByteBuffer.allocate(8).putLong(currentTime).array());
+        Assert.equals( CoAP.ResponseCode.CONTENT, response.getCode());
+        String payload = new String (response.getPayload());
+        String expectValueStr = expectDate.toString();
+        String actualValueStr = payload.substring(payload.indexOf(VALUE_SUB_LWM2M_POST_COAP_RESPONSE) + VALUE_SUB_LWM2M_POST_COAP_RESPONSE.length());
+        Assert.equals(expectValueStr, actualValueStr);
+    }
+
+    @Test
+    public void testRequestPostValueString_Result_CONTENT() throws Exception {
+        String path3_0_14 =  DEVICE + "/" + OBJECT_INSTANCE_ID_0 + "/" + RESOURCE_ID_14;
+        LwM2mPath lwM2mPath = new LwM2mPath(path3_0_14);
+        String expectUtcOffset = new SimpleDateFormat("X").format(Calendar.getInstance().getTime());
+        String url = this.serverURI + "/" + lwM2MTestClient.getEndpoint() + "/" + lwM2mPath.toString().trim();
+        CoapResponse  response = requestPost(url, expectUtcOffset.getBytes());
+        Assert.equals( CoAP.ResponseCode.CONTENT, response.getCode());
+        String payload = new String (response.getPayload());
+        String actualValueStr = payload.substring(payload.indexOf(VALUE_SUB_LWM2M_POST_COAP_RESPONSE) + VALUE_SUB_LWM2M_POST_COAP_RESPONSE.length());
+        Assert.equals(expectUtcOffset, actualValueStr);
+    }
+
+    @Test
+    public void testRequestPostValueOpaqueMultipleResourced_Result_CONTENT() throws Exception {
+        String path19_1_0_2 =  BINARY_APP_DATA_CONTAINER + "/" + OBJECT_INSTANCE_ID_1 + "/" + RESOURCE_ID_0+ "/" + RESOURCE_INSTANCE_ID_2;
+        LwM2mPath lwM2mPath = new LwM2mPath(path19_1_0_2);
+         byte [] valueOpaque = Hex.decodeHex((dataHexDec).toCharArray());
+        String url = this.serverURI + "/" + lwM2MTestClient.getEndpoint() + "/" + lwM2mPath.toString().trim();
+        CoapResponse  response = requestPost(url, valueOpaque);
+        Assert.equals( CoAP.ResponseCode.CONTENT, response.getCode());
+        String payload = new String (response.getPayload());
+        String expectOpaqueValueStr = valueOpaque.length + " Bytes, " + Hex.encodeHexString(valueOpaque);
+        String actualValueStr = payload.substring(payload.indexOf(VALUE_SUB_LWM2M_POST_COAP_RESPONSE) + VALUE_SUB_LWM2M_POST_COAP_RESPONSE.length());
+        Assert.isTrue(expectOpaqueValueStr.contains(actualValueStr));
+    }
+
+    @Test
+    public void testRequestPostBadEndpoint_Result_UNAUTHORIZED() throws Exception {
+        String path3_0_9 =  DEVICE + "/" + OBJECT_INSTANCE_ID_0 + "/" + RESOURCE_ID_9;
+        LwM2mPath lwM2mPath = new LwM2mPath(path3_0_9);
+        int batteryLevel = RANDOM.nextInt(101);
+        String url = this.serverURI + "/" + lwM2MTestClient.getEndpoint() + "_UNAUTHORIZED" + "/" + lwM2mPath.toString().trim();
+        CoapResponse  response = requestPost(url, ByteBuffer.allocate(4).putInt(batteryLevel).array());
+        Assert.equals( CoAP.ResponseCode.UNAUTHORIZED, response.getCode());
+        String payload = new String (response.getPayload());
+        Integer actualValue = Integer.parseInt(payload.substring(payload.indexOf(VALUE_SUB_LWM2M_POST_COAP_RESPONSE) + VALUE_SUB_LWM2M_POST_COAP_RESPONSE.length()),16);
+        Assert.equals(batteryLevel, actualValue);
+    }
+
+    @Test
+    public void testRequestPostInvalidPathResource_Result_BAD_REQUEST() throws Exception {
+        String path3_0_9 =  DEVICE + "/" + OBJECT_INSTANCE_ID_0;
+        LwM2mPath lwM2mPath = new LwM2mPath(path3_0_9);
+        int batteryLevel = RANDOM.nextInt(101);
+        String url = this.serverURI + "/" + lwM2MTestClient.getEndpoint() + "/" + lwM2mPath.toString().trim();
+        CoapResponse  response = requestPost(url, ByteBuffer.allocate(4).putInt(batteryLevel).array());
+        Assert.equals( CoAP.ResponseCode.BAD_REQUEST, response.getCode());
+        String actualPayload = new String (response.getPayload());
+        String expectValue = String.format("Invalid LwM2mPath resource, must be LwM2mResourceInstance or LwM2mSingleResource. Lwm2m coap Post request: [%s, %s, , %d, %d]",
+                LWM2M_POST_COAP_RESOURCE, lwM2MTestClient.getEndpoint(), lwM2mPath.getObjectId(), lwM2mPath.getObjectInstanceId());
+        Assert.equals(actualPayload,expectValue);
+    }
+
+    @Test
+    public void testRequestPostInvalidUriPath_Result_BAD_OPTION() throws Exception {
+        int batteryLevel = RANDOM.nextInt(101);
+        String uriPath = this.serverURI + "/" + lwM2MTestClient.getEndpoint();
+        CoapResponse  response = requestPost(uriPath, ByteBuffer.allocate(4).putInt(batteryLevel).array());
+        Assert.equals( CoAP.ResponseCode.BAD_OPTION, response.getCode());
+        String actualPayload = new String (response.getPayload());
+        String expectValue = String.format("Invalid UriPath. Lwm2m coap Post request: [%s, %s]",
+                LWM2M_POST_COAP_RESOURCE, lwM2MTestClient.getEndpoint());
+        Assert.equals(actualPayload,expectValue);
+    }
+
+    public CoapResponse requestPost(String url, Object value) {
+        try {
+            CoapClient client = new CoapClient(url);
+            Request request = new Request(CoAP.Code.POST);
+            OptionSet options = new OptionSet();
+            options.setContentFormat(ContentFormat.CBOR_CODE);
+            options.setBlock2(6, false, 0);
+            request.setOptions(options);
+            if (value instanceof byte[]) {
+                request.setPayload((byte[]) value);
+            }
+            client.useEarlyNegotiation(1024);
+            request.setMaxResourceBodySize(this.lwM2MTestClient.getLeshanClient().coap().getServer().getConfig().get(MAX_RESOURCE_BODY_SIZE));
+            return client.advanced(request);
+        } catch (ConnectorException | IOException e) {
+            log.error("Error occurred while sending request: " + e);
+            return null;
+        }
+    }
+}

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
@@ -54,6 +54,7 @@ import static org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_PSK_W
 import static org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
 import static org.thingsboard.server.transport.lwm2m.server.LwM2MNetworkConfig.getCoapConfig;
 import static org.thingsboard.server.transport.lwm2m.server.ota.DefaultLwM2MOtaUpdateService.FIRMWARE_UPDATE_COAP_RESOURCE;
+import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.LWM2M_POST_COAP_RESOURCE;
 
 @Slf4j
 @Component
@@ -88,6 +89,8 @@ public class DefaultLwM2mTransportService implements LwM2MTransportService {
          */
         LwM2mTransportCoapResource otaCoapResource = new LwM2mTransportCoapResource(otaPackageDataCache, FIRMWARE_UPDATE_COAP_RESOURCE);
         this.server.coap().getServer().add(otaCoapResource);
+        LwM2mTransportCoapResource dataPostCoapResource = new LwM2mTransportCoapResource(null, LWM2M_POST_COAP_RESOURCE);
+        this.server.coap().getServer().add(dataPostCoapResource);
         this.context.setServer(server);
         this.startLhServer();
     }

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
@@ -20,15 +20,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
-import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mDecoder;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mEncoder;
-import org.eclipse.leshan.core.request.SendRequest;
 import org.eclipse.leshan.server.californium.LeshanServer;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.californium.registration.CaliforniumRegistrationStore;
-import org.eclipse.leshan.server.registration.Registration;
-import org.eclipse.leshan.server.send.SendListener;
 import org.springframework.stereotype.Component;
 import org.thingsboard.server.cache.ota.OtaPackageDataCache;
 import org.thingsboard.server.common.data.DataConstants;
@@ -38,13 +34,14 @@ import org.thingsboard.server.queue.util.TbLwM2mTransportComponent;
 import org.thingsboard.server.transport.lwm2m.config.LwM2MTransportServerConfig;
 import org.thingsboard.server.transport.lwm2m.secure.TbLwM2MAuthorizer;
 import org.thingsboard.server.transport.lwm2m.secure.TbLwM2MDtlsCertificateVerifier;
+import org.thingsboard.server.transport.lwm2m.server.coapresource.LwM2mTransportCoapResource;
 import org.thingsboard.server.transport.lwm2m.server.store.TbSecurityStore;
 import org.thingsboard.server.transport.lwm2m.server.uplink.DefaultLwM2mUplinkMsgHandler;
+import org.thingsboard.server.transport.lwm2m.server.uplink.LwM2mUplinkMsgHandler;
 import org.thingsboard.server.transport.lwm2m.utils.LwM2mValueConverterImpl;
 
 import javax.annotation.PreDestroy;
 import java.security.cert.X509Certificate;
-import java.util.Map;
 
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CURVES_ONLY;
@@ -74,6 +71,7 @@ public class DefaultLwM2mTransportService implements LwM2MTransportService {
     private final TbLwM2MDtlsCertificateVerifier certificateVerifier;
     private final TbLwM2MAuthorizer authorizer;
     private final LwM2mVersionedModelProvider modelProvider;
+    private final LwM2mUplinkMsgHandler service;
 
     private LeshanServer server;
 
@@ -87,9 +85,9 @@ public class DefaultLwM2mTransportService implements LwM2MTransportService {
          * nameFile = "BC68JAR01A09_TO_BC68JAR01A10.bin"
          * "coap://host:port/{path}/{token}/{nameFile}"
          */
-        LwM2mTransportCoapResource otaCoapResource = new LwM2mTransportCoapResource(otaPackageDataCache, FIRMWARE_UPDATE_COAP_RESOURCE);
+        LwM2mTransportCoapResource otaCoapResource = new LwM2mTransportCoapResource(otaPackageDataCache, FIRMWARE_UPDATE_COAP_RESOURCE, service);
         this.server.coap().getServer().add(otaCoapResource);
-        LwM2mTransportCoapResource dataPostCoapResource = new LwM2mTransportCoapResource(null, LWM2M_POST_COAP_RESOURCE);
+        LwM2mTransportCoapResource dataPostCoapResource = new LwM2mTransportCoapResource(null, LWM2M_POST_COAP_RESOURCE, service);
         this.server.coap().getServer().add(dataPostCoapResource);
         this.context.setServer(server);
         this.startLhServer();

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportCoapResource.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportCoapResource.java
@@ -24,6 +24,8 @@ import org.eclipse.californium.core.observe.ObserveRelation;
 import org.eclipse.californium.core.server.resources.CoapExchange;
 import org.eclipse.californium.core.server.resources.Resource;
 import org.eclipse.californium.core.server.resources.ResourceObserver;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.util.Hex;
 import org.thingsboard.server.cache.ota.OtaPackageDataCache;
 
 import java.util.List;
@@ -34,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.thingsboard.server.transport.lwm2m.server.ota.DefaultLwM2MOtaUpdateService.FIRMWARE_UPDATE_COAP_RESOURCE;
 import static org.thingsboard.server.transport.lwm2m.server.ota.DefaultLwM2MOtaUpdateService.SOFTWARE_UPDATE_COAP_RESOURCE;
+import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.LWM2M_POST_COAP_RESOURCE;
 
 @Slf4j
 public class LwM2mTransportCoapResource extends AbstractLwM2mTransportResource {
@@ -82,6 +85,21 @@ public class LwM2mTransportCoapResource extends AbstractLwM2mTransportResource {
     @Override
     protected void processHandlePost(CoapExchange exchange) {
         log.debug("processHandlePost [{}]", exchange);
+        try {
+            List<String> uriPath = exchange.getRequestOptions().getUriPath();
+            if (uriPath.size() == 3 && LWM2M_POST_COAP_RESOURCE.equals(uriPath.get(0))) {
+                String endpoint = uriPath.get(1);
+                LwM2mPath lwM2mPath = new LwM2mPath(uriPath.get(2).replaceAll("-", "/"));
+                byte[] payLoadRequest = exchange.getRequestPayload();
+                String payLoadRequestStr = Hex.encodeHexString(exchange.getRequestPayload());
+                this.sendDataToTransport(exchange, lwM2mPath, endpoint, payLoadRequest);
+
+            } else {
+                log.error("Invalid UriPath. Lwm2m coap Post request: {}", uriPath);
+            }
+        } catch (Exception e) {
+            log.error("Invalid Lwm2m coap Post request: [{}]", e.getMessage());
+        }
     }
 
     /**
@@ -159,4 +177,11 @@ public class LwM2mTransportCoapResource extends AbstractLwM2mTransportResource {
         return otaPackageDataCache.get(currentId.toString());
     }
 
+    private void sendDataToTransport(CoapExchange exchange, LwM2mPath lwM2mPath, String endpoint, byte[] payLoadRequest) {
+
+        Response response = new Response(CoAP.ResponseCode.CONTENT);
+        String payLoadResponse = lwM2mPath.toString() + ", size = " + exchange.getRequestPayloadSize();
+        response.setPayload(payLoadResponse);
+        exchange.respond(response);
+    }
 }

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/coapresource/LwM2MCoapRequestPost.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/coapresource/LwM2MCoapRequestPost.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.server.coapresource;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Slf4j
+@Data
+public class LwM2MCoapRequestPost {
+
+    CoapExchange exchange;
+    List<String> uriPath;
+    String endpoint;
+    LwM2mPath lwM2mPath;
+    String payLoadResponse;
+
+    public boolean validateParamsRequest() {
+        try {
+            this.endpoint = uriPath.get(1);
+            List<String> lwM2mPathList =
+                    IntStream.range(2, uriPath.size())
+                            .mapToObj(uriPath::get)
+                            .collect(Collectors.toList());
+            String lwM2mPathStr = StringUtils.join(lwM2mPathList, "/");
+            this.lwM2mPath = new LwM2mPath(lwM2mPathStr);
+            if (exchange.getRequestPayload() != null && StringUtils.isNotEmpty(endpoint)) {
+                if (this.lwM2mPath.isResourceInstance() || this.lwM2mPath.isResource()) {
+                    return true;
+                } else {
+                    this.payLoadResponse = String.format("Invalid LwM2mPath resource, must be LwM2mResourceInstance or  LwM2mSingleResource. Lwm2m coap Post request: %s", uriPath);
+                    log.error(payLoadResponse);
+                }
+            } else {
+                this.payLoadResponse = String.format("Invalid Endpoint or PayLoadRequest. Lwm2m coap Post request: %s", uriPath);
+                log.error(payLoadResponse);
+            }
+        } catch (Exception e) {
+            this.payLoadResponse = String.format("Invalid Lwm2m coap Post request: [%s]", e.getMessage());
+            log.error(payLoadResponse);
+        }
+        return false;
+    }
+}

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/coapresource/LwM2MCoapRequestPost.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/coapresource/LwM2MCoapRequestPost.java
@@ -19,7 +19,9 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.LwM2mPath;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -28,11 +30,13 @@ import java.util.stream.IntStream;
 @Data
 public class LwM2MCoapRequestPost {
 
-    CoapExchange exchange;
-    List<String> uriPath;
-    String endpoint;
-    LwM2mPath lwM2mPath;
-    String payLoadResponse;
+    private CoapExchange exchange;
+    private List<String> uriPath;
+    private String endpoint;
+    private LwM2mPath lwM2mPath;
+    private String payLoadResponse;
+    private ResourceModel.Type type;
+    private String valueStr;
 
     public boolean validateParamsRequest() {
         try {
@@ -47,7 +51,7 @@ public class LwM2MCoapRequestPost {
                 if (this.lwM2mPath.isResourceInstance() || this.lwM2mPath.isResource()) {
                     return true;
                 } else {
-                    this.payLoadResponse = String.format("Invalid LwM2mPath resource, must be LwM2mResourceInstance or  LwM2mSingleResource. Lwm2m coap Post request: %s", uriPath);
+                    this.payLoadResponse = String.format("Invalid LwM2mPath resource, must be LwM2mResourceInstance or LwM2mSingleResource. Lwm2m coap Post request: %s", uriPath);
                     log.error(payLoadResponse);
                 }
             } else {

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/LwM2mUplinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/LwM2mUplinkMsgHandler.java
@@ -29,6 +29,7 @@ import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.transport.lwm2m.config.LwM2MTransportServerConfig;
 import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
+import org.thingsboard.server.transport.lwm2m.server.coapresource.LwM2MCoapRequestPost;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -44,6 +45,8 @@ public interface LwM2mUplinkMsgHandler {
     void onSleepingDev(Registration registration);
 
     void onUpdateValueAfterReadResponse(Registration registration, String path, ReadResponse response);
+
+    boolean onUpdateResourceValueAfterCoapRequestPost(LwM2MCoapRequestPost coapRequestPost);
 
     void onUpdateValueAfterReadCompositeResponse(Registration registration, ReadCompositeResponse response);
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
@@ -93,6 +93,7 @@ public class LwM2MTransportUtil {
     public static final String LOG_LWM2M_ERROR = "error";
     public static final String LOG_LWM2M_WARN = "warn";
     public static final int BOOTSTRAP_DEFAULT_SHORT_ID = 0;
+    public static final String LWM2M_POST_COAP_RESOURCE = "tbpost";
 
     public enum LwM2MClientStrategy {
         CLIENT_STRATEGY_1(1, "Read only resources marked as observation"),

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
@@ -96,6 +96,7 @@ public class LwM2MTransportUtil {
     public static final String LOG_LWM2M_WARN = "warn";
     public static final int BOOTSTRAP_DEFAULT_SHORT_ID = 0;
     public static final String LWM2M_POST_COAP_RESOURCE = "tbpost";
+    public static final String VALUE_SUB_LWM2M_POST_COAP_RESPONSE =  "value: ";
 
     public enum LwM2MClientStrategy {
         CLIENT_STRATEGY_1(1, "Read only resources marked as observation"),
@@ -550,5 +551,13 @@ public class LwM2MTransportUtil {
             default:
                 return null;
         }
+    }
+
+    public static String setValueStr1024(String str) {
+        String valueStr = str;
+        if (str != null && str.length() > 1024) {
+            valueStr =  str.substring(0, 1024);
+        }
+        return valueStr;
     }
 }


### PR DESCRIPTION
## Pull Request description

This fixes the issue https://github.com/thingsboard/thingsboard/issues/6286)

###    Add new coap resource to lwmw2m server :
```
LwM2mTransportCoapResource dataPostCoapResource = new LwM2mTransportCoapResource(null, LWM2M_POST_COAP_RESOURCE);
this.server.coap().getServer().add(dataPostCoapResource);
```
The format request from client:
```
[coap://](coap://%D0%A5){host}:5685//tbpost/{endpoint}/{resource}
[coap://](coap://%D0%A5){host}:5685//tbpost/{endpoint}/{resourceInstance}
```
Any **value** from the client read from the request -> getRequestPayload() must be in the format: byte[] (byte array);
Example:
- UnSecure
```
coap://localhost:5685/tbpost/LwNoSec00000000/19/0/0
```
```
coap://localhost:5685/tbpost/LwNoSec00000000/19/0/0/25
```
- Secure
```
coaps://localhost:5685/tbpost/LwNoSec00000000/19/0/0
```
### Update resource value if client session is open

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.