### PR TITLE
[3.4] UI: Fixed show double dialog with redirect

### DIFF
--- a/ui-ngx/src/app/core/guards/confirm-on-exit.guard.ts
+++ b/ui-ngx/src/app/core/guards/confirm-on-exit.guard.ts
@@ -21,7 +21,7 @@ import { select, Store } from '@ngrx/store';
 import { AppState } from '@core/core.state';
 import { AuthState } from '@core/auth/auth.models';
 import { selectAuth } from '@core/auth/auth.selectors';
-import { take } from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 import { DialogService } from '@core/services/dialog.service';
 import { TranslateService } from '@ngx-translate/core';
 import { isDefined } from '../utils';
@@ -69,6 +69,13 @@ export class ConfirmOnExitGuard implements CanDeactivate<HasConfirmForm & HasDir
         return this.dialogService.confirm(
           this.translate.instant('confirm-on-exit.title'),
           this.translate.instant('confirm-on-exit.html-message')
+        ).pipe(
+          map((dialogResult) => {
+            if (dialogResult) {
+              component.confirmForm().markAsPristine();
+            }
+            return dialogResult;
+          })
         );
       }
     }

--- a/ui-ngx/src/app/core/guards/confirm-on-exit.guard.ts
+++ b/ui-ngx/src/app/core/guards/confirm-on-exit.guard.ts
@@ -72,7 +72,11 @@ export class ConfirmOnExitGuard implements CanDeactivate<HasConfirmForm & HasDir
         ).pipe(
           map((dialogResult) => {
             if (dialogResult) {
-              component.confirmForm().markAsPristine();
+              if (component.confirmForm && component.confirmForm()) {
+                component.confirmForm().markAsPristine();
+              } else {
+                component.isDirty = false;
+              }
             }
             return dialogResult;
           })


### PR DESCRIPTION
## Pull Request description
Issue: [#6349](https://github.com/thingsboard/thingsboard/issues/6349)
Before fix:
canDeactivate dialog shows double times with redirect.

After fix:
Dialog shows one time.

![image](https://user-images.githubusercontent.com/83352633/161067324-71d8b1b3-f827-493d-bc30-e125c85fc84b.png)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



