### PR TITLE
WIP Disable chart zooming on device with small screens (768px width)

### DIFF
--- a/ui-ngx/src/app/core/services/utils.service.ts
+++ b/ui-ngx/src/app/core/services/utils.service.ts
@@ -88,6 +88,7 @@ export class UtilsService {
 
   iframeMode = false;
   widgetEditMode = false;
+  isMobile:boolean = null;
   editWidgetInfo: WidgetInfo = null;
 
   defaultDataKey: DataKey = {
@@ -473,5 +474,12 @@ export class UtilsService {
     } else {
       return defaultValue;
     }
+  }
+
+  public isMobileDevice(): boolean {
+    if (this.isMobile === null) {
+       this.isMobile = this.window.matchMedia('only screen and (max-width: 768px)').matches;
+    }
+    return this.isMobile;
   }
 }

--- a/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
@@ -179,7 +179,7 @@ export class TbFlot {
         autoHighlight: this.tooltipIndividual === true,
         markings: []
       },
-      selection : { mode : 'x' },
+      selection : { mode : this.getSelectionMode() },
       legend : {
         show: false
       }
@@ -1147,7 +1147,7 @@ export class TbFlot {
   private enableMouseEvents() {
     this.$element.css('pointer-events', '');
     this.$element.addClass('mouse-events');
-    this.options.selection = { mode : 'x' };
+    this.options.selection = { mode : this.getSelectionMode() };
     this.$element.bind('plothover', this.flotHoverHandler);
     this.$element.bind('plotselected', this.flotSelectHandler);
     this.$element.bind('dblclick', this.dblclickHandler);
@@ -1475,6 +1475,10 @@ export class TbFlot {
       const entityLabel = entityInfo ? entityInfo.entityLabel : null;
       this.ctx.actionsApi.handleWidgetAction($event, descriptors[0], entityId, entityName, item, entityLabel);
     }
+  }
+
+  private getSelectionMode(): JQueryPlotSelectionMode {
+    return this.utils.isMobileDevice() ? null : 'x';
   }
 
 }


### PR DESCRIPTION
## Pull Request description

Issue: [#6226](https://github.com/thingsboard/thingsboard/issues/6226)
To scroll charts on device with small screens (less than 768px width) this PR is disabling chart zooming (selection feature).

## General checklist

- [x ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  



