### PR TITLE
[3.4] UI: Fix displaying 'Unit title' and 'value timestamp' for Digital gauges widgets

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/canvas-digital-gauge.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/canvas-digital-gauge.ts
@@ -628,7 +628,7 @@ function barDimensions(context: DigitalGaugeCanvasRenderingContext2D,
     bd.labelY = bd.baseY + bd.height;
     bd.timeseriesLabelY = determineTimeseriesLabelY(options, bd.labelY, bd.fontSizeFactor)
     if (options.showUnitTitle || options.showTimestamp) {
-      bd.barBottom = bd.labelY * 1.1 - (8 + options.fontLabelSize) * bd.fontSizeFactor;
+      bd.barBottom = bd.labelY - options.fontLabelSize * bd.fontSizeFactor;
     } else {
       bd.barBottom = bd.labelY
     }

--- a/ui-ngx/src/app/modules/home/components/widget/lib/canvas-digital-gauge.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/canvas-digital-gauge.ts
@@ -86,6 +86,9 @@ export interface CanvasDigitalGaugeOptions extends GenericOptions {
   colorTicks?: string;
   tickWidth?: number;
 
+  labelTimestamp?: string
+  unitTitle?: string;
+  showUnitTitle?: boolean;
   showTimestamp?: boolean;
 }
 
@@ -362,7 +365,7 @@ export class CanvasDigitalGauge extends BaseGauge {
       const options = this.options as CanvasDigitalGaugeOptions;
       const elementClone = canvas.elementClone as HTMLCanvasElementClone;
       if (!elementClone.initialized) {
-        const context = canvas.contextClone;
+        let context = canvas.contextClone;
 
         // clear the cache
         context.clearRect(x, y, w, h);
@@ -378,8 +381,9 @@ export class CanvasDigitalGauge extends BaseGauge {
 
         drawDigitalTitle(context, options);
 
-        if (!options.showTimestamp) {
-          drawDigitalLabel(context, options);
+        if (options.showUnitTitle) {
+          drawDigitalLabel(context, options, options.unitTitle);
+          context['barDimensions'].labelY += 20;
         }
 
         drawDigitalMinMax(context, options);
@@ -406,7 +410,7 @@ export class CanvasDigitalGauge extends BaseGauge {
         drawDigitalValue(context, options, this.elementValueClone.renderedValue);
 
         if (options.showTimestamp) {
-          drawDigitalLabel(context, options);
+          drawDigitalLabel(context, options, options.labelTimestamp);
           this.elementValueClone.renderedTimestamp = this.timestamp;
         }
 
@@ -751,8 +755,8 @@ function drawDigitalTitle(context: DigitalGaugeCanvasRenderingContext2D, options
   context.restore();
 }
 
-function drawDigitalLabel(context: DigitalGaugeCanvasRenderingContext2D, options: CanvasDigitalGaugeOptions) {
-  if (!options.label || options.label === '') {
+function drawDigitalLabel(context: DigitalGaugeCanvasRenderingContext2D, options: CanvasDigitalGaugeOptions, text: string) {
+  if (!text || text === '') {
     return;
   }
 
@@ -766,7 +770,7 @@ function drawDigitalLabel(context: DigitalGaugeCanvasRenderingContext2D, options
   context.textAlign = 'center';
   context.font = Drawings.font(options, 'Label', fontSizeFactor);
   context.lineWidth = 0;
-  drawText(context, options, 'Label', options.label, textX, textY);
+  drawText(context, options, 'Label', text, textX, textY);
   context.restore();
 }
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/canvas-digital-gauge.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/canvas-digital-gauge.ts
@@ -102,7 +102,6 @@ const defaultDigitalGaugeOptions: CanvasDigitalGaugeOptions = { ...GenericOption
     levelColors: ['blue'],
 
     symbol: '',
-    label: '',
     hideValue: false,
     hideMinMax: false,
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/canvas-digital-gauge.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/canvas-digital-gauge.ts
@@ -664,7 +664,6 @@ function barDimensions(context: DigitalGaugeCanvasRenderingContext2D,
   return bd;
 }
 
-
 function determineTimeseriesLabelY(options: CanvasDigitalGaugeOptions, labelY: number, fontSizeFactor: number){
   if (options.showUnitTitle) {
     return  labelY + options.fontLabelSize * fontSizeFactor * 1.2;
@@ -672,6 +671,7 @@ function determineTimeseriesLabelY(options: CanvasDigitalGaugeOptions, labelY: n
     return labelY;
   }
 }
+
 function determineFontHeight(options: CanvasDigitalGaugeOptions, target: string, baseSize: number): FontHeightInfo {
   const fontStyleStr = 'font-style:' + options['font' + target + 'Style'] + ';font-weight:' +
     options['font' + target + 'Weight'] + ';font-size:' +

--- a/ui-ngx/src/app/modules/home/components/widget/lib/digital-gauge.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/digital-gauge.ts
@@ -189,7 +189,6 @@ export class TbCanvasDigitalGauge {
       roundedLineCap: this.localSettings.roundedLineCap,
 
       symbol: this.localSettings.units,
-      // label: this.localSettings.unitTitle,
       unitTitle: this.localSettings.unitTitle,
       showUnitTitle: this.localSettings.showUnitTitle,
       showTimestamp: this.localSettings.showTimestamp,

--- a/ui-ngx/src/app/modules/home/components/widget/lib/digital-gauge.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/digital-gauge.ts
@@ -72,6 +72,7 @@ export class TbCanvasDigitalGauge {
       (settings.unitTitle && settings.unitTitle.length > 0 ?
         settings.unitTitle : dataKey.label) : '');
 
+    this.localSettings.showUnitTitle = settings.showUnitTitle === true;
     this.localSettings.showTimestamp = settings.showTimestamp === true;
     this.localSettings.timestampFormat = settings.timestampFormat && settings.timestampFormat.length ?
       settings.timestampFormat : 'yyyy-MM-dd HH:mm:ss';
@@ -188,7 +189,9 @@ export class TbCanvasDigitalGauge {
       roundedLineCap: this.localSettings.roundedLineCap,
 
       symbol: this.localSettings.units,
-      label: this.localSettings.unitTitle,
+      // label: this.localSettings.unitTitle,
+      unitTitle: this.localSettings.unitTitle,
+      showUnitTitle: this.localSettings.showUnitTitle,
       showTimestamp: this.localSettings.showTimestamp,
       hideValue: this.localSettings.hideValue,
       hideMinMax: this.localSettings.hideMinMax,
@@ -407,7 +410,7 @@ export class TbCanvasDigitalGauge {
         if (this.localSettings.showTimestamp) {
           timestamp = tvPair[0];
           const filter = this.ctx.$injector.get(DatePipe);
-          (this.gauge.options as CanvasDigitalGaugeOptions).label =
+          (this.gauge.options as CanvasDigitalGaugeOptions).labelTimestamp =
             filter.transform(timestamp, this.localSettings.timestampFormat);
         }
         const value = tvPair[1];


### PR DESCRIPTION
## Pull Request description

Issue: https://github.com/thingsboard/thingsboard/issues/6461   

## General checklist

- [X] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [X] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [X] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [X] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [X] No merge conflicts, commented blocks of code, code formatting issues.
- [X] Changes are backward compatible or upgrade script is provided.
- [X] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [X] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [X] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [X] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

![image](https://user-images.githubusercontent.com/43555187/164690306-d1bf19ac-ed37-4265-92e8-67afbb7b79ea.png)

Before:
![image](https://user-images.githubusercontent.com/43555187/164690452-e720960d-e5f8-47d4-90dd-79299bce50ef.png)

After:
![image](https://user-images.githubusercontent.com/43555187/164690663-9fd4e506-2e73-42d6-850c-0c2cfc4a6959.png)





