### PR TITLE
[3.4] UI: Fixed not correct work vertical resize in knob widget

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/rpc/knob.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/rpc/knob.component.html
@@ -15,8 +15,8 @@
     limitations under the License.
 
 -->
-<div class="tb-knob" fxLayout="column" [ngStyle]="{'pointerEvents': ctx.isEdit ? 'none' : 'all'}">
-  <div #knobContainer id="knob-container" fxFlex fxLayout="column" fxLayoutAlign="center center">
+<div #knobContainer class="tb-knob" fxLayout="column" [ngStyle]="{'pointerEvents': ctx.isEdit ? 'none' : 'all'}">
+  <div fxFlex fxLayout="column" fxLayoutAlign="center center">
     <div #knob class="knob">
       <div #knobValueContainer class="value-container" fxLayout="row" fxLayoutAlign="center center">
         <span #knobValue class="knob-value">{{ value }}</span>


### PR DESCRIPTION
## Pull Request description

Fixed #6141
Knob Control widget incorrect resize by negative vertical.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

Before:
![image](https://user-images.githubusercontent.com/18036670/173056834-92ac36b0-04d0-468c-82c1-70474034b407.png)

After:
![image](https://user-images.githubusercontent.com/18036670/173056884-93a0fab7-0ef3-45b0-80f1-93977d5872e4.png)

