### PR TITLE
[3.4] UI: Fixed incorrect switch edit widget panel when active add widget panel in dashboard page

### DIFF
--- a/ui-ngx/src/app/modules/home/components/dashboard-page/dashboard-page.component.ts
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/dashboard-page.component.ts
@@ -1127,6 +1127,13 @@ export class DashboardPageComponent extends PageComponent implements IDashboardC
 
   editWidget($event: Event, layoutCtx: DashboardPageLayoutContext, widget: Widget) {
     $event.stopPropagation();
+
+    if (this.isAddingWidget) {
+      this.onAddWidgetClosed();
+      this.isAddingWidgetClosed = true;
+      this.isEditingWidgetClosed = false;
+    }
+
     if (this.editingWidgetOriginal === widget) {
       this.onEditWidgetClosed();
     } else {


### PR DESCRIPTION
## Pull Request description

Fixed #6020 
We could not switch from the widget add panel to the widget edit panel in dashboard page.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


