### PR TITLE
[UI][3.4] Fixed bug with incorrect display of delayed status

### DIFF
--- a/ui-ngx/src/app/modules/home/components/edge/edge-downlink-table-config.ts
+++ b/ui-ngx/src/app/modules/home/components/edge/edge-downlink-table-config.ts
@@ -138,7 +138,7 @@ export class EdgeDownlinkTableConfig extends EntityTableConfig<EdgeEvent, TimePa
   }
 
   private updateEdgeEventStatus(createdTime: number): string {
-    if (this.queueStartTs && createdTime < this.queueStartTs) {
+    if (this.queueStartTs && createdTime <= this.queueStartTs) {
       return this.translate.instant('edge.deployed');
     } else {
       return this.translate.instant('edge.pending');


### PR DESCRIPTION
## Pull Request description

Fixed incorrect display of 'Deployed' status on edge tab:
BEFORE FIX:
![image](https://user-images.githubusercontent.com/3466101/173088994-8aae7a0a-bbe7-44cc-a747-4111e156b6b6.png)

AFTER FIX:
![image](https://user-images.githubusercontent.com/3466101/173090423-7705c909-e5ca-4209-898d-9564a9328d94.png)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



