### PR TITLE
[WIP][3.4.x] User activation timeout fix

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/AuthController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/AuthController.java
@@ -259,11 +259,7 @@ public class AuthController extends BaseController {
             String email = user.getEmail();
 
             if (sendActivationMail) {
-                try {
-                    mailService.sendAccountActivatedEmail(loginUrl, email);
-                } catch (Exception e) {
-                    log.info("Unable to send account activation email [{}]", e.getMessage());
-                }
+                mailService.sendAccountActivatedEmailAsync(loginUrl, email);
             }
 
             sendEntityNotificationMsg(user.getTenantId(), user.getId(), EdgeEventActionType.CREDENTIALS_UPDATED);

--- a/common/util/src/main/java/org/thingsboard/common/util/DonAsynchron.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/DonAsynchron.java
@@ -22,6 +22,8 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 public class DonAsynchron {
@@ -61,6 +63,34 @@ public class DonAsynchron {
 
     public static <T> ListenableFuture<T> submit(Callable<T> task, Consumer<T> onSuccess, Consumer<Throwable> onFailure, Executor executor, Executor callbackExecutor) {
         ListenableFuture<T> future = Futures.submit(task, executor);
+        withCallback(future, onSuccess, onFailure, callbackExecutor);
+        return future;
+    }
+
+    public static <T> ListenableFuture<T> submitWithTimeout(
+            Callable<T> task,
+            long timeout, TimeUnit timeUnit,
+            Executor executor,
+            ScheduledExecutorService timeoutExecutor
+    ) {
+        var future = Futures.submit(task, executor);
+        Futures.withTimeout(future, timeout, timeUnit, timeoutExecutor);
+        return future;
+    }
+
+    public static <T> ListenableFuture<T> submitWithTimeout(
+            Callable<T> task,
+            Consumer<T> onSuccess,
+            Consumer<Throwable> onFailure,
+            long timeout, TimeUnit timeUnit,
+            Executor executor,
+            Executor callbackExecutor,
+            ScheduledExecutorService timeoutExecutor
+    ) {
+        var future = submitWithTimeout(
+                task, timeout, timeUnit,
+                executor, timeoutExecutor
+        );
         withCallback(future, onSuccess, onFailure, callbackExecutor);
         return future;
     }

--- a/common/util/src/test/java/org/thingsboard/common/util/DonAsynchronTest.java
+++ b/common/util/src/test/java/org/thingsboard/common/util/DonAsynchronTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.thingsboard.common.util;
 
 import org.awaitility.Awaitility;

--- a/common/util/src/test/java/org/thingsboard/common/util/DonAsynchronTest.java
+++ b/common/util/src/test/java/org/thingsboard/common/util/DonAsynchronTest.java
@@ -1,0 +1,95 @@
+package org.thingsboard.common.util;
+
+import org.awaitility.Awaitility;
+import org.junit.Test;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class DonAsynchronTest {
+
+    private final Executor executor = Executors.newSingleThreadExecutor();
+    private final Executor callbackExecutor = Executors.newSingleThreadExecutor();
+    private final ScheduledExecutorService timeoutExecutor = Executors.newSingleThreadScheduledExecutor();
+
+    private final long timeout = 1000;
+    private final TimeUnit timeUnit = TimeUnit.MILLISECONDS;
+
+    @Test
+    public void testSubmitWithTimeout() throws Exception {
+        var task1 = DonAsynchron.submitWithTimeout(
+                () -> {
+                    timeUnit.sleep(timeout / 2);
+                    return true;
+                },
+                timeout, timeUnit,
+                executor, timeoutExecutor
+        );
+        Awaitility.await()
+                .atMost(timeout, timeUnit)
+                .until(task1::get);
+        assertThat(task1.get()).isTrue();
+
+        AtomicBoolean successCallbackFlag = new AtomicBoolean(false);
+        DonAsynchron.submitWithTimeout(
+                () -> {
+                    timeUnit.sleep(timeout / 2);
+                    return null;
+                },
+                (b) -> successCallbackFlag.set(true),
+                (e) -> {},
+                timeout, timeUnit,
+                executor, callbackExecutor, timeoutExecutor
+        );
+        Awaitility.await()
+                .atMost(timeout, timeUnit)
+                .until(successCallbackFlag::get);
+        assertThat(successCallbackFlag.get()).isTrue();
+
+
+        var task2 = DonAsynchron.submitWithTimeout(
+                () -> {
+                    timeUnit.sleep(timeout + timeout);
+                    return true;
+                },
+                timeout, timeUnit,
+                executor, timeoutExecutor
+        );
+        Awaitility.await()
+                .atLeast(timeout, timeUnit)
+                .until(task2::isCancelled);
+        assertThatThrownBy(task2::get)
+                .isInstanceOf(CancellationException.class)
+                .hasMessage("Task was cancelled.");
+
+        AtomicReference<Throwable> throwableCaptor = new AtomicReference<>();
+        DonAsynchron.submitWithTimeout(
+                () -> {
+                    timeUnit.sleep(timeout + timeout);
+                    return null;
+                },
+                (b) -> {},
+                (e) -> {
+                    successCallbackFlag.set(false);
+                    throwableCaptor.set(e);
+                },
+                timeout, timeUnit,
+                executor, callbackExecutor, timeoutExecutor
+        );
+        Awaitility.await()
+                .atLeast(timeout, timeUnit)
+                .until(() -> !successCallbackFlag.get());
+        assertThat(successCallbackFlag.get()).isFalse();
+        assertThat(throwableCaptor.get())
+                .isExactlyInstanceOf(CancellationException.class)
+                .hasMessage("Task was cancelled.");
+    }
+}

--- a/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/MailService.java
+++ b/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/MailService.java
@@ -36,6 +36,8 @@ public interface MailService {
 
     void sendAccountActivatedEmail(String loginLink, String email) throws ThingsboardException;
 
+    void sendAccountActivatedEmailAsync(String loginLink, String email);
+
     void sendResetPasswordEmail(String passwordResetLink, String email) throws ThingsboardException;
 
     void sendResetPasswordEmailAsync(String passwordResetLink, String email);


### PR DESCRIPTION
## Pull Request description

Issue: #6710 

The cause of the problem is that `timeout` parameter was not used at all, when we use invalid data (host, port, etc.) - mail sender throwing exception immediately, but if the host and port are correct but something else (login or password) is invalid - we just waiting for default timeout (around 2 mins) and timeout from sysadmin configs is not being used

Add *submitWithTimeout* method to `DonAsynchron` class
Add support for timeout in sending messages
Add async sending the 'account activated' email
Add corresponding tests

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



