### PR TITLE
[3.4] Postgres await startup in docker containers with Postgres bundled

### DIFF
--- a/msa/tb/docker-cassandra/start-db.sh
+++ b/msa/tb/docker-cassandra/start-db.sh
@@ -24,22 +24,22 @@ if [ ! -d ${PGDATA} ]; then
     ${PG_CTL} initdb
 fi
 
-exec setsid nohup postgres >> ${PGLOG}/postgres.log 2>&1 &
+echo "Starting Postgresql..."
+${PG_CTL} start
+
+RETRIES="${PG_ISREADY_RETRIES:-300}"
+until pg_isready -U ${pkg.user} -d postgres --quiet || [ $RETRIES -eq 0 ]
+do
+    echo "Connecting to Postgres, $((RETRIES--)) attempts left..."
+    sleep 1
+done
 
 if [ ! -f ${firstlaunch} ]; then
-    sleep 2
-    while ! psql -U ${pkg.user} -d postgres -c "CREATE DATABASE thingsboard"
-    do
-      sleep 1
-    done
-else
-    RETRIES="${PG_ISREADY_RETRIES:-300}"
-    until pg_isready -U ${pkg.user} -d thingsboard --quiet || [ $RETRIES -eq 0 ]
-    do
-        echo "Connecting to Postgres, $((RETRIES--)) attempts left..."
-        sleep 1
-    done
+    echo "Creating database..."
+    psql -U ${pkg.user} -d postgres -c "CREATE DATABASE thingsboard"
 fi
+
+echo "Postgresql is ready"
 
 cassandra_data_dir=${CASSANDRA_DATA}
 cassandra_data_link=/var/lib/cassandra

--- a/msa/tb/docker-cassandra/start-db.sh
+++ b/msa/tb/docker-cassandra/start-db.sh
@@ -32,6 +32,13 @@ if [ ! -f ${firstlaunch} ]; then
     do
       sleep 1
     done
+else
+    RETRIES="${PG_ISREADY_RETRIES:-300}"
+    until pg_isready -U ${pkg.user} -d thingsboard --quiet || [ $RETRIES -eq 0 ]
+    do
+        echo "Connecting to Postgres, $((RETRIES--)) attempts left..."
+        sleep 1
+    done
 fi
 
 cassandra_data_dir=${CASSANDRA_DATA}

--- a/msa/tb/docker-postgres/start-db.sh
+++ b/msa/tb/docker-postgres/start-db.sh
@@ -22,14 +22,22 @@ PG_CTL=$(find /usr/lib/postgresql/ -name pg_ctl)
 if [ ! -d ${PGDATA} ]; then
     mkdir -p ${PGDATA}
     ${PG_CTL} initdb
+else
+    ${PG_CTL} start
 fi
 
 exec setsid nohup postgres >> ${PGLOG}/postgres.log 2>&1 &
 
 if [ ! -f ${firstlaunch} ]; then
     sleep 2
-    while ! psql -U ${pkg.user} -d postgres -c "CREATE DATABASE thingsboard"
+    while ! psql -U thingsboard -d postgres -c "CREATE DATABASE thingsboard"
     do
       sleep 1
+    done
+else
+    until pg_isready --dbname thingsboard --quiet
+    do
+        sleep 1
+        echo "Waiting for db"
     done
 fi

--- a/msa/tb/docker-postgres/start-db.sh
+++ b/msa/tb/docker-postgres/start-db.sh
@@ -22,22 +22,21 @@ PG_CTL=$(find /usr/lib/postgresql/ -name pg_ctl)
 if [ ! -d ${PGDATA} ]; then
     mkdir -p ${PGDATA}
     ${PG_CTL} initdb
-else
-    ${PG_CTL} start
 fi
 
 exec setsid nohup postgres >> ${PGLOG}/postgres.log 2>&1 &
 
 if [ ! -f ${firstlaunch} ]; then
     sleep 2
-    while ! psql -U thingsboard -d postgres -c "CREATE DATABASE thingsboard"
+    while ! psql -U ${pkg.user} -d postgres -c "CREATE DATABASE thingsboard"
     do
       sleep 1
     done
 else
-    until pg_isready --dbname thingsboard --quiet
+    RETRIES="${PG_ISREADY_RETRIES:-300}"
+    until pg_isready -U ${pkg.user} -d thingsboard --quiet || [ $RETRIES -eq 0 ]
     do
+        echo "Connecting to Postgres, $((RETRIES--)) attempts left..."
         sleep 1
-        echo "Waiting for db"
     done
 fi

--- a/msa/tb/docker-postgres/start-db.sh
+++ b/msa/tb/docker-postgres/start-db.sh
@@ -24,19 +24,19 @@ if [ ! -d ${PGDATA} ]; then
     ${PG_CTL} initdb
 fi
 
-exec setsid nohup postgres >> ${PGLOG}/postgres.log 2>&1 &
+echo "Starting Postgresql..."
+${PG_CTL} start
+
+RETRIES="${PG_ISREADY_RETRIES:-300}"
+until pg_isready -U ${pkg.user} -d postgres --quiet || [ $RETRIES -eq 0 ]
+do
+    echo "Connecting to Postgres, $((RETRIES--)) attempts left..."
+    sleep 1
+done
 
 if [ ! -f ${firstlaunch} ]; then
-    sleep 2
-    while ! psql -U ${pkg.user} -d postgres -c "CREATE DATABASE thingsboard"
-    do
-      sleep 1
-    done
-else
-    RETRIES="${PG_ISREADY_RETRIES:-300}"
-    until pg_isready -U ${pkg.user} -d thingsboard --quiet || [ $RETRIES -eq 0 ]
-    do
-        echo "Connecting to Postgres, $((RETRIES--)) attempts left..."
-        sleep 1
-    done
+    echo "Creating database..."
+    psql -U ${pkg.user} -d postgres -c "CREATE DATABASE thingsboard"
 fi
+
+echo "Postgresql is ready"

--- a/msa/tb/docker/install-tb.sh
+++ b/msa/tb/docker/install-tb.sh
@@ -46,6 +46,8 @@ source "${CONF_FOLDER}/${configfile}"
 
 echo "Starting ThingsBoard installation ..."
 
+set -e
+
 java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardInstallApplication \
                     -Dinstall.load_demo=${loadDemo} \
                     -Dspring.jpa.hibernate.ddl-auto=none \

--- a/msa/tb/docker/start-tb.sh
+++ b/msa/tb/docker/start-tb.sh
@@ -25,15 +25,18 @@ firstlaunch=${DATA_FOLDER}/.firstlaunch
 source "${CONF_FOLDER}/${configfile}"
 
 if [ ! -f ${firstlaunch} ]; then
-    install-tb.sh --loadDemo
-    touch ${firstlaunch}
+    install-tb.sh --loadDemo && touch ${firstlaunch}
 fi
 
-echo "Starting ThingsBoard ..."
+if [ -f ${firstlaunch} ]; then
+    echo "Starting ThingsBoard ..."
 
-java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardServerApplication \
-                    -Dspring.jpa.hibernate.ddl-auto=none \
-                    -Dlogging.config=${CONF_FOLDER}/logback.xml \
-                    org.springframework.boot.loader.PropertiesLauncher
+    java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardServerApplication \
+                        -Dspring.jpa.hibernate.ddl-auto=none \
+                        -Dlogging.config=${CONF_FOLDER}/logback.xml \
+                        org.springframework.boot.loader.PropertiesLauncher
+else
+    echo "ERROR: ThingsBoard is not installed"
+fi
 
 stop-db.sh


### PR DESCRIPTION
## Pull Request description

Await Postgres startup.
Before this, Postgres was started in the background and Thingsboard starts in parallel.
In some cases when the database size is big and the shutdown was unclean, the Postgres might start for a couple of minutes. This led to ThingsBoard failing to start and the whole container restarted by the loop.

It is highly recommended to spin up a Postgres in a separate container to isolate applications and increase fault tolerance

Another improvement is the first lunch reliability. If the installation fails (port already bound, etc), the process will start from the beginning. 

PE: https://github.com/thingsboard/thingsboard-pe/pull/914

Let's test the result:

Builld ThingsBoard docker images with Postgresql
`mvn --projects msa/tb --also-make -T 1C license:format clean install -DskipTests -Ddockerfile.skip=false`

Prepare Thingsboard deployment for docker-compose
`cat > docker-compose.yml`
```yaml
version: '3'
services:
  zookeeper:
    image: docker.io/bitnami/zookeeper:3.7
    network_mode: "host"
    restart: "always"
    volumes:
      - zookeeper:/bitnami
    environment:
      ALLOW_ANONYMOUS_LOGIN: "yes"
      ZOO_ENABLE_ADMIN_SERVER: "no"
      JVMFLAGS: "-Xmx128m -Xms128m -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9199 -Dcom.sun.management.jmxremote.rmi.port=9199  -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1"
  kafka:
    image: docker.io/bitnami/kafka:3
    network_mode: "host"
    restart: "always"
    volumes:
      - kafka:/bitnami
    environment:
      - KAFKA_CFG_ZOOKEEPER_CONNECT=localhost:2181
      - ALLOW_PLAINTEXT_LISTENER=yes
    depends_on:
      - zookeeper
  tb:
    depends_on:
      - kafka
    image: "thingsboard/tb-postgres:3.4.0-SNAPSHOT"
    network_mode: "host"
    restart: "always"
    volumes:
      - thingsboard-data:/data
      - thingsboard-logs:/var/log/thingsboard
    environment:
      DATABASE_TS_TYPE: "sql"
      TB_QUEUE_TYPE: "kafka"
      TB_KAFKA_BATCH_SIZE: "65536" # default is 16384 - it helps to produce messages much efficiently
      TB_KAFKA_LINGER_MS: "5" # default is 1
      TB_QUEUE_KAFKA_MAX_POLL_RECORDS: "2048" # default is 8192
      TB_SERVICE_ID: "tb-node-0"
      HTTP_BIND_PORT: "8080"
      TB_QUEUE_RE_MAIN_PACK_PROCESSING_TIMEOUT_MS: "30000"
      # Java options for 8G instance and JMX enabled
      JAVA_OPTS: " -Xmx3072M -Xms3072M -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9999 -Dcom.sun.management.jmxremote.rmi.port=9999 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1"
volumes: # to persist data between container restarts or being recreated
  kafka:
  zookeeper:
  thingsboard-data:
  thingsboard-logs:
```
`docker-compose up`

Run performance test for a couple hours to make a big database

```bash
docker run -it --rm --network host --name tb-perf-test \
  --env DEVICE_END_IDX=10000 \
  --env MESSAGES_PER_SECOND=10000 \
  --env ALARMS_PER_SECOND=50 \
  --env DURATION_IN_SECONDS=86400 \
  --env DEVICE_CREATE_ON_START=true \
  thingsboard/tb-ce-performance-test:3.3.3
```

Then stop with force many times and start again.

The result is successful recovery and starting ThingsBoard only after Postgres is ready

![image](https://user-images.githubusercontent.com/79898499/173759174-dd030225-a334-45ba-8ada-72a926436d32.png)

![image](https://user-images.githubusercontent.com/79898499/173790652-d1245c36-36da-413d-8932-1034b201bc63.png)

Data size tested is 100+ GiB
![image](https://user-images.githubusercontent.com/79898499/173791779-da5d9a2b-5c5c-479c-99a3-034806bfdb79.png)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



