### PR TITLE
[WIP][3.4] Cassandra partition table optional

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -219,6 +219,7 @@ cassandra:
     default_fetch_size: "${CASSANDRA_DEFAULT_FETCH_SIZE:2000}"
     # Specify partitioning size for timestamp key-value storage. Example: MINUTES, HOURS, DAYS, MONTHS, INDEFINITE
     ts_key_value_partitioning: "${TS_KV_PARTITIONING:MONTHS}"
+    ts_key_value_partitioning_always_exist_in_reading: "${TS_KV_PARTITIONING_ALWAYS_EXIST_IN_READING:false}"
     ts_key_value_partitions_max_cache_size: "${TS_KV_PARTITIONS_MAX_CACHE_SIZE:100000}"
     ts_key_value_ttl: "${TS_KV_TTL:0}"
     events_ttl: "${TS_EVENTS_TTL:0}"

--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDao.java
@@ -90,6 +90,10 @@ public class CassandraBaseTimeseriesDao extends AbstractCassandraBaseTimeseriesD
     @Value("${cassandra.query.ts_key_value_partitioning}")
     private String partitioning;
 
+    @Getter
+    @Value("${cassandra.query.ts_key_value_partitioning_always_exist_in_reading:false}")
+    private boolean partitioningAlwaysExistInReading;
+
     @Value("${cassandra.query.ts_key_value_partitions_max_cache_size:100000}")
     private long partitionsCacheSize;
 
@@ -398,8 +402,25 @@ public class CassandraBaseTimeseriesDao extends AbstractCassandraBaseTimeseriesD
         if (isFixedPartitioning()) { //no need to fetch partitions from DB
             return Futures.immediateFuture(FIXED_PARTITION);
         }
+        if (isPartitioningAlwaysExistInReading()) {
+            return Futures.immediateFuture(calculatePartitions(minPartition, maxPartition));
+        }
         TbResultSetFuture partitionsFuture = fetchPartitions(tenantId, entityId, query.getKey(), minPartition, maxPartition);
         return Futures.transformAsync(partitionsFuture, getPartitionsArrayFunction(), readResultsProcessingExecutor);
+    }
+
+    List<Long> calculatePartitions(long minPartition, long maxPartition) {
+        if (minPartition == maxPartition) {
+            return Collections.singletonList(minPartition);
+        }
+
+        List<Long> partitions = Arrays.asList(minPartition, maxPartition);
+        long currentPartition = minPartition;
+        while (maxPartition > (currentPartition = toPartitionTs(currentPartition + TimeUnit.DAYS.toMillis(32)))){
+            partitions.add(currentPartition);
+        }
+
+        return partitions;
     }
 
     private AsyncFunction<List<Long>, List<TbResultSet>> getFetchChunksAsyncFunction(TenantId tenantId, EntityId entityId, String key, Aggregation aggregation, long startTs, long endTs) {

--- a/dao/src/test/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDaoTest.java
@@ -1,0 +1,78 @@
+/**
+ * ThingsBoard, Inc. ("COMPANY") CONFIDENTIAL
+ *
+ * Copyright © 2016-2021 ThingsBoard, Inc. All Rights Reserved.
+ *
+ * NOTICE: All information contained herein is, and remains
+ * the property of ThingsBoard, Inc. and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to ThingsBoard, Inc.
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ *
+ * Dissemination of this information or reproduction of this material is strictly forbidden
+ * unless prior written permission is obtained from COMPANY.
+ *
+ * Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees,
+ * managers or contractors who have executed Confidentiality and Non-disclosure agreements
+ * explicitly covering such access.
+ *
+ * The copyright notice above does not evidence any actual or intended publication
+ * or disclosure  of  this source code, which includes
+ * information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.
+ * ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
+ * OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT
+ * THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED,
+ * AND IN VIOLATION OF APPLICABLE LAWS AND INTERNATIONAL TREATIES.
+ * THE RECEIPT OR POSSESSION OF THIS SOURCE CODE AND/OR RELATED INFORMATION
+ * DOES NOT CONVEY OR IMPLY ANY RIGHTS TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS,
+ * OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+ */
+package org.thingsboard.server.dao.timeseries;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.thingsboard.server.dao.cassandra.CassandraCluster;
+import org.thingsboard.server.dao.nosql.CassandraBufferedRateExecutor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = CassandraBaseTimeseriesDao.class)
+@TestPropertySource(properties = {
+        "cassandra.query.ts_key_value_partitioning=MONTHS",
+        "cassandra.query.ts_key_value_partitioning_always_exist_in_reading=true",
+        "cassandra.query.ts_key_value_partitions_max_cache_size=100000",
+        "cassandra.query.ts_key_value_partitions_cache_stats_enabled=true",
+        "cassandra.query.ts_key_value_partitions_cache_stats_interval=60",
+        "cassandra.query.ts_key_value_ttl=0",
+        "cassandra.query.set_null_values_enabled=false",
+})
+@Slf4j
+public class CassandraBaseTimeseriesDaoTest {
+
+    @SpyBean
+    CassandraBaseTimeseriesDao tsDao;
+
+    @MockBean(answer = Answers.RETURNS_MOCKS)
+    @Qualifier("CassandraCluster")
+    CassandraCluster cassandraCluster;
+    @MockBean
+    CassandraBufferedRateExecutor cassandraBufferedRateExecutor;
+
+    @Test
+    public void testCalculatePartitions() {
+        assertThat(tsDao.calculatePartitions(0, 0)).isEqualTo(List.of(0L));
+        assertThat(tsDao.calculatePartitions(0, 1)).isEqualTo(List.of(0L, 1L));
+    }
+}

--- a/dao/src/test/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDaoTest.java
@@ -34,22 +34,26 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.thingsboard.server.dao.cassandra.CassandraCluster;
-import org.thingsboard.server.dao.nosql.CassandraBufferedRateExecutor;
+import org.thingsboard.server.dao.nosql.CassandraBufferedRateReadExecutor;
+import org.thingsboard.server.dao.nosql.CassandraBufferedRateWriteExecutor;
 
+import java.text.ParseException;
 import java.util.List;
 
+import static org.apache.commons.lang3.time.DateFormatUtils.ISO_DATETIME_TIME_ZONE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = CassandraBaseTimeseriesDao.class)
 @TestPropertySource(properties = {
+        "database.ts.type=cassandra",
         "cassandra.query.ts_key_value_partitioning=MONTHS",
         "cassandra.query.ts_key_value_partitioning_always_exist_in_reading=true",
         "cassandra.query.ts_key_value_partitions_max_cache_size=100000",
@@ -61,18 +65,70 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Slf4j
 public class CassandraBaseTimeseriesDaoTest {
 
-    @SpyBean
+    @Autowired
     CassandraBaseTimeseriesDao tsDao;
 
     @MockBean(answer = Answers.RETURNS_MOCKS)
     @Qualifier("CassandraCluster")
     CassandraCluster cassandraCluster;
     @MockBean
-    CassandraBufferedRateExecutor cassandraBufferedRateExecutor;
+    CassandraBufferedRateReadExecutor cassandraBufferedRateReadExecutor;
+    @MockBean
+    CassandraBufferedRateWriteExecutor cassandraBufferedRateWriteExecutor;
 
     @Test
-    public void testCalculatePartitions() {
+    public void testToPartitionsMonths() throws ParseException {
+        assertThat(tsDao.getPartitioning()).isEqualTo("MONTHS");
+        assertThat(tsDao.toPartitionTs(ISO_DATETIME_TIME_ZONE_FORMAT.parse("2022-01-01T00:00:00Z").getTime())).isEqualTo(1640995200000L);
+        assertThat(tsDao.toPartitionTs(ISO_DATETIME_TIME_ZONE_FORMAT.parse("2022-05-01T00:00:00Z").getTime())).isEqualTo(1651363200000L);
+        assertThat(tsDao.toPartitionTs(ISO_DATETIME_TIME_ZONE_FORMAT.parse("2022-05-01T00:00:01Z").getTime())).isEqualTo(1651363200000L);
+        assertThat(tsDao.toPartitionTs(ISO_DATETIME_TIME_ZONE_FORMAT.parse("2022-05-31T23:59:59Z").getTime())).isEqualTo(1651363200000L);
+        assertThat(tsDao.toPartitionTs(ISO_DATETIME_TIME_ZONE_FORMAT.parse("2023-12-31T23:59:59Z").getTime())).isEqualTo(1701388800000L);
+    }
+
+    @Test
+    public void testCalculatePartitions() throws ParseException {
+        long startTs = tsDao.toPartitionTs(ISO_DATETIME_TIME_ZONE_FORMAT.parse("2019-12-12T00:00:00Z").getTime());
+        long nextTs = tsDao.toPartitionTs(ISO_DATETIME_TIME_ZONE_FORMAT.parse("2020-01-31T23:59:59Z").getTime());
+        long leapTs = tsDao.toPartitionTs(ISO_DATETIME_TIME_ZONE_FORMAT.parse("2020-02-29T23:59:59Z").getTime());
+        long endTs = tsDao.toPartitionTs(ISO_DATETIME_TIME_ZONE_FORMAT.parse("2021-01-31T23:59:59Z").getTime());
+
+        log.warn("startTs {}, nextTs {}, leapTs {}, endTs {}", startTs, nextTs, leapTs, endTs);
+
         assertThat(tsDao.calculatePartitions(0, 0)).isEqualTo(List.of(0L));
         assertThat(tsDao.calculatePartitions(0, 1)).isEqualTo(List.of(0L, 1L));
+        assertThat(tsDao.calculatePartitions(startTs, startTs)).isEqualTo(List.of(1575158400000L));
+        assertThat(tsDao.calculatePartitions(startTs, nextTs)).isEqualTo(List.of(1575158400000L, 1577836800000L));
+        assertThat(tsDao.calculatePartitions(startTs, leapTs)).isEqualTo(List.of(1575158400000L, 1577836800000L, 1580515200000L));
+
+        assertThat(tsDao.calculatePartitions(startTs, endTs)).hasSize(14);
+        assertThat(tsDao.calculatePartitions(startTs, endTs)).isEqualTo(List.of(
+                1575158400000L,
+                1577836800000L, 1580515200000L, 1583020800000L,
+                1585699200000L, 1588291200000L, 1590969600000L,
+                1593561600000L, 1596240000000L, 1598918400000L,
+                1601510400000L, 1604188800000L, 1606780800000L,
+                1609459200000L));
     }
+
+    @Test
+    public void givenPartitioning_whenInit_thenPartitionMaxMsSet() {
+        assertThat(tsDao.partition_max_ms).isEqualTo(31 * 24 * 60 * 60 * 1000L);
+    }
+
+    @Test
+    public void givenPartitioning_whenCalculatePartitioningMaxTs_thenReturnMs() {
+        assertThat(tsDao.calculatePartitionMaxMs("MINUTES")).as("MINUTES").isEqualTo(60 * 1000L);
+        assertThat(tsDao.calculatePartitionMaxMs("HOURS")).as("HOURS").isEqualTo(60 * 60 * 1000L);
+        assertThat(tsDao.calculatePartitionMaxMs("DAYS")).as("DAYS").isEqualTo(24 * 60 * 60 * 1000L);
+        assertThat(tsDao.calculatePartitionMaxMs("MONTHS")).as("MONTHS").isEqualTo(31 * 24 * 60 * 60 * 1000L);
+        assertThat(tsDao.calculatePartitionMaxMs("YEARS")).as("YEARS").isEqualTo(366 * 24 * 60 * 60 * 1000L);
+        assertThat(tsDao.calculatePartitionMaxMs("INDEFINITE")).as("INDEFINITE").isEqualTo(0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void givenPartitioningUnknown_whenCalculatePartitioningMaxTs_thenException() {
+        tsDao.calculatePartitionMaxMs("LARGE");
+    }
+
 }


### PR DESCRIPTION
## Cassandra partition table optional

The motivation is to increase Cassandra TS performance for most cases whether ts is constantly written and read partition table returns 99,999% partitions exists.

The old approach (where we read partitions first and then read the ts data on the second round trip) is much more efficient where time-series wrote not regularly and the percent of existing partitions is very low.

The partition table approach is especially effective when we read more than one partition. For instance, fetching the year my months telemetry.

But a single request from the dashboard is not impacting the system performance. The major performance impact is made by requests from the rule engine by rule nodes. The most cases rule engine made some aggregation in a short time frame so the partitions per data read ratio are almost 1:1. The actual load profile you can observe using your Cassandra metrics in Grafana.
![image](https://user-images.githubusercontent.com/79898499/174789972-f4f31d5e-84aa-4764-8ba9-dfb2373fc89f.png)


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.


