### PR TITLE
[3.4] Docker compose bump zookeeper version up to 3.8.0

### DIFF
--- a/docker/docker-compose.aws-sqs.yml
+++ b/docker/docker-compose.aws-sqs.yml
@@ -23,59 +23,33 @@ services:
   tb-core1:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper
-      - redis
   tb-core2:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper
-      - redis
   tb-rule-engine1:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper
-      - redis
   tb-rule-engine2:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper
-      - redis
   tb-mqtt-transport1:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper
   tb-mqtt-transport2:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper
   tb-http-transport1:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper
   tb-http-transport2:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper
   tb-coap-transport:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper
   tb-lwm2m-transport:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper
   tb-snmp-transport:
     env_file:
       - queue-aws-sqs.env
-    depends_on:
-      - zookeeper

--- a/docker/docker-compose.confluent.yml
+++ b/docker/docker-compose.confluent.yml
@@ -23,23 +23,15 @@ services:
   tb-core1:
     env_file:
       - queue-confluent.env
-    depends_on:
-      - redis
   tb-core2:
     env_file:
       - queue-confluent.env
-    depends_on:
-      - redis
   tb-rule-engine1:
     env_file:
       - queue-confluent.env
-    depends_on:
-      - redis
   tb-rule-engine2:
     env_file:
       - queue-confluent.env
-    depends_on:
-      - redis
   tb-mqtt-transport1:
     env_file:
       - queue-confluent.env

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,12 +20,13 @@ version: '2.2'
 services:
   zookeeper:
     restart: always
-    image: "zookeeper:3.5"
+    image: "zookeeper:3.8.0"
     ports:
       - "2181"
     environment:
       ZOO_MY_ID: 1
       ZOO_SERVERS: server.1=zookeeper:2888:3888;zookeeper:2181
+      ZOO_ADMINSERVER_ENABLED: "false"
   tb-js-executor:
     restart: always
     image: "${DOCKER_REPO}/${JS_EXECUTOR_DOCKER_NAME}:${TB_VERSION}"


### PR DESCRIPTION
##  zookeeper version bumped to 3.8.0

msa tests passed, the newest **3.8.0** image appeared :
![image](https://user-images.githubusercontent.com/79898499/175294869-c44f2605-9f16-432d-aa0a-5928b4736b9b.png)

The newest version is running in production for a while

Depend_on **cleanup** (zookeeper and redis) for external services. Depends_on already declared in respective services

**Disabled** new admin feature from Zookeeper that binds port 8080 and may cause port conflict and security issue for network=host mode.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



