### PR TITLE
[3.4.x OAuth] Add support of JSON path in OAuth mapper.

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -278,12 +278,11 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/BasicMapperUtils.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/BasicMapperUtils.java
@@ -15,9 +15,13 @@
  */
 package org.thingsboard.server.service.security.auth.oauth2;
 
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.springframework.util.StringUtils;
+import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.oauth2.OAuth2MapperConfig;
 import org.thingsboard.server.dao.oauth2.OAuth2User;
 
@@ -69,7 +73,12 @@ public class BasicMapperUtils {
     public static String getStringAttributeByKey(Map<String, Object> attributes, String key) {
         String result = null;
         try {
-            result = (String) attributes.get(key);
+            if (key.startsWith("$")) {
+                Object json = Configuration.defaultConfiguration().jsonProvider().parse(JacksonUtil.toString(attributes));
+                result = JsonPath.read(json, key);
+            } else {
+                result = (String) attributes.get(key);
+            }
         } catch (Exception e) {
             log.warn("Can't convert attribute to String by key " + key);
         }

--- a/application/src/test/java/org/thingsboard/server/service/security/auth/oauth2/BasicMapperUtilsTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/security/auth/oauth2/BasicMapperUtilsTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.security.auth.oauth2;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.thingsboard.common.util.JacksonUtil;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+public class BasicMapperUtilsTest {
+    private final String userName = "Test user";
+    private final String token = "12345";
+    private final String json = "{ \"user\": { \"name\": \"" + userName + "\" }, \"token\": \"" + token + "\" }";
+
+    @Test
+    public void testSimpleKey() {
+        TypeReference<HashMap<String,Object>> typeRef = new TypeReference<>() {};
+        HashMap<String, Object> attributes = JacksonUtil.fromString(json, typeRef);
+
+        assertEquals(token, BasicMapperUtils.getStringAttributeByKey(attributes, "token"));
+    }
+
+    @Test
+    public void testJsonPathKey() {
+        TypeReference<HashMap<String,Object>> typeRef = new TypeReference<>() {};
+        HashMap<String, Object> attributes = JacksonUtil.fromString(json, typeRef);
+
+        assertEquals(token, BasicMapperUtils.getStringAttributeByKey(attributes, "$.token"));
+        assertEquals(userName, BasicMapperUtils.getStringAttributeByKey(attributes, "$.user.name"));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1204,13 +1204,11 @@
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path</artifactId>
                 <version>${json-path.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path-assert</artifactId>
                 <version>${json-path.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>


### PR DESCRIPTION
## Pull Request description

This PR let admins to map nested field in OAuth response, for example, `mail` in `attributes`.
```json
{
"attributes": {
    "mail": "xxxx",
    "oauthClientId": "client"
},
"client_id": "client",
"id": "soula",
"service": "http://domain_here:8080/authorized"
}
```

## General checklist

Related [discussion](https://github.com/thingsboard/thingsboard/issues/6778#issuecomment-1163468471).




