### PR TITLE
[3.4] Redis cluster startup slow down avoiding an issue with cluster create

### DIFF
--- a/docker/docker-compose.redis-cluster.yml
+++ b/docker/docker-compose.redis-cluster.yml
@@ -31,6 +31,8 @@ services:
     image: bitnami/redis-cluster:7.0
     volumes:
       - ./tb-node/redis-cluster-data-1:/bitnami/redis/data
+    depends_on:
+      - redis-node-0
     environment:
       - 'REDIS_PASSWORD=thingsboard'
       - 'REDISCLI_AUTH=thingsboard'
@@ -40,6 +42,8 @@ services:
     image: bitnami/redis-cluster:7.0
     volumes:
       - ./tb-node/redis-cluster-data-2:/bitnami/redis/data
+    depends_on:
+      - redis-node-1
     environment:
       - 'REDIS_PASSWORD=thingsboard'
       - 'REDISCLI_AUTH=thingsboard'
@@ -49,6 +53,8 @@ services:
     image: bitnami/redis-cluster:7.0
     volumes:
       - ./tb-node/redis-cluster-data-3:/bitnami/redis/data
+    depends_on:
+      - redis-node-2
     environment:
       - 'REDIS_PASSWORD=thingsboard'
       - 'REDISCLI_AUTH=thingsboard'
@@ -58,6 +64,8 @@ services:
     image: bitnami/redis-cluster:7.0
     volumes:
       - ./tb-node/redis-cluster-data-4:/bitnami/redis/data
+    depends_on:
+      - redis-node-3
     environment:
       - 'REDIS_PASSWORD=thingsboard'
       - 'REDISCLI_AUTH=thingsboard'


### PR DESCRIPTION
## Redis cluster startup slow down avoiding an issue with cluster create

Sometimes cluster does not create properly when nodes start in parallel. 
This led to exceptions on the ThingsBoard on the Jedis driver and the cause is not obvious to a user. 
```
Caused by: org.springframework.dao.DataAccessResourceFailureException: Cannot obtain connection to node 7ce8a34df194ab76b44cc109a404d94cb6b3ff2as as it is not associated with a hostname!
        at org.springframework.data.redis.connection.jedis.JedisClusterConnection$JedisClusterNodeResourceProvider.getConnectionForSpecificNode(JedisClusterConnection.java:968)
        at org.springframework.data.redis.connection.jedis.JedisClusterConnection$JedisClusterNodeResourceProvider.getResourceForSpecificNode(JedisClusterConnection.java:943)
        at org.springframework.data.redis.connection.jedis.JedisClusterConnection$JedisClusterNodeResourceProvider.getResourceForSpecificNode(JedisClusterConnection.java:900)
        at org.springframework.data.redis.connection.ClusterCommandExecutor.executeMultiKeyCommandOnSingleNode(ClusterCommandExecutor.java:312)
        at org.springframework.data.redis.connection.ClusterCommandExecutor.lambda$executeMultiKeyCommand$2(ClusterCommandExecutor.java:297)
```
The problem fires _randomly_, probably when an unhealthy Redis node has been chosen as the seed node to discover cluster topology.

Here is the command line to diagnose the broken cluster nodes
```
for i in {0..5}; do docker exec -it docker_redis-node-${i}_1 redis-cli cluster nodes ; done
```
before this PR (`:0@0 master,noaddr`, `:0@0 slave,noaddr`):
![image](https://user-images.githubusercontent.com/79898499/176112031-73eb4e5e-471a-4796-a390-b82b6f97e0ce.png)

after this PR (nominal cluster state on each node):
![image](https://user-images.githubusercontent.com/79898499/176111566-650eca11-7666-4812-90f7-2250ca394185.png)

PE: https://github.com/thingsboard/thingsboard-pe-docker-compose/pull/34

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



