### PR TITLE
[3.4] docker-compose checkFolders: create and set owner

### DIFF
--- a/docker/compose-utils.sh
+++ b/docker/compose-utils.sh
@@ -177,7 +177,7 @@ function checkFolders() {
     if [ -z "$DIR" ]; then # skip empty lines
           continue
     fi
-    MESSAGE="Checking user ${USR} group ${GRP} dir ${DIR} "
+    MESSAGE="Checking user ${USR} group ${GRP} dir ${DIR}"
     if [[ -d "$DIR" ]] &&
        [[ $(ls -ldn "$DIR" | awk '{print $3}') -eq "$USR" ]] &&
        [[ $(ls -ldn "$DIR" | awk '{print $4}') -eq "$GRP" ]]

--- a/docker/compose-utils.sh
+++ b/docker/compose-utils.sh
@@ -121,3 +121,77 @@ function additionalStartupServices() {
 
     echo $ADDITIONAL_STARTUP_SERVICES
 }
+
+function permissionList() {
+    PERMISSION_LIST="
+      799  799  tb-node/log
+      799  799  tb-transports/coap/log
+      799  799  tb-transports/lwm2m/log
+      799  799  tb-transports/http/log
+      799  799  tb-transports/mqtt/log
+      799  799  tb-transports/snmp/log
+      799  799  tb-transports/coap/log
+      799  799  tb-vc-executor/log
+      999  999  tb-node/postgres
+      "
+
+    source .env
+
+    if [ "$DATABASE" = "hybrid" ]; then
+      PERMISSION_LIST="$PERMISSION_LIST
+      999  999  tb-node/cassandra
+      "
+    fi
+
+    CACHE="${CACHE:-redis}"
+    case $CACHE in
+        redis)
+          PERMISSION_LIST="$PERMISSION_LIST
+          1001 1001 tb-node/redis-data
+          "
+        ;;
+        redis-cluster)
+          PERMISSION_LIST="$PERMISSION_LIST
+          1001 1001 tb-node/redis-cluster-data-0
+          1001 1001 tb-node/redis-cluster-data-1
+          1001 1001 tb-node/redis-cluster-data-2
+          1001 1001 tb-node/redis-cluster-data-3
+          1001 1001 tb-node/redis-cluster-data-4
+          1001 1001 tb-node/redis-cluster-data-5
+          "
+        ;;
+        *)
+        echo "Unknown CACHE value specified in the .env file: '${CACHE}'. Should be either 'redis' or 'redis-cluster'." >&2
+        exit 1
+    esac
+
+    echo "$PERMISSION_LIST"
+}
+
+function checkFolders() {
+  EXIT_CODE=0
+  PERMISSION_LIST=$(permissionList) || exit $?
+  set -e
+  while read -r USR GRP DIR
+  do
+    if [ -z "$DIR" ]; then # skip empty lines
+          continue
+    fi
+    MESSAGE="Checking user ${USR} group ${GRP} dir ${DIR} "
+    if [[ -d "$DIR" ]] &&
+       [[ $(ls -ldn "$DIR" | awk '{print $3}') -eq "$USR" ]] &&
+       [[ $(ls -ldn "$DIR" | awk '{print $4}') -eq "$GRP" ]]
+    then
+      MESSAGE="$MESSAGE OK"
+    else
+      if [ "$1" = "--create" ]; then
+        echo "Create and chown: user ${USR} group ${GRP} dir ${DIR}"
+        mkdir -p "$DIR" && sudo chown -R "$USR":"$GRP" "$DIR"
+      else
+        echo "$MESSAGE FAILED"
+        EXIT_CODE=1
+      fi
+    fi
+  done < <(echo "$PERMISSION_LIST")
+  return $EXIT_CODE
+}

--- a/docker/docker-check-log-folders.sh
+++ b/docker/docker-check-log-folders.sh
@@ -16,19 +16,6 @@
 #
 
 set -e
-
 source compose-utils.sh
-
-checkFolders --create || exit $?
-
-ADDITIONAL_COMPOSE_QUEUE_ARGS=$(additionalComposeQueueArgs) || exit $?
-
-ADDITIONAL_COMPOSE_ARGS=$(additionalComposeArgs) || exit $?
-
-ADDITIONAL_CACHE_ARGS=$(additionalComposeCacheArgs) || exit $?
-
-ADDITIONAL_COMPOSE_MONITORING_ARGS=$(additionalComposeMonitoringArgs) || exit $?
-
-docker-compose \
-  -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS $ADDITIONAL_COMPOSE_MONITORING_ARGS \
-  up -d
+checkFolders || exit $?
+echo "OK"

--- a/docker/docker-create-log-folders.sh
+++ b/docker/docker-create-log-folders.sh
@@ -15,39 +15,6 @@
 # limitations under the License.
 #
 
-mkdir -p tb-node/log && sudo chown -R 799:799 tb-node/log
-
-mkdir -p tb-transports/coap/log && sudo chown -R 799:799 tb-transports/coap/log
-
-mkdir -p tb-transports/lwm2m/log && sudo chown -R 799:799 tb-transports/lwm2m/log
-
-mkdir -p tb-transports/http/log && sudo chown -R 799:799 tb-transports/http/log
-
-mkdir -p tb-transports/mqtt/log && sudo chown -R 799:799 tb-transports/mqtt/log
-
-mkdir -p tb-transports/snmp/log && sudo chown -R 799:799 tb-transports/snmp/log
-
-mkdir -p tb-vc-executor/log && sudo chown -R 799:799 tb-vc-executor/log
-
-mkdir -p tb-node/postgres && sudo chown -R 999:999 tb-node/postgres
-
-mkdir -p tb-node/cassandra && sudo chown -R 999:999 tb-node/cassandra
-
-source .env
-CACHE="${CACHE:-redis}"
-case $CACHE in
-    redis)
-    mkdir -p tb-node/redis-data && sudo chown -R 1001:1001 tb-node/redis-data
-    ;;
-    redis-cluster)
-    mkdir -p tb-node/redis-cluster-data-0 && sudo chown -R 1001:1001 tb-node/redis-cluster-data-0
-    mkdir -p tb-node/redis-cluster-data-1 && sudo chown -R 1001:1001 tb-node/redis-cluster-data-1
-    mkdir -p tb-node/redis-cluster-data-2 && sudo chown -R 1001:1001 tb-node/redis-cluster-data-2
-    mkdir -p tb-node/redis-cluster-data-3 && sudo chown -R 1001:1001 tb-node/redis-cluster-data-3
-    mkdir -p tb-node/redis-cluster-data-4 && sudo chown -R 1001:1001 tb-node/redis-cluster-data-4
-    mkdir -p tb-node/redis-cluster-data-5 && sudo chown -R 1001:1001 tb-node/redis-cluster-data-5
-    ;;
-    *)
-    echo "Unknown CACHE value specified in the .env file: '${CACHE}'. Should be either 'redis' or 'redis-cluster'." >&2
-    exit 1
-esac
+set -e
+source compose-utils.sh
+checkFolders --create

--- a/docker/docker-install-tb.sh
+++ b/docker/docker-install-tb.sh
@@ -41,8 +41,6 @@ set -e
 
 source compose-utils.sh
 
-checkFolders --create || exit $?
-
 ADDITIONAL_COMPOSE_QUEUE_ARGS=$(additionalComposeQueueArgs) || exit $?
 
 ADDITIONAL_COMPOSE_ARGS=$(additionalComposeArgs) || exit $?
@@ -50,6 +48,8 @@ ADDITIONAL_COMPOSE_ARGS=$(additionalComposeArgs) || exit $?
 ADDITIONAL_CACHE_ARGS=$(additionalComposeCacheArgs) || exit $?
 
 ADDITIONAL_STARTUP_SERVICES=$(additionalStartupServices) || exit $?
+
+checkFolders --create || exit $?
 
 if [ ! -z "${ADDITIONAL_STARTUP_SERVICES// }" ]; then
     docker-compose \

--- a/docker/docker-install-tb.sh
+++ b/docker/docker-install-tb.sh
@@ -41,6 +41,8 @@ set -e
 
 source compose-utils.sh
 
+checkFolders --create || exit $?
+
 ADDITIONAL_COMPOSE_QUEUE_ARGS=$(additionalComposeQueueArgs) || exit $?
 
 ADDITIONAL_COMPOSE_ARGS=$(additionalComposeArgs) || exit $?

--- a/docker/docker-start-services.sh
+++ b/docker/docker-start-services.sh
@@ -19,8 +19,6 @@ set -e
 
 source compose-utils.sh
 
-checkFolders --create || exit $?
-
 ADDITIONAL_COMPOSE_QUEUE_ARGS=$(additionalComposeQueueArgs) || exit $?
 
 ADDITIONAL_COMPOSE_ARGS=$(additionalComposeArgs) || exit $?
@@ -28,6 +26,8 @@ ADDITIONAL_COMPOSE_ARGS=$(additionalComposeArgs) || exit $?
 ADDITIONAL_CACHE_ARGS=$(additionalComposeCacheArgs) || exit $?
 
 ADDITIONAL_COMPOSE_MONITORING_ARGS=$(additionalComposeMonitoringArgs) || exit $?
+
+checkFolders --create || exit $?
 
 docker-compose \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS $ADDITIONAL_COMPOSE_MONITORING_ARGS \

--- a/docker/docker-upgrade-tb.sh
+++ b/docker/docker-upgrade-tb.sh
@@ -40,8 +40,6 @@ set -e
 
 source compose-utils.sh
 
-checkFolders --create || exit $?
-
 ADDITIONAL_COMPOSE_QUEUE_ARGS=$(additionalComposeQueueArgs) || exit $?
 
 ADDITIONAL_COMPOSE_ARGS=$(additionalComposeArgs) || exit $?
@@ -49,6 +47,8 @@ ADDITIONAL_COMPOSE_ARGS=$(additionalComposeArgs) || exit $?
 ADDITIONAL_CACHE_ARGS=$(additionalComposeCacheArgs) || exit $?
 
 ADDITIONAL_STARTUP_SERVICES=$(additionalStartupServices) || exit $?
+
+checkFolders --create || exit $?
 
 docker-compose \
   -f docker-compose.yml $ADDITIONAL_CACHE_ARGS $ADDITIONAL_COMPOSE_ARGS $ADDITIONAL_COMPOSE_QUEUE_ARGS \

--- a/docker/docker-upgrade-tb.sh
+++ b/docker/docker-upgrade-tb.sh
@@ -40,6 +40,8 @@ set -e
 
 source compose-utils.sh
 
+checkFolders --create || exit $?
+
 ADDITIONAL_COMPOSE_QUEUE_ARGS=$(additionalComposeQueueArgs) || exit $?
 
 ADDITIONAL_COMPOSE_ARGS=$(additionalComposeArgs) || exit $?


### PR DESCRIPTION
## docker-compose check folders: create and set owner

This PR will check and set the owner for data folders on install, start, and upgrade scripts
Here is the sample output:

![image](https://user-images.githubusercontent.com/79898499/176221920-9b00ffbf-48df-44cb-9667-a4f1964fb743.png)

A new script `./docker-check-log-folders.sh` was added. It only checks folders and returns "OK" or errors. Here is the sample output:

![image](https://user-images.githubusercontent.com/79898499/176222620-57730d18-8944-4b0d-adcf-b1be5e6aeb9e.png)

PE: https://github.com/thingsboard/thingsboard-pe-docker-compose/pull/35

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



