### PR TITLE
[3.4] Black box tests memory limit

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -26,3 +26,6 @@ LOAD_BALANCER_NAME=haproxy-certbot
 
 # If enabled Prometheus and Grafana containers are deployed along with other containers
 MONITORING_ENABLED=false
+
+# Limit memory usage for each Java application
+# JAVA_OPTS=-Xmx2048M -Xms2048M -Xss384k -XX:+AlwaysPreTouch

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       TB_SERVICE_ID: tb-core1
       TB_SERVICE_TYPE: tb-core
       EDGES_ENABLED: "true"
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-node.env
     volumes:
@@ -73,6 +74,7 @@ services:
       TB_SERVICE_ID: tb-core2
       TB_SERVICE_TYPE: tb-core
       EDGES_ENABLED: "true"
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-node.env
     volumes:
@@ -96,6 +98,7 @@ services:
     environment:
       TB_SERVICE_ID: tb-rule-engine1
       TB_SERVICE_TYPE: tb-rule-engine
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-node.env
     volumes:
@@ -117,6 +120,7 @@ services:
     environment:
       TB_SERVICE_ID: tb-rule-engine2
       TB_SERVICE_TYPE: tb-rule-engine
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-node.env
     volumes:
@@ -132,6 +136,7 @@ services:
       - "1883"
     environment:
       TB_SERVICE_ID: tb-mqtt-transport1
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-mqtt-transport.env
     volumes:
@@ -148,6 +153,7 @@ services:
       - "1883"
     environment:
       TB_SERVICE_ID: tb-mqtt-transport2
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-mqtt-transport.env
     volumes:
@@ -164,6 +170,7 @@ services:
       - "8081"
     environment:
       TB_SERVICE_ID: tb-http-transport1
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-http-transport.env
     volumes:
@@ -180,6 +187,7 @@ services:
       - "8081"
     environment:
       TB_SERVICE_ID: tb-http-transport2
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-http-transport.env
     volumes:
@@ -196,6 +204,7 @@ services:
       - "5683:5683/udp"
     environment:
       TB_SERVICE_ID: tb-coap-transport
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-coap-transport.env
     volumes:
@@ -212,6 +221,7 @@ services:
       - "5685:5685/udp"
     environment:
       TB_SERVICE_ID: tb-lwm2m-transport
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-lwm2m-transport.env
     volumes:
@@ -226,6 +236,7 @@ services:
     image: "${DOCKER_REPO}/${SNMP_TRANSPORT_DOCKER_NAME}:${TB_VERSION}"
     environment:
       TB_SERVICE_ID: tb-snmp-transport
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-snmp-transport.env
     volumes:
@@ -256,6 +267,7 @@ services:
       - "8081"
     environment:
       TB_SERVICE_ID: tb-vc-executor1
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-vc-executor.env
     volumes:
@@ -272,6 +284,7 @@ services:
       - "8081"
     environment:
       TB_SERVICE_ID: tb-vc-executor2
+      JAVA_OPTS: "${JAVA_OPTS}"
     env_file:
       - tb-vc-executor.env
     volumes:

--- a/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/ThingsBoardDbInstaller.java
+++ b/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/ThingsBoardDbInstaller.java
@@ -46,6 +46,7 @@ public class ThingsBoardDbInstaller extends ExternalResource {
     private final static String TB_MQTT_TRANSPORT_LOG_VOLUME = "tb-mqtt-transport-log-test-volume";
     private final static String TB_SNMP_TRANSPORT_LOG_VOLUME = "tb-snmp-transport-log-test-volume";
     private final static String TB_VC_EXECUTOR_LOG_VOLUME = "tb-vc-executor-log-test-volume";
+    private final static String JAVA_OPTS = "-Xmx384m -Xss256k";
 
     private final DockerComposeExecutor dockerCompose;
 
@@ -102,6 +103,7 @@ public class ThingsBoardDbInstaller extends ExternalResource {
         dockerCompose = new DockerComposeExecutor(composeFiles, project);
 
         env = new HashMap<>();
+        env.put("JAVA_OPTS", JAVA_OPTS);
         env.put("POSTGRES_DATA_VOLUME", postgresDataVolume);
         if (IS_HYBRID_MODE) {
             env.put("CASSANDRA_DATA_VOLUME", cassandraDataVolume);


### PR DESCRIPTION
## Black box tests memory limit

This limits Java memory usage under black-box tests. Without limits, Java claims too much memory and it worms up the Build machine.
It is also possible to set JAVA_OPTS for docker-compose

```
JAVA_OPTS = "-Xmx384m -Xss256k"
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



