### PR TITLE
[3.4] Edge push to rule chain node

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructor.java
@@ -17,7 +17,6 @@ package org.thingsboard.server.service.edge.rpc.constructor;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.id.RuleChainId;

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructor.java
@@ -15,44 +15,31 @@
  */
 package org.thingsboard.server.service.edge.rpc.constructor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.rule.engine.flow.TbRuleChainInputNode;
-import org.thingsboard.rule.engine.flow.TbRuleChainInputNodeConfiguration;
-import org.thingsboard.rule.engine.flow.TbRuleChainOutputNode;
 import org.thingsboard.server.common.data.id.RuleChainId;
-import org.thingsboard.server.common.data.rule.NodeConnectionInfo;
+import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.rule.RuleChain;
-import org.thingsboard.server.common.data.rule.RuleChainConnectionInfo;
 import org.thingsboard.server.common.data.rule.RuleChainMetaData;
-import org.thingsboard.server.common.data.rule.RuleNode;
+import org.thingsboard.server.dao.queue.QueueService;
 import org.thingsboard.server.gen.edge.v1.EdgeVersion;
-import org.thingsboard.server.gen.edge.v1.NodeConnectionInfoProto;
-import org.thingsboard.server.gen.edge.v1.RuleChainConnectionInfoProto;
 import org.thingsboard.server.gen.edge.v1.RuleChainMetadataUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.RuleChainUpdateMsg;
-import org.thingsboard.server.gen.edge.v1.RuleNodeProto;
 import org.thingsboard.server.gen.edge.v1.UpdateMsgType;
 import org.thingsboard.server.queue.util.TbCoreComponent;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.NavigableSet;
-import java.util.TreeSet;
-import java.util.UUID;
-import java.util.stream.Collectors;
+import org.thingsboard.server.service.edge.rpc.constructor.rule.RuleChainMetadataConstructor;
+import org.thingsboard.server.service.edge.rpc.constructor.rule.RuleChainMetadataConstructorFactory;
 
 @Component
 @Slf4j
 @TbCoreComponent
+@AllArgsConstructor
 public class RuleChainMsgConstructor {
 
-    private static final String RULE_CHAIN_INPUT_NODE = TbRuleChainInputNode.class.getName();
-    private static final String TB_RULE_CHAIN_OUTPUT_NODE = TbRuleChainOutputNode.class.getName();
+    private final QueueService queueService;
 
     public RuleChainUpdateMsg constructRuleChainUpdatedMsg(RuleChainId edgeRootRuleChainId, UpdateMsgType msgType, RuleChain ruleChain) {
         RuleChainUpdateMsg.Builder builder = RuleChainUpdateMsg.newBuilder()
@@ -70,229 +57,13 @@ public class RuleChainMsgConstructor {
         return builder.build();
     }
 
-    public RuleChainMetadataUpdateMsg constructRuleChainMetadataUpdatedMsg(UpdateMsgType msgType,
+    public RuleChainMetadataUpdateMsg constructRuleChainMetadataUpdatedMsg(TenantId tenantId,
+                                                                           UpdateMsgType msgType,
                                                                            RuleChainMetaData ruleChainMetaData,
                                                                            EdgeVersion edgeVersion) {
-        try {
-            RuleChainMetadataUpdateMsg.Builder builder = RuleChainMetadataUpdateMsg.newBuilder();
-            switch (edgeVersion) {
-                case V_3_3_0:
-                    constructRuleChainMetadataUpdatedMsg_V_3_3_0(builder, ruleChainMetaData);
-                    break;
-                case V_3_3_3:
-                default:
-                    constructRuleChainMetadataUpdatedMsg_V_3_3_3(builder, ruleChainMetaData);
-                    break;
-            }
-            builder.setMsgType(msgType);
-            return builder.build();
-        } catch (JsonProcessingException ex) {
-            log.error("Can't construct RuleChainMetadataUpdateMsg", ex);
-        }
-        return null;
-    }
-
-    private void constructRuleChainMetadataUpdatedMsg_V_3_3_3(RuleChainMetadataUpdateMsg.Builder builder,
-                                                                                           RuleChainMetaData ruleChainMetaData) throws JsonProcessingException {
-        builder.setRuleChainIdMSB(ruleChainMetaData.getRuleChainId().getId().getMostSignificantBits())
-                .setRuleChainIdLSB(ruleChainMetaData.getRuleChainId().getId().getLeastSignificantBits())
-                .addAllNodes(constructNodes(ruleChainMetaData.getNodes()))
-                .addAllConnections(constructConnections(ruleChainMetaData.getConnections()))
-                .addAllRuleChainConnections(constructRuleChainConnections(ruleChainMetaData.getRuleChainConnections(), new TreeSet<>()));
-        if (ruleChainMetaData.getFirstNodeIndex() != null) {
-            builder.setFirstNodeIndex(ruleChainMetaData.getFirstNodeIndex());
-        } else {
-            builder.setFirstNodeIndex(-1);
-        }
-    }
-
-    private void constructRuleChainMetadataUpdatedMsg_V_3_3_0(RuleChainMetadataUpdateMsg.Builder builder,
-                                                                                           RuleChainMetaData ruleChainMetaData) throws JsonProcessingException {
-        List<RuleNode> supportedNodes = filterNodes_V_3_3_0(ruleChainMetaData.getNodes());
-        NavigableSet<Integer> removedNodeIndexes = getRemovedNodeIndexes(ruleChainMetaData.getNodes(), ruleChainMetaData.getConnections());
-        List<NodeConnectionInfo> connections = filterConnections_V_3_3_0(ruleChainMetaData.getNodes(), ruleChainMetaData.getConnections(), removedNodeIndexes);
-
-        List<RuleChainConnectionInfo> ruleChainConnections = new ArrayList<>();
-        if (ruleChainMetaData.getRuleChainConnections() != null) {
-            ruleChainConnections.addAll(ruleChainMetaData.getRuleChainConnections());
-        }
-        ruleChainConnections.addAll(addRuleChainConnections_V_3_3_0(ruleChainMetaData.getNodes(), ruleChainMetaData.getConnections()));
-        builder.setRuleChainIdMSB(ruleChainMetaData.getRuleChainId().getId().getMostSignificantBits())
-                .setRuleChainIdLSB(ruleChainMetaData.getRuleChainId().getId().getLeastSignificantBits())
-                .addAllNodes(constructNodes(supportedNodes))
-                .addAllConnections(constructConnections(connections))
-                .addAllRuleChainConnections(constructRuleChainConnections(ruleChainConnections, removedNodeIndexes));
-        if (ruleChainMetaData.getFirstNodeIndex() != null) {
-            Integer firstNodeIndex = ruleChainMetaData.getFirstNodeIndex();
-            // decrease index because of removed nodes
-            for (Integer removedIndex : removedNodeIndexes) {
-                if (firstNodeIndex > removedIndex) {
-                    firstNodeIndex = firstNodeIndex - 1;
-                }
-            }
-            builder.setFirstNodeIndex(firstNodeIndex);
-        } else {
-            builder.setFirstNodeIndex(-1);
-        }
-    }
-
-    private List<NodeConnectionInfo> filterConnections_V_3_3_0(List<RuleNode> nodes, List<NodeConnectionInfo> connections, NavigableSet<Integer> removedNodeIndexes) {
-        List<NodeConnectionInfo> result = new ArrayList<>();
-        if (connections != null) {
-            result = connections.stream().filter(conn -> {
-                for (int i = 0; i < nodes.size(); i++) {
-                    RuleNode node = nodes.get(i);
-                    if (node.getType().equalsIgnoreCase(RULE_CHAIN_INPUT_NODE)
-                            || node.getType().equalsIgnoreCase(TB_RULE_CHAIN_OUTPUT_NODE)) {
-                        if (conn.getFromIndex() == i || conn.getToIndex() == i) {
-                            return false;
-                        }
-                    }
-                }
-                return true;
-            }).map(conn -> {
-                NodeConnectionInfo newConn = new NodeConnectionInfo();
-                newConn.setFromIndex(conn.getFromIndex());
-                newConn.setToIndex(conn.getToIndex());
-                newConn.setType(conn.getType());
-                return newConn;
-            }).collect(Collectors.toList());
-        }
-
-        // decrease index because of removed nodes
-        for (Integer removedIndex : removedNodeIndexes) {
-            for (NodeConnectionInfo newConn : result) {
-                if (newConn.getToIndex() > removedIndex) {
-                    newConn.setToIndex(newConn.getToIndex() - 1);
-                }
-                if (newConn.getFromIndex() > removedIndex) {
-                    newConn.setFromIndex(newConn.getFromIndex() - 1);
-                }
-            }
-        }
-
-        return result;
-    }
-
-    private NavigableSet<Integer> getRemovedNodeIndexes(List<RuleNode> nodes, List<NodeConnectionInfo> connections) {
-        TreeSet<Integer> removedIndexes = new TreeSet<>();
-        for (NodeConnectionInfo connection : connections) {
-            for (int i = 0; i < nodes.size(); i++) {
-                RuleNode node = nodes.get(i);
-                if (node.getType().equalsIgnoreCase(RULE_CHAIN_INPUT_NODE)
-                        || node.getType().equalsIgnoreCase(TB_RULE_CHAIN_OUTPUT_NODE)) {
-                    if (connection.getFromIndex() == i || connection.getToIndex() == i) {
-                        removedIndexes.add(i);
-                    }
-                }
-            }
-        }
-        return removedIndexes.descendingSet();
-    }
-
-    private List<NodeConnectionInfoProto> constructConnections(List<NodeConnectionInfo> connections) {
-        List<NodeConnectionInfoProto> result = new ArrayList<>();
-        if (connections != null && !connections.isEmpty()) {
-            for (NodeConnectionInfo connection : connections) {
-                result.add(constructConnection(connection));
-            }
-        }
-        return result;
-    }
-
-    private NodeConnectionInfoProto constructConnection(NodeConnectionInfo connection) {
-        return NodeConnectionInfoProto.newBuilder()
-                .setFromIndex(connection.getFromIndex())
-                .setToIndex(connection.getToIndex())
-                .setType(connection.getType())
-                .build();
-    }
-
-    private List<RuleNode> filterNodes_V_3_3_0(List<RuleNode> nodes) {
-        List<RuleNode> result = new ArrayList<>();
-        for (RuleNode node : nodes) {
-            if (RULE_CHAIN_INPUT_NODE.equals(node.getType())
-                    || TB_RULE_CHAIN_OUTPUT_NODE.equals(node.getType())) {
-                log.trace("Skipping not supported rule node {}", node);
-            } else {
-                result.add(node);
-            }
-        }
-        return result;
-    }
-
-    private List<RuleNodeProto> constructNodes(List<RuleNode> nodes) throws JsonProcessingException {
-        List<RuleNodeProto> result = new ArrayList<>();
-        if (nodes != null && !nodes.isEmpty()) {
-            for (RuleNode node : nodes) {
-                result.add(constructNode(node));
-            }
-        }
-        return result;
-    }
-
-    private List<RuleChainConnectionInfo> addRuleChainConnections_V_3_3_0(List<RuleNode> nodes, List<NodeConnectionInfo> connections) throws JsonProcessingException {
-        List<RuleChainConnectionInfo> result = new ArrayList<>();
-        for (int i = 0; i < nodes.size(); i++) {
-            RuleNode node = nodes.get(i);
-            if (node.getType().equalsIgnoreCase(RULE_CHAIN_INPUT_NODE)) {
-                for (NodeConnectionInfo connection : connections) {
-                    if (connection.getToIndex() == i) {
-                        RuleChainConnectionInfo e = new RuleChainConnectionInfo();
-                        e.setFromIndex(connection.getFromIndex());
-                        TbRuleChainInputNodeConfiguration configuration = JacksonUtil.treeToValue(node.getConfiguration(), TbRuleChainInputNodeConfiguration.class);
-                        e.setTargetRuleChainId(new RuleChainId(UUID.fromString(configuration.getRuleChainId())));
-                        e.setAdditionalInfo(node.getAdditionalInfo());
-                        e.setType(connection.getType());
-                        result.add(e);
-                    }
-                }
-            }
-        }
-        return result;
-    }
-
-    private List<RuleChainConnectionInfoProto> constructRuleChainConnections(List<RuleChainConnectionInfo> ruleChainConnections, NavigableSet<Integer> removedNodeIndexes) throws JsonProcessingException {
-        List<RuleChainConnectionInfoProto> result = new ArrayList<>();
-        if (ruleChainConnections != null && !ruleChainConnections.isEmpty()) {
-            for (RuleChainConnectionInfo ruleChainConnectionInfo : ruleChainConnections) {
-                result.add(constructRuleChainConnection(ruleChainConnectionInfo, removedNodeIndexes));
-            }
-        }
-        return result;
-    }
-
-    private RuleChainConnectionInfoProto constructRuleChainConnection(RuleChainConnectionInfo ruleChainConnectionInfo, NavigableSet<Integer> removedNodeIndexes) throws JsonProcessingException {
-        int fromIndex = ruleChainConnectionInfo.getFromIndex();
-        // decrease index because of removed nodes
-        for (Integer removedIndex : removedNodeIndexes) {
-            if (fromIndex > removedIndex) {
-                fromIndex = fromIndex - 1;
-            }
-        }
-        ObjectNode additionalInfo = (ObjectNode) ruleChainConnectionInfo.getAdditionalInfo();
-        if (additionalInfo.get("ruleChainNodeId") == null) {
-            additionalInfo.put("ruleChainNodeId", "rule-chain-node-UNDEFINED");
-        }
-        return RuleChainConnectionInfoProto.newBuilder()
-                .setFromIndex(fromIndex)
-                .setTargetRuleChainIdMSB(ruleChainConnectionInfo.getTargetRuleChainId().getId().getMostSignificantBits())
-                .setTargetRuleChainIdLSB(ruleChainConnectionInfo.getTargetRuleChainId().getId().getLeastSignificantBits())
-                .setType(ruleChainConnectionInfo.getType())
-                .setAdditionalInfo(JacksonUtil.OBJECT_MAPPER.writeValueAsString(additionalInfo))
-                .build();
-    }
-
-    private RuleNodeProto constructNode(RuleNode node) throws JsonProcessingException {
-        return RuleNodeProto.newBuilder()
-                .setIdMSB(node.getId().getId().getMostSignificantBits())
-                .setIdLSB(node.getId().getId().getLeastSignificantBits())
-                .setType(node.getType())
-                .setName(node.getName())
-                .setDebugMode(node.isDebugMode())
-                .setConfiguration(JacksonUtil.OBJECT_MAPPER.writeValueAsString(node.getConfiguration()))
-                .setAdditionalInfo(JacksonUtil.OBJECT_MAPPER.writeValueAsString(node.getAdditionalInfo()))
-                .build();
+        RuleChainMetadataConstructor ruleChainMetadataConstructor
+                = RuleChainMetadataConstructorFactory.getByEdgeVersion(edgeVersion, queueService);
+        return ruleChainMetadataConstructor.constructRuleChainMetadataUpdatedMsg(tenantId, msgType, ruleChainMetaData);
     }
 
     public RuleChainUpdateMsg constructRuleChainDeleteMsg(RuleChainId ruleChainId) {
@@ -301,5 +72,4 @@ public class RuleChainMsgConstructor {
                 .setIdMSB(ruleChainId.getId().getMostSignificantBits())
                 .setIdLSB(ruleChainId.getId().getLeastSignificantBits()).build();
     }
-
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/AbstractRuleChainMetadataConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/AbstractRuleChainMetadataConstructor.java
@@ -45,7 +45,8 @@ import java.util.UUID;
 @AllArgsConstructor
 public abstract class AbstractRuleChainMetadataConstructor implements RuleChainMetadataConstructor {
 
-    public static final String CHECKPOINT_NODE = TbCheckpointNode.class.getName();
+    public static final List<String> nodeTypes = List.of(TbCheckpointNode.class.getName());
+
     private final QueueService queueService;
 
     @Override
@@ -144,10 +145,10 @@ public abstract class AbstractRuleChainMetadataConstructor implements RuleChainM
                 .build();
     }
 
-    protected List<RuleNode> updateCheckpointNodesConfiguration(TenantId tenantId, List<RuleNode> nodes) {
+    protected List<RuleNode> updateQueueIdToQueueNameNodeConfiguration(TenantId tenantId, List<RuleNode> nodes) {
         List<RuleNode> result = new ArrayList<>();
         for (RuleNode node : nodes) {
-            if (CHECKPOINT_NODE.equals(node.getType())) {
+            if (nodeTypes.contains(node.getType())) {
                 ObjectNode configuration = (ObjectNode) node.getConfiguration();
                 JsonNode queueIdNode = configuration.remove("queueId");
                 if (queueIdNode != null) {

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/AbstractRuleChainMetadataConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/AbstractRuleChainMetadataConstructor.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.rpc.constructor.rule;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.rule.NodeConnectionInfo;
+import org.thingsboard.server.common.data.rule.RuleChainConnectionInfo;
+import org.thingsboard.server.common.data.rule.RuleChainMetaData;
+import org.thingsboard.server.common.data.rule.RuleNode;
+import org.thingsboard.server.gen.edge.v1.NodeConnectionInfoProto;
+import org.thingsboard.server.gen.edge.v1.RuleChainConnectionInfoProto;
+import org.thingsboard.server.gen.edge.v1.RuleChainMetadataUpdateMsg;
+import org.thingsboard.server.gen.edge.v1.RuleNodeProto;
+import org.thingsboard.server.gen.edge.v1.UpdateMsgType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NavigableSet;
+
+@Slf4j
+public abstract class AbstractRuleChainMetadataConstructor implements RuleChainMetadataConstructor {
+
+    @Override
+    public RuleChainMetadataUpdateMsg constructRuleChainMetadataUpdatedMsg(TenantId tenantId,
+                                                                           UpdateMsgType msgType,
+                                                                           RuleChainMetaData ruleChainMetaData) {
+        try {
+            RuleChainMetadataUpdateMsg.Builder builder = RuleChainMetadataUpdateMsg.newBuilder();
+            builder.setRuleChainIdMSB(ruleChainMetaData.getRuleChainId().getId().getMostSignificantBits())
+                    .setRuleChainIdLSB(ruleChainMetaData.getRuleChainId().getId().getLeastSignificantBits());
+            constructRuleChainMetadataUpdatedMsg(tenantId, builder, ruleChainMetaData);
+            builder.setMsgType(msgType);
+            return builder.build();
+        } catch (JsonProcessingException ex) {
+            log.error("Can't construct RuleChainMetadataUpdateMsg", ex);
+        }
+        return null;
+    }
+
+    protected abstract void constructRuleChainMetadataUpdatedMsg(TenantId tenantId,
+                                                                 RuleChainMetadataUpdateMsg.Builder builder,
+                                                                 RuleChainMetaData ruleChainMetaData) throws JsonProcessingException;
+
+    protected List<NodeConnectionInfoProto> constructConnections(List<NodeConnectionInfo> connections) {
+        List<NodeConnectionInfoProto> result = new ArrayList<>();
+        if (connections != null && !connections.isEmpty()) {
+            for (NodeConnectionInfo connection : connections) {
+                result.add(constructConnection(connection));
+            }
+        }
+        return result;
+    }
+
+    private NodeConnectionInfoProto constructConnection(NodeConnectionInfo connection) {
+        return NodeConnectionInfoProto.newBuilder()
+                .setFromIndex(connection.getFromIndex())
+                .setToIndex(connection.getToIndex())
+                .setType(connection.getType())
+                .build();
+    }
+
+    protected List<RuleNodeProto> constructNodes(List<RuleNode> nodes) throws JsonProcessingException {
+        List<RuleNodeProto> result = new ArrayList<>();
+        if (nodes != null && !nodes.isEmpty()) {
+            for (RuleNode node : nodes) {
+                result.add(constructNode(node));
+            }
+        }
+        return result;
+    }
+
+    protected List<RuleChainConnectionInfoProto> constructRuleChainConnections(List<RuleChainConnectionInfo> ruleChainConnections, NavigableSet<Integer> removedNodeIndexes) throws JsonProcessingException {
+        List<RuleChainConnectionInfoProto> result = new ArrayList<>();
+        if (ruleChainConnections != null && !ruleChainConnections.isEmpty()) {
+            for (RuleChainConnectionInfo ruleChainConnectionInfo : ruleChainConnections) {
+                result.add(constructRuleChainConnection(ruleChainConnectionInfo, removedNodeIndexes));
+            }
+        }
+        return result;
+    }
+
+    private RuleChainConnectionInfoProto constructRuleChainConnection(RuleChainConnectionInfo ruleChainConnectionInfo, NavigableSet<Integer> removedNodeIndexes) throws JsonProcessingException {
+        int fromIndex = ruleChainConnectionInfo.getFromIndex();
+        // decrease index because of removed nodes
+        for (Integer removedIndex : removedNodeIndexes) {
+            if (fromIndex > removedIndex) {
+                fromIndex = fromIndex - 1;
+            }
+        }
+        ObjectNode additionalInfo = (ObjectNode) ruleChainConnectionInfo.getAdditionalInfo();
+        if (additionalInfo.get("ruleChainNodeId") == null) {
+            additionalInfo.put("ruleChainNodeId", "rule-chain-node-UNDEFINED");
+        }
+        return RuleChainConnectionInfoProto.newBuilder()
+                .setFromIndex(fromIndex)
+                .setTargetRuleChainIdMSB(ruleChainConnectionInfo.getTargetRuleChainId().getId().getMostSignificantBits())
+                .setTargetRuleChainIdLSB(ruleChainConnectionInfo.getTargetRuleChainId().getId().getLeastSignificantBits())
+                .setType(ruleChainConnectionInfo.getType())
+                .setAdditionalInfo(JacksonUtil.OBJECT_MAPPER.writeValueAsString(additionalInfo))
+                .build();
+    }
+
+    private RuleNodeProto constructNode(RuleNode node) throws JsonProcessingException {
+        return RuleNodeProto.newBuilder()
+                .setIdMSB(node.getId().getId().getMostSignificantBits())
+                .setIdLSB(node.getId().getId().getLeastSignificantBits())
+                .setType(node.getType())
+                .setName(node.getName())
+                .setDebugMode(node.isDebugMode())
+                .setConfiguration(JacksonUtil.OBJECT_MAPPER.writeValueAsString(node.getConfiguration()))
+                .setAdditionalInfo(JacksonUtil.OBJECT_MAPPER.writeValueAsString(node.getAdditionalInfo()))
+                .build();
+    }
+
+}

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructor.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.rpc.constructor.rule;
+
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.rule.RuleChainMetaData;
+import org.thingsboard.server.gen.edge.v1.RuleChainMetadataUpdateMsg;
+import org.thingsboard.server.gen.edge.v1.UpdateMsgType;
+
+public interface RuleChainMetadataConstructor {
+
+    RuleChainMetadataUpdateMsg constructRuleChainMetadataUpdatedMsg(TenantId tenantId,
+                                                                    UpdateMsgType msgType,
+                                                                    RuleChainMetaData ruleChainMetaData);
+}

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorFactory.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorFactory.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.rpc.constructor.rule;
+
+import org.thingsboard.server.dao.queue.QueueService;
+import org.thingsboard.server.gen.edge.v1.EdgeVersion;
+
+public final class RuleChainMetadataConstructorFactory {
+
+    public static RuleChainMetadataConstructor getByEdgeVersion(EdgeVersion edgeVersion,
+                                                                QueueService queueService) {
+        switch (edgeVersion) {
+            case V_3_3_0:
+                return new RuleChainMetadataConstructorV330();
+            case V_3_3_3:
+                return new RuleChainMetadataConstructorV333(queueService);
+            case V_3_4_0:
+            default:
+                return new RuleChainMetadataConstructorV340();
+        }
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorFactory.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorFactory.java
@@ -24,12 +24,12 @@ public final class RuleChainMetadataConstructorFactory {
                                                                 QueueService queueService) {
         switch (edgeVersion) {
             case V_3_3_0:
-                return new RuleChainMetadataConstructorV330();
+                return new RuleChainMetadataConstructorV330(queueService);
             case V_3_3_3:
                 return new RuleChainMetadataConstructorV333(queueService);
             case V_3_4_0:
             default:
-                return new RuleChainMetadataConstructorV340();
+                return new RuleChainMetadataConstructorV340(queueService);
         }
     }
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV330.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV330.java
@@ -27,6 +27,7 @@ import org.thingsboard.server.common.data.rule.NodeConnectionInfo;
 import org.thingsboard.server.common.data.rule.RuleChainConnectionInfo;
 import org.thingsboard.server.common.data.rule.RuleChainMetaData;
 import org.thingsboard.server.common.data.rule.RuleNode;
+import org.thingsboard.server.dao.queue.QueueService;
 import org.thingsboard.server.gen.edge.v1.RuleChainMetadataUpdateMsg;
 
 import java.util.ArrayList;
@@ -42,11 +43,17 @@ public class RuleChainMetadataConstructorV330 extends AbstractRuleChainMetadataC
     private static final String RULE_CHAIN_INPUT_NODE = TbRuleChainInputNode.class.getName();
     private static final String TB_RULE_CHAIN_OUTPUT_NODE = TbRuleChainOutputNode.class.getName();
 
+    public RuleChainMetadataConstructorV330(QueueService queueService) {
+        super(queueService);
+    }
+
     @Override
     protected void constructRuleChainMetadataUpdatedMsg(TenantId tenantId,
                                                         RuleChainMetadataUpdateMsg.Builder builder,
                                                         RuleChainMetaData ruleChainMetaData) throws JsonProcessingException {
         List<RuleNode> supportedNodes = filterNodes(ruleChainMetaData.getNodes());
+        supportedNodes = updateCheckpointNodesConfiguration(tenantId, supportedNodes);
+
         NavigableSet<Integer> removedNodeIndexes = getRemovedNodeIndexes(ruleChainMetaData.getNodes(), ruleChainMetaData.getConnections());
         List<NodeConnectionInfo> connections = filterConnections(ruleChainMetaData.getNodes(), ruleChainMetaData.getConnections(), removedNodeIndexes);
 

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV330.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV330.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.rpc.constructor.rule;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.rule.engine.flow.TbRuleChainInputNode;
+import org.thingsboard.rule.engine.flow.TbRuleChainInputNodeConfiguration;
+import org.thingsboard.rule.engine.flow.TbRuleChainOutputNode;
+import org.thingsboard.server.common.data.id.RuleChainId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.rule.NodeConnectionInfo;
+import org.thingsboard.server.common.data.rule.RuleChainConnectionInfo;
+import org.thingsboard.server.common.data.rule.RuleChainMetaData;
+import org.thingsboard.server.common.data.rule.RuleNode;
+import org.thingsboard.server.gen.edge.v1.RuleChainMetadataUpdateMsg;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class RuleChainMetadataConstructorV330 extends AbstractRuleChainMetadataConstructor {
+
+    private static final String RULE_CHAIN_INPUT_NODE = TbRuleChainInputNode.class.getName();
+    private static final String TB_RULE_CHAIN_OUTPUT_NODE = TbRuleChainOutputNode.class.getName();
+
+    @Override
+    protected void constructRuleChainMetadataUpdatedMsg(TenantId tenantId,
+                                                        RuleChainMetadataUpdateMsg.Builder builder,
+                                                        RuleChainMetaData ruleChainMetaData) throws JsonProcessingException {
+        List<RuleNode> supportedNodes = filterNodes(ruleChainMetaData.getNodes());
+        NavigableSet<Integer> removedNodeIndexes = getRemovedNodeIndexes(ruleChainMetaData.getNodes(), ruleChainMetaData.getConnections());
+        List<NodeConnectionInfo> connections = filterConnections(ruleChainMetaData.getNodes(), ruleChainMetaData.getConnections(), removedNodeIndexes);
+
+        List<RuleChainConnectionInfo> ruleChainConnections = new ArrayList<>();
+        if (ruleChainMetaData.getRuleChainConnections() != null) {
+            ruleChainConnections.addAll(ruleChainMetaData.getRuleChainConnections());
+        }
+        ruleChainConnections.addAll(addRuleChainConnections(ruleChainMetaData.getNodes(), ruleChainMetaData.getConnections()));
+        builder.addAllNodes(constructNodes(supportedNodes))
+                .addAllConnections(constructConnections(connections))
+                .addAllRuleChainConnections(constructRuleChainConnections(ruleChainConnections, removedNodeIndexes));
+        if (ruleChainMetaData.getFirstNodeIndex() != null) {
+            Integer firstNodeIndex = ruleChainMetaData.getFirstNodeIndex();
+            // decrease index because of removed nodes
+            for (Integer removedIndex : removedNodeIndexes) {
+                if (firstNodeIndex > removedIndex) {
+                    firstNodeIndex = firstNodeIndex - 1;
+                }
+            }
+            builder.setFirstNodeIndex(firstNodeIndex);
+        } else {
+            builder.setFirstNodeIndex(-1);
+        }
+    }
+
+    private NavigableSet<Integer> getRemovedNodeIndexes(List<RuleNode> nodes, List<NodeConnectionInfo> connections) {
+        TreeSet<Integer> removedIndexes = new TreeSet<>();
+        for (NodeConnectionInfo connection : connections) {
+            for (int i = 0; i < nodes.size(); i++) {
+                RuleNode node = nodes.get(i);
+                if (node.getType().equalsIgnoreCase(RULE_CHAIN_INPUT_NODE)
+                        || node.getType().equalsIgnoreCase(TB_RULE_CHAIN_OUTPUT_NODE)) {
+                    if (connection.getFromIndex() == i || connection.getToIndex() == i) {
+                        removedIndexes.add(i);
+                    }
+                }
+            }
+        }
+        return removedIndexes.descendingSet();
+    }
+
+    private List<NodeConnectionInfo> filterConnections(List<RuleNode> nodes,
+                                                       List<NodeConnectionInfo> connections,
+                                                       NavigableSet<Integer> removedNodeIndexes) {
+        List<NodeConnectionInfo> result = new ArrayList<>();
+        if (connections != null) {
+            result = connections.stream().filter(conn -> {
+                for (int i = 0; i < nodes.size(); i++) {
+                    RuleNode node = nodes.get(i);
+                    if (node.getType().equalsIgnoreCase(RULE_CHAIN_INPUT_NODE)
+                            || node.getType().equalsIgnoreCase(TB_RULE_CHAIN_OUTPUT_NODE)) {
+                        if (conn.getFromIndex() == i || conn.getToIndex() == i) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }).map(conn -> {
+                NodeConnectionInfo newConn = new NodeConnectionInfo();
+                newConn.setFromIndex(conn.getFromIndex());
+                newConn.setToIndex(conn.getToIndex());
+                newConn.setType(conn.getType());
+                return newConn;
+            }).collect(Collectors.toList());
+        }
+
+        // decrease index because of removed nodes
+        for (Integer removedIndex : removedNodeIndexes) {
+            for (NodeConnectionInfo newConn : result) {
+                if (newConn.getToIndex() > removedIndex) {
+                    newConn.setToIndex(newConn.getToIndex() - 1);
+                }
+                if (newConn.getFromIndex() > removedIndex) {
+                    newConn.setFromIndex(newConn.getFromIndex() - 1);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private List<RuleNode> filterNodes(List<RuleNode> nodes) {
+        List<RuleNode> result = new ArrayList<>();
+        for (RuleNode node : nodes) {
+            if (RULE_CHAIN_INPUT_NODE.equals(node.getType())
+                    || TB_RULE_CHAIN_OUTPUT_NODE.equals(node.getType())) {
+                log.trace("Skipping not supported rule node {}", node);
+            } else {
+                result.add(node);
+            }
+        }
+        return result;
+    }
+
+    private List<RuleChainConnectionInfo> addRuleChainConnections(List<RuleNode> nodes, List<NodeConnectionInfo> connections) {
+        List<RuleChainConnectionInfo> result = new ArrayList<>();
+        for (int i = 0; i < nodes.size(); i++) {
+            RuleNode node = nodes.get(i);
+            if (node.getType().equalsIgnoreCase(RULE_CHAIN_INPUT_NODE)) {
+                for (NodeConnectionInfo connection : connections) {
+                    if (connection.getToIndex() == i) {
+                        RuleChainConnectionInfo e = new RuleChainConnectionInfo();
+                        e.setFromIndex(connection.getFromIndex());
+                        TbRuleChainInputNodeConfiguration configuration = JacksonUtil.treeToValue(node.getConfiguration(), TbRuleChainInputNodeConfiguration.class);
+                        e.setTargetRuleChainId(new RuleChainId(UUID.fromString(configuration.getRuleChainId())));
+                        e.setAdditionalInfo(node.getAdditionalInfo());
+                        e.setType(connection.getType());
+                        result.add(e);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV330.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV330.java
@@ -52,7 +52,7 @@ public class RuleChainMetadataConstructorV330 extends AbstractRuleChainMetadataC
                                                         RuleChainMetadataUpdateMsg.Builder builder,
                                                         RuleChainMetaData ruleChainMetaData) throws JsonProcessingException {
         List<RuleNode> supportedNodes = filterNodes(ruleChainMetaData.getNodes());
-        supportedNodes = updateCheckpointNodesConfiguration(tenantId, supportedNodes);
+        supportedNodes = updateQueueIdToQueueNameNodeConfiguration(tenantId, supportedNodes);
 
         NavigableSet<Integer> removedNodeIndexes = getRemovedNodeIndexes(ruleChainMetaData.getNodes(), ruleChainMetaData.getConnections());
         List<NodeConnectionInfo> connections = filterConnections(ruleChainMetaData.getNodes(), ruleChainMetaData.getConnections(), removedNodeIndexes);

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV333.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV333.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.rpc.constructor.rule;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.rule.engine.flow.TbCheckpointNode;
+import org.thingsboard.rule.engine.flow.TbCheckpointNodeConfiguration;
+import org.thingsboard.server.common.data.id.QueueId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.queue.Queue;
+import org.thingsboard.server.common.data.rule.RuleChainMetaData;
+import org.thingsboard.server.common.data.rule.RuleNode;
+import org.thingsboard.server.dao.queue.QueueService;
+import org.thingsboard.server.gen.edge.v1.RuleChainMetadataUpdateMsg;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.UUID;
+
+@Slf4j
+@AllArgsConstructor
+public class RuleChainMetadataConstructorV333 extends AbstractRuleChainMetadataConstructor {
+
+    public static final String CHECKPOINT_NODE = TbCheckpointNode.class.getName();
+    private final QueueService queueService;
+
+    @Override
+    protected void constructRuleChainMetadataUpdatedMsg(TenantId tenantId,
+                                                        RuleChainMetadataUpdateMsg.Builder builder,
+                                                        RuleChainMetaData ruleChainMetaData) throws JsonProcessingException {
+        List<RuleNode> nodes = updateCheckpointNodesConfiguration(tenantId, ruleChainMetaData.getNodes());
+
+        builder.addAllNodes(constructNodes(nodes))
+                .addAllConnections(constructConnections(ruleChainMetaData.getConnections()))
+                .addAllRuleChainConnections(constructRuleChainConnections(ruleChainMetaData.getRuleChainConnections(), new TreeSet<>()));
+        if (ruleChainMetaData.getFirstNodeIndex() != null) {
+            builder.setFirstNodeIndex(ruleChainMetaData.getFirstNodeIndex());
+        } else {
+            builder.setFirstNodeIndex(-1);
+        }
+    }
+
+    private List<RuleNode> updateCheckpointNodesConfiguration(TenantId tenantId, List<RuleNode> nodes) throws JsonProcessingException {
+        List<RuleNode> result = new ArrayList<>();
+        for (RuleNode node : nodes) {
+            if (CHECKPOINT_NODE.equals(node.getType())) {
+                TbCheckpointNodeConfiguration configuration =
+                        JacksonUtil.treeToValue(node.getConfiguration(), TbCheckpointNodeConfiguration.class);
+                Queue queueById = queueService.findQueueById(tenantId, new QueueId(UUID.fromString(configuration.getQueueId())));
+                if (queueById != null) {
+                    node.setConfiguration(JacksonUtil.OBJECT_MAPPER.readTree("{\"queueName\":\"" + queueById.getName() + "\"}"));
+                }
+            }
+            result.add(node);
+        }
+        return result;
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV333.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV333.java
@@ -16,37 +16,28 @@
 package org.thingsboard.server.service.edge.rpc.constructor.rule;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.rule.engine.flow.TbCheckpointNode;
-import org.thingsboard.rule.engine.flow.TbCheckpointNodeConfiguration;
-import org.thingsboard.server.common.data.id.QueueId;
 import org.thingsboard.server.common.data.id.TenantId;
-import org.thingsboard.server.common.data.queue.Queue;
 import org.thingsboard.server.common.data.rule.RuleChainMetaData;
 import org.thingsboard.server.common.data.rule.RuleNode;
 import org.thingsboard.server.dao.queue.QueueService;
 import org.thingsboard.server.gen.edge.v1.RuleChainMetadataUpdateMsg;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
-import java.util.UUID;
 
 @Slf4j
-@AllArgsConstructor
 public class RuleChainMetadataConstructorV333 extends AbstractRuleChainMetadataConstructor {
 
-    public static final String CHECKPOINT_NODE = TbCheckpointNode.class.getName();
-    private final QueueService queueService;
+    public RuleChainMetadataConstructorV333(QueueService queueService) {
+        super(queueService);
+    }
 
     @Override
     protected void constructRuleChainMetadataUpdatedMsg(TenantId tenantId,
                                                         RuleChainMetadataUpdateMsg.Builder builder,
                                                         RuleChainMetaData ruleChainMetaData) throws JsonProcessingException {
         List<RuleNode> nodes = updateCheckpointNodesConfiguration(tenantId, ruleChainMetaData.getNodes());
-
         builder.addAllNodes(constructNodes(nodes))
                 .addAllConnections(constructConnections(ruleChainMetaData.getConnections()))
                 .addAllRuleChainConnections(constructRuleChainConnections(ruleChainMetaData.getRuleChainConnections(), new TreeSet<>()));
@@ -55,21 +46,5 @@ public class RuleChainMetadataConstructorV333 extends AbstractRuleChainMetadataC
         } else {
             builder.setFirstNodeIndex(-1);
         }
-    }
-
-    private List<RuleNode> updateCheckpointNodesConfiguration(TenantId tenantId, List<RuleNode> nodes) throws JsonProcessingException {
-        List<RuleNode> result = new ArrayList<>();
-        for (RuleNode node : nodes) {
-            if (CHECKPOINT_NODE.equals(node.getType())) {
-                TbCheckpointNodeConfiguration configuration =
-                        JacksonUtil.treeToValue(node.getConfiguration(), TbCheckpointNodeConfiguration.class);
-                Queue queueById = queueService.findQueueById(tenantId, new QueueId(UUID.fromString(configuration.getQueueId())));
-                if (queueById != null) {
-                    node.setConfiguration(JacksonUtil.OBJECT_MAPPER.readTree("{\"queueName\":\"" + queueById.getName() + "\"}"));
-                }
-            }
-            result.add(node);
-        }
-        return result;
     }
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV333.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV333.java
@@ -37,7 +37,7 @@ public class RuleChainMetadataConstructorV333 extends AbstractRuleChainMetadataC
     protected void constructRuleChainMetadataUpdatedMsg(TenantId tenantId,
                                                         RuleChainMetadataUpdateMsg.Builder builder,
                                                         RuleChainMetaData ruleChainMetaData) throws JsonProcessingException {
-        List<RuleNode> nodes = updateCheckpointNodesConfiguration(tenantId, ruleChainMetaData.getNodes());
+        List<RuleNode> nodes = updateQueueIdToQueueNameNodeConfiguration(tenantId, ruleChainMetaData.getNodes());
         builder.addAllNodes(constructNodes(nodes))
                 .addAllConnections(constructConnections(ruleChainMetaData.getConnections()))
                 .addAllRuleChainConnections(constructRuleChainConnections(ruleChainMetaData.getRuleChainConnections(), new TreeSet<>()));

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV340.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV340.java
@@ -19,12 +19,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.rule.RuleChainMetaData;
+import org.thingsboard.server.dao.queue.QueueService;
 import org.thingsboard.server.gen.edge.v1.RuleChainMetadataUpdateMsg;
 
 import java.util.TreeSet;
 
 @Slf4j
 public class RuleChainMetadataConstructorV340 extends AbstractRuleChainMetadataConstructor {
+
+    public RuleChainMetadataConstructorV340(QueueService queueService) {
+        super(queueService);
+    }
 
     @Override
     protected void constructRuleChainMetadataUpdatedMsg(TenantId tenantId,

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV340.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/rule/RuleChainMetadataConstructorV340.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.rpc.constructor.rule;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.rule.RuleChainMetaData;
+import org.thingsboard.server.gen.edge.v1.RuleChainMetadataUpdateMsg;
+
+import java.util.TreeSet;
+
+@Slf4j
+public class RuleChainMetadataConstructorV340 extends AbstractRuleChainMetadataConstructor {
+
+    @Override
+    protected void constructRuleChainMetadataUpdatedMsg(TenantId tenantId,
+                                                        RuleChainMetadataUpdateMsg.Builder builder,
+                                                        RuleChainMetaData ruleChainMetaData) throws JsonProcessingException {
+        builder.addAllNodes(constructNodes(ruleChainMetaData.getNodes()))
+                .addAllConnections(constructConnections(ruleChainMetaData.getConnections()))
+                .addAllRuleChainConnections(constructRuleChainConnections(ruleChainMetaData.getRuleChainConnections(), new TreeSet<>()));
+        if (ruleChainMetaData.getFirstNodeIndex() != null) {
+            builder.setFirstNodeIndex(ruleChainMetaData.getFirstNodeIndex());
+        } else {
+            builder.setFirstNodeIndex(-1);
+        }
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/RuleChainEdgeProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/RuleChainEdgeProcessor.java
@@ -71,7 +71,7 @@ public class RuleChainEdgeProcessor extends BaseEdgeProcessor {
         if (ruleChain != null) {
             RuleChainMetaData ruleChainMetaData = ruleChainService.loadRuleChainMetaData(edgeEvent.getTenantId(), ruleChainId);
             RuleChainMetadataUpdateMsg ruleChainMetadataUpdateMsg =
-                    ruleChainMsgConstructor.constructRuleChainMetadataUpdatedMsg(msgType, ruleChainMetaData, edgeVersion);
+                    ruleChainMsgConstructor.constructRuleChainMetadataUpdatedMsg(edgeEvent.getTenantId(), msgType, ruleChainMetaData, edgeVersion);
             if (ruleChainMetadataUpdateMsg != null) {
                 downlinkMsg = DownlinkMsg.newBuilder()
                         .setDownlinkMsgId(EdgeUtils.nextPositiveInt())

--- a/application/src/test/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructorTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructorTest.java
@@ -66,6 +66,10 @@ public class RuleChainMsgConstructorTest {
         queueService = mock(QueueService.class);
         constructor = new RuleChainMsgConstructor(queueService);
         tenantId = new TenantId(UUID.randomUUID());
+
+        Queue queue = new Queue();
+        queue.setName("HighPriority");
+        Mockito.when(queueService.findQueueById(tenantId, new QueueId(UUID.fromString(queueId)))).thenReturn(queue);
     }
 
     @Test
@@ -89,10 +93,6 @@ public class RuleChainMsgConstructorTest {
 
     @Test
     public void testConstructRuleChainMetadataUpdatedMsg_V_3_3_3() throws JsonProcessingException {
-        Queue queue = new Queue();
-        queue.setName("HighPriority");
-        Mockito.when(queueService.findQueueById(tenantId, new QueueId(UUID.fromString(queueId)))).thenReturn(queue);
-
         RuleChainId ruleChainId = new RuleChainId(UUID.randomUUID());
         RuleChainMetaData ruleChainMetaData = createRuleChainMetaData(
                 ruleChainId, 3, createRuleNodes(ruleChainId), createConnections());
@@ -108,16 +108,6 @@ public class RuleChainMsgConstructorTest {
         assertCheckpointRuleNodeConfiguration(
                 ruleChainMetadataUpdateMsg.getNodesList(),
                 "{\"queueName\":\"HighPriority\"}");
-    }
-
-    private void assertCheckpointRuleNodeConfiguration(List<RuleNodeProto> nodesList,
-                                                       String expectedConfiguration) {
-        Optional<RuleNodeProto> checkpointRuleNodeOpt = nodesList.stream()
-                .filter(rn -> RuleChainMetadataConstructorV333.CHECKPOINT_NODE.equals(rn.getType()))
-                .findFirst();
-        Assert.assertTrue(checkpointRuleNodeOpt.isPresent());
-        RuleNodeProto checkpointRuleNode = checkpointRuleNodeOpt.get();
-        Assert.assertEquals(expectedConfiguration, checkpointRuleNode.getConfiguration());
     }
 
     private void assetV_3_3_3_and_V_3_4_0(RuleChainMetadataUpdateMsg ruleChainMetadataUpdateMsg) {
@@ -176,6 +166,10 @@ public class RuleChainMsgConstructorTest {
                 ruleChainConnection.getAdditionalInfo());
         Assert.assertTrue("Target rule chain id MSB incorrect!", ruleChainConnection.getTargetRuleChainIdMSB() != 0);
         Assert.assertTrue("Target rule chain id LSB incorrect!", ruleChainConnection.getTargetRuleChainIdLSB() != 0);
+
+        assertCheckpointRuleNodeConfiguration(
+                ruleChainMetadataUpdateMsg.getNodesList(),
+                "{\"queueName\":\"HighPriority\"}");
     }
 
     @Test
@@ -214,6 +208,20 @@ public class RuleChainMsgConstructorTest {
                 ruleChainConnection.getAdditionalInfo());
         Assert.assertTrue("Target rule chain id MSB incorrect!", ruleChainConnection.getTargetRuleChainIdMSB() != 0);
         Assert.assertTrue("Target rule chain id LSB incorrect!", ruleChainConnection.getTargetRuleChainIdLSB() != 0);
+
+        assertCheckpointRuleNodeConfiguration(
+                ruleChainMetadataUpdateMsg.getNodesList(),
+                "{\"queueName\":\"HighPriority\"}");
+    }
+
+    private void assertCheckpointRuleNodeConfiguration(List<RuleNodeProto> nodesList,
+                                                       String expectedConfiguration) {
+        Optional<RuleNodeProto> checkpointRuleNodeOpt = nodesList.stream()
+                .filter(rn -> RuleChainMetadataConstructorV333.CHECKPOINT_NODE.equals(rn.getType()))
+                .findFirst();
+        Assert.assertTrue(checkpointRuleNodeOpt.isPresent());
+        RuleNodeProto checkpointRuleNode = checkpointRuleNodeOpt.get();
+        Assert.assertEquals(expectedConfiguration, checkpointRuleNode.getConfiguration());
     }
 
     private void compareNodeConnectionInfoAndProto(NodeConnectionInfo expected, org.thingsboard.server.gen.edge.v1.NodeConnectionInfoProto actual) {

--- a/application/src/test/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructorTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructorTest.java
@@ -217,7 +217,7 @@ public class RuleChainMsgConstructorTest {
     private void assertCheckpointRuleNodeConfiguration(List<RuleNodeProto> nodesList,
                                                        String expectedConfiguration) {
         Optional<RuleNodeProto> checkpointRuleNodeOpt = nodesList.stream()
-                .filter(rn -> RuleChainMetadataConstructorV333.CHECKPOINT_NODE.equals(rn.getType()))
+                .filter(rn -> "org.thingsboard.rule.engine.flow.TbCheckpointNode".equals(rn.getType()))
                 .findFirst();
         Assert.assertTrue(checkpointRuleNodeOpt.isPresent());
         RuleNodeProto checkpointRuleNode = checkpointRuleNodeOpt.get();

--- a/application/src/test/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructorTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructorTest.java
@@ -15,43 +15,113 @@
  */
 package org.thingsboard.server.service.edge.rpc.constructor;
 
+import com.datastax.driver.core.utils.UUIDs;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.id.QueueId;
 import org.thingsboard.server.common.data.id.RuleChainId;
 import org.thingsboard.server.common.data.id.RuleNodeId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.queue.Queue;
 import org.thingsboard.server.common.data.rule.NodeConnectionInfo;
 import org.thingsboard.server.common.data.rule.RuleChainMetaData;
 import org.thingsboard.server.common.data.rule.RuleNode;
+import org.thingsboard.server.dao.queue.QueueService;
 import org.thingsboard.server.gen.edge.v1.EdgeVersion;
 import org.thingsboard.server.gen.edge.v1.RuleChainConnectionInfoProto;
 import org.thingsboard.server.gen.edge.v1.RuleChainMetadataUpdateMsg;
+import org.thingsboard.server.gen.edge.v1.RuleNodeProto;
 import org.thingsboard.server.gen.edge.v1.UpdateMsgType;
+import org.thingsboard.server.service.edge.rpc.constructor.rule.RuleChainMetadataConstructorV333;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
 
 @Slf4j
 @RunWith(MockitoJUnitRunner.class)
 public class RuleChainMsgConstructorTest {
 
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private RuleChainMsgConstructor constructor;
+
+    private QueueService queueService;
+
+    private TenantId tenantId;
+
+    private String queueId = "af588000-6c7c-11ec-bafd-c9a47a5c8d99";
+
+    @Before
+    public void setup() {
+        queueService = mock(QueueService.class);
+        constructor = new RuleChainMsgConstructor(queueService);
+        tenantId = new TenantId(UUID.randomUUID());
+    }
+
+    @Test
+    public void testConstructRuleChainMetadataUpdatedMsg_V_3_4_0() throws JsonProcessingException {
+        RuleChainId ruleChainId = new RuleChainId(UUID.randomUUID());
+        RuleChainMetaData ruleChainMetaData = createRuleChainMetaData(
+                ruleChainId, 3, createRuleNodes(ruleChainId), createConnections());
+        RuleChainMetadataUpdateMsg ruleChainMetadataUpdateMsg =
+                constructor.constructRuleChainMetadataUpdatedMsg(
+                        tenantId,
+                        UpdateMsgType.ENTITY_CREATED_RPC_MESSAGE,
+                        ruleChainMetaData,
+                        EdgeVersion.V_3_4_0);
+
+        assetV_3_3_3_and_V_3_4_0(ruleChainMetadataUpdateMsg);
+
+        assertCheckpointRuleNodeConfiguration(
+                ruleChainMetadataUpdateMsg.getNodesList(),
+                "{\"queueId\":\"" + queueId + "\"}");
+    }
 
     @Test
     public void testConstructRuleChainMetadataUpdatedMsg_V_3_3_3() throws JsonProcessingException {
-        RuleChainId ruleChainId = new RuleChainId(UUID.randomUUID());
-        RuleChainMsgConstructor constructor = new RuleChainMsgConstructor();
-        RuleChainMetaData ruleChainMetaData = createRuleChainMetaData(ruleChainId, 3, createRuleNodes(ruleChainId), createConnections());
-        RuleChainMetadataUpdateMsg ruleChainMetadataUpdateMsg =
-                constructor.constructRuleChainMetadataUpdatedMsg(UpdateMsgType.ENTITY_CREATED_RPC_MESSAGE, ruleChainMetaData, EdgeVersion.V_3_3_3);
+        Queue queue = new Queue();
+        queue.setName("HighPriority");
+        Mockito.when(queueService.findQueueById(tenantId, new QueueId(UUID.fromString(queueId)))).thenReturn(queue);
 
+        RuleChainId ruleChainId = new RuleChainId(UUID.randomUUID());
+        RuleChainMetaData ruleChainMetaData = createRuleChainMetaData(
+                ruleChainId, 3, createRuleNodes(ruleChainId), createConnections());
+        RuleChainMetadataUpdateMsg ruleChainMetadataUpdateMsg =
+                constructor.constructRuleChainMetadataUpdatedMsg(
+                        tenantId,
+                        UpdateMsgType.ENTITY_CREATED_RPC_MESSAGE,
+                        ruleChainMetaData,
+                        EdgeVersion.V_3_3_3);
+
+        assetV_3_3_3_and_V_3_4_0(ruleChainMetadataUpdateMsg);
+
+        assertCheckpointRuleNodeConfiguration(
+                ruleChainMetadataUpdateMsg.getNodesList(),
+                "{\"queueName\":\"HighPriority\"}");
+    }
+
+    private void assertCheckpointRuleNodeConfiguration(List<RuleNodeProto> nodesList,
+                                                       String expectedConfiguration) {
+        Optional<RuleNodeProto> checkpointRuleNodeOpt = nodesList.stream()
+                .filter(rn -> RuleChainMetadataConstructorV333.CHECKPOINT_NODE.equals(rn.getType()))
+                .findFirst();
+        Assert.assertTrue(checkpointRuleNodeOpt.isPresent());
+        RuleNodeProto checkpointRuleNode = checkpointRuleNodeOpt.get();
+        Assert.assertEquals(expectedConfiguration, checkpointRuleNode.getConfiguration());
+    }
+
+    private void assetV_3_3_3_and_V_3_4_0(RuleChainMetadataUpdateMsg ruleChainMetadataUpdateMsg) {
         Assert.assertEquals("First rule node index incorrect!", 3, ruleChainMetadataUpdateMsg.getFirstNodeIndex());
         Assert.assertEquals("Nodes count incorrect!", 12, ruleChainMetadataUpdateMsg.getNodesCount());
         Assert.assertEquals("Connections count incorrect!", 13, ruleChainMetadataUpdateMsg.getConnectionsCount());
@@ -75,10 +145,13 @@ public class RuleChainMsgConstructorTest {
     @Test
     public void testConstructRuleChainMetadataUpdatedMsg_V_3_3_0() throws JsonProcessingException {
         RuleChainId ruleChainId = new RuleChainId(UUID.randomUUID());
-        RuleChainMsgConstructor constructor = new RuleChainMsgConstructor();
         RuleChainMetaData ruleChainMetaData = createRuleChainMetaData(ruleChainId, 3, createRuleNodes(ruleChainId), createConnections());
         RuleChainMetadataUpdateMsg ruleChainMetadataUpdateMsg =
-                constructor.constructRuleChainMetadataUpdatedMsg(UpdateMsgType.ENTITY_CREATED_RPC_MESSAGE, ruleChainMetaData, EdgeVersion.V_3_3_0);
+                constructor.constructRuleChainMetadataUpdatedMsg(
+                        tenantId,
+                        UpdateMsgType.ENTITY_CREATED_RPC_MESSAGE,
+                        ruleChainMetaData,
+                        EdgeVersion.V_3_3_0);
 
         Assert.assertEquals("First rule node index incorrect!", 2, ruleChainMetadataUpdateMsg.getFirstNodeIndex());
         Assert.assertEquals("Nodes count incorrect!", 10, ruleChainMetadataUpdateMsg.getNodesCount());
@@ -110,10 +183,13 @@ public class RuleChainMsgConstructorTest {
     public void testConstructRuleChainMetadataUpdatedMsg_V_3_3_0_inDifferentOrder() throws JsonProcessingException {
         // same rule chain metadata, but different order of rule nodes
         RuleChainId ruleChainId = new RuleChainId(UUID.randomUUID());
-        RuleChainMsgConstructor constructor = new RuleChainMsgConstructor();
         RuleChainMetaData ruleChainMetaData1 = createRuleChainMetaData(ruleChainId, 8, createRuleNodesInDifferentOrder(ruleChainId), createConnectionsInDifferentOrder());
         RuleChainMetadataUpdateMsg ruleChainMetadataUpdateMsg =
-                constructor.constructRuleChainMetadataUpdatedMsg(UpdateMsgType.ENTITY_CREATED_RPC_MESSAGE, ruleChainMetaData1, EdgeVersion.V_3_3_0);
+                constructor.constructRuleChainMetadataUpdatedMsg(
+                        tenantId,
+                        UpdateMsgType.ENTITY_CREATED_RPC_MESSAGE, 
+                        ruleChainMetaData1, 
+                        EdgeVersion.V_3_3_0);
 
         Assert.assertEquals("First rule node index incorrect!", 7, ruleChainMetadataUpdateMsg.getFirstNodeIndex());
         Assert.assertEquals("Nodes count incorrect!", 10, ruleChainMetadataUpdateMsg.getNodesCount());
@@ -253,8 +329,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.flow.TbRuleChainOutputNode",
                 "Output node",
-                mapper.readTree("{\"version\":0}"),
-                mapper.readTree("{\"description\":\"\",\"layoutX\":178,\"layoutY\":592}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"version\":0}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"description\":\"\",\"layoutX\":178,\"layoutY\":592}"));
     }
 
     @NotNull
@@ -262,8 +338,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.flow.TbCheckpointNode",
                 "Checkpoint node",
-                mapper.readTree("{\"queueName\":\"HighPriority\"}"),
-                mapper.readTree("{\"description\":\"\",\"layoutX\":178,\"layoutY\":647}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"queueId\":\"" + queueId + "\"}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"description\":\"\",\"layoutX\":178,\"layoutY\":647}"));
     }
 
     @NotNull
@@ -271,8 +347,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.telemetry.TbMsgTimeseriesNode",
                 "Save Timeseries",
-                mapper.readTree("{\"defaultTTL\":0}"),
-                mapper.readTree("{\"layoutX\":823,\"layoutY\":157}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"defaultTTL\":0}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"layoutX\":823,\"layoutY\":157}"));
     }
 
     @NotNull
@@ -280,8 +356,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.filter.TbMsgTypeSwitchNode",
                 "Message Type Switch",
-                mapper.readTree("{\"version\":0}"),
-                mapper.readTree("{\"layoutX\":347,\"layoutY\":149}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"version\":0}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"layoutX\":347,\"layoutY\":149}"));
     }
 
     @NotNull
@@ -289,8 +365,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.action.TbLogNode",
                 "Log Other",
-                mapper.readTree("{\"jsScript\":\"return '\\\\nIncoming message:\\\\n' + JSON.stringify(msg) + '\\\\nIncoming metadata:\\\\n' + JSON.stringify(metadata);\"}"),
-                mapper.readTree("{\"layoutX\":824,\"layoutY\":378}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"jsScript\":\"return '\\\\nIncoming message:\\\\n' + JSON.stringify(msg) + '\\\\nIncoming metadata:\\\\n' + JSON.stringify(metadata);\"}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"layoutX\":824,\"layoutY\":378}"));
     }
 
     @NotNull
@@ -298,8 +374,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.edge.TbMsgPushToCloudNode",
                 "Push to cloud",
-                mapper.readTree("{\"scope\":\"SERVER_SCOPE\"}"),
-                mapper.readTree("{\"layoutX\":1129,\"layoutY\":52}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"scope\":\"SERVER_SCOPE\"}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"layoutX\":1129,\"layoutY\":52}"));
     }
 
     @NotNull
@@ -307,8 +383,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.flow.TbAckNode",
                 "Acknowledge node",
-                mapper.readTree("{\"version\":0}"),
-                mapper.readTree("{\"description\":\"\",\"layoutX\":177,\"layoutY\":703}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"version\":0}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"description\":\"\",\"layoutX\":177,\"layoutY\":703}"));
     }
 
     @NotNull
@@ -316,8 +392,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.profile.TbDeviceProfileNode",
                 "Device Profile Node",
-                mapper.readTree("{\"persistAlarmRulesState\":false,\"fetchAlarmRulesStateOnStart\":false}"),
-                mapper.readTree("{\"description\":\"Process incoming messages from devices with the alarm rules defined in the device profile. Dispatch all incoming messages with \\\"Success\\\" relation type.\",\"layoutX\":187,\"layoutY\":468}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"persistAlarmRulesState\":false,\"fetchAlarmRulesStateOnStart\":false}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"description\":\"Process incoming messages from devices with the alarm rules defined in the device profile. Dispatch all incoming messages with \\\"Success\\\" relation type.\",\"layoutX\":187,\"layoutY\":468}"));
     }
 
     @NotNull
@@ -325,8 +401,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.telemetry.TbMsgAttributesNode",
                 "Save Client Attributes",
-                mapper.readTree("{\"scope\":\"CLIENT_SCOPE\"}"),
-                mapper.readTree("{\"layoutX\":824,\"layoutY\":52}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"scope\":\"CLIENT_SCOPE\"}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"layoutX\":824,\"layoutY\":52}"));
     }
 
     @NotNull
@@ -334,8 +410,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.action.TbLogNode",
                 "Log RPC from Device",
-                mapper.readTree("{\"jsScript\":\"return '\\\\nIncoming message:\\\\n' + JSON.stringify(msg) + '\\\\nIncoming metadata:\\\\n' + JSON.stringify(metadata);\"}"),
-                mapper.readTree("{\"layoutX\":825,\"layoutY\":266}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"jsScript\":\"return '\\\\nIncoming message:\\\\n' + JSON.stringify(msg) + '\\\\nIncoming metadata:\\\\n' + JSON.stringify(metadata);\"}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"layoutX\":825,\"layoutY\":266}"));
     }
 
     @NotNull
@@ -343,8 +419,8 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.rpc.TbSendRPCRequestNode",
                 "RPC Call Request",
-                mapper.readTree("{\"timeoutInSeconds\":60}"),
-                mapper.readTree("{\"layoutX\":824,\"layoutY\":466}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"timeoutInSeconds\":60}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"layoutX\":824,\"layoutY\":466}"));
     }
 
     @NotNull
@@ -352,7 +428,7 @@ public class RuleChainMsgConstructorTest {
         return createRuleNode(ruleChainId,
                 "org.thingsboard.rule.engine.flow.TbRuleChainInputNode",
                 "Push to Analytics",
-                mapper.readTree("{\"ruleChainId\":\"af588000-6c7c-11ec-bafd-c9a47a5c8d99\"}"),
-                mapper.readTree("{\"description\":\"\",\"layoutX\":477,\"layoutY\":560}"));
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"ruleChainId\":\"af588000-6c7c-11ec-bafd-c9a47a5c8d99\"}"),
+                JacksonUtil.OBJECT_MAPPER.readTree("{\"description\":\"\",\"layoutX\":477,\"layoutY\":560}"));
     }
 }

--- a/application/src/test/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructorTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/rpc/constructor/RuleChainMsgConstructorTest.java
@@ -15,7 +15,6 @@
  */
 package org.thingsboard.server.service.edge.rpc.constructor;
 
-import com.datastax.driver.core.utils.UUIDs;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.extern.slf4j.Slf4j;

--- a/common/edge-api/src/main/proto/edge.proto
+++ b/common/edge-api/src/main/proto/edge.proto
@@ -33,6 +33,7 @@ service EdgeRpcService {
 enum EdgeVersion {
   V_3_3_0 = 0;
   V_3_3_3 = 1;
+  V_3_4_0 = 2;
 }
 
 /**


### PR DESCRIPTION
## Pull Request description

PR related to this ticket:
https://github.com/thingsboard/thingsboard-edge/issues/16

In the 3.4+ release checkpoint, rule node configuration was updated - the edge layer must handle this properly and send correct metadata according to the edge version.
Scope of changes:
- Multiple (v330, v333, and v340) metadata constructors were introduced from the monolith rulechain metadata constructor.
- Factory for different rule chain metadata constructors was introduced.
- Checkpoint rule node configuration update was added.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



