### PR TITLE
Let custom widget to process no-data case

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/widget-config.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-config.component.html
@@ -305,11 +305,14 @@
                 <input matInput formControlName="decimals" type="number" min="0" max="15" step="1">
               </mat-form-field>
             </div>
-            <div fxLayout="row">
-              <mat-form-field fxFlex>
+            <div fxLayout.xs="column" fxLayout="row" fxLayoutGap="8px">
+              <mat-form-field fxFlex="grow">
                 <mat-label translate>widget-config.no-data-display-message</mat-label>
                 <input matInput formControlName="noDataDisplayMessage">
               </mat-form-field>
+              <mat-slide-toggle fxFlex="none" class="mat-slide"  formControlName="processNoDataByWidget">
+                {{ 'widget-config.process-no-data' | translate }}
+              </mat-slide-toggle>
             </div>
           </ng-template>
         </mat-expansion-panel>

--- a/ui-ngx/src/app/modules/home/components/widget/widget-config.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-config.component.ts
@@ -213,8 +213,16 @@ export class WidgetConfigComponent extends PageComponent implements OnInit, Cont
       units: [null, []],
       decimals: [null, [Validators.min(0), Validators.max(15), Validators.pattern(/^\d*$/)]],
       noDataDisplayMessage: [null, []],
+      processNoDataByWidget: [null, []],
       showLegend: [null, []],
       legendConfig: [null, []]
+    });
+    this.widgetSettings.get('processNoDataByWidget').valueChanges.subscribe((value: boolean) => {
+      if (value) {
+        this.widgetSettings.get('noDataDisplayMessage').disable({emitEvent: false});
+      } else {
+        this.widgetSettings.get('noDataDisplayMessage').enable({emitEvent: false});
+      }
     });
     this.widgetSettings.get('showTitle').valueChanges.subscribe((value: boolean) => {
       if (value) {
@@ -420,6 +428,7 @@ export class WidgetConfigComponent extends PageComponent implements OnInit, Cont
             units: config.units,
             decimals: config.decimals,
             noDataDisplayMessage: isDefined(config.noDataDisplayMessage) ? config.noDataDisplayMessage : '',
+            processNoDataByWidget: isDefined(config.processNoDataByWidget) ? config.processNoDataByWidget : false,
             showLegend: isDefined(config.showLegend) ? config.showLegend :
               this.widgetType === widgetType.timeseries,
             legendConfig: config.legendConfig || defaultLegendConfig(this.widgetType)

--- a/ui-ngx/src/app/modules/home/components/widget/widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget.component.ts
@@ -399,7 +399,7 @@ export class WidgetComponent extends PageComponent implements OnInit, AfterViewI
   }
 
   private displayWidgetInstance(): boolean {
-    if (this.widget.type !== widgetType.static) {
+    if (this.widget.type !== widgetType.static || !this.widgetContext.settings.processNoDataByWidget) {
       for (const id of Object.keys(this.widgetContext.subscriptions)) {
         const subscription = this.widgetContext.subscriptions[id];
         if (subscription.isDataResolved()) {

--- a/ui-ngx/src/app/shared/models/widget.models.ts
+++ b/ui-ngx/src/app/shared/models/widget.models.ts
@@ -511,6 +511,7 @@ export interface WidgetConfig {
   units?: string;
   decimals?: number;
   noDataDisplayMessage?: string;
+  processNoDataByWidget?: boolean;
   actions?: {[actionSourceId: string]: Array<WidgetActionDescriptor>};
   settings?: any;
   alarmSource?: Datasource;

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -3151,7 +3151,8 @@
         "icon-size": "Icon size",
         "advanced-settings": "Advanced settings",
         "data-settings": "Data settings",
-        "no-data-display-message": "\"No data to display\" alternative message"
+        "no-data-display-message": "\"No data to display\" alternative message",
+        "process-no-data": "Process \"No data\" by widget"
     },
     "widget-type": {
         "import": "Import widget type",


### PR DESCRIPTION
This PR adds configuration option to widget data settings to let a (custom) widget to process by its own the case there is no subscription data. As of version 3.3.4.1 widget shows predefined message in case of no data.

This is simplified version of suggested improvements in #6865