### PR TITLE
[3.4] UI: Fix binding to dashboard timewindow for timeseries widgets used within state widget

### DIFF
--- a/ui-ngx/src/app/modules/home/components/dashboard-page/layout/dashboard-layout.component.ts
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/layout/dashboard-layout.component.ts
@@ -27,7 +27,7 @@ import {
   IDashboardComponent,
   WidgetContextMenuItem
 } from '@home/models/dashboard-component.models';
-import { merge, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { Hotkey } from 'angular2-hotkeys';
 import { TranslateService } from '@ngx-translate/core';
 import { ItemBufferService } from '@app/core/services/item-buffer.service';
@@ -94,11 +94,8 @@ export class DashboardLayoutComponent extends PageComponent implements ILayoutCo
   }
 
   ngOnInit(): void {
-    const dashboardTimewindowChanged = [this.dashboard.dashboardTimewindowChanged];
-    if (this.parentDashboard) {
-      dashboardTimewindowChanged.push(this.parentDashboard.dashboardTimewindowChanged);
-    }
-    this.rxSubscriptions.push(merge(...dashboardTimewindowChanged).subscribe(
+    const dashboardTimewindowChanged = this.parentDashboard ? this.parentDashboard.dashboardTimewindowChanged : this.dashboard.dashboardTimewindowChanged;    
+    this.rxSubscriptions.push(dashboardTimewindowChanged.subscribe(
       (dashboardTimewindow) => {
         this.dashboardCtx.dashboardTimewindow = dashboardTimewindow;
         this.dashboardCtx.runChangeDetection();

--- a/ui-ngx/src/app/modules/home/components/dashboard-page/layout/dashboard-layout.component.ts
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/layout/dashboard-layout.component.ts
@@ -27,7 +27,7 @@ import {
   IDashboardComponent,
   WidgetContextMenuItem
 } from '@home/models/dashboard-component.models';
-import { Subscription } from 'rxjs';
+import { merge, Subscription } from 'rxjs';
 import { Hotkey } from 'angular2-hotkeys';
 import { TranslateService } from '@ngx-translate/core';
 import { ItemBufferService } from '@app/core/services/item-buffer.service';
@@ -94,7 +94,11 @@ export class DashboardLayoutComponent extends PageComponent implements ILayoutCo
   }
 
   ngOnInit(): void {
-    this.rxSubscriptions.push(this.dashboard.dashboardTimewindowChanged.subscribe(
+    const dashboardTimewindowChanged = [this.dashboard.dashboardTimewindowChanged];
+    if (this.parentDashboard) {
+      dashboardTimewindowChanged.push(this.parentDashboard.dashboardTimewindowChanged);
+    }
+    this.rxSubscriptions.push(merge(...dashboardTimewindowChanged).subscribe(
       (dashboardTimewindow) => {
         this.dashboardCtx.dashboardTimewindow = dashboardTimewindow;
         this.dashboardCtx.runChangeDetection();


### PR DESCRIPTION
Fixed #6908 

## Pull Request description

The timeseries widget with the 'Use dashboard timewindow' option enabled won't react to dashboard timewindow update in a case when the dashboard state containing this widget is used within the State widget. Widget data won't be updated accordingly when selecting a new time period.

The binding for dashboard timewindow is fixed.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



