### PR TITLE
[3.4] fix_bug_tests coap

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/coap/rpc/AbstractCoapServerSideRpcIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/coap/rpc/AbstractCoapServerSideRpcIntegrationTest.java
@@ -43,6 +43,7 @@ import org.thingsboard.server.transport.coap.CoapTestClient;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -75,14 +76,23 @@ public abstract class AbstractCoapServerSideRpcIntegrationTest extends AbstractC
         CoapTestCallback callbackCoap = new TestCoapCallbackForRPC(client, 1, true, protobuf);
 
         CoapObserveRelation observeRelation = client.getObserveRelation(callbackCoap);
-        callbackCoap.getLatch().await(3, TimeUnit.SECONDS);
+        String awaitAlias = "await One Way Rpc (client.getObserveRelation)";
+        await(awaitAlias)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> CoAP.ResponseCode.VALID.equals(callbackCoap.getResponseCode()) &&
+                        callbackCoap.getObserve() != null &&
+                        0 == callbackCoap.getObserve().intValue());
         validateCurrentStateNotification(callbackCoap);
-
-        CountDownLatch latch = new CountDownLatch(1);
+        int expectedObserveBeforeGpioRequestCnt = callbackCoap.getObserve().intValue() + 1;
         String setGpioRequest = "{\"method\":\"setGpio\",\"params\":{\"pin\": \"23\",\"value\": 1}}";
         String deviceId = savedDevice.getId().getId().toString();
         String result = doPostAsync("/api/rpc/oneway/" + deviceId, setGpioRequest, String.class, status().isOk());
-        latch.await(3, TimeUnit.SECONDS);
+        awaitAlias = "await One Way Rpc setGpio(method, params, value)";
+        await(awaitAlias)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> CoAP.ResponseCode.CONTENT.equals(callbackCoap.getResponseCode()) &&
+                        callbackCoap.getObserve() != null &&
+                        expectedObserveBeforeGpioRequestCnt == callbackCoap.getObserve().intValue());
         validateOneWayStateChangedNotification(callbackCoap, result);
 
         observeRelation.proactiveCancel();
@@ -94,23 +104,38 @@ public abstract class AbstractCoapServerSideRpcIntegrationTest extends AbstractC
         CoapTestCallback callbackCoap = new TestCoapCallbackForRPC(client, 1, false, protobuf);
 
         CoapObserveRelation observeRelation = client.getObserveRelation(callbackCoap);
-        callbackCoap.getLatch().await(3, TimeUnit.SECONDS);
-
+        String awaitAlias = "await Two Way Rpc (client.getObserveRelation)";
+        await(awaitAlias)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> CoAP.ResponseCode.VALID.equals(callbackCoap.getResponseCode()) &&
+                        callbackCoap.getObserve() != null &&
+                        0 == callbackCoap.getObserve().intValue());
         validateCurrentStateNotification(callbackCoap);
 
         String setGpioRequest = "{\"method\":\"setGpio\",\"params\":{\"pin\": \"26\",\"value\": 1}}";
         String deviceId = savedDevice.getId().getId().toString();
-
+        int expectedObserveBeforeGpioRequestAddCnt1 = callbackCoap.getObserve().intValue() + 1;
         String actualResult = doPostAsync("/api/rpc/twoway/" + deviceId, setGpioRequest, String.class, status().isOk());
-        callbackCoap.getLatch().await(3, TimeUnit.SECONDS);
+        awaitAlias = "await Two Way Rpc (setGpio(method, params, value) first";
+        await(awaitAlias)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> CoAP.ResponseCode.CONTENT.equals(callbackCoap.getResponseCode()) &&
+                        callbackCoap.getObserve() != null &&
+                        expectedObserveBeforeGpioRequestAddCnt1 == callbackCoap.getObserve().intValue());
+        validateTwoWayStateChangedNotification(callbackCoap, expectedResponseResult, actualResult);
 
-        validateTwoWayStateChangedNotification(callbackCoap, 1, expectedResponseResult, actualResult);
+        validateTwoWayStateChangedNotification(callbackCoap, expectedResponseResult, actualResult);
 
-        CountDownLatch latch = new CountDownLatch(1);
+        int expectedObserveBeforeGpioRequestAddCnt2 = callbackCoap.getObserve().intValue() + 1;
         actualResult = doPostAsync("/api/rpc/twoway/" + deviceId, setGpioRequest, String.class, status().isOk());
-        callbackCoap.getLatch().await(3, TimeUnit.SECONDS);
+        awaitAlias = "await Two Way Rpc (setGpio(method, params, value) first";
+        await(awaitAlias)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> CoAP.ResponseCode.CONTENT.equals(callbackCoap.getResponseCode()) &&
+                        callbackCoap.getObserve() != null &&
+                        expectedObserveBeforeGpioRequestAddCnt2 == callbackCoap.getObserve().intValue());
 
-        validateTwoWayStateChangedNotification(callbackCoap, 2, expectedResponseResult, actualResult);
+        validateTwoWayStateChangedNotification(callbackCoap, expectedResponseResult, actualResult);
 
         observeRelation.proactiveCancel();
         assertTrue(observeRelation.isCanceled());
@@ -184,25 +209,16 @@ public abstract class AbstractCoapServerSideRpcIntegrationTest extends AbstractC
 
     private void validateCurrentStateNotification(CoapTestCallback callback) {
         assertArrayEquals(EMPTY_PAYLOAD, callback.getPayloadBytes());
-        assertNotNull(callback.getObserve());
-        assertEquals(callback.getResponseCode(), CoAP.ResponseCode.VALID);
-        assertEquals(0, callback.getObserve().intValue());
     }
 
     private void validateOneWayStateChangedNotification(CoapTestCallback callback, String result) {
         assertTrue(StringUtils.isEmpty(result));
         assertNotNull(callback.getPayloadBytes());
-        assertNotNull(callback.getObserve());
-        assertEquals(CoAP.ResponseCode.CONTENT, callback.getResponseCode());
-        assertEquals(1, callback.getObserve().intValue());
     }
 
-    private void validateTwoWayStateChangedNotification(CoapTestCallback callback, int expectedObserveNumber, String expectedResult, String actualResult) {
+    private void validateTwoWayStateChangedNotification(CoapTestCallback callback, String expectedResult, String actualResult) {
         assertEquals(expectedResult, actualResult);
         assertNotNull(callback.getPayloadBytes());
-        assertNotNull(callback.getObserve());
-        assertEquals(CoAP.ResponseCode.CONTENT, callback.getResponseCode());
-        assertEquals(expectedObserveNumber, callback.getObserve().intValue());
     }
 
     protected class TestCoapCallbackForRPC extends CoapTestCallback {

--- a/application/src/test/java/org/thingsboard/server/transport/coap/rpc/CoapServerSideRpcJsonIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/coap/rpc/CoapServerSideRpcJsonIntegrationTest.java
@@ -52,5 +52,4 @@ public class CoapServerSideRpcJsonIntegrationTest extends AbstractCoapServerSide
     public void testServerCoapTwoWayRpc() throws Exception {
         processTwoWayRpcTest("{\"value1\":\"A\",\"value2\":\"B\"}", false);
     }
-
 }


### PR DESCRIPTION
## Pull Request description

_Problem tests:_
`Not enough time to respond after request`

**CoapAttributesUpdatesIntegrationTest**
- testSubscribeToAttributesUpdatesFromTheServer()
- testSubscribeToAttributesUpdatesFromTheServerWithEmptyCurrentStateNotification()

**CoapAttributesUpdatesJsonIntegrationTest**
- testSubscribeToAttributesUpdatesFromTheServer()
- testSubscribeToAttributesUpdatesFromTheServerWithEmptyCurrentStateNotification()

**CoapAttributesUpdatesProtoIntegrationTest**
- testSubscribeToAttributesUpdatesFromTheServer()
- testSubscribeToAttributesUpdatesFromTheServerWithEmptyCurrentStateNotification() 

**CoapServerSideRpcDefaultIntegrationTest**
- testServerCoapOneWayRpc()
- testServerCoapTwoWayRpc()

**CoapServerSideRpcJsonIntegrationTest**
- testServerCoapOneWayRpc()
- testServerCoapTwoWayRpc()

**CoapServerSideRpcProtoIntegrationTest**
- testServerCoapOneWayRpc()
- testServerCoapTwoWayRpc()   

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



