### PR TITLE
[3.4] UI: Fixed incorrect import/export/copy alarm type widgets

### DIFF
--- a/ui-ngx/src/app/core/services/dashboard-utils.service.ts
+++ b/ui-ngx/src/app/core/services/dashboard-utils.service.ts
@@ -30,7 +30,7 @@ import {
   WidgetLayout
 } from '@shared/models/dashboard.models';
 import { isDefined, isString, isUndefined } from '@core/utils';
-import { Datasource, DatasourceType, Widget } from '@app/shared/models/widget.models';
+import { Datasource, DatasourceType, Widget, widgetType } from '@app/shared/models/widget.models';
 import { EntityType } from '@shared/models/entity-type.models';
 import { AliasFilterType, EntityAlias, EntityAliasFilter } from '@app/shared/models/alias.models';
 import { EntityId } from '@app/shared/models/id/entity-id';
@@ -106,7 +106,8 @@ export class DashboardUtilsService {
     const targetDevicesByAliasId: {[aliasId: string]: Array<Array<string>>} = {};
     for (const widgetId of Object.keys(dashboard.configuration.widgets)) {
       const widget = dashboard.configuration.widgets[widgetId];
-      widget.config.datasources.forEach((datasource) => {
+      const datasources = widget.type === widgetType.alarm ? [widget.config.alarmSource] : widget.config.datasources;
+      datasources.forEach((datasource) => {
         if (datasource.entityAliasId) {
           const aliasId = datasource.entityAliasId;
           let aliasDatasources = datasourcesByAliasId[aliasId];

--- a/ui-ngx/src/app/core/services/item-buffer.service.ts
+++ b/ui-ngx/src/app/core/services/item-buffer.service.ts
@@ -17,7 +17,14 @@
 import { Injectable } from '@angular/core';
 import { Dashboard, DashboardLayoutId } from '@app/shared/models/dashboard.models';
 import { AliasesInfo, EntityAlias, EntityAliases, EntityAliasInfo } from '@shared/models/alias.models';
-import { DatasourceType, Widget, WidgetPosition, WidgetSize } from '@shared/models/widget.models';
+import {
+  Datasource,
+  DatasourceType,
+  Widget,
+  WidgetPosition,
+  WidgetSize,
+  widgetType
+} from '@shared/models/widget.models';
 import { DashboardUtilsService } from '@core/services/dashboard-utils.service';
 import { deepClone, isEqual } from '@core/utils';
 import { UtilsService } from '@core/services/utils.service';
@@ -87,12 +94,13 @@ export class ItemBufferService {
     };
     const originalColumns = this.getOriginalColumns(dashboard, sourceState, sourceLayout);
     const originalSize = this.getOriginalSize(dashboard, sourceState, sourceLayout, widget);
+    const datasources: Datasource[] = widget.type === widgetType.alarm ? [widget.config.alarmSource] : widget.config.datasources;
     if (widget.config && dashboard.configuration
       && dashboard.configuration.entityAliases) {
       let entityAlias: EntityAlias;
-      if (widget.config.datasources) {
-        for (let i = 0; i < widget.config.datasources.length; i++) {
-          const datasource = widget.config.datasources[i];
+      if (datasources) {
+        for (let i = 0; i < datasources.length; i++) {
+          const datasource = datasources[i];
           if ((datasource.type === DatasourceType.entity || datasource.type === DatasourceType.entityCount) && datasource.entityAliasId) {
             entityAlias = dashboard.configuration.entityAliases[datasource.entityAliasId];
             if (entityAlias) {
@@ -116,9 +124,9 @@ export class ItemBufferService {
     if (widget.config && dashboard.configuration
       && dashboard.configuration.filters) {
       let filter: Filter;
-      if (widget.config.datasources) {
-        for (let i = 0; i < widget.config.datasources.length; i++) {
-          const datasource = widget.config.datasources[i];
+      if (datasources) {
+        for (let i = 0; i < datasources.length; i++) {
+          const datasource = datasources[i];
           if ((datasource.type === DatasourceType.entity || datasource.type === DatasourceType.entityCount) && datasource.filterId) {
             filter = dashboard.configuration.filters[datasource.filterId];
             if (filter) {
@@ -438,7 +446,11 @@ export class ItemBufferService {
       const datasourceIndex = Number(datasourceIndexStr);
       aliasInfo = aliasesInfo.datasourceAliases[datasourceIndex];
       newAliasId = this.getEntityAliasId(entityAliases, aliasInfo);
-      widget.config.datasources[datasourceIndex].entityAliasId = newAliasId;
+      if (widget.type === widgetType.alarm) {
+        widget.config.alarmSource.entityAliasId = newAliasId;
+      } else {
+        widget.config.datasources[datasourceIndex].entityAliasId = newAliasId;
+      }
     }
     for (const targetDeviceAliasIndexStr of Object.keys(aliasesInfo.targetDeviceAliases)) {
       const targetDeviceAliasIndex = Number(targetDeviceAliasIndexStr);
@@ -457,7 +469,11 @@ export class ItemBufferService {
       const datasourceIndex = Number(datasourceIndexStr);
       filterInfo = filtersInfo.datasourceFilters[datasourceIndex];
       newFilterId = this.getFilterId(filters, filterInfo);
-      widget.config.datasources[datasourceIndex].filterId = newFilterId;
+      if (widget.type === widgetType.alarm) {
+        widget.config.alarmSource.filterId = newFilterId;
+      } else {
+        widget.config.datasources[datasourceIndex].filterId = newFilterId;
+      }
     }
     return filters;
   }


### PR DESCRIPTION
## Pull Request description

After copying or exporting the alarm widget to another dashboard, it would not quit loading

before:
![image](https://user-images.githubusercontent.com/18036670/178683781-81dcd2c2-5347-432c-a8a7-7ce2477794cb.png)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


