### PR TITLE
UI: Add rule chain selector to toolbar of rule chain page.

### DIFF
--- a/ui-ngx/src/app/modules/common/modules-map.ts
+++ b/ui-ngx/src/app/modules/common/modules-map.ts
@@ -120,6 +120,7 @@ import * as TimeintervalComponent from '@shared/components/time/timeinterval.com
 import * as QuickTimeIntervalComponent from '@shared/components/time/quick-time-interval.component';
 import * as DashboardSelectComponent from '@shared/components/dashboard-select.component';
 import * as DashboardSelectPanelComponent from '@shared/components/dashboard-select-panel.component';
+import * as RuleChainSelectComponent from '@shared/components/rulechain-select.component';
 import * as DatetimePeriodComponent from '@shared/components/time/datetime-period.component';
 import * as DatetimeComponent from '@shared/components/time/datetime.component';
 import * as TimezoneSelectComponent from '@shared/components/time/timezone-select.component';
@@ -402,6 +403,7 @@ class ModulesMap implements IModulesMap {
     '@shared/components/time/quick-time-interval.component': QuickTimeIntervalComponent,
     '@shared/components/dashboard-select.component': DashboardSelectComponent,
     '@shared/components/dashboard-select-panel.component': DashboardSelectPanelComponent,
+    '@shared/components/rulechain-select.component': RuleChainSelectComponent,
     '@shared/components/time/datetime-period.component': DatetimePeriodComponent,
     '@shared/components/time/datetime.component': DatetimeComponent,
     '@shared/components/time/timezone-select.component': TimezoneSelectComponent,

--- a/ui-ngx/src/app/modules/home/pages/rulechain/rulechain-page.component.html
+++ b/ui-ngx/src/app/modules/home/pages/rulechain/rulechain-page.component.html
@@ -38,32 +38,38 @@
                     [opened]="isLibraryOpen"
                     position="start"
                     fxLayout="column">
-          <mat-toolbar color="primary" class="tb-dark">
-            <div class="mat-toolbar-tools">
-              <button mat-button mat-icon-button class="tb-small"
-                matTooltip="{{'rulenode.search' | translate}}"
-                matTooltipPosition="above">
-                <mat-icon>search</mat-icon>
-              </button>
-              <mat-form-field fxFlex floatLabel="always">
-                <mat-label></mat-label>
-                <input #ruleNodeSearchInput matInput
-                       [(ngModel)]="ruleNodeTypeSearch"
-                       placeholder="{{'rulenode.search' | translate}}"/>
-              </mat-form-field>
-              <button mat-button mat-icon-button class="tb-small"
-                      [fxShow]="ruleNodeTypeSearch !== ''"
-                      (click)="ruleNodeTypeSearch = ''; updateRuleChainLibrary()"
-                      matTooltip="{{'action.clear-search' | translate}}"
-                      matTooltipPosition="above">
-                <mat-icon>close</mat-icon>
-              </button>
-              <button mat-button mat-icon-button class="tb-small"
-                      (click)="isLibraryOpen = false"
-                      matTooltip="{{'action.close' | translate}}"
-                      matTooltipPosition="above">
-                <mat-icon>chevron_left</mat-icon>
-              </button>
+          <mat-toolbar color="primary" class="tb-dark" fxLayout="column" fxLayoutAlign="space-evenly center">
+            <tb-rulechain-select
+              [(ngModel)]="ruleChain.id.id"
+              (ngModelChange)="currentRuleChainIdChanged(ruleChain.id?.id)">
+            </tb-rulechain-select>
+            <div>
+              <div class="mat-toolbar-tools">
+                <button mat-button mat-icon-button class="tb-small"
+                  matTooltip="{{'rulenode.search' | translate}}"
+                  matTooltipPosition="above">
+                  <mat-icon>search</mat-icon>
+                </button>
+                <mat-form-field fxFlex floatLabel="always">
+                  <mat-label></mat-label>
+                  <input #ruleNodeSearchInput matInput
+                        [(ngModel)]="ruleNodeTypeSearch"
+                        placeholder="{{'rulenode.search' | translate}}"/>
+                </mat-form-field>
+                <button mat-button mat-icon-button class="tb-small"
+                        [fxShow]="ruleNodeTypeSearch !== ''"
+                        (click)="ruleNodeTypeSearch = ''; updateRuleChainLibrary()"
+                        matTooltip="{{'action.clear-search' | translate}}"
+                        matTooltipPosition="above">
+                  <mat-icon>close</mat-icon>
+                </button>
+                <button mat-button mat-icon-button class="tb-small"
+                        (click)="isLibraryOpen = false"
+                        matTooltip="{{'action.close' | translate}}"
+                        matTooltipPosition="above">
+                  <mat-icon>chevron_left</mat-icon>
+                </button>
+              </div>
             </div>
           </mat-toolbar>
           <div class="tb-rulechain-library-panel-group">

--- a/ui-ngx/src/app/modules/home/pages/rulechain/rulechain-page.component.html
+++ b/ui-ngx/src/app/modules/home/pages/rulechain/rulechain-page.component.html
@@ -40,6 +40,8 @@
                     fxLayout="column">
           <mat-toolbar color="primary" class="tb-dark" fxLayout="column" fxLayoutAlign="space-evenly center">
             <tb-rulechain-select
+              *ngIf="!isImport"
+              [disabled]="isDirtyValue"
               [(ngModel)]="ruleChain.id.id"
               (ngModelChange)="currentRuleChainIdChanged(ruleChain.id?.id)">
             </tb-rulechain-select>

--- a/ui-ngx/src/app/modules/home/pages/rulechain/rulechain-page.component.scss
+++ b/ui-ngx/src/app/modules/home/pages/rulechain/rulechain-page.component.scss
@@ -74,14 +74,17 @@
     min-width: 250px;
 
     .mat-toolbar {
-      height: 48px;
-      min-height: 48px;
+      height: 96px;
+      min-height: 96px;
       padding: 0;
+
+      .mat-toolbar-tools, tb-rulechain-select {
+        font-size: 14px;
+      }
 
       .mat-toolbar-tools {
         height: 48px;
         padding: 0 6px;
-        font-size: 14px;
 
         .mat-form-field {
           .mat-form-field-infix {

--- a/ui-ngx/src/app/modules/home/pages/rulechain/rulechain-page.component.ts
+++ b/ui-ngx/src/app/modules/home/pages/rulechain/rulechain-page.component.ts
@@ -281,6 +281,13 @@ export class RuleChainPageComponent extends PageComponent
     this.updateRuleNodesHighlight();
   }
 
+  currentRuleChainIdChanged(ruleChainId: string) {
+    if (this.isEditingRuleNode) {
+      return;
+    }
+    this.router.navigateByUrl(`ruleChains/${ruleChainId}`);
+  }
+
   private init() {
     this.initHotKeys();
     this.isImport = this.route.snapshot.data.import;

--- a/ui-ngx/src/app/shared/components/rulechain-select.component.html
+++ b/ui-ngx/src/app/shared/components/rulechain-select.component.html
@@ -15,8 +15,7 @@
     limitations under the License.
 
 -->
-<mat-select [(ngModel)]="ruleChainId"
-            (ngModelChange)="ruleChainIdChanged()">
+<mat-select [disabled]="disabled" [(ngModel)]="ruleChainId" (ngModelChange)="ruleChainIdChanged()">
   <mat-option *ngFor="let ruleChain of ruleChains$ | async" [value]="ruleChain.id?.id">
     {{ruleChain.name}}
   </mat-option>

--- a/ui-ngx/src/app/shared/components/rulechain-select.component.html
+++ b/ui-ngx/src/app/shared/components/rulechain-select.component.html
@@ -1,0 +1,23 @@
+<!--
+
+    Copyright © 2016-2022 The Thingsboard Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-select [(ngModel)]="ruleChainId"
+            (ngModelChange)="ruleChainIdChanged()">
+  <mat-option *ngFor="let ruleChain of ruleChains$ | async" [value]="ruleChain.id?.id">
+    {{ruleChain.name}}
+  </mat-option>
+</mat-select>

--- a/ui-ngx/src/app/shared/components/rulechain-select.component.scss
+++ b/ui-ngx/src/app/shared/components/rulechain-select.component.scss
@@ -1,0 +1,41 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+:host {
+  width: min-content; //for Safari
+  min-width: 52px;
+
+  mat-select {
+    max-width: 300px;
+    pointer-events: all;
+  }
+
+  .tb-rulechain-select {
+    min-height: 32px;
+
+    span {
+      pointer-events: all;
+      cursor: pointer;
+    }
+  }
+}
+
+:host ::ng-deep {
+  mat-select {
+    .mat-select-value {
+      max-width: 282px;
+    }
+  }
+}

--- a/ui-ngx/src/app/shared/components/rulechain-select.component.ts
+++ b/ui-ngx/src/app/shared/components/rulechain-select.component.ts
@@ -17,13 +17,7 @@
 import {
   Component,
   forwardRef,
-  Inject,
-  Injector,
-  Input,
   OnInit,
-  StaticProvider,
-  ViewChild,
-  ViewContainerRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Observable, of } from 'rxjs';
@@ -32,14 +26,6 @@ import { map, share } from 'rxjs/operators';
 import { PageData } from '@shared/models/page/page-data';
 import { RuleChain, RuleChainType } from '@app/shared/models/rule-chain.models';
 import { RuleChainService } from '@core/http/rule-chain.service';
-import { Store } from '@ngrx/store';
-import { AppState } from '@app/core/core.state';
-import { TooltipPosition } from '@angular/material/tooltip';
-import { CdkOverlayOrigin, ConnectedPosition, Overlay, OverlayConfig, OverlayRef } from '@angular/cdk/overlay';
-import { BreakpointObserver } from '@angular/cdk/layout';
-import { DOCUMENT } from '@angular/common';
-import { WINDOW } from '@core/services/window.service';
-import { ComponentPortal } from '@angular/cdk/portal';
 
 // @dynamic
 @Component({
@@ -53,25 +39,15 @@ import { ComponentPortal } from '@angular/cdk/portal';
   }]
 })
 export class RuleChainSelectComponent implements ControlValueAccessor, OnInit {
-  @Input()
-  tooltipPosition: TooltipPosition = 'above';
 
   ruleChains$: Observable<Array<RuleChain>>;
-
   ruleChainId: string | null;
 
-  @ViewChild('ruleChainSelectPanelOrigin') ruleChainSelectPanelOrigin: CdkOverlayOrigin;
+  disabled: boolean;
 
   private propagateChange = (v: any) => { };
 
-  constructor(private store: Store<AppState>,
-              private ruleChainService: RuleChainService,
-              private overlay: Overlay,
-              private breakpointObserver: BreakpointObserver,
-              private viewContainerRef: ViewContainerRef,
-              @Inject(DOCUMENT) private document: Document,
-              @Inject(WINDOW) private window: Window) {
-  }
+  constructor(private ruleChainService: RuleChainService) {}
 
   registerOnChange(fn: any): void {
     this.propagateChange = fn;
@@ -81,13 +57,16 @@ export class RuleChainSelectComponent implements ControlValueAccessor, OnInit {
   }
 
   ngOnInit() {
-
     const pageLink = new PageLink(100);
-
     this.ruleChains$ = this.getRuleChains(pageLink).pipe(
       map((pageData) => pageData.data),
       share()
     );
+    this.disabled = false;
+  }
+
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
   }
 
   writeValue(value: string | null): void {

--- a/ui-ngx/src/app/shared/components/rulechain-select.component.ts
+++ b/ui-ngx/src/app/shared/components/rulechain-select.component.ts
@@ -1,0 +1,109 @@
+///
+/// Copyright © 2016-2022 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+import {
+  Component,
+  forwardRef,
+  Inject,
+  Injector,
+  Input,
+  OnInit,
+  StaticProvider,
+  ViewChild,
+  ViewContainerRef
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Observable, of } from 'rxjs';
+import { PageLink } from '@shared/models/page/page-link';
+import { map, share } from 'rxjs/operators';
+import { PageData } from '@shared/models/page/page-data';
+import { RuleChain, RuleChainType } from '@app/shared/models/rule-chain.models';
+import { RuleChainService } from '@core/http/rule-chain.service';
+import { Store } from '@ngrx/store';
+import { AppState } from '@app/core/core.state';
+import { TooltipPosition } from '@angular/material/tooltip';
+import { CdkOverlayOrigin, ConnectedPosition, Overlay, OverlayConfig, OverlayRef } from '@angular/cdk/overlay';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { DOCUMENT } from '@angular/common';
+import { WINDOW } from '@core/services/window.service';
+import { ComponentPortal } from '@angular/cdk/portal';
+
+// @dynamic
+@Component({
+  selector: 'tb-rulechain-select',
+  templateUrl: './rulechain-select.component.html',
+  styleUrls: ['./rulechain-select.component.scss'],
+  providers: [{
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => RuleChainSelectComponent),
+    multi: true
+  }]
+})
+export class RuleChainSelectComponent implements ControlValueAccessor, OnInit {
+  @Input()
+  tooltipPosition: TooltipPosition = 'above';
+
+  ruleChains$: Observable<Array<RuleChain>>;
+
+  ruleChainId: string | null;
+
+  @ViewChild('ruleChainSelectPanelOrigin') ruleChainSelectPanelOrigin: CdkOverlayOrigin;
+
+  private propagateChange = (v: any) => { };
+
+  constructor(private store: Store<AppState>,
+              private ruleChainService: RuleChainService,
+              private overlay: Overlay,
+              private breakpointObserver: BreakpointObserver,
+              private viewContainerRef: ViewContainerRef,
+              @Inject(DOCUMENT) private document: Document,
+              @Inject(WINDOW) private window: Window) {
+  }
+
+  registerOnChange(fn: any): void {
+    this.propagateChange = fn;
+  }
+
+  registerOnTouched(fn: any): void {
+  }
+
+  ngOnInit() {
+
+    const pageLink = new PageLink(100);
+
+    this.ruleChains$ = this.getRuleChains(pageLink).pipe(
+      map((pageData) => pageData.data),
+      share()
+    );
+  }
+
+  writeValue(value: string | null): void {
+    this.ruleChainId = value;
+  }
+
+  ruleChainIdChanged() {
+    this.updateView();
+  }
+
+  private updateView() {
+    this.propagateChange(this.ruleChainId);
+  }
+
+  private getRuleChains(pageLink: PageLink): Observable<PageData<RuleChain>> {
+    return this.ruleChainService.getRuleChains(pageLink, RuleChainType.CORE, {ignoreLoading: true});
+  }
+
+}

--- a/ui-ngx/src/app/shared/shared.module.ts
+++ b/ui-ngx/src/app/shared/shared.module.ts
@@ -104,6 +104,7 @@ import {
 } from '@shared/components/fab-toolbar.component';
 import { DashboardSelectPanelComponent } from '@shared/components/dashboard-select-panel.component';
 import { DashboardSelectComponent } from '@shared/components/dashboard-select.component';
+import { RuleChainSelectComponent } from '@shared/components/rulechain-select.component';
 import { WidgetsBundleSelectComponent } from '@shared/components/widgets-bundle-select.component';
 import { KeyboardShortcutPipe } from '@shared/pipe/keyboard-shortcut.pipe';
 import { TbErrorComponent } from '@shared/components/tb-error.component';
@@ -216,6 +217,7 @@ export function MarkedOptionsFactory(markedOptionsService: MarkedOptionsService)
     QuickTimeIntervalComponent,
     DashboardSelectComponent,
     DashboardSelectPanelComponent,
+    RuleChainSelectComponent,
     DatetimePeriodComponent,
     DatetimeComponent,
     TimezoneSelectComponent,
@@ -365,6 +367,7 @@ export function MarkedOptionsFactory(markedOptionsService: MarkedOptionsService)
     TimeintervalComponent,
     QuickTimeIntervalComponent,
     DashboardSelectComponent,
+    RuleChainSelectComponent,
     DatetimePeriodComponent,
     DatetimeComponent,
     TimezoneSelectComponent,


### PR DESCRIPTION
Such selector saves time when you are debugging several rule chains at time.

I copied code from *DashboardSelectComponent* but without *DashboardSelectPanelComponent* because rule chain selector looks good both on the desktop and mobile devices. Screenshots attached.

![rule-chain-selector-desktop-closed](https://user-images.githubusercontent.com/86909129/178836460-9ad20915-1732-4dd8-b655-e34b61621b8e.jpg)
![rule-chain-selector-desktop-opened](https://user-images.githubusercontent.com/86909129/178836486-20960a78-bd9f-4a78-9041-5e938b6914c9.jpg)
![rule-chain-selector-mobile](https://user-images.githubusercontent.com/86909129/178836504-c3cb7b53-9221-4dd2-86bf-2295b8100b58.jpg)

