### PR TITLE
[3.4.1][UI] Check for missing edge rule chain during unassign of rule chain(s) from edge

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/rulechain/rulechains-table-config.resolver.ts
+++ b/ui-ngx/src/app/modules/home/pages/rulechain/rulechains-table-config.resolver.ts
@@ -409,6 +409,31 @@ export class RuleChainsTableConfigResolver implements Resolve<EntityTableConfig<
     );
   }
 
+  private checkMissingToRelatedRuleChains() {
+    this.edgeService.findMissingToRelatedRuleChains(this.config.componentsData.edgeId).subscribe(
+      (missingRuleChains) => {
+        if (missingRuleChains && Object.keys(missingRuleChains).length > 0) {
+          const formattedMissingRuleChains: Array<string> = new Array<string>();
+          for (const missingRuleChain of Object.keys(missingRuleChains)) {
+            const arrayOfMissingRuleChains = missingRuleChains[missingRuleChain];
+            const tmp = '- \'' + missingRuleChain + '\': \'' + arrayOfMissingRuleChains.join('\', ') + '\'';
+            formattedMissingRuleChains.push(tmp);
+          }
+          const message = this.translate.instant('edge.missing-related-rule-chains-text',
+            {missingRuleChains: formattedMissingRuleChains.join('<br>')});
+          this.dialogService.alert(this.translate.instant('edge.missing-related-rule-chains-title'),
+            message, this.translate.instant('action.close'), true).subscribe(
+            () => {
+              this.config.updateData();
+            }
+          );
+        } else {
+          this.config.updateData();
+        }
+      }
+    );
+  }
+
   addRuleChainsToEdge($event: Event) {
     if ($event) {
       $event.stopPropagation();
@@ -424,28 +449,7 @@ export class RuleChainsTableConfigResolver implements Resolve<EntityTableConfig<
     }).afterClosed()
       .subscribe((res) => {
           if (res) {
-            this.edgeService.findMissingToRelatedRuleChains(this.config.componentsData.edgeId).subscribe(
-              (missingRuleChains) => {
-                if (missingRuleChains && Object.keys(missingRuleChains).length > 0) {
-                  const formattedMissingRuleChains: Array<string> = new Array<string>();
-                  for (const missingRuleChain of Object.keys(missingRuleChains)) {
-                    const arrayOfMissingRuleChains = missingRuleChains[missingRuleChain];
-                    const tmp = '- \'' + missingRuleChain + '\': \'' + arrayOfMissingRuleChains.join('\', ') + '\'';
-                    formattedMissingRuleChains.push(tmp);
-                  }
-                  const message = this.translate.instant('edge.missing-related-rule-chains-text',
-                    {missingRuleChains: formattedMissingRuleChains.join('<br>')});
-                  this.dialogService.alert(this.translate.instant('edge.missing-related-rule-chains-title'),
-                    message, this.translate.instant('action.close'), true).subscribe(
-                    () => {
-                      this.config.updateData();
-                    }
-                  );
-                } else {
-                  this.config.updateData();
-                }
-              }
-            );
+            this.checkMissingToRelatedRuleChains();
           }
         }
       );
@@ -465,7 +469,7 @@ export class RuleChainsTableConfigResolver implements Resolve<EntityTableConfig<
         if (res) {
           this.ruleChainService.unassignRuleChainFromEdge(this.config.componentsData.edgeId, ruleChain.id.id).subscribe(
             () => {
-              this.config.updateData(this.config.componentsData.ruleChainScope !== 'tenant');
+              this.checkMissingToRelatedRuleChains();
             }
           );
         }
@@ -493,7 +497,7 @@ export class RuleChainsTableConfigResolver implements Resolve<EntityTableConfig<
           );
           forkJoin(tasks).subscribe(
             () => {
-              this.config.updateData();
+              this.checkMissingToRelatedRuleChains();
             }
           );
         }


### PR DESCRIPTION
## Pull Request description

This pull request will show a warning message of missing rule chains during the unassign action (at the moment only on assigned actions this check happens).
Related issue:
https://github.com/thingsboard/thingsboard/issues/7042

Added check during unassing action.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


