### PR TITLE
[3.4.2] Add option to either put or not RPC request to response metadata.

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/rpc/TbSendRpcRequestNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/rpc/TbSendRpcRequestNodeConfiguration.java
@@ -23,10 +23,13 @@ public class TbSendRpcRequestNodeConfiguration implements NodeConfiguration<TbSe
 
     private int timeoutInSeconds;
 
+    private boolean addRequestToResponseMetadata;
+
     @Override
     public TbSendRpcRequestNodeConfiguration defaultConfiguration() {
         TbSendRpcRequestNodeConfiguration configuration = new TbSendRpcRequestNodeConfiguration();
         configuration.setTimeoutInSeconds(60);
+        configuration.setAddRequestToResponseMetadata(false);
         return configuration;
     }
 }


### PR DESCRIPTION
As of 3.3.4.1 version Thingsboard server puts in Rule Chain message data of RPC response either empty object (`{}`) or response from device. It is not enough at least in case of oneway RPC without response because there is no information in  Rule Chain message what RPC was processed.

Link to rule-config-ui PR: [#83](https://github.com/thingsboard/thingsboard-rule-config-ui-ngx/pull/83)