### PR TITLE
[3.4] fix_bug_tests lwm2m Security

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/AbstractSecurityLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/AbstractSecurityLwM2MIntegrationTest.java
@@ -196,7 +196,7 @@ public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2M
         device.getId().getId().toString();
         lwM2MTestClient.start(isStartLw);
         await(awaitAlias)
-                .atMost(5000, TimeUnit.MILLISECONDS)
+                .atMost(20, TimeUnit.SECONDS)
                 .until(() -> finishState.equals(lwM2MTestClient.getClientState()));
         Assert.assertEquals(expectedStatuses, lwM2MTestClient.getClientStates());
     }
@@ -234,7 +234,7 @@ public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2M
         String deviceId = device.getId().getId().toString();
         lwM2MTestClient.start(true);
         await(awaitAlias)
-                .atMost(5000, TimeUnit.MILLISECONDS)
+                .atMost(20, TimeUnit.SECONDS)
                 .until(() -> ON_REGISTRATION_SUCCESS.equals(lwM2MTestClient.getClientState()));
         Assert.assertEquals(expectedStatusesLwm2m, lwM2MTestClient.getClientStates());
 
@@ -246,7 +246,7 @@ public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2M
         expectedStatusesBs.add(ON_DEREGISTRATION_STARTED);
         expectedStatusesBs.add(ON_DEREGISTRATION_SUCCESS);
         await(awaitAlias)
-                .atMost(5000, TimeUnit.MILLISECONDS)
+                .atMost(20, TimeUnit.SECONDS)
                 .until(() -> ON_REGISTRATION_SUCCESS.equals(lwM2MTestClient.getClientState()));
         Assert.assertEquals(expectedStatusesBs, lwM2MTestClient.getClientStates());
     }


### PR DESCRIPTION
## Pull Request description

**The client closes faster than it passes registration to the server**

```
NoSecLwM2MIntegrationTest.testWithNoSecConnectLwm2mSuccessBootstrapRequestTriggerConnectBsSuccess_UpdateTwoSectionAndLm2m_ConnectLwm2mSuccess
NoSecLwM2MIntegrationTest.testWithNoSecConnectLwm2mSuccessBootstrapRequestTriggerConnectBsSuccess_UpdateLwm2mSectionAndLm2m_ConnectLwm2mSuccess
RpkLwM2MIntegrationTest.testWithRpkConnectBsSuccess_UpdateTwoSectionsBootstrapAndLm2m_ConnectLwm2mSuccess
X509_TrustLwM2MIntegrationTest.testWithX509TrustConnectBsSuccess_UpdateTwoSectionsBootstrapAndLm2m_ConnectLwm2mSuccess
X509_NoTrustLwM2MIntegrationTest.testWithX509NoTrustConnectBsSuccess_UpdateTwoSectionsBootstrapAndLm2m_ConnectLwm2mSuccess
PskLwm2mIntegrationTest.testWithPskConnectBsSuccess_UpdateTwoSectionsBootstrapAndLm2m_ConnectLwm2mSuccess  
```
```
2022-07-11 17:06:07,788 [test-lwm2m-scheduled-47-thread-3] INFO  o.e.l.c.e.DefaultRegistrationEngine - Bootstrap task interrupted. 
2022-07-11 17:06:07,798 [main] INFO  o.e.l.c.californium.LeshanClient - Leshan client destroyed.

java.lang.RuntimeException: Failed to await TimeOut lwm2m client initialization!

	at org.thingsboard.server.transport.lwm2m.client.LwM2MTestClient.awaitClientAfterStartConnectLw(LwM2MTestClient.java:350)
	at org.thingsboard.server.transport.lwm2m.client.LwM2MTestClient.start(LwM2MTestClient.java:335)
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



