### PR TITLE
[3.4.1] UI: Add relation tab to user details.

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/user/user-tabs.component.html
+++ b/ui-ngx/src/app/modules/home/pages/user/user-tabs.component.html
@@ -32,6 +32,10 @@
                       [entityName]="entity.name">
   </tb-attribute-table>
 </mat-tab>
+<mat-tab *ngIf="entity"
+         label="{{ 'relation.relations' | translate }}" #relationsTab="matTab">
+  <tb-relation-table [active]="relationsTab.isActive" [entityId]="entity.id"></tb-relation-table>
+</mat-tab>
 <mat-tab *ngIf="entity && authUser.authority === authorities.TENANT_ADMIN"
          label="{{ 'audit-log.audit-logs' | translate }}" #auditLogsTab="matTab">
   <tb-audit-log-table [active]="auditLogsTab.isActive" [auditLogMode]="auditLogModes.USER" [userId]="entity.id" detailsMode="true"></tb-audit-log-table>


### PR DESCRIPTION
Asset and device details page lets a user to review theirs relation either to user or some other entity, so it would make sense to have such tab for users as well.