### PR TITLE
[3.4.1] Fix start up failure due to Spring circular dependencies

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/service/validator/AssetDataValidator.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/service/validator/AssetDataValidator.java
@@ -42,6 +42,7 @@ public class AssetDataValidator extends DataValidator<Asset> {
     private AssetDao assetDao;
 
     @Autowired
+    @Lazy
     private TenantService tenantService;
 
     @Autowired


### PR DESCRIPTION
Without this changes my locally built Docker instance cannot event start. Issue with log [#6982](https://github.com/thingsboard/thingsboard/issues/6982).

Strange why already existing `spring.main.allow-circular-references: "true"` in `thinsboard.yml` doesn't resolve the case.