### PR TITLE
[3.4.1] UI: Add id to closing button of dashboard state dialog.

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/dialog/embed-dashboard-dialog.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/dialog/embed-dashboard-dialog.component.html
@@ -31,7 +31,8 @@
                        [currentState]="state" [dashboard]="dashboard" style="width: 100%; height: 100%;"></tb-dashboard-page>
   </div>
   <div mat-dialog-actions fxLayoutAlign="end center">
-    <button mat-button color="primary"
+    <button [id]="stateId"
+            mat-button color="primary"
             type="button"
             [disabled]="(isLoading$ | async)"
             (click)="close()" cdkFocusInitial>

--- a/ui-ngx/src/app/modules/home/components/widget/dialog/embed-dashboard-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/dialog/embed-dashboard-dialog.component.ts
@@ -29,6 +29,7 @@ import { AppState } from '@core/core.state';
 import { Router } from '@angular/router';
 import { DialogComponent } from '@shared/components/dialog.component';
 import { Dashboard } from '@shared/models/dashboard.models';
+import { base64toObj } from '@core/utils';
 
 export interface EmbedDashboardDialogData {
   dashboard: Dashboard;
@@ -51,6 +52,7 @@ export class EmbedDashboardDialogComponent extends DialogComponent<EmbedDashboar
 
   dashboard = this.data.dashboard;
   state = this.data.state;
+  stateId = base64toObj(this.data.state)[0]?.id;
   title = this.data.title;
   hideToolbar = this.data.hideToolbar;
 


### PR DESCRIPTION
I wish to close dashboard state opened in dialog from my custom widget. I could not find a way to pass `MatDialogRef` to each widget context and no one (unfortunately, as usual) helped me (see [#6867](https://github.com/thingsboard/thingsboard/issues/6867)) in finding the right way.

So I added id to closing button which (id) is a current dashboard state. So now I can trigger button click from my custom widget and close the dashboard state dialog. Like this:
```javascript
$(`button[id$='${self.ctx.stateController.getStateId()}']`).click();
```

