### PR TITLE
[3.4.1] UI: No black background behind snack bar.

### DIFF
--- a/ui-ngx/src/styles.scss
+++ b/ui-ngx/src/styles.scss
@@ -1159,8 +1159,8 @@ mat-label {
 
   .mat-snack-bar-container {
     position: absolute;
-    background: none;
-    box-shadow: none;
+    background: none !important;
+    box-shadow: none !important;
     margin: 0;
     padding: 0;
     border: none;


### PR DESCRIPTION
**Before**
![before](https://user-images.githubusercontent.com/86909129/181714847-ec67b1cf-82ad-4aef-b9af-7d02d1da9f2b.jpg)

**After**

![after](https://user-images.githubusercontent.com/86909129/181714895-51b30910-03bf-4e36-9235-c87766067d31.jpg)

