### PR TITLE
[fix_bug] NullNode to bytes

### DIFF
--- a/common/data/src/main/java/org/thingsboard/server/common/data/SearchTextBasedWithAdditionalInfo.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/SearchTextBasedWithAdditionalInfo.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.server.common.data.id.UUIDBased;
 
@@ -26,8 +27,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.function.Supplier;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Created by ashvayka on 19.02.18.
@@ -98,7 +99,11 @@ public abstract class SearchTextBasedWithAdditionalInfo<I extends UUIDBased> ext
     public static void setJson(JsonNode json, Consumer<JsonNode> jsonConsumer, Consumer<byte[]> bytesConsumer) {
         jsonConsumer.accept(json);
         try {
-            bytesConsumer.accept(mapper.writeValueAsBytes(json));
+            if (json instanceof NullNode) {
+                bytesConsumer.accept(null);
+            } else {
+                bytesConsumer.accept(mapper.writeValueAsBytes(json));
+            }
         } catch (JsonProcessingException e) {
             log.warn("Can't serialize json data: ", e);
         }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/SearchTextBasedWithAdditionalInfo.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/SearchTextBasedWithAdditionalInfo.java
@@ -99,7 +99,7 @@ public abstract class SearchTextBasedWithAdditionalInfo<I extends UUIDBased> ext
     public static void setJson(JsonNode json, Consumer<JsonNode> jsonConsumer, Consumer<byte[]> bytesConsumer) {
         jsonConsumer.accept(json);
         try {
-            if (json instanceof NullNode) {
+            if (json instanceof NullNode || json == null) {
                 bytesConsumer.accept(null);
             } else {
                 bytesConsumer.accept(mapper.writeValueAsBytes(json));

--- a/common/data/src/main/java/org/thingsboard/server/common/data/SearchTextBasedWithAdditionalInfo.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/SearchTextBasedWithAdditionalInfo.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.server.common.data.id.UUIDBased;
 
@@ -97,11 +97,12 @@ public abstract class SearchTextBasedWithAdditionalInfo<I extends UUIDBased> ext
     }
 
     public static void setJson(JsonNode json, Consumer<JsonNode> jsonConsumer, Consumer<byte[]> bytesConsumer) {
-        jsonConsumer.accept(json);
         try {
-            if (json instanceof NullNode || json == null) {
+            if (json == null || json.getNodeType() == JsonNodeType.NULL) {
+                jsonConsumer.accept(null);
                 bytesConsumer.accept(null);
             } else {
+                jsonConsumer.accept(json);
                 bytesConsumer.accept(mapper.writeValueAsBytes(json));
             }
         } catch (JsonProcessingException e) {


### PR DESCRIPTION
## Pull Request description
Entity entity getData:
**Role:**
```
public void setPermissions(JsonNode permissions) {
    setJson(permissions, json -> this.permissions = json, bytes -> this.permissionsBytes = bytes);
}
```
If parameter permissions == NullNode (value to string is "null")  or permissions == null
-  then permissions Bytes = [110, 117, 108, 108] equals "null"

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



