### PR TITLE
[3.4.1] fixed update or remove inactivityTimeout kv

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -271,17 +271,16 @@ public class DefaultDeviceStateService extends AbstractPartitionBasedService<Dev
 
     @Override
     public void onDeviceInactivityTimeoutUpdate(TenantId tenantId, DeviceId deviceId, long inactivityTimeout) {
-        if (inactivityTimeout <= 0L) {
-            return;
-        }
         if (cleanDeviceStateIfBelongsExternalPartition(tenantId, deviceId)) {
             return;
+        }
+        if (inactivityTimeout <= 0L) {
+            inactivityTimeout = defaultInactivityTimeoutInSec;
         }
         log.trace("on Device Activity Timeout Update device id {} inactivityTimeout {}", deviceId, inactivityTimeout);
         DeviceStateData stateData = getOrFetchDeviceStateData(deviceId);
         stateData.getState().setInactivityTimeout(inactivityTimeout);
         checkAndUpdateState(deviceId, stateData);
-
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
@@ -278,7 +278,15 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
     private void updateDeviceInactivityTimeout(TenantId tenantId, EntityId entityId, List<? extends KvEntry> kvEntries) {
         for (KvEntry kvEntry : kvEntries) {
             if (kvEntry.getKey().equals(DefaultDeviceStateService.INACTIVITY_TIMEOUT)) {
-                deviceStateService.onDeviceInactivityTimeoutUpdate(tenantId, new DeviceId(entityId.getId()), kvEntry.getLongValue().orElse(0L));
+                deviceStateService.onDeviceInactivityTimeoutUpdate(tenantId, new DeviceId(entityId.getId()), getLongValue(kvEntry));
+            }
+        }
+    }
+
+    private void deleteDeviceInactivityTimeout(TenantId tenantId, EntityId entityId, List<String> keys) {
+        for (String key : keys) {
+            if (key.equals(DefaultDeviceStateService.INACTIVITY_TIMEOUT)) {
+                deviceStateService.onDeviceInactivityTimeoutUpdate(tenantId, new DeviceId(entityId.getId()), 0);
             }
         }
     }
@@ -340,6 +348,9 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
                     }
                     return subscriptionUpdate;
                 }, false);
+        if (entityId.getEntityType() == EntityType.DEVICE) {
+            deleteDeviceInactivityTimeout(tenantId, entityId, keys);
+        }
         callback.onSuccess();
     }
 
@@ -364,6 +375,9 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
                     }
                     return subscriptionUpdate;
                 }, false);
+        if (entityId.getEntityType() == EntityType.DEVICE) {
+            deleteDeviceInactivityTimeout(tenantId, entityId, keys);
+        }
         callback.onSuccess();
     }
 
@@ -555,6 +569,29 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
                                 .setAlarmSubUpdate(builder.build()).build())
                 .build();
         return new TbProtoQueueMsg<>(subscription.getEntityId().getId(), toCoreMsg);
+    }
+
+    private static long getLongValue(KvEntry kve) {
+        switch (kve.getDataType()) {
+            case LONG:
+                return kve.getLongValue().orElse(0L);
+            case DOUBLE:
+                return kve.getDoubleValue().orElse(0.0).longValue();
+            case STRING:
+                try {
+                    return Long.parseLong(kve.getStrValue().orElse("0"));
+                } catch (NumberFormatException e) {
+                    return 0L;
+                }
+            case JSON:
+                try {
+                    return Long.parseLong(kve.getJsonValue().orElse("0"));
+                } catch (NumberFormatException e) {
+                    return 0L;
+                }
+            default:
+                return 0L;
+        }
     }
 
 }


### PR DESCRIPTION
## Pull Request description

We should set the default value after update with incorrect value or remove the inactivityTimeout.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



