### PR TITLE
[3.4.1] Firmware ID not synced from cloud  to edge in device / device profiles

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/DeviceMsgConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/DeviceMsgConstructor.java
@@ -59,6 +59,10 @@ public class DeviceMsgConstructor {
         if (device.getAdditionalInfo() != null) {
             builder.setAdditionalInfo(JacksonUtil.toString(device.getAdditionalInfo()));
         }
+        if (device.getFirmwareId() != null) {
+            builder.setFirmwareIdMSB(device.getFirmwareId().getId().getMostSignificantBits())
+                    .setFirmwareIdLSB(device.getFirmwareId().getId().getLeastSignificantBits());
+        }
         if (conflictName != null) {
             builder.setConflictName(conflictName);
         }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/DeviceProfileMsgConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/DeviceProfileMsgConstructor.java
@@ -20,9 +20,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.thingsboard.server.common.data.DeviceProfile;
 import org.thingsboard.server.common.data.id.DeviceProfileId;
-import org.thingsboard.server.queue.util.DataDecodingEncodingService;
 import org.thingsboard.server.gen.edge.v1.DeviceProfileUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.UpdateMsgType;
+import org.thingsboard.server.queue.util.DataDecodingEncodingService;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 
 import java.nio.charset.StandardCharsets;
@@ -65,6 +65,10 @@ public class DeviceProfileMsgConstructor {
         }
         if (deviceProfile.getImage() != null) {
             builder.setImage(ByteString.copyFrom(deviceProfile.getImage().getBytes(StandardCharsets.UTF_8)));
+        }
+        if (deviceProfile.getFirmwareId() != null) {
+            builder.setFirmwareIdMSB(deviceProfile.getFirmwareId().getId().getMostSignificantBits())
+                    .setFirmwareIdLSB(deviceProfile.getFirmwareId().getId().getLeastSignificantBits());
         }
         return builder.build();
     }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/OtaPackageMsgConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/OtaPackageMsgConstructor.java
@@ -33,12 +33,15 @@ public class OtaPackageMsgConstructor {
                 .setMsgType(msgType)
                 .setIdMSB(otaPackage.getId().getId().getMostSignificantBits())
                 .setIdLSB(otaPackage.getId().getId().getLeastSignificantBits())
-                .setDeviceProfileIdMSB(otaPackage.getDeviceProfileId().getId().getMostSignificantBits())
-                .setDeviceProfileIdLSB(otaPackage.getDeviceProfileId().getId().getLeastSignificantBits())
                 .setType(otaPackage.getType().name())
                 .setTitle(otaPackage.getTitle())
                 .setVersion(otaPackage.getVersion())
                 .setTag(otaPackage.getTag());
+
+        if (otaPackage.getDeviceProfileId() != null) {
+            builder.setDeviceProfileIdMSB(otaPackage.getDeviceProfileId().getId().getMostSignificantBits())
+                    .setDeviceProfileIdLSB(otaPackage.getDeviceProfileId().getId().getLeastSignificantBits());
+        }
 
         if (otaPackage.getUrl() != null) {
             builder.setUrl(otaPackage.getUrl());

--- a/common/edge-api/src/main/proto/edge.proto
+++ b/common/edge-api/src/main/proto/edge.proto
@@ -198,6 +198,8 @@ message DeviceUpdateMsg {
   optional string label = 10;
   optional string additionalInfo = 11;
   optional string conflictName = 12;
+  int64 firmwareIdMSB = 13;
+  int64 firmwareIdLSB = 14;
 }
 
 message DeviceProfileUpdateMsg {
@@ -216,6 +218,8 @@ message DeviceProfileUpdateMsg {
   bytes profileDataBytes = 13;
   optional string provisionDeviceKey = 14;
   optional bytes image = 15;
+  int64 firmwareIdMSB = 16;
+  int64 firmwareIdLSB = 17;
 }
 
 message DeviceCredentialsUpdateMsg {

--- a/common/edge-api/src/main/proto/edge.proto
+++ b/common/edge-api/src/main/proto/edge.proto
@@ -198,8 +198,8 @@ message DeviceUpdateMsg {
   optional string label = 10;
   optional string additionalInfo = 11;
   optional string conflictName = 12;
-  int64 firmwareIdMSB = 13;
-  int64 firmwareIdLSB = 14;
+  optional int64 firmwareIdMSB = 13;
+  optional int64 firmwareIdLSB = 14;
 }
 
 message DeviceProfileUpdateMsg {
@@ -218,8 +218,8 @@ message DeviceProfileUpdateMsg {
   bytes profileDataBytes = 13;
   optional string provisionDeviceKey = 14;
   optional bytes image = 15;
-  int64 firmwareIdMSB = 16;
-  int64 firmwareIdLSB = 17;
+  optional int64 firmwareIdMSB = 16;
+  optional int64 firmwareIdLSB = 17;
 }
 
 message DeviceCredentialsUpdateMsg {


### PR DESCRIPTION
## Pull Request description

Firmware ID is not propagated from cloud to edge in device and device profile entities.
Related issue:
https://github.com/thingsboard/thingsboard-edge/issues/18

Changes implemented - firmware ID added to the proto file and propagated to edge from the cloud in contructors.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.


