### PR TITLE
[3.4.2] UI: Fixed DatetimeAdapter for 'en-GB' locale

### DIFF
--- a/ui-ngx/src/app/shared/adapter/custom-datatime-adapter.ts
+++ b/ui-ngx/src/app/shared/adapter/custom-datatime-adapter.ts
@@ -1,0 +1,37 @@
+///
+/// Copyright © 2016-2022 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+import { Injectable } from '@angular/core';
+import { NativeDatetimeAdapter } from '@mat-datetimepicker/core';
+
+
+@Injectable()
+export class CustomDateAdapter extends NativeDatetimeAdapter {
+
+  parse(value: string, parseFormat: any): any {
+    if (typeof value === 'number') {
+      return new Date(value);
+    }
+    let newDate = null;
+    const formatToParts = Intl.DateTimeFormat(this.locale).formatToParts();
+    if (formatToParts[0].type.toLowerCase() === 'day') {
+      const literal = formatToParts[1].value;
+      newDate = value.replace(new RegExp(`(\\d+[${literal}])(\\d+[${literal}])`), '$2$1');
+    }
+    return value ? new Date(Date.parse(newDate || value)) : null;
+  }
+
+}

--- a/ui-ngx/src/app/shared/adapter/custom-datatime-adapter.ts
+++ b/ui-ngx/src/app/shared/adapter/custom-datatime-adapter.ts
@@ -21,7 +21,7 @@ import { NativeDatetimeAdapter } from '@mat-datetimepicker/core';
 @Injectable()
 export class CustomDateAdapter extends NativeDatetimeAdapter {
 
-  parse(value: string, parseFormat: any): any {
+  parse(value: string): Date {
     if (typeof value === 'number') {
       return new Date(value);
     }

--- a/ui-ngx/src/app/shared/adapter/custom-datatime-adapter.ts
+++ b/ui-ngx/src/app/shared/adapter/custom-datatime-adapter.ts
@@ -17,21 +17,20 @@
 import { Injectable } from '@angular/core';
 import { NativeDatetimeAdapter } from '@mat-datetimepicker/core';
 
-
 @Injectable()
 export class CustomDateAdapter extends NativeDatetimeAdapter {
 
-  parse(value: string): Date {
+  parse(value: string | number): Date {
     if (typeof value === 'number') {
       return new Date(value);
     }
-    let newDate = null;
+    let newDate = value;
     const formatToParts = Intl.DateTimeFormat(this.locale).formatToParts();
     if (formatToParts[0].type.toLowerCase() === 'day') {
       const literal = formatToParts[1].value;
-      newDate = value.replace(new RegExp(`(\\d+[${literal}])(\\d+[${literal}])`), '$2$1');
+      newDate = newDate.replace(new RegExp(`(\\d+[${literal}])(\\d+[${literal}])`), '$2$1');
     }
-    return value ? new Date(Date.parse(newDate || value)) : null;
+    return newDate ? new Date(Date.parse(newDate)) : null;
   }
 
 }

--- a/ui-ngx/src/app/shared/shared.module.ts
+++ b/ui-ngx/src/app/shared/shared.module.ts
@@ -53,7 +53,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatListModule } from '@angular/material/list';
-import { MatDatetimepickerModule, MatNativeDatetimeModule } from '@mat-datetimepicker/core';
+import { DatetimeAdapter, MatDatetimepickerModule, MatNativeDatetimeModule } from '@mat-datetimepicker/core';
 import { NgxDaterangepickerMd } from 'ngx-daterangepicker-material';
 import { GridsterModule } from 'angular-gridster2';
 import { FlexLayoutModule } from '@angular/flex-layout';
@@ -165,6 +165,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 import { MultipleImageInputComponent } from '@shared/components/multiple-image-input.component';
 import { BranchAutocompleteComponent } from '@shared/components/vc/branch-autocomplete.component';
 import { PhoneInputComponent } from '@shared/components/phone-input.component';
+import { CustomDateAdapter } from '@shared/adapter/custom-datatime-adapter';
 
 export function MarkedOptionsFactory(markedOptionsService: MarkedOptionsService) {
   return markedOptionsService;
@@ -188,6 +189,7 @@ export function MarkedOptionsFactory(markedOptionsService: MarkedOptionsService)
       provide: MAT_DATE_LOCALE,
       useValue: 'en-GB'
     },
+    { provide: DatetimeAdapter, useClass: CustomDateAdapter },
     { provide: HELP_MARKDOWN_COMPONENT_TOKEN, useValue: HelpMarkdownComponent },
     { provide: SHARED_MODULE_TOKEN, useValue: SharedModule },
     TbPopoverService


### PR DESCRIPTION
## Pull Request description
Issue: [#7091](https://github.com/thingsboard/thingsboard/issues/7091)

Bug: After manual editing day and month change position.
![image](https://user-images.githubusercontent.com/83352633/184848492-ed0bc3c0-65dc-47d7-af39-81cc918b70c6.png)
![image](https://user-images.githubusercontent.com/83352633/184849556-9f9d4a61-41a9-4b12-b099-63cb45f6a5d1.png)

Fix: Added custom datetimeAdaptor which get locale and parse the date in the right format.
![image](https://user-images.githubusercontent.com/83352633/184872778-d502e420-a526-45e7-91b0-f21043166c81.png)
![image](https://user-images.githubusercontent.com/83352633/184872995-b13ad71c-f6c9-44d0-a479-e561d6dda5b1.png)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


