### PR TITLE
[3.4.1] UI: Fixed table shift after triple click

### DIFF
--- a/ui-ngx/src/app/modules/home/components/entity/entities-table.component.scss
+++ b/ui-ngx/src/app/modules/home/components/entity/entities-table.component.scss
@@ -19,6 +19,11 @@
   width: 100%;
   height: 100%;
   display: block;
+
+  mat-drawer-container {
+    overflow: clip;
+  }
+
   .tb-entity-table {
     .tb-entity-table-content {
       width: 100%;


### PR DESCRIPTION
## Pull Request description
Issue: [#7107](https://github.com/thingsboard/thingsboard/issues/7107)
When you triple-click on the entity view, the image shifts to the left. when you triple-click again, it goes back.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to the Entity View;
2. Go to any Entity View group;
3. Triple-click on any entity view. The image shifts to the left;
4. Repeated triple-click shifts the image to the right.

Before fix: 
![image](https://user-images.githubusercontent.com/83352633/185156500-c8c03a70-1e7e-4ca8-8b80-df2e1e058b0a.png)
After fix: 
![image](https://user-images.githubusercontent.com/83352633/185157081-62b6377a-e150-4a3d-9c4c-f44006dc8ae3.png)
Everything works fine (Screenshot after triple click).

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



