### PR TITLE
[3.4.2] Cassandra cloud connects to Datastax Astra DB

### DIFF
--- a/application/src/main/java/org/thingsboard/server/install/ThingsboardInstallService.java
+++ b/application/src/main/java/org/thingsboard/server/install/ThingsboardInstallService.java
@@ -26,6 +26,7 @@ import org.thingsboard.server.service.component.ComponentDiscoveryService;
 import org.thingsboard.server.service.install.DatabaseEntitiesUpgradeService;
 import org.thingsboard.server.service.install.DatabaseTsUpgradeService;
 import org.thingsboard.server.service.install.EntityDatabaseSchemaService;
+import org.thingsboard.server.service.install.NoSqlKeyspaceService;
 import org.thingsboard.server.service.install.SystemDataLoaderService;
 import org.thingsboard.server.service.install.TsDatabaseSchemaService;
 import org.thingsboard.server.service.install.TsLatestDatabaseSchemaService;
@@ -50,6 +51,9 @@ public class ThingsboardInstallService {
 
     @Autowired
     private EntityDatabaseSchemaService entityDatabaseSchemaService;
+
+    @Autowired(required = false)
+    private NoSqlKeyspaceService noSqlKeyspaceService;
 
     @Autowired
     private TsDatabaseSchemaService tsDatabaseSchemaService;
@@ -247,6 +251,10 @@ public class ThingsboardInstallService {
                 entityDatabaseSchemaService.createDatabaseSchema();
 
                 log.info("Installing DataBase schema for timeseries...");
+
+                if (noSqlKeyspaceService != null) {
+                    noSqlKeyspaceService.createDatabaseSchema();
+                }
 
                 tsDatabaseSchemaService.createDatabaseSchema();
 

--- a/application/src/main/java/org/thingsboard/server/service/install/CassandraKeyspaceService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/CassandraKeyspaceService.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.install;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.thingsboard.server.dao.util.NoSqlAnyDaoNonCloud;
+
+/*
+* Create keyspace for Cassandra NoSQL database for non-cloud deployment.
+* For cloud service like Astra DBaas admin have to create keyspace manually on cloud UI.
+* Then create tokens with database admin role and put it on Thingsboard parameters.
+* Without this service cloud DB will end up with exception like
+* UnauthorizedException: Missing correct permission on thingsboard
+* */
+@Service
+@NoSqlAnyDaoNonCloud
+@Profile("install")
+public class CassandraKeyspaceService extends CassandraAbstractDatabaseSchemaService
+        implements NoSqlKeyspaceService {
+    public CassandraKeyspaceService() {
+        super("schema-keyspace.cql");
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/install/NoSqlKeyspaceService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/NoSqlKeyspaceService.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.install;
+
+public interface NoSqlKeyspaceService extends DatabaseSchemaService {
+}

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -200,6 +200,14 @@ cassandra:
   username: "${CASSANDRA_USERNAME:}"
   # Specify your password
   password: "${CASSANDRA_PASSWORD:}"
+  # Astra DB connect https://astra.datastax.com/
+  cloud:
+    # /etc/thingsboard/astra/secure-connect-thingsboard.zip
+    secure_connect_bundle_path: "${CASSANDRA_CLOUD_SECURE_BUNDLE_PATH:}"
+    # DucitQPHMzPCBOZqFYexAfKk
+    client_id: "${CASSANDRA_CLOUD_CLIENT_ID:}"
+    # ZnF7FpuHp43FP5BzM+KY8wGmSb4Ql6BhT4Z7sOU13ze+gXQ-n7OkFpNuB,oACUIQObQnK0g4bSPoZhK5ejkcF9F.j6f64j71Sr.tiRe0Fsq2hPS1ZCGSfAaIgg63IydG
+    client_secret: "${CASSANDRA_CLOUD_CLIENT_SECRET:}"
 
   # Cassandra cluster connection socket parameters #
   socket:

--- a/application/src/test/java/org/thingsboard/server/transport/TransportNoSqlTestSuite.java
+++ b/application/src/test/java/org/thingsboard/server/transport/TransportNoSqlTestSuite.java
@@ -35,6 +35,7 @@ public class TransportNoSqlTestSuite {
     public static CustomCassandraCQLUnit cassandraUnit =
             new CustomCassandraCQLUnit(
                     Arrays.asList(
+                            new ClassPathCQLDataSet("cassandra/schema-keyspace.cql", false, false),
                             new ClassPathCQLDataSet("cassandra/schema-ts.cql", false, false),
                             new ClassPathCQLDataSet("cassandra/schema-ts-latest.cql", false, false)
                     ),

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/cassandra/guava/GuavaDriverContext.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/cassandra/guava/GuavaDriverContext.java
@@ -40,26 +40,8 @@ import java.util.function.Predicate;
  */
 public class GuavaDriverContext extends DefaultDriverContext {
 
-    public GuavaDriverContext(
-            DriverConfigLoader configLoader,
-            List<TypeCodec<?>> typeCodecs,
-            NodeStateListener nodeStateListener,
-            SchemaChangeListener schemaChangeListener,
-            RequestTracker requestTracker,
-            Map<String, String> localDatacenters,
-            Map<String, Predicate<Node>> nodeFilters,
-            ClassLoader classLoader) {
-        super(
-                configLoader,
-                ProgrammaticArguments.builder()
-                        .addTypeCodecs(typeCodecs.toArray(new TypeCodec<?>[0]))
-                        .withNodeStateListener(nodeStateListener)
-                        .withSchemaChangeListener(schemaChangeListener)
-                        .withRequestTracker(requestTracker)
-                        .withLocalDatacenters(localDatacenters)
-                        .withNodeFilters(nodeFilters)
-                        .withClassLoader(classLoader)
-                        .build());
+    public GuavaDriverContext(DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+        super(configLoader, programmaticArguments);
     }
 
     @Override

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/cassandra/guava/GuavaSessionBuilder.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/cassandra/guava/GuavaSessionBuilder.java
@@ -25,18 +25,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class GuavaSessionBuilder extends SessionBuilder<GuavaSessionBuilder, GuavaSession> {
 
     @Override
-    protected DriverContext buildContext(
-            DriverConfigLoader configLoader,
-            ProgrammaticArguments programmaticArguments) {
-        return new GuavaDriverContext(
-                configLoader,
-                programmaticArguments.getTypeCodecs(),
-                programmaticArguments.getNodeStateListener(),
-                programmaticArguments.getSchemaChangeListener(),
-                programmaticArguments.getRequestTracker(),
-                programmaticArguments.getLocalDatacenters(),
-                programmaticArguments.getNodeFilters(),
-                programmaticArguments.getClassLoader());
+    protected DriverContext buildContext(DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+        return new GuavaDriverContext(configLoader, programmaticArguments);
     }
 
     @Override

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/util/NoSqlAnyDaoNonCloud.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/util/NoSqlAnyDaoNonCloud.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.util;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@ConditionalOnExpression("('${database.ts.type}'=='cassandra' || '${database.ts_latest.type}'=='cassandra') " +
+        "&& ('${cassandra.cloud.secure_connect_bundle_path}' == null || '${cassandra.cloud.secure_connect_bundle_path}'.isBlank() )")
+public @interface NoSqlAnyDaoNonCloud {
+}

--- a/dao/src/main/resources/cassandra/schema-keyspace.cql
+++ b/dao/src/main/resources/cassandra/schema-keyspace.cql
@@ -14,15 +14,8 @@
 -- limitations under the License.
 --
 
-CREATE TABLE IF NOT EXISTS thingsboard.ts_kv_latest_cf (
-    entity_type text, // (DEVICE, CUSTOMER, TENANT)
-    entity_id timeuuid,
-    key text,
-    ts bigint,
-    bool_v boolean,
-    str_v text,
-    long_v bigint,
-    dbl_v double,
-    json_v text,
-    PRIMARY KEY (( entity_type, entity_id ), key)
-) WITH compaction = { 'class' :  'LeveledCompactionStrategy'  };
+CREATE KEYSPACE IF NOT EXISTS thingsboard
+WITH replication = {
+	'class' : 'SimpleStrategy',
+	'replication_factor' : 1
+};

--- a/dao/src/main/resources/cassandra/schema-ts.cql
+++ b/dao/src/main/resources/cassandra/schema-ts.cql
@@ -14,12 +14,6 @@
 -- limitations under the License.
 --
 
-CREATE KEYSPACE IF NOT EXISTS thingsboard
-WITH replication = {
-	'class' : 'SimpleStrategy',
-	'replication_factor' : 1
-};
-
 CREATE TABLE IF NOT EXISTS thingsboard.ts_kv_cf (
     entity_type text, // (DEVICE, CUSTOMER, TENANT)
     entity_id timeuuid,

--- a/dao/src/test/java/org/thingsboard/server/dao/NoSqlDaoServiceTestSuite.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/NoSqlDaoServiceTestSuite.java
@@ -33,6 +33,7 @@ public class NoSqlDaoServiceTestSuite {
     public static CustomCassandraCQLUnit cassandraUnit =
             new CustomCassandraCQLUnit(
                     Arrays.asList(
+                            new ClassPathCQLDataSet("cassandra/schema-keyspace.cql", false, false),
                             new ClassPathCQLDataSet("cassandra/schema-ts.cql", false, false),
                             new ClassPathCQLDataSet("cassandra/schema-ts-latest.cql", false, false)
                     ),

--- a/tools/src/main/java/org/thingsboard/client/tools/migrator/README.md
+++ b/tools/src/main/java/org/thingsboard/client/tools/migrator/README.md
@@ -63,7 +63,7 @@ Tool execution time depends on DB size, CPU resources and Disk throughput
 * Note that this this part works only for single node Cassandra Cluster. If you have more nodes - it is better to use `sstableloader` tool.
 
 1. [Optional] install Cassandra on the instance
-2. [Optional] Using `cqlsh` create `thingsboard` keyspace and requred tables from this files `schema-ts.cql` and `schema-ts-latest.cql` using `source` command
+2. [Optional] Using `cqlsh` create `thingsboard` keyspace and requred tables from this files `schema-keyspace.cql`, `schema-ts.cql` and `schema-ts-latest.cql` using `source` command
 3. Stop Cassandra
 4. Look at `/var/lib/cassandra/data/thingsboard` and check for names of data folders
 5. Copy generated SSTable files into cassandra data dir using next command:


### PR DESCRIPTION
## Cassandra cloud connects to Datastax Astra DB 

This PR allows connecting to Cassandra on the cloud ([Datastax Astra DB](https://astra.datastax.com))

Decoupled 'CREATE KEYSPACE' into a separate service. For cloud, we have to create keyspace manually using cloud UI, then create a user and token to access the cloud.

Refactored GuavaSessionBuilder and GuavaDriverContext: deprecated constructor replaced to support the newest features, like cloud bundles.

new env vars in YAML:

```yaml
    # /etc/thingsboard/astra/secure-connect-thingsboard.zip
    secure_connect_bundle_path: "${CASSANDRA_CLOUD_SECURE_BUNDLE_PATH:}"
    # DucitQPHMzPCBOZqFYexAfKk
    client_id: "${CASSANDRA_CLOUD_CLIENT_ID:}"
    # ZnF7FpuHp43FP5BzM+KY8wGmSb4Ql6BhT4Z7sOU13ze+gXQ-n7OkFpNuB,oACUIQObQnK0g4bSPoZhK5ejkcF9F.j6f64j71Sr.tiRe0Fsq2hPS1ZCGSfAaIgg63IydG
    client_secret: "${CASSANDRA_CLOUD_CLIENT_SECRET:}"
```

The result is on the screenshots:
![image](https://user-images.githubusercontent.com/79898499/185250676-d2aa4b48-ad2b-4671-9fde-900ed385e0cc.png)
![image](https://user-images.githubusercontent.com/79898499/185303817-85dac639-20d0-4231-bbcc-d87e8953e911.png)
![image](https://user-images.githubusercontent.com/79898499/185303480-a7a48ca1-ca6c-4f1b-9d8f-6ce390ae2727.png)

You need a 'Database administrator' role to install the Thingsboard schema
![image](https://user-images.githubusercontent.com/79898499/185250207-5fd4deb8-e81e-4726-adb3-df7c5b6cb5db.png)

Schema install for on-premise Cassandra got a new line `schema-keyspace.cql`:
![image](https://user-images.githubusercontent.com/79898499/185250873-b058d1ba-e864-443e-8e02-5ee99ce7bcd3.png)

For the cloud install is running without creating keyspace:

![image](https://user-images.githubusercontent.com/79898499/185251065-3d4b61a8-5e2a-4723-a099-8243a8deca4a.png)

Before decoupling keyspace creation, cloud install fired exception:
![image](https://user-images.githubusercontent.com/79898499/185251188-5400196f-ce74-4d30-895c-0f1814804a8f.png)

Before refactoring GuavaSessionBuilder and GuavaDriverContext the cloud connection failed like that:
```
2022-08-18 01:06:07,783 [s0-admin-1] WARN  c.d.o.d.i.c.c.ControlConnection - [s0] Error connecting to Node(endPoint=8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com:29042:a837fe38-9fd5-49a6-958e-7f7ca71ae890, hostId=null, hashCode=6d6ca852), trying next node (ConnectionInitException: [s0|control|id: 0xcd628587, L:/10.8.0.66:19332 - R:8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com/34.77.135.39:29042] Protocol initialization request, step 1 (OPTIONS): unexpected failure (com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer))
2022-08-18 01:06:07,887 [s0-admin-1] WARN  c.d.o.d.i.c.c.ControlConnection - [s0] Error connecting to Node(endPoint=8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com:29042:b16cc260-ee81-4017-b6cf-6b793a5b9935, hostId=null, hashCode=1808cb7d), trying next node (ConnectionInitException: [s0|control|id: 0x9dd712b1, L:/10.8.0.66:12602 - R:8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com/34.78.6.86:29042] Protocol initialization request, step 1 (OPTIONS): unexpected failure (com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer))
2022-08-18 01:06:07,995 [s0-admin-1] WARN  c.d.o.d.i.c.c.ControlConnection - [s0] Error connecting to Node(endPoint=8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com:29042:ba266e06-dfa4-4171-88cb-75758881bcba, hostId=null, hashCode=160cca48), trying next node (ConnectionInitException: [s0|control|id: 0x16f5a8ec, L:/10.8.0.66:38954 - R:8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com/34.140.171.129:29042] Protocol initialization request, step 1 (OPTIONS): unexpected failure (com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer))

com.datastax.oss.driver.api.core.AllNodesFailedException: Could not reach any contact point, make sure you've provided valid addresses (showing first 3 nodes, use getAllErrors() for more): Node(endPoint=8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com:29042:a837fe38-9fd5-49a6-958e-7f7ca71ae890, hostId=null, hashCode=6d6ca852): [com.datastax.oss.driver.api.core.connection.ConnectionInitException: [s0|control|id: 0xcd628587, L:/10.8.0.66:19332 - R:8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com/34.77.135.39:29042] Protocol initialization request, step 1 (OPTIONS): unexpected failure (com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer)], Node(endPoint=8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com:29042:b16cc260-ee81-4017-b6cf-6b793a5b9935, hostId=null, hashCode=1808cb7d): [com.datastax.oss.driver.api.core.connection.ConnectionInitException: [s0|control|id: 0x9dd712b1, L:/10.8.0.66:12602 - R:8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com/34.78.6.86:29042] Protocol initialization request, step 1 (OPTIONS): unexpected failure (com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer)], Node(endPoint=8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com:29042:ba266e06-dfa4-4171-88cb-75758881bcba, hostId=null, hashCode=160cca48): [com.datastax.oss.driver.api.core.connection.ConnectionInitException: [s0|control|id: 0x16f5a8ec, L:/10.8.0.66:38954 - R:8ca57896-18c4-4a61-bb26-e2fc05985081-europe-west1.db.astra.datastax.com/34.140.171.129:29042] Protocol initialization request, step 1 (OPTIONS): unexpected failure (com.datastax.oss.driver.api.core.connection.ClosedConnectionException: Lost connection to remote peer)]
```

The total spending during the test takes about 8 hours with 3k telemetry points per second:
![image](https://user-images.githubusercontent.com/79898499/185304332-1959ae62-462a-47e8-bb60-c6aed6582e11.png)


Test with `docker-compose.yml` :
```yml
version: '3'
services:
  tb:
    image: "thingsboard/tb-postgres:3.4.1-SNAPSHOT"
    network_mode: "host"
    restart: "always"
    volumes:
      - /home/your_user/projects/astra/secure-connect-thingsboard.zip:/etc/thingsboard/astra/secure-connect-thingsboard.zip
    environment:
      HTTP_BIND_PORT: "8080"
      DATABASE_TS_TYPE: "cassandra"
      PERSIST_STATE_TO_TELEMETRY: "true" # Persist device state to the Cassandra. Default is false (Postgres, as device server_scope attributes)
      # Cassandra on cloud
      CASSANDRA_CLOUD_SECURE_BUNDLE_PATH: "/etc/thingsboard/astra/secure-connect-thingsboard.zip"
      # dbadmin
      CASSANDRA_CLOUD_CLIENT_ID: "KNpxZasfKNpxZasfKNpxZasf"
      CASSANDRA_CLOUD_CLIENT_SECRET: "6Rht+1oh8H_v4f3dbFiZ.KHBim6Rht+1oh8H_v4f3dbFiZ.KHBim6Rht+1oh8H_v4f3dbFiZ.KHBim"

```

Performance test to put some telemetry:
```bash
docker run -it --rm --network host --name tb-perf-test \
           --pull always --log-driver none \
           --env REST_URL=http://127.0.0.1:8080 \
           --env MQTT_HOST=127.0.0.1 \
           --env REST_USERNAME=tenant@thingsboard.org \
           --env REST_PASSWORD=tenant \
           --env DEVICE_END_IDX=1111 \
           --env MESSAGES_PER_SECOND=1000 \
           --env DURATION_IN_SECONDS=86400 \
           --env ALARMS_PER_SECOND=1 \
           --env DEVICE_CREATE_ON_START=true \
           --env TEST_PAYLOAD_TYPE=SMART_METER \
           thingsboard/tb-ce-performance-test:latest
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



