### PR TITLE
[3.4.2] UI: Remove selection (mode:x) for Pie-flot widget

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
@@ -1213,9 +1213,9 @@ export class TbFlot {
     if (this.chartType !== 'pie') {
       this.options.selection = {mode: 'x'};
       this.$element.bind('plotselected', this.flotSelectHandler);
+      this.$element.bind('dblclick', this.dblclickHandler);
     }
     this.$element.bind('plothover', this.flotHoverHandler);
-    this.$element.bind('dblclick', this.dblclickHandler);
     this.$element.bind('mousedown', this.mousedownHandler);
     this.$element.bind('mouseup', this.mouseupHandler);
     this.$element.bind('mouseleave', this.mouseleaveHandler);
@@ -1228,9 +1228,9 @@ export class TbFlot {
     if (this.chartType !== 'pie') {
       this.options.selection = {mode: null};
       this.$element.unbind('plotselected', this.flotSelectHandler);
+      this.$element.unbind('dblclick', this.dblclickHandler);
     }
     this.$element.unbind('plothover', this.flotHoverHandler);
-    this.$element.unbind('dblclick', this.dblclickHandler);
     this.$element.unbind('mousedown', this.mousedownHandler);
     this.$element.unbind('mouseup', this.mouseupHandler);
     this.$element.unbind('mouseleave', this.mouseleaveHandler);

--- a/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
@@ -159,13 +159,13 @@ export class TbFlot {
         autoHighlight: this.tooltipIndividual === true,
         markings: []
       },
-      selection : { mode : 'x' },
       legend : {
         show: false
       }
     };
 
     if (this.chartType === 'line' || this.chartType === 'bar' || this.chartType === 'state') {
+      this.options.selection = { mode : 'x' };
       this.options.xaxes = [];
       this.xaxis = {
         mode: 'time',
@@ -1210,9 +1210,11 @@ export class TbFlot {
   private enableMouseEvents() {
     this.$element.css('pointer-events', '');
     this.$element.addClass('mouse-events');
-    this.options.selection = { mode : 'x' };
+    if (this.chartType !== 'pie') {
+      this.options.selection = {mode: 'x'};
+      this.$element.bind('plotselected', this.flotSelectHandler);
+    }
     this.$element.bind('plothover', this.flotHoverHandler);
-    this.$element.bind('plotselected', this.flotSelectHandler);
     this.$element.bind('dblclick', this.dblclickHandler);
     this.$element.bind('mousedown', this.mousedownHandler);
     this.$element.bind('mouseup', this.mouseupHandler);
@@ -1223,9 +1225,11 @@ export class TbFlot {
   private disableMouseEvents() {
     this.$element.css('pointer-events', 'none');
     this.$element.removeClass('mouse-events');
-    this.options.selection = { mode : null };
+    if (this.chartType !== 'pie') {
+      this.options.selection = {mode: null};
+      this.$element.unbind('plotselected', this.flotSelectHandler);
+    }
     this.$element.unbind('plothover', this.flotHoverHandler);
-    this.$element.unbind('plotselected', this.flotSelectHandler);
     this.$element.unbind('dblclick', this.dblclickHandler);
     this.$element.unbind('mousedown', this.mousedownHandler);
     this.$element.unbind('mouseup', this.mouseupHandler);


### PR DESCRIPTION
## Pull Request description

Issue: https://github.com/thingsboard/thingsboard/issues/7128

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

Before:
Pie-flot widget has selection: {mode:x} as a result widget has bug with time:
![image](https://user-images.githubusercontent.com/43555187/185906530-7b5a679d-5f72-4b7c-aff7-cc311249f203.png)

After:
Removed 'selection: {mode:x}' +  reset Timevindow after boudle clicking for pie widgets:
![image](https://user-images.githubusercontent.com/43555187/185906761-d647f82a-683d-4785-bc41-290731cd5fc3.png)




