### PR TITLE
[3.4.2] Update bouncycastle from 1.67 to 1.69 to avoid duplicate of dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <swagger-annotations.version>1.6.3</swagger-annotations.version>
         <spatial4j.version>0.7</spatial4j.version>
         <jts.version>1.18.2</jts.version>
-        <bouncycastle.version>1.67</bouncycastle.version>
+        <bouncycastle.version>1.69</bouncycastle.version>
         <winsw.version>2.0.1</winsw.version>
         <postgresql.driver.version>42.2.20</postgresql.driver.version>
         <sonar.exclusions>org/thingsboard/server/gen/**/*,


### PR DESCRIPTION
## Pull Request description

Updated bouncycastle dependency to 1.69 to be in sync with Apache Pulsar dependency in PE version.
This will remove duplicate jar files and reduce the general size of PE jar version.
Scope of changes:
- update version of bouncycastle dependency.

No tests added - integration tests to check apache pulsar integration is going to be added in PE in the scope of covering all integrations by tests.

**Apache Pulsar integration was validated manually in the local environment.**

Size before changes:
**467** jars

Size after changes:
**465** jars

Diff:
![image](https://user-images.githubusercontent.com/3466101/186921375-6a0cc7ce-9133-462c-95fe-4cc74fc59a19.png)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description contains human-readable scope of changes.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
