### PR TITLE
[3.4.2] UI: fixed displaying of Markdown/HTML value function content in markdown widget settings

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/markdown-widget-settings.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/markdown-widget-settings.component.ts
@@ -51,7 +51,7 @@ export class MarkdownWidgetSettingsComponent extends WidgetSettingsComponent {
     this.markdownWidgetSettingsForm = this.fb.group({
       useMarkdownTextFunction: [settings.useMarkdownTextFunction, []],
       markdownTextPattern: [settings.markdownTextPattern, []],
-      markdownTextFunction: [settings.qrCodeTextFunction, []],
+      markdownTextFunction: [settings.markdownTextFunction, []],
       markdownCss: [settings.markdownCss, []]
     });
   }


### PR DESCRIPTION
## Pull Request description
Fixed #7158 

Before:
Markdown/HTML value function content in markdown widget settings is not displayed, while the function value isn't empty.
![image](https://user-images.githubusercontent.com/17936317/186958898-c4170b96-01f5-4366-87f3-e31ef2ea5f4e.png)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



