### PR TITLE
[fix bug] pushEntityActionToRuleEngine endpoint if tenantId == null

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/action/EntityActionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/action/EntityActionService.java
@@ -198,7 +198,7 @@ public class EntityActionService {
                     }
                 }
                 TbMsg tbMsg = TbMsg.newMsg(msgType, entityId, customerId, metaData, TbMsgDataType.JSON, json.writeValueAsString(entityNode));
-                if (tenantId.isNullUid()) {
+                if (tenantId == null || tenantId.isNullUid()) {
                     if (entity instanceof HasTenantId) {
                         tenantId = ((HasTenantId) entity).getTenantId();
                     }

--- a/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbClusterService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbClusterService.java
@@ -41,7 +41,6 @@ import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.DeviceProfileId;
 import org.thingsboard.server.common.data.id.EdgeId;
 import org.thingsboard.server.common.data.id.EntityId;
-import org.thingsboard.server.common.data.id.QueueId;
 import org.thingsboard.server.common.data.id.RuleChainId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.plugin.ComponentLifecycleEvent;
@@ -53,7 +52,6 @@ import org.thingsboard.server.common.msg.plugin.ComponentLifecycleMsg;
 import org.thingsboard.server.common.msg.queue.ServiceType;
 import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
 import org.thingsboard.server.common.msg.rpc.FromDeviceRpcResponse;
-import org.thingsboard.server.queue.util.DataDecodingEncodingService;
 import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.gen.transport.TransportProtos.FromDeviceRPCResponseProto;
 import org.thingsboard.server.gen.transport.TransportProtos.ToCoreMsg;
@@ -68,11 +66,11 @@ import org.thingsboard.server.queue.common.TbProtoQueueMsg;
 import org.thingsboard.server.queue.discovery.NotificationsTopicService;
 import org.thingsboard.server.queue.discovery.PartitionService;
 import org.thingsboard.server.queue.provider.TbQueueProducerProvider;
+import org.thingsboard.server.queue.util.DataDecodingEncodingService;
 import org.thingsboard.server.service.gateway_device.GatewayNotificationsService;
 import org.thingsboard.server.service.ota.OtaPackageStateService;
 import org.thingsboard.server.service.profile.TbDeviceProfileCache;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -167,7 +165,10 @@ public class DefaultTbClusterService implements TbClusterService {
 
     @Override
     public void pushMsgToRuleEngine(TenantId tenantId, EntityId entityId, TbMsg tbMsg, TbQueueCallback callback) {
-        if (tenantId.isNullUid()) {
+        if (tenantId == null) {
+            log.warn("tenantId [null] [{}] Received invalid message: {}", entityId, tbMsg);
+            return;
+        } else if (tenantId.isNullUid()) {
             if (entityId.getEntityType().equals(EntityType.TENANT)) {
                 tenantId = TenantId.fromUUID(entityId.getId());
             } else {

--- a/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbClusterService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbClusterService.java
@@ -165,10 +165,7 @@ public class DefaultTbClusterService implements TbClusterService {
 
     @Override
     public void pushMsgToRuleEngine(TenantId tenantId, EntityId entityId, TbMsg tbMsg, TbQueueCallback callback) {
-        if (tenantId == null) {
-            log.warn("tenantId [null] [{}] Received invalid message: {}", entityId, tbMsg);
-            return;
-        } else if (tenantId.isNullUid()) {
+        if (tenantId == null || tenantId.isNullUid()) {
             if (entityId.getEntityType().equals(EntityType.TENANT)) {
                 tenantId = TenantId.fromUUID(entityId.getId());
             } else {


### PR DESCRIPTION
## Pull Request description
 EntityActionService ->  pushEntityActionToRuleEngine(
**... TenantId tenantId == null..**.)
```
[05:29:35] :	 [Step 3/6] 2022-09-13 05:29:35,955 [main] WARN  o.t.s.s.action.EntityActionService - [0df83410-3325-11ed-a833-9ba4da4d847c] Failed to push entity action to rule engine: ADDED
[05:29:35] :	 [Step 3/6] java.lang.NullPointerException: null
[05:29:35] :	 [Step 3/6] 	at org.thingsboard.server.service.action.EntityActionService.pushEntityActionToRuleEngine(EntityActionService.java:201)
[05:29:35] :	 [Step 3/6] 	at org.thingsboard.server.service.entitiy.DefaultTbNotificationEntityService.logEntityAction(DefaultTbNotificationEntityService.java:95)
[05:29:35] :	 [Step 3/6] 	at org.thingsboard.server.service.entitiy.DefaultTbNotificationEntityService.logEntityAction(DefaultTbNotificationEntityService.java:72)
[05:29:35] :	 [Step 3/6] 	at org.thingsboard.server.service.resource.DefaultTbResourceService.save(DefaultTbResourceService.java:188)
[05:29:35] :	 [Step 3/6] 	at org.thingsboard.server.service.resource.DefaultTbResourceService.save(DefaultTbResourceService.java:59)
[05:29:35] :	 [Step 3/6] 	at org.thingsboard.server.service.entitiy.SimpleTbEntityService.save(SimpleTbEntityService.java:23)
[05:29:35] :	 [Step 3/6] 	at org.thingsboard.server.service.resource.sql.BaseTbResourceServiceTest.testFindResourceById(BaseTbResourceServiceTest.java:293)
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



