### PR TITLE
[3.4.2] UI: Add API to create telemetry websocket updater in custom widgets.

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/dynamic-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/dynamic-widget.component.ts
@@ -40,6 +40,7 @@ import { AuthService } from '@core/auth/auth.service';
 import { DialogService } from '@core/services/dialog.service';
 import { CustomDialogService } from '@home/components/widget/dialog/custom-dialog.service';
 import { ResourceService } from '@core/http/resource.service';
+import { TelemetryWebsocketService } from '@core/ws/telemetry-websocket.service';
 import { DatePipe } from '@angular/common';
 import { TranslateService } from '@ngx-translate/core';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -80,6 +81,7 @@ export class DynamicWidgetComponent extends PageComponent implements IDynamicWid
     this.ctx.dialogs = $injector.get(DialogService);
     this.ctx.customDialog = $injector.get(CustomDialogService);
     this.ctx.resourceService = $injector.get(ResourceService);
+    this.ctx.telemetryWsService = $injector.get(TelemetryWebsocketService);
     this.ctx.date = $injector.get(DatePipe);
     this.ctx.translate = $injector.get(TranslateService);
     this.ctx.http = $injector.get(HttpClient);

--- a/ui-ngx/src/app/modules/home/models/services.map.ts
+++ b/ui-ngx/src/app/modules/home/models/services.map.ts
@@ -39,6 +39,7 @@ import { OtaPackageService } from '@core/http/ota-package.service';
 import { AuthService } from '@core/auth/auth.service';
 import { ResourceService } from '@core/http/resource.service';
 import { TwoFactorAuthenticationService } from '@core/http/two-factor-authentication.service';
+import { TelemetryWebsocketService } from '@core/ws/telemetry-websocket.service';
 
 export const ServicesMap = new Map<string, Type<any>>(
   [
@@ -65,6 +66,7 @@ export const ServicesMap = new Map<string, Type<any>>(
    ['otaPackageService', OtaPackageService],
    ['authService', AuthService],
    ['resourceService', ResourceService],
-   ['twoFactorAuthenticationService', TwoFactorAuthenticationService]
+   ['twoFactorAuthenticationService', TwoFactorAuthenticationService],
+   ['telemetryWsService', TelemetryWebsocketService]
   ]
 );

--- a/ui-ngx/src/app/modules/home/models/widget-component.models.ts
+++ b/ui-ngx/src/app/modules/home/models/widget-component.models.ts
@@ -73,6 +73,7 @@ import { DialogService } from '@core/services/dialog.service';
 import { CustomDialogService } from '@home/components/widget/dialog/custom-dialog.service';
 import { AuthService } from '@core/auth/auth.service';
 import { ResourceService } from '@core/http/resource.service';
+import { TelemetryWebsocketService } from '@core/ws/telemetry-websocket.service';
 import { DatePipe } from '@angular/common';
 import { TranslateService } from '@ngx-translate/core';
 import { PageLink } from '@shared/models/page/page-link';
@@ -84,6 +85,7 @@ import * as RxJS from 'rxjs';
 import * as RxJSOperators from 'rxjs/operators';
 import { TbPopoverComponent } from '@shared/components/popover.component';
 import { EntityId } from '@shared/models/id/entity-id';
+import { TelemetrySubscriber } from '@app/shared/public-api';
 
 export interface IWidgetAction {
   name: string;
@@ -173,6 +175,8 @@ export class WidgetContext {
   dialogs: DialogService;
   customDialog: CustomDialogService;
   resourceService: ResourceService;
+  telemetryWsService: TelemetryWebsocketService;
+  telemetrySubscriber?: TelemetrySubscriber;
   date: DatePipe;
   translate: TranslateService;
   http: HttpClient;


### PR DESCRIPTION
Description of problem is in #7258

With this PR I would receive continuous updates  in my custom widgets from all timeseries data keys without explicitly specifying them in widget configuration:
```
self.onInit = function() {
    let utils = self.ctx.$scope.$injector.get(self.ctx.servicesMap.get('utils'));

    utils.subscribeToEntityTelemetry(self.ctx).subscribe(
        data => console.log('Data: ', data),
        error => console.log('Error: ', error));
}

self.onDestroy = function() {
    if (self.ctx.telemetrySubscriber) {
        self.ctx.telemetrySubscriber.unsubscribe();
    }
}
```