### PR TITLE
[3.4.2] Feature: Redirect to the targeted url after successful login via oauth2

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -25,6 +25,8 @@ import javax.servlet.http.HttpServletResponse;
 @Component
 public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
     public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String PREV_URI_PARAMETER = "prevUri";
+    public static final String PREV_URI_COOKIE_NAME = "prev_uri";
     private static final int cookieExpireSeconds = 180;
 
     @Override
@@ -39,6 +41,9 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
         if (authorizationRequest == null) {
             CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
             return;
+        }
+        if (request.getParameter(PREV_URI_PARAMETER) != null) {
+            CookieUtils.addCookie(response, PREV_URI_COOKIE_NAME, request.getParameter(PREV_URI_PARAMETER), cookieExpireSeconds);
         }
         CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
     }

--- a/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/Oauth2AuthenticationSuccessHandler.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/Oauth2AuthenticationSuccessHandler.java
@@ -37,12 +37,16 @@ import org.thingsboard.server.service.security.model.SecurityUser;
 import org.thingsboard.server.service.security.model.token.JwtTokenFactory;
 import org.thingsboard.server.service.security.system.SystemSecurityService;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.UUID;
+
+import static org.thingsboard.server.service.security.auth.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.PREV_URI_COOKIE_NAME;
 
 @Slf4j
 @Component(value = "oauth2AuthenticationSuccessHandler")
@@ -85,6 +89,11 @@ public class Oauth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             baseUrl = callbackUrlScheme + ":";
         } else {
             baseUrl = this.systemSecurityService.getBaseUrl(TenantId.SYS_TENANT_ID, new CustomerId(EntityId.NULL_UUID), request);
+            Optional<Cookie> prevUrlOpt = CookieUtils.getCookie(request, PREV_URI_COOKIE_NAME);
+            if (prevUrlOpt.isPresent()) {
+                baseUrl += prevUrlOpt.get().getValue();
+                CookieUtils.deleteCookie(request, response, PREV_URI_COOKIE_NAME);
+            }
         }
         try {
             OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;

--- a/ui-ngx/src/app/modules/login/pages/login/login.component.html
+++ b/ui-ngx/src/app/modules/login/pages/login/login.component.html
@@ -30,7 +30,7 @@
             <span style="height: 50px;"></span>
             <div class="oauth-container tb-default" fxLayout="column" fxLayoutGap="16px" *ngIf="oauth2Clients?.length">
               <ng-container *ngFor="let oauth2Client of oauth2Clients">
-                <a mat-raised-button class="login-with-button" href="{{ oauth2Client.url }}">
+                <a mat-raised-button class="login-with-button" href="{{ addPrevUriIfExists(oauth2Client) }}">
                   <mat-icon class="icon" svgIcon="{{ oauth2Client.icon }}"></mat-icon>
                   {{ 'login.login-with' | translate: {name: oauth2Client.name} }}
                 </a>

--- a/ui-ngx/src/app/modules/login/pages/login/login.component.html
+++ b/ui-ngx/src/app/modules/login/pages/login/login.component.html
@@ -30,7 +30,7 @@
             <span style="height: 50px;"></span>
             <div class="oauth-container tb-default" fxLayout="column" fxLayoutGap="16px" *ngIf="oauth2Clients?.length">
               <ng-container *ngFor="let oauth2Client of oauth2Clients">
-                <a mat-raised-button class="login-with-button" href="{{ addPrevUriIfExists(oauth2Client) }}">
+                <a mat-raised-button class="login-with-button" href="{{ getOAuth2Uri(oauth2Client) }}">
                   <mat-icon class="icon" svgIcon="{{ oauth2Client.icon }}"></mat-icon>
                   {{ 'login.login-with' | translate: {name: oauth2Client.name} }}
                 </a>

--- a/ui-ngx/src/app/modules/login/pages/login/login.component.ts
+++ b/ui-ngx/src/app/modules/login/pages/login/login.component.ts
@@ -69,4 +69,11 @@ export class LoginComponent extends PageComponent implements OnInit {
     }
   }
 
+  addPrevUriIfExists(oauth2Client: OAuth2ClientInfo): string {
+    let result = "";
+    if (this.authService.redirectUrl) {
+      result += "?prevUri=" + this.authService.redirectUrl;
+    }
+    return oauth2Client.url + result;
+  }
 }

--- a/ui-ngx/src/app/modules/login/pages/login/login.component.ts
+++ b/ui-ngx/src/app/modules/login/pages/login/login.component.ts
@@ -69,7 +69,7 @@ export class LoginComponent extends PageComponent implements OnInit {
     }
   }
 
-  addPrevUriIfExists(oauth2Client: OAuth2ClientInfo): string {
+  getOAuth2Uri(oauth2Client: OAuth2ClientInfo): string {
     let result = "";
     if (this.authService.redirectUrl) {
       result += "?prevUri=" + this.authService.redirectUrl;


### PR DESCRIPTION
## Pull Request description

When the admin shares the link to a dashboard with the user by clicking the URL the user is forced to log in to TB first. This is normal behavior. One can authenticate via credentials or from configured IDP / SSO provider. But after a successful sign-in, one is forwarded to a Home page instead of the targeted dashboard.

The user indeed is authorized to see the dashboard. To view it, they need to click the URL again which is not convenient. 

With this feature user will be redirected to the targeted url.

PR is related to the issue:
[#7277
](https://github.com/thingsboard/thingsboard/issues/7277)

No tests were added due to impossibility of mocking required redirects that are required from third party services.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.




