### PR TITLE
[3.4.2] UI: Let data keys of entities widget to hide in mobile mode.

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/alarms-table-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/alarms-table-widget.component.ts
@@ -423,7 +423,7 @@ export class AlarmsTableWidgetComponent extends PageComponent implements OnInit,
         this.contentsInfo[dataKey.def].units = dataKey.units;
         this.contentsInfo[dataKey.def].decimals = dataKey.decimals;
         this.columnWidth[dataKey.def] = getColumnWidth(keySettings);
-        this.columnDefaultVisibility[dataKey.def] = getColumnDefaultVisibility(keySettings);
+        this.columnDefaultVisibility[dataKey.def] = getColumnDefaultVisibility(keySettings, this.ctx);
         this.columnSelectionAvailability[dataKey.def] = getColumnSelectionAvailability(keySettings);
         this.columns.push(dataKey);
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/entities-table-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/entities-table-widget.component.ts
@@ -444,7 +444,7 @@ export class EntitiesTableWidgetComponent extends PageComponent implements OnIni
         this.contentsInfo[dataKey.def].units = dataKey.units;
         this.contentsInfo[dataKey.def].decimals = dataKey.decimals;
         this.columnWidth[dataKey.def] = getColumnWidth(keySettings);
-        this.columnDefaultVisibility[dataKey.def] = getColumnDefaultVisibility(keySettings);
+        this.columnDefaultVisibility[dataKey.def] = getColumnDefaultVisibility(keySettings, this.ctx);
         this.columnSelectionAvailability[dataKey.def] = getColumnSelectionAvailability(keySettings);
         this.columns.push(dataKey);
       });

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/entities-table-key-settings.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/entities-table-key-settings.component.html
@@ -79,6 +79,9 @@
       <mat-option [value]="'hidden'">
         {{ 'widgets.table.column-visibility-hidden' | translate }}
       </mat-option>
+      <mat-option [value]="'hidden-mobile'">
+        {{ 'widgets.table.column-visibility-hidden-mobile' | translate }}
+      </mat-option>
     </mat-select>
   </mat-form-field>
   <mat-form-field fxFlex class="mat-block">

--- a/ui-ngx/src/app/modules/home/components/widget/lib/table-widget.models.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/table-widget.models.ts
@@ -27,7 +27,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 const tinycolor = tinycolor_;
 
-type ColumnVisibilityOptions = 'visible' | 'hidden';
+type ColumnVisibilityOptions = 'visible' | 'hidden' | 'hidden-mobile';
 
 type ColumnSelectionOptions = 'enabled' | 'disabled';
 
@@ -302,8 +302,9 @@ export function widthStyle(width: string): any {
   return widthStyleObj;
 }
 
-export function getColumnDefaultVisibility(keySettings: TableWidgetDataKeySettings): boolean {
-  return !(isDefined(keySettings.defaultColumnVisibility) && keySettings.defaultColumnVisibility === 'hidden');
+export function getColumnDefaultVisibility(keySettings: TableWidgetDataKeySettings, ctx?: WidgetContext): boolean {
+  return !(isDefined(keySettings.defaultColumnVisibility) && (keySettings.defaultColumnVisibility === 'hidden' ||
+      (ctx && ctx.isMobile && keySettings.defaultColumnVisibility === 'hidden-mobile')));
 }
 
 export function getColumnSelectionAvailability(keySettings: TableWidgetDataKeySettings): boolean {

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -4608,6 +4608,7 @@
             "default-column-visibility": "Default column visibility",
             "column-visibility-visible": "Visible",
             "column-visibility-hidden": "Hidden",
+            "column-visibility-hidden-mobile": "Hidden in mobile mode",
             "column-selection-to-display": "Column selection in 'Columns to Display'",
             "column-selection-to-display-enabled": "Enabled",
             "column-selection-to-display-disabled": "Disabled",


### PR DESCRIPTION
This PR lets to configure data keys of entities widget not only to hide or show but to show only in desktop mode and hide in mobile mode.