### PR TITLE
[3.4.2] Fix for rate limits filter

### DIFF
--- a/application/src/main/java/org/thingsboard/server/config/RateLimitProcessingFilter.java
+++ b/application/src/main/java/org/thingsboard/server/config/RateLimitProcessingFilter.java
@@ -22,7 +22,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
 import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.EntityId;
@@ -35,8 +35,8 @@ import org.thingsboard.server.service.security.model.SecurityUser;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
@@ -45,7 +45,7 @@ import java.util.concurrent.ConcurrentMap;
 
 @Slf4j
 @Component
-public class RateLimitProcessingFilter extends GenericFilterBean {
+public class RateLimitProcessingFilter extends OncePerRequestFilter {
 
     @Autowired
     private ThingsboardErrorResponseHandler errorResponseHandler;
@@ -58,13 +58,13 @@ public class RateLimitProcessingFilter extends GenericFilterBean {
     private final ConcurrentMap<CustomerId, TbRateLimits> perCustomerLimits = new ConcurrentHashMap<>();
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         SecurityUser user = getCurrentUser();
         if (user != null && !user.isSystemAdmin()) {
             var profile = tenantProfileCache.get(user.getTenantId());
             if (profile == null) {
                 log.debug("[{}] Failed to lookup tenant profile", user.getTenantId());
-                errorResponseHandler.handle(new BadCredentialsException("Failed to lookup tenant profile"), (HttpServletResponse) response);
+                errorResponseHandler.handle(new BadCredentialsException("Failed to lookup tenant profile"), response);
                 return;
             }
             var profileConfiguration = profile.getDefaultProfileConfiguration();

--- a/application/src/main/java/org/thingsboard/server/config/RateLimitProcessingFilter.java
+++ b/application/src/main/java/org/thingsboard/server/config/RateLimitProcessingFilter.java
@@ -80,6 +80,16 @@ public class RateLimitProcessingFilter extends OncePerRequestFilter {
         chain.doFilter(request, response);
     }
 
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return false;
+    }
+
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return false;
+    }
+
     private <I extends EntityId> boolean checkRateLimits(I ownerId, String rateLimitConfig, Map<I, TbRateLimits> rateLimitsMap, ServletResponse response) {
         if (StringUtils.isNotEmpty(rateLimitConfig)) {
             TbRateLimits rateLimits = rateLimitsMap.get(ownerId);

--- a/application/src/test/java/org/thingsboard/server/system/BaseRestApiLimitsTest.java
+++ b/application/src/test/java/org/thingsboard/server/system/BaseRestApiLimitsTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.system;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.server.common.data.TenantProfile;
+import org.thingsboard.server.common.data.page.PageData;
+import org.thingsboard.server.common.data.page.PageLink;
+import org.thingsboard.server.common.data.tenant.profile.DefaultTenantProfileConfiguration;
+import org.thingsboard.server.common.data.tenant.profile.TenantProfileConfiguration;
+import org.thingsboard.server.common.data.tenant.profile.TenantProfileData;
+import org.thingsboard.server.controller.AbstractControllerTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Illia Barkov
+ */
+
+@Slf4j
+public abstract class BaseRestApiLimitsTest extends AbstractControllerTest {
+
+    private static int MESSAGES_LIMIT = 10;
+    private static int TIME_FOR_LIMIT = 5;
+
+    TenantProfile tenantProfile;
+
+    @Before
+    public void before() throws Exception {
+        loginSysAdmin();
+        tenantProfile = getDefaultTenantProfile();
+        logout();
+    }
+
+    @After
+    public void after() throws Exception {
+        logout();
+        loginSysAdmin();
+        saveTenantProfileWitConfiguration(tenantProfile, new DefaultTenantProfileConfiguration());
+        logout();
+    }
+
+    @Test
+    public void testCustomerRestApiLimits() throws Exception {
+        loginSysAdmin();
+
+        String customerRestLimit = MESSAGES_LIMIT + ":" + TIME_FOR_LIMIT;
+
+        DefaultTenantProfileConfiguration configurationWithCustomerRestLimits = createTenantProfileConfigurationWithRestLimits(null, customerRestLimit);
+
+        saveTenantProfileWitConfiguration(tenantProfile, configurationWithCustomerRestLimits);
+
+        logout();
+
+        loginCustomerUser();
+
+        for (int i = 0; i < MESSAGES_LIMIT; i++) {
+            doGet("/api/device/types").andExpect(status().isOk());
+        }
+        doGet("/api/device/types").andExpect(status().is4xxClientError());
+        logout();
+    }
+
+    @Test
+    public void testTenantRestApiLimits() throws Exception {
+        loginSysAdmin();
+
+        String tenantRestLimit = MESSAGES_LIMIT + ":" + TIME_FOR_LIMIT;
+
+        DefaultTenantProfileConfiguration configurationWithTenantRestLimits = createTenantProfileConfigurationWithRestLimits(tenantRestLimit, null);
+
+        saveTenantProfileWitConfiguration(tenantProfile, configurationWithTenantRestLimits);
+
+        logout();
+
+        loginCustomerUser();
+
+        for (int i = 0; i < MESSAGES_LIMIT; i++) {
+            doGet("/api/device/types").andExpect(status().isOk());
+        }
+        doGet("/api/device/types").andExpect(status().is4xxClientError());
+        logout();
+    }
+
+    private TenantProfile getDefaultTenantProfile() throws Exception {
+
+        PageLink pageLink = new PageLink(17);
+        PageData<TenantProfile> pageData = doGetTypedWithPageLink("/api/tenantProfiles?",
+                new TypeReference<>(){}, pageLink);
+        Assert.assertFalse(pageData.hasNext());
+        Assert.assertEquals(1, pageData.getTotalElements());
+        List<TenantProfile> tenantProfiles = new ArrayList<>(pageData.getData());
+
+        Optional<TenantProfile> optionalDefaultProfile = tenantProfiles.stream().filter(TenantProfile::isDefault).reduce((a, b) -> null);
+        Assert.assertTrue(optionalDefaultProfile.isPresent());
+
+        return optionalDefaultProfile.get();
+    }
+
+    private DefaultTenantProfileConfiguration createTenantProfileConfigurationWithRestLimits(String tenantLimits, String customerLimits) {
+        DefaultTenantProfileConfiguration.DefaultTenantProfileConfigurationBuilder builder = DefaultTenantProfileConfiguration.builder();
+        builder.tenantServerRestLimitsConfiguration(tenantLimits);
+        builder.customerServerRestLimitsConfiguration(customerLimits);
+        return builder.build();
+
+    }
+
+    private void saveTenantProfileWitConfiguration(TenantProfile tenantProfile, TenantProfileConfiguration tenantProfileConfiguration) {
+        TenantProfileData tenantProfileData = tenantProfile.getProfileData();
+        tenantProfileData.setConfiguration(tenantProfileConfiguration);
+        TenantProfile savedTenantProfile = doPost("/api/tenantProfile", tenantProfile, TenantProfile.class);
+        Assert.assertNotNull(savedTenantProfile);
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/system/sql/RestApiLimitsSqlTest.java
+++ b/application/src/test/java/org/thingsboard/server/system/sql/RestApiLimitsSqlTest.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.system.sql;
+
+import org.thingsboard.server.dao.service.DaoSqlTest;
+import org.thingsboard.server.system.BaseRestApiLimitsTest;
+
+
+@DaoSqlTest
+public class RestApiLimitsSqlTest extends BaseRestApiLimitsTest {
+}


### PR DESCRIPTION
## Pull Request description

Replaced basic class filter for rate limits filter. 
GenericFilterBean was used as a base class for filter, but it apply filter function twice for every received request. So to avoid extra rate limit charge we should use OncePerRequestFilter as a base class for rate limit filter.
Jira ticket - PROD-1547

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.



