### PR TITLE
[3.4.2] Rule Engine: Added support of creating relation to USER entity.

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateRelationNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateRelationNode.java
@@ -32,6 +32,7 @@ import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.EdgeId;
 import org.thingsboard.server.common.data.id.EntityViewId;
 import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.id.UserId;
 import org.thingsboard.server.common.data.plugin.ComponentType;
 import org.thingsboard.server.common.data.relation.EntityRelation;
 import org.thingsboard.server.common.data.relation.RelationTypeGroup;
@@ -143,6 +144,8 @@ public class TbCreateRelationNode extends TbAbstractRelationActionNode<TbCreateR
                 return processEdge(ctx, entityContainer, sdId, relationType);
             case TENANT:
                 return processTenant(ctx, entityContainer, sdId, relationType);
+            case USER:
+                return processUser(ctx, entityContainer, sdId, relationType);
         }
         return Futures.immediateFuture(true);
     }
@@ -210,6 +213,16 @@ public class TbCreateRelationNode extends TbAbstractRelationActionNode<TbCreateR
     private ListenableFuture<Boolean> processTenant(TbContext ctx, EntityContainer entityContainer, SearchDirectionIds sdId, String relationType) {
         return Futures.transformAsync(ctx.getTenantService().findTenantByIdAsync(ctx.getTenantId(), TenantId.fromUUID(entityContainer.getEntityId().getId())), tenant -> {
             if (tenant != null) {
+                return processSave(ctx, sdId, relationType);
+            } else {
+                return Futures.immediateFuture(true);
+            }
+        }, ctx.getDbCallbackExecutor());
+    }
+
+    private ListenableFuture<Boolean> processUser(TbContext ctx, EntityContainer entityContainer, SearchDirectionIds sdId, String relationType) {
+        return Futures.transformAsync(ctx.getUserService().findUserByIdAsync(ctx.getTenantId(), new UserId(entityContainer.getEntityId().getId())), user -> {
+            if (user != null) {
                 return processSave(ctx, sdId, relationType);
             } else {
                 return Futures.immediateFuture(true);


### PR DESCRIPTION
## Pull Request description
*Create relation* node now support creating relation to user.

I think it is not correct to return *SUCCESS* status from this node (see `return Futures.immediateFuture(true);`) in case if some target entity type is not supported at the moment. But I didn't reimplement this behaviour in the PR.


