### PR TITLE
[3.4.2] UI: Add widget context API call to create alarm queries.

### DIFF
--- a/ui-ngx/src/app/modules/home/models/widget-component.models.ts
+++ b/ui-ngx/src/app/modules/home/models/widget-component.models.ts
@@ -75,7 +75,7 @@ import { AuthService } from '@core/auth/auth.service';
 import { ResourceService } from '@core/http/resource.service';
 import { DatePipe } from '@angular/common';
 import { TranslateService } from '@ngx-translate/core';
-import { PageLink } from '@shared/models/page/page-link';
+import { PageLink, TimePageLink } from '@shared/models/page/page-link';
 import { SortOrder } from '@shared/models/page/sort-order';
 import { DomSanitizer } from '@angular/platform-browser';
 import { Router } from '@angular/router';
@@ -84,6 +84,7 @@ import * as RxJS from 'rxjs';
 import * as RxJSOperators from 'rxjs/operators';
 import { TbPopoverComponent } from '@shared/components/popover.component';
 import { EntityId } from '@shared/models/id/entity-id';
+import { AlarmQuery, AlarmSearchStatus, AlarmStatus} from '@app/shared/models/alarm.models';
 
 export interface IWidgetAction {
   name: string;
@@ -393,6 +394,14 @@ export class WidgetContext {
 
   pageLink(pageSize: number, page: number = 0, textSearch: string = null, sortOrder: SortOrder = null): PageLink {
     return new PageLink(pageSize, page, textSearch, sortOrder);
+  }
+
+  timePageLink(startTime: number, endTime: number, pageSize: number, page: number = 0, textSearch: string = null, sortOrder: SortOrder = null) {
+    return new TimePageLink(pageSize, page, textSearch, sortOrder, startTime, endTime);
+  }
+
+  alarmQuery(entityId: EntityId, pageLink: TimePageLink, searchStatus: AlarmSearchStatus, status: AlarmStatus, fetchOriginator: boolean) {
+    return new AlarmQuery(entityId, pageLink, searchStatus, status, fetchOriginator);
   }
 }
 


### PR DESCRIPTION
## Pull Request description

The widget context already provides access to `alarmService`, but to find specific alarms we need to create instance of `AlarmQuery`. So this PR is to add API call that helps in creating such data objects.

*In general*: to avoid implementing such constructor proxies I would like to suggest core team to move up `toQuery()`-like methods from such data classes as `AlarmQuery` and others to corresponding service or additional layer for converting purpose.




