### PR TITLE
[WIP] [3.4.2] Do not send script body to remote JS executor on each invoke request

### DIFF
--- a/application/src/test/java/org/thingsboard/server/service/script/RemoteJsInvokeServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/script/RemoteJsInvokeServiceTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.script;
+
+import com.google.common.util.concurrent.Futures;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.thingsboard.server.gen.js.JsInvokeProtos;
+import org.thingsboard.server.gen.js.JsInvokeProtos.RemoteJsRequest;
+import org.thingsboard.server.gen.js.JsInvokeProtos.RemoteJsResponse;
+import org.thingsboard.server.queue.TbQueueRequestTemplate;
+import org.thingsboard.server.queue.common.TbProtoJsQueueMsg;
+import org.thingsboard.server.queue.common.TbProtoQueueMsg;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class RemoteJsInvokeServiceTest {
+
+    private RemoteJsInvokeService remoteJsInvokeService;
+    private TbQueueRequestTemplate<TbProtoJsQueueMsg<RemoteJsRequest>, TbProtoQueueMsg<RemoteJsResponse>> jsRequestTemplate;
+
+
+    @BeforeEach
+    public void beforeEach() {
+        remoteJsInvokeService = new RemoteJsInvokeService(null, null);
+        jsRequestTemplate = mock(TbQueueRequestTemplate.class);
+        remoteJsInvokeService.requestTemplate = jsRequestTemplate;
+    }
+
+    @AfterEach
+    public void afterEach() {
+        reset(jsRequestTemplate);
+    }
+
+    @Test
+    public void whenInvokingFunction_thenDoNotSendScriptBody() throws Exception {
+        UUID scriptId = UUID.randomUUID();
+        remoteJsInvokeService.scriptIdToBodysMap.put(scriptId, "scriptscriptscript");
+
+        String expectedInvocationResult = "scriptInvocationResult";
+        doReturn(Futures.immediateFuture(new TbProtoJsQueueMsg<>(UUID.randomUUID(), RemoteJsResponse.newBuilder()
+                .setInvokeResponse(JsInvokeProtos.JsInvokeResponse.newBuilder()
+                        .setSuccess(true)
+                        .setResult(expectedInvocationResult)
+                        .build())
+                .build())))
+                .when(jsRequestTemplate).send(any());
+
+        ArgumentCaptor<TbProtoJsQueueMsg<RemoteJsRequest>> jsRequestCaptor = ArgumentCaptor.forClass(TbProtoJsQueueMsg.class);
+        Object invocationResult = remoteJsInvokeService.doInvokeFunction(scriptId, "f", new Object[]{"a"}).get();
+        verify(jsRequestTemplate).send(jsRequestCaptor.capture());
+
+        JsInvokeProtos.JsInvokeRequest jsInvokeRequestMade = jsRequestCaptor.getValue().getValue().getInvokeRequest();
+        assertThat(jsInvokeRequestMade.getScriptIdLSB()).isEqualTo(scriptId.getLeastSignificantBits());
+        assertThat(jsInvokeRequestMade.getScriptIdMSB()).isEqualTo(scriptId.getMostSignificantBits());
+        assertThat(jsInvokeRequestMade.getScriptBody()).isNullOrEmpty();
+        assertThat(invocationResult).isEqualTo(expectedInvocationResult);
+    }
+
+    @Test
+    public void whenInvokingFunctionAndRemoteJsExecutorRemovedScript_thenHandleNotFoundErrorAndMakeInvokeRequestWithScriptBody() throws Exception {
+        UUID scriptId = UUID.randomUUID();
+        String scriptBody = "scriptscriptscript";
+        remoteJsInvokeService.scriptIdToBodysMap.put(scriptId, scriptBody);
+
+        doReturn(Futures.immediateFuture(new TbProtoJsQueueMsg<>(UUID.randomUUID(), RemoteJsResponse.newBuilder()
+                .setInvokeResponse(JsInvokeProtos.JsInvokeResponse.newBuilder()
+                        .setSuccess(false)
+                        .setErrorCode(JsInvokeProtos.JsInvokeErrorCode.NOT_FOUND_ERROR)
+                        .build())
+                .build())))
+                .when(jsRequestTemplate).send(argThat(jsQueueMsg -> {
+                    return StringUtils.isEmpty(jsQueueMsg.getValue().getInvokeRequest().getScriptBody());
+                }));
+
+        String expectedInvocationResult = "invocationResult";
+        doReturn(Futures.immediateFuture(new TbProtoJsQueueMsg<>(UUID.randomUUID(), RemoteJsResponse.newBuilder()
+                .setInvokeResponse(JsInvokeProtos.JsInvokeResponse.newBuilder()
+                        .setSuccess(true)
+                        .setResult(expectedInvocationResult)
+                        .build())
+                .build())))
+                .when(jsRequestTemplate).send(argThat(jsQueueMsg -> {
+                    return StringUtils.isNotEmpty(jsQueueMsg.getValue().getInvokeRequest().getScriptBody());
+                }));
+
+        ArgumentCaptor<TbProtoJsQueueMsg<RemoteJsRequest>> jsRequestsCaptor = ArgumentCaptor.forClass(TbProtoJsQueueMsg.class);
+        Object invocationResult = remoteJsInvokeService.doInvokeFunction(scriptId, "f", new Object[]{"a"}).get();
+        verify(jsRequestTemplate, times(2)).send(jsRequestsCaptor.capture());
+
+        List<TbProtoJsQueueMsg<RemoteJsRequest>> jsInvokeRequestsMade = jsRequestsCaptor.getAllValues();
+
+        JsInvokeProtos.JsInvokeRequest firstRequestMade = jsInvokeRequestsMade.get(0).getValue().getInvokeRequest();
+        assertThat(firstRequestMade.getScriptBody()).isNullOrEmpty();
+
+        JsInvokeProtos.JsInvokeRequest secondRequestMade = jsInvokeRequestsMade.get(1).getValue().getInvokeRequest();
+        assertThat(secondRequestMade.getScriptBody()).isEqualTo(scriptBody);
+
+        assertThat(invocationResult).isEqualTo(expectedInvocationResult);
+    }
+
+}

--- a/common/cluster-api/src/main/proto/jsinvoke.proto
+++ b/common/cluster-api/src/main/proto/jsinvoke.proto
@@ -23,6 +23,7 @@ enum JsInvokeErrorCode {
   COMPILATION_ERROR = 0;
   RUNTIME_ERROR = 1;
   TIMEOUT_ERROR = 2;
+  NOT_FOUND_ERROR = 3;
 }
 
 message RemoteJsRequest {


### PR DESCRIPTION
## Pull Request description

Now, when submitting a script invoke request to remote JS executor, script body will not be sent, expecting the executor to have it in its `scriptMap`. In case the script was removed from the map or the executor was restarted, `NOT_FOUND_ERROR` code will be returned, and `RemoteJsInvokeService` in turn will send the same invoke request again but with the needed script body in it.   

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



