### PR TITLE
[3.4.2] Improvements for remote JS executor

### DIFF
--- a/application/src/test/java/org/thingsboard/server/service/script/LocalJsInvokeServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/script/LocalJsInvokeServiceTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
         "js.max_result_size=50",
         "js.local.max_errors=2"
 })
-class JsInvokeServiceTest extends AbstractControllerTest {
+class LocalJsInvokeServiceTest extends AbstractControllerTest {
 
     @Autowired
     private NashornJsInvokeService jsInvokeService;

--- a/application/src/test/java/org/thingsboard/server/service/script/RemoteJsInvokeServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/script/RemoteJsInvokeServiceTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.script;
+
+import com.google.common.util.concurrent.Futures;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.thingsboard.server.gen.js.JsInvokeProtos;
+import org.thingsboard.server.gen.js.JsInvokeProtos.RemoteJsRequest;
+import org.thingsboard.server.gen.js.JsInvokeProtos.RemoteJsResponse;
+import org.thingsboard.server.queue.TbQueueRequestTemplate;
+import org.thingsboard.server.queue.common.TbProtoJsQueueMsg;
+import org.thingsboard.server.queue.common.TbProtoQueueMsg;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class RemoteJsInvokeServiceTest {
+
+    private RemoteJsInvokeService remoteJsInvokeService;
+    private TbQueueRequestTemplate<TbProtoJsQueueMsg<RemoteJsRequest>, TbProtoQueueMsg<RemoteJsResponse>> jsRequestTemplate;
+
+
+    @BeforeEach
+    public void beforeEach() {
+        remoteJsInvokeService = new RemoteJsInvokeService(null, null);
+        jsRequestTemplate = mock(TbQueueRequestTemplate.class);
+        remoteJsInvokeService.requestTemplate = jsRequestTemplate;
+    }
+
+    @AfterEach
+    public void afterEach() {
+        reset(jsRequestTemplate);
+    }
+
+    @Test
+    public void whenInvokingFunction_thenDoNotSendScriptBody() throws Exception {
+        UUID scriptId = UUID.randomUUID();
+        remoteJsInvokeService.scriptIdToBodysMap.put(scriptId, "scriptscriptscript");
+
+        String expectedInvocationResult = "scriptInvocationResult";
+        doReturn(Futures.immediateFuture(new TbProtoJsQueueMsg<>(UUID.randomUUID(), RemoteJsResponse.newBuilder()
+                .setInvokeResponse(JsInvokeProtos.JsInvokeResponse.newBuilder()
+                        .setSuccess(true)
+                        .setResult(expectedInvocationResult)
+                        .build())
+                .build())))
+                .when(jsRequestTemplate).send(any());
+
+        ArgumentCaptor<TbProtoJsQueueMsg<RemoteJsRequest>> jsRequestCaptor = ArgumentCaptor.forClass(TbProtoJsQueueMsg.class);
+        Object invocationResult = remoteJsInvokeService.doInvokeFunction(scriptId, "f", new Object[]{"a"}).get();
+        verify(jsRequestTemplate).send(jsRequestCaptor.capture());
+
+        JsInvokeProtos.JsInvokeRequest jsInvokeRequestMade = jsRequestCaptor.getValue().getValue().getInvokeRequest();
+        assertThat(jsInvokeRequestMade.getScriptIdLSB()).isEqualTo(scriptId.getLeastSignificantBits());
+        assertThat(jsInvokeRequestMade.getScriptIdMSB()).isEqualTo(scriptId.getMostSignificantBits());
+        assertThat(jsInvokeRequestMade.getScriptBody()).isNullOrEmpty();
+        assertThat(invocationResult).isEqualTo(expectedInvocationResult);
+    }
+
+    @Test
+    public void whenInvokingFunctionAndRemoteJsExecutorRemovedScript_thenHandleNotFoundErrorAndMakeInvokeRequestWithScriptBody() throws Exception {
+        UUID scriptId = UUID.randomUUID();
+        String scriptBody = "scriptscriptscript";
+        remoteJsInvokeService.scriptIdToBodysMap.put(scriptId, scriptBody);
+
+        doReturn(Futures.immediateFuture(new TbProtoJsQueueMsg<>(UUID.randomUUID(), RemoteJsResponse.newBuilder()
+                .setInvokeResponse(JsInvokeProtos.JsInvokeResponse.newBuilder()
+                        .setSuccess(false)
+                        .setErrorCode(JsInvokeProtos.JsInvokeErrorCode.NOT_FOUND_ERROR)
+                        .build())
+                .build())))
+                .when(jsRequestTemplate).send(argThat(jsQueueMsg -> {
+                    return StringUtils.isEmpty(jsQueueMsg.getValue().getInvokeRequest().getScriptBody());
+                }));
+
+        String expectedInvocationResult = "invocationResult";
+        doReturn(Futures.immediateFuture(new TbProtoJsQueueMsg<>(UUID.randomUUID(), RemoteJsResponse.newBuilder()
+                .setInvokeResponse(JsInvokeProtos.JsInvokeResponse.newBuilder()
+                        .setSuccess(true)
+                        .setResult(expectedInvocationResult)
+                        .build())
+                .build())))
+                .when(jsRequestTemplate).send(argThat(jsQueueMsg -> {
+                    return StringUtils.isNotEmpty(jsQueueMsg.getValue().getInvokeRequest().getScriptBody());
+                }));
+
+        ArgumentCaptor<TbProtoJsQueueMsg<RemoteJsRequest>> jsRequestsCaptor = ArgumentCaptor.forClass(TbProtoJsQueueMsg.class);
+        Object invocationResult = remoteJsInvokeService.doInvokeFunction(scriptId, "f", new Object[]{"a"}).get();
+        verify(jsRequestTemplate, times(2)).send(jsRequestsCaptor.capture());
+
+        List<TbProtoJsQueueMsg<RemoteJsRequest>> jsInvokeRequestsMade = jsRequestsCaptor.getAllValues();
+
+        JsInvokeProtos.JsInvokeRequest firstRequestMade = jsInvokeRequestsMade.get(0).getValue().getInvokeRequest();
+        assertThat(firstRequestMade.getScriptBody()).isNullOrEmpty();
+
+        JsInvokeProtos.JsInvokeRequest secondRequestMade = jsInvokeRequestsMade.get(1).getValue().getInvokeRequest();
+        assertThat(secondRequestMade.getScriptBody()).isEqualTo(scriptBody);
+
+        assertThat(invocationResult).isEqualTo(expectedInvocationResult);
+    }
+
+}

--- a/common/cluster-api/src/main/proto/jsinvoke.proto
+++ b/common/cluster-api/src/main/proto/jsinvoke.proto
@@ -41,39 +41,34 @@ message RemoteJsResponse {
 }
 
 message JsCompileRequest {
-  int64 scriptIdMSB = 1;
-  int64 scriptIdLSB = 2;
-  string functionName = 3;
-  string scriptBody = 4;
+  string scriptHash = 1;
+  string functionName = 2;
+  string scriptBody = 3;
 }
 
 message JsReleaseRequest {
-  int64 scriptIdMSB = 1;
-  int64 scriptIdLSB = 2;
-  string functionName = 3;
+  string scriptHash = 1;
+  string functionName = 2;
 }
 
 message JsReleaseResponse {
   bool success = 1;
-  int64 scriptIdMSB = 2;
-  int64 scriptIdLSB = 3;
+  string scriptHash = 2;
 }
 
 message JsCompileResponse {
   bool success = 1;
-  int64 scriptIdMSB = 2;
-  int64 scriptIdLSB = 3;
-  JsInvokeErrorCode errorCode = 4;
-  string errorDetails = 5;
+  string scriptHash = 2;
+  JsInvokeErrorCode errorCode = 3;
+  string errorDetails = 4;
 }
 
 message JsInvokeRequest {
-  int64 scriptIdMSB = 1;
-  int64 scriptIdLSB = 2;
-  string functionName = 3;
-  string scriptBody = 4;
-  int32 timeout = 5;
-  repeated string args = 6;
+  string scriptHash = 1;
+  string functionName = 2;
+  string scriptBody = 3;
+  int32 timeout = 4;
+  repeated string args = 5;
 }
 
 message JsInvokeResponse {
@@ -82,4 +77,3 @@ message JsInvokeResponse {
   JsInvokeErrorCode errorCode = 3;
   string errorDetails = 4;
 }
-

--- a/common/cluster-api/src/main/proto/jsinvoke.proto
+++ b/common/cluster-api/src/main/proto/jsinvoke.proto
@@ -41,34 +41,34 @@ message RemoteJsResponse {
 }
 
 message JsCompileRequest {
-  string scriptHash = 1;
-  string functionName = 2;
-  string scriptBody = 3;
+  string functionName = 3;
+  string scriptBody = 4;
+  string scriptHash = 5;
 }
 
 message JsReleaseRequest {
-  string scriptHash = 1;
-  string functionName = 2;
+  string functionName = 3;
+  string scriptHash = 4;
 }
 
 message JsReleaseResponse {
   bool success = 1;
-  string scriptHash = 2;
+  string scriptHash = 4;
 }
 
 message JsCompileResponse {
   bool success = 1;
-  string scriptHash = 2;
-  JsInvokeErrorCode errorCode = 3;
-  string errorDetails = 4;
+  JsInvokeErrorCode errorCode = 4;
+  string errorDetails = 5;
+  string scriptHash = 6;
 }
 
 message JsInvokeRequest {
-  string scriptHash = 1;
-  string functionName = 2;
-  string scriptBody = 3;
-  int32 timeout = 4;
-  repeated string args = 5;
+  string functionName = 3;
+  string scriptBody = 4;
+  int32 timeout = 5;
+  repeated string args = 6;
+  string scriptHash = 7;
 }
 
 message JsInvokeResponse {

--- a/common/cluster-api/src/main/proto/jsinvoke.proto
+++ b/common/cluster-api/src/main/proto/jsinvoke.proto
@@ -23,6 +23,7 @@ enum JsInvokeErrorCode {
   COMPILATION_ERROR = 0;
   RUNTIME_ERROR = 1;
   TIMEOUT_ERROR = 2;
+  NOT_FOUND_ERROR = 3;
 }
 
 message RemoteJsRequest {

--- a/msa/js-executor/api/jsExecutor.models.ts
+++ b/msa/js-executor/api/jsExecutor.models.ts
@@ -16,8 +16,7 @@
 
 
 export interface TbMessage {
-    scriptIdMSB: string;
-    scriptIdLSB: string;
+    scriptHash: string;
 }
 
 export interface RemoteJsRequest {

--- a/msa/js-executor/api/jsExecutor.models.ts
+++ b/msa/js-executor/api/jsExecutor.models.ts
@@ -16,6 +16,8 @@
 
 
 export interface TbMessage {
+    scriptIdMSB: string; // deprecated
+    scriptIdLSB: string; // deprecated
     scriptHash: string;
 }
 

--- a/msa/js-executor/api/jsInvokeMessageProcessor.ts
+++ b/msa/js-executor/api/jsInvokeMessageProcessor.ts
@@ -18,7 +18,7 @@ import config from 'config';
 import { _logger } from '../config/logger';
 import { JsExecutor, TbScript } from './jsExecutor';
 import { performance } from 'perf_hooks';
-import { isString, parseJsErrorDetails, toUUIDString, UUIDFromBuffer, UUIDToBits } from './utils';
+import { isString, parseJsErrorDetails, toUUIDString, UUIDFromBuffer, UUIDToBits, isNotUUID } from './utils';
 import { IQueue } from '../queue/queue.models';
 import {
     JsCompileRequest,
@@ -176,7 +176,7 @@ export class JsInvokeMessageProcessor {
                             this.logger.debug('[%s] Sending success invoke response, scriptId: [%s]', requestId, scriptId);
                             this.sendResponse(requestId, responseTopic, headers, scriptId, undefined, invokeResponse);
                         } else {
-                            let err = {
+                            const err = {
                                 name: 'Error',
                                 message: 'script invocation result exceeds maximum allowed size of ' + maxResultSize + ' symbols'
                             }
@@ -200,7 +200,7 @@ export class JsInvokeMessageProcessor {
             },
             (err: any) => {
                 let errorCode = COMPILATION_ERROR;
-                if (err && isString(err.name) && err.name.includes('script body not found')) {
+                if (err?.name === 'script body not found') {
                     errorCode = NOT_FOUND_ERROR;
                 }
                 const invokeResponse = JsInvokeMessageProcessor.createInvokeResponse("", false, errorCode, err);
@@ -301,12 +301,26 @@ export class JsInvokeMessageProcessor {
     }
 
     private static createCompileResponse(scriptId: string, success: boolean, errorCode?: number, err?: any): JsCompileResponse {
-        return {
-            errorCode: errorCode,
-            success: success,
-            errorDetails: parseJsErrorDetails(err),
-            scriptHash: scriptId,
-        };
+        if (isNotUUID(scriptId)) {
+            return {
+                errorCode: errorCode,
+                success: success,
+                errorDetails: parseJsErrorDetails(err),
+                scriptIdMSB: "0",
+                scriptIdLSB: "0",
+                scriptHash: scriptId
+            };
+        } else { // this is for backward compatibility (to be able to work with tb-node of previous version) - todo: remove in the next release
+            let scriptIdBits = UUIDToBits(scriptId);
+            return {
+                errorCode: errorCode,
+                success: success,
+                errorDetails: parseJsErrorDetails(err),
+                scriptIdMSB: scriptIdBits[0],
+                scriptIdLSB: scriptIdBits[1],
+                scriptHash: ""
+            };
+        }
     }
 
     private static createInvokeResponse(result: string, success: boolean, errorCode?: number, err?: any): JsInvokeResponse {
@@ -319,14 +333,26 @@ export class JsInvokeMessageProcessor {
     }
 
     private static createReleaseResponse(scriptId: string, success: boolean): JsReleaseResponse {
-        return {
-            success: success,
-            scriptHash: scriptId,
-        };
+        if (isNotUUID(scriptId)) {
+            return {
+                success: success,
+                scriptIdMSB: "0",
+                scriptIdLSB: "0",
+                scriptHash: scriptId,
+            };
+        } else { // todo: remove in the next release
+            let scriptIdBits = UUIDToBits(scriptId);
+            return {
+                success: success,
+                scriptIdMSB: scriptIdBits[0],
+                scriptIdLSB: scriptIdBits[1],
+                scriptHash: ""
+            }
+        }
     }
 
     private static getScriptId(request: TbMessage): string {
-        return request.scriptHash;
+        return request.scriptHash ? request.scriptHash : toUUIDString(request.scriptIdMSB, request.scriptIdLSB);
     }
 
     private incrementUseScriptId(scriptId: string) {

--- a/msa/js-executor/api/utils.ts
+++ b/msa/js-executor/api/utils.ts
@@ -58,3 +58,7 @@ export function parseJsErrorDetails(err: any): string | undefined {
     }
     return details;
 }
+
+export function isNotUUID(candidate: string) {
+    return candidate.length != 36 || !candidate.includes('-');
+}

--- a/msa/js-executor/queue/awsSqsTemplate.ts
+++ b/msa/js-executor/queue/awsSqsTemplate.ts
@@ -123,10 +123,10 @@ export class AwsSqsTemplate implements IQueue {
         this.timer = setTimeout(() => {this.getAndProcessMessage(messageProcessor, params)}, this.pollInterval);
     }
 
-    async send(responseTopic: string, scriptId: string, rawResponse: Buffer, headers: any): Promise<any> {
+    async send(responseTopic: string, msgKey: string, rawResponse: Buffer, headers: any): Promise<any> {
         let msgBody = JSON.stringify(
             {
-                key: scriptId,
+                key: msgKey,
                 data: [...rawResponse],
                 headers: headers
             });

--- a/msa/js-executor/queue/kafkaTemplate.ts
+++ b/msa/js-executor/queue/kafkaTemplate.ts
@@ -149,12 +149,11 @@ export class KafkaTemplate implements IQueue {
         });
 }
 
-    async send(responseTopic: string, scriptId: string, rawResponse: Buffer, headers: any): Promise<any> {
-        this.logger.debug('Pending queue response, scriptId: [%s]', scriptId);
+    async send(responseTopic: string, msgKey: string, rawResponse: Buffer, headers: any): Promise<any> {
         const message = {
             topic: responseTopic,
             messages: [{
-                key: scriptId,
+                key: msgKey,
                 value: rawResponse,
                 headers: headers.data
             }]

--- a/msa/js-executor/queue/pubSubTemplate.ts
+++ b/msa/js-executor/queue/pubSubTemplate.ts
@@ -80,7 +80,7 @@ export class PubSubTemplate implements IQueue {
         subscription.on('message', messageHandler);
     }
 
-    async send(responseTopic: string, scriptId: string, rawResponse: Buffer, headers: any): Promise<any> {
+    async send(responseTopic: string, msgKey: string, rawResponse: Buffer, headers: any): Promise<any> {
         if (!(this.subscriptions.includes(responseTopic) && this.topics.includes(this.requestTopic))) {
             await this.createTopic(this.requestTopic);
             await this.createSubscription(this.requestTopic);
@@ -88,7 +88,7 @@ export class PubSubTemplate implements IQueue {
 
         let data = JSON.stringify(
             {
-                key: scriptId,
+                key: msgKey,
                 data: [...rawResponse],
                 headers: headers
             });

--- a/msa/js-executor/queue/queue.models.ts
+++ b/msa/js-executor/queue/queue.models.ts
@@ -17,6 +17,6 @@
 export interface IQueue {
     name: string;
     init(): Promise<void>;
-    send(responseTopic: string, scriptId: string, rawResponse: Buffer, headers: any): Promise<any>;
+    send(responseTopic: string, msgKey: string, rawResponse: Buffer, headers: any): Promise<any>;
     destroy(): Promise<void>;
 }

--- a/msa/js-executor/queue/rabbitmqTemplate.ts
+++ b/msa/js-executor/queue/rabbitmqTemplate.ts
@@ -65,7 +65,7 @@ export class RabbitMqTemplate implements IQueue {
         })
     }
 
-    async send(responseTopic: string, scriptId: string, rawResponse: Buffer, headers: any): Promise<any> {
+    async send(responseTopic: string, msgKey: string, rawResponse: Buffer, headers: any): Promise<any> {
 
         if (!this.topics.includes(responseTopic)) {
             await this.createQueue(responseTopic);
@@ -74,7 +74,7 @@ export class RabbitMqTemplate implements IQueue {
 
         let data = JSON.stringify(
             {
-                key: scriptId,
+                key: msgKey,
                 data: [...rawResponse],
                 headers: headers
             });

--- a/msa/js-executor/queue/serviceBusTemplate.ts
+++ b/msa/js-executor/queue/serviceBusTemplate.ts
@@ -82,7 +82,7 @@ export class ServiceBusTemplate implements IQueue {
         this.receiver.subscribe({processMessage: messageHandler, processError: errorHandler})
     }
 
-    async send(responseTopic: string, scriptId: string, rawResponse: Buffer, headers: any): Promise<any> {
+    async send(responseTopic: string, msgKey: string, rawResponse: Buffer, headers: any): Promise<any> {
         if (!this.queues.includes(this.requestTopic)) {
             await this.createQueueIfNotExist(this.requestTopic);
             this.queues.push(this.requestTopic);
@@ -96,7 +96,7 @@ export class ServiceBusTemplate implements IQueue {
         }
 
         let data = {
-            key: scriptId,
+            key: msgKey,
             data: [...rawResponse],
             headers: headers
         };


### PR DESCRIPTION
## Pull Request description

Now, when submitting a script invoke request to remote JS executor, script body will not be sent, expecting the executor to have it in its `scriptMap`. In case the script was not in the map , `NOT_FOUND_ERROR` code will be returned, and `RemoteJsInvokeService` in turn will send the same invoke request again (to the same partition) but with the needed script body in it.

Also, migrated from using UUID script id for remote executor to a hash of tenant id and script body. This will reduce the amount of compiled scripts with same body, and also the amount of scripts will not depend on the rule engine instance count.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



