### PR TITLE
[3.4.2] Feature -upgrade protobuf version from 3.17.2 -> 3.21.7, support Mac M1(ARM Core) protobuf files compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <mail.version>1.6.2</mail.version>
         <curator.version>4.2.0</curator.version>
         <zookeeper.version>3.5.5</zookeeper.version>
-        <protobuf.version>3.21.7</protobuf.version>
+        <protobuf.version>3.21.9</protobuf.version>
         <grpc.version>1.42.1</grpc.version>
         <lombok.version>1.18.18</lombok.version>
         <paho.client.version>1.2.4</paho.client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <mail.version>1.6.2</mail.version>
         <curator.version>4.2.0</curator.version>
         <zookeeper.version>3.5.5</zookeeper.version>
-        <protobuf.version>3.17.2</protobuf.version>
+        <protobuf.version>3.21.7</protobuf.version>
         <grpc.version>1.42.1</grpc.version>
         <lombok.version>1.18.18</lombok.version>
         <paho.client.version>1.2.4</paho.client.version>


### PR DESCRIPTION
## Pull Request description

upgrade protobuf version from 3.17.2 -> 3.21.7, support Mac M1(ARM Core) protobuf files compile,
fixed issue #5734

**(3.17.2)older protobuf version don't have protoc-osx-aarch file**  
![image](https://user-images.githubusercontent.com/23117382/196380398-9b8e2c26-8cc3-4113-bc09-51d754008e08.png)

as of version 3.21.7 version, protoc-osx-aarch has been added, and it compiled on my Mac M1 computer。✅
![image](https://user-images.githubusercontent.com/23117382/196380471-b8fbbe3f-e8b0-4027-b378-76c7a1ef552c.png)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
  


