### PR TITLE
[3.4.2] UI: Use row layout on screen bigger than xs size.

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/value-source.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/value-source.component.html
@@ -31,8 +31,8 @@
     <mat-label translate>widgets.value-source.value</mat-label>
     <input matInput type="number" formControlName="value">
   </mat-form-field>
-  <section [fxShow]="valueSourceFormGroup.get('valueSource').value === 'entityAttribute'" fxLayout="column" fxLayout.gt-xs="column"
-           fxLayoutGap.gt-xs="8px" fxLayoutAlign.gt-xs="start center">
+  <section [fxShow]="valueSourceFormGroup.get('valueSource').value === 'entityAttribute'"
+           fxLayout="row" fxLayout.xs="column" fxLayoutGap="8px" fxLayoutAlign="start center">
     <mat-form-field fxFlex class="mat-block">
       <mat-label>{{ 'widgets.value-source.source-entity-alias' | translate }}</mat-label>
       <input matInput type="text" placeholder="{{ 'entity.entity-alias' | translate }}"


### PR DESCRIPTION
Without this PR it is `column` for all screen sizes.