### PR TITLE
[3.4.2] UI: Chart thresholds support array of values

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
@@ -911,8 +911,7 @@ export class TbFlot {
     data.forEach((keyData) => {
       const skip = isLatest && !keyData.dataKey.settings.useAsThreshold;
       if (!skip && keyData && keyData.data && keyData.data[0]) {
-        const value = keyData.data[0][1];
-        const values = Array.isArray(value) ? value : [value];
+        const values = this.parsThresholdData(keyData.data[0][1]);
         values.forEach(v => {
           const threshold = this.processSingleDataValue(v, keyData, keyData.dataKey.settings, existingThresholds, isLatest);
           if (threshold != null) {
@@ -924,7 +923,19 @@ export class TbFlot {
     return thresholds;
   }
 
-  private processSingleDataValue(attrValue: number, keyData: DatasourceData, latestSettings: TbFlotLatestKeySettings, existingThresholds: TbFlotThresholdMarking[], isLatest = false) {
+  private parsThresholdData(value: any): Array<any> {
+    let values;
+    try {
+      const parseData = JSON.parse(value);
+      values = Array.isArray(parseData) ? parseData : [parseData];
+    } catch (e) {
+      values = [value];
+    }
+    return values;
+  }
+
+  private processSingleDataValue(attrValue: number, keyData: DatasourceData, latestSettings: TbFlotLatestKeySettings,
+                                 existingThresholds: TbFlotThresholdMarking[], isLatest = false) {
     if (isNumeric(attrValue) && isFinite(attrValue)) {
       let yaxis: number;
       let lineWidth: number;
@@ -941,7 +952,6 @@ export class TbFlot {
       }
       const colorIndex = this.subscription.data.length + existingThresholds.length;
       return this.generateThreshold(existingThresholds, yaxis, lineWidth, color, colorIndex, attrValue);
-
     }
   }
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
@@ -911,7 +911,7 @@ export class TbFlot {
     data.forEach((keyData) => {
       const skip = isLatest && !keyData.dataKey.settings.useAsThreshold;
       if (!skip && keyData && keyData.data && keyData.data[0]) {
-        const values = this.parsThresholdData(keyData.data[0][1]);
+        const values = this.parseThresholdData(keyData.data[0][1]);
         values.forEach(v => {
           const threshold = this.processSingleDataValue(v, keyData, keyData.dataKey.settings, existingThresholds, isLatest);
           if (threshold != null) {
@@ -923,11 +923,11 @@ export class TbFlot {
     return thresholds;
   }
 
-  private parsThresholdData(value: any): Array<any> {
+  private parseThresholdData(value: any): Array<any> {
     let values;
     try {
-      const parseData = JSON.parse(value);
-      values = Array.isArray(parseData) ? parseData : [parseData];
+      const parsedData = JSON.parse(value);
+      values = Array.isArray(parsedData) ? parsedData : [parsedData];
     } catch (e) {
       values = [value];
     }

--- a/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.ts
@@ -909,39 +909,40 @@ export class TbFlot {
                                        isLatest = false): TbFlotThresholdMarking[] {
     const thresholds: TbFlotThresholdMarking[] = [];
     data.forEach((keyData) => {
-      let skip = false;
-      let latestSettings: TbFlotLatestKeySettings;
-      if (isLatest) {
-        latestSettings = keyData.dataKey.settings;
-        if (!latestSettings.useAsThreshold) {
-          skip = true;
-        }
-      }
+      const skip = isLatest && !keyData.dataKey.settings.useAsThreshold;
       if (!skip && keyData && keyData.data && keyData.data[0]) {
-        const attrValue = keyData.data[0][1];
-        if (isNumeric(attrValue) && isFinite(attrValue)) {
-          let yaxis: number;
-          let lineWidth: number;
-          let color: string;
-          if (isLatest) {
-            yaxis = 1;
-            lineWidth = latestSettings.thresholdLineWidth;
-            color = latestSettings.thresholdColor || keyData.dataKey.color;
-          } else {
-            const settings: TbFlotThresholdKeySettings = keyData.dataKey.settings;
-            yaxis = settings.yaxis;
-            lineWidth = settings.lineWidth;
-            color = settings.color || keyData.dataKey.color;
-          }
-          const colorIndex = this.subscription.data.length + existingThresholds.length;
-          const threshold = this.generateThreshold(existingThresholds, yaxis, lineWidth, color, colorIndex, attrValue);
+        const value = keyData.data[0][1];
+        const values = Array.isArray(value) ? value : [value];
+        values.forEach(v => {
+          const threshold = this.processSingleDataValue(v, keyData, keyData.dataKey.settings, existingThresholds, isLatest);
           if (threshold != null) {
             thresholds.push(threshold);
           }
-        }
+        });
       }
     });
     return thresholds;
+  }
+
+  private processSingleDataValue(attrValue: number, keyData: DatasourceData, latestSettings: TbFlotLatestKeySettings, existingThresholds: TbFlotThresholdMarking[], isLatest = false) {
+    if (isNumeric(attrValue) && isFinite(attrValue)) {
+      let yaxis: number;
+      let lineWidth: number;
+      let color: string;
+      if (isLatest) {
+        yaxis = 1;
+        lineWidth = latestSettings.thresholdLineWidth;
+        color = latestSettings.thresholdColor || keyData.dataKey.color;
+      } else {
+        const settings: TbFlotThresholdKeySettings = keyData.dataKey.settings;
+        yaxis = settings.yaxis;
+        lineWidth = settings.lineWidth;
+        color = settings.color || keyData.dataKey.color;
+      }
+      const colorIndex = this.subscription.data.length + existingThresholds.length;
+      return this.generateThreshold(existingThresholds, yaxis, lineWidth, color, colorIndex, attrValue);
+
+    }
   }
 
   private generateThreshold(existingThresholds: TbFlotThresholdMarking[], yaxis: number, lineWidth: number,


### PR DESCRIPTION
## Pull Request description

With the help of this PR, chart would be able to draw not only single threshold lines but a set of lines based on an array of values provided in the entity attribute.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



