### PR TITLE
[3.4.2] UI: Add API to create telemetry websocket updater in custom widgets

### DIFF
--- a/ui-ngx/src/app/core/services/utils.service.ts
+++ b/ui-ngx/src/app/core/services/utils.service.ts
@@ -43,6 +43,15 @@ import { WidgetInfo } from '@home/models/widget-component.models';
 import jsonSchemaDefaults from 'json-schema-defaults';
 import materialIconsCodepoints from '!raw-loader!./material-icons-codepoints.raw';
 import { Observable, of, ReplaySubject } from 'rxjs';
+import { publishReplay, refCount } from 'rxjs/operators';
+import { WidgetContext } from '@app/modules/home/models/widget-component.models';
+import {
+  AttributeData,
+  TelemetrySubscriber,
+  TelemetryType,
+  LatestTelemetry
+} from '@shared/models/telemetry/telemetry.models';
+import { EntityId } from '@shared/models/id/entity-id';
 
 const i18nRegExp = new RegExp(`{${i18nPrefix}:[^{}]+}`, 'g');
 
@@ -478,5 +487,35 @@ export class UtilsService {
     } else {
       return defaultValue;
     }
+  }
+
+  public getEntityIdFromDatasource(dataSource: Datasource): EntityId {
+    return {id: dataSource.entityId, entityType: dataSource.entityType};
+  }
+
+  public createTelemetrySubscriber(ctx: WidgetContext,
+                                   entityId?: EntityId,
+                                   type: TelemetryType = LatestTelemetry.LATEST_TELEMETRY,
+                                   keys: string[] = null): TelemetrySubscriber {
+    if (!entityId && ctx.datasources.length > 0) {
+      entityId = this.getEntityIdFromDatasource(ctx.datasources[0]);
+    }
+    return TelemetrySubscriber.createEntityAttributesSubscription(ctx.telemetryWsService, entityId, type, ctx.ngZone, keys);
+  }
+
+  public subscribeToEntityTelemetry(ctx: WidgetContext,
+                                    entityId?: EntityId,
+                                    type: TelemetryType = LatestTelemetry.LATEST_TELEMETRY,
+                                    keys: string[] = null): Observable<Array<AttributeData>> {
+    const subscription = this.createTelemetrySubscriber(ctx, entityId, type, keys);
+    if (!ctx.telemetrySubscribers) {
+      ctx.telemetrySubscribers = [];
+    }
+    ctx.telemetrySubscribers.push(subscription);
+    subscription.subscribe();
+    return subscription.attributeData$().pipe(
+      publishReplay(1),
+      refCount()
+    );
   }
 }

--- a/ui-ngx/src/app/core/services/utils.service.ts
+++ b/ui-ngx/src/app/core/services/utils.service.ts
@@ -47,9 +47,9 @@ import { publishReplay, refCount } from 'rxjs/operators';
 import { WidgetContext } from '@app/modules/home/models/widget-component.models';
 import {
   AttributeData,
+  LatestTelemetry,
   TelemetrySubscriber,
-  TelemetryType,
-  LatestTelemetry
+  TelemetryType
 } from '@shared/models/telemetry/telemetry.models';
 import { EntityId } from '@shared/models/id/entity-id';
 
@@ -489,25 +489,18 @@ export class UtilsService {
     }
   }
 
-  public getEntityIdFromDatasource(dataSource: Datasource): EntityId {
+  private getEntityIdFromDatasource(dataSource: Datasource): EntityId {
     return {id: dataSource.entityId, entityType: dataSource.entityType};
-  }
-
-  public createTelemetrySubscriber(ctx: WidgetContext,
-                                   entityId?: EntityId,
-                                   type: TelemetryType = LatestTelemetry.LATEST_TELEMETRY,
-                                   keys: string[] = null): TelemetrySubscriber {
-    if (!entityId && ctx.datasources.length > 0) {
-      entityId = this.getEntityIdFromDatasource(ctx.datasources[0]);
-    }
-    return TelemetrySubscriber.createEntityAttributesSubscription(ctx.telemetryWsService, entityId, type, ctx.ngZone, keys);
   }
 
   public subscribeToEntityTelemetry(ctx: WidgetContext,
                                     entityId?: EntityId,
                                     type: TelemetryType = LatestTelemetry.LATEST_TELEMETRY,
                                     keys: string[] = null): Observable<Array<AttributeData>> {
-    const subscription = this.createTelemetrySubscriber(ctx, entityId, type, keys);
+    if (!entityId && ctx.datasources.length > 0) {
+      entityId = this.getEntityIdFromDatasource(ctx.datasources[0]);
+    }
+    const subscription = TelemetrySubscriber.createEntityAttributesSubscription(ctx.telemetryWsService, entityId, type, ctx.ngZone, keys);
     if (!ctx.telemetrySubscribers) {
       ctx.telemetrySubscribers = [];
     }

--- a/ui-ngx/src/app/modules/home/components/widget/dynamic-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/dynamic-widget.component.ts
@@ -40,6 +40,7 @@ import { AuthService } from '@core/auth/auth.service';
 import { DialogService } from '@core/services/dialog.service';
 import { CustomDialogService } from '@home/components/widget/dialog/custom-dialog.service';
 import { ResourceService } from '@core/http/resource.service';
+import { TelemetryWebsocketService } from '@core/ws/telemetry-websocket.service';
 import { DatePipe } from '@angular/common';
 import { TranslateService } from '@ngx-translate/core';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -80,6 +81,7 @@ export class DynamicWidgetComponent extends PageComponent implements IDynamicWid
     this.ctx.dialogs = $injector.get(DialogService);
     this.ctx.customDialog = $injector.get(CustomDialogService);
     this.ctx.resourceService = $injector.get(ResourceService);
+    this.ctx.telemetryWsService = $injector.get(TelemetryWebsocketService);
     this.ctx.date = $injector.get(DatePipe);
     this.ctx.translate = $injector.get(TranslateService);
     this.ctx.http = $injector.get(HttpClient);
@@ -100,7 +102,9 @@ export class DynamicWidgetComponent extends PageComponent implements IDynamicWid
   }
 
   ngOnDestroy(): void {
-
+    if (this.ctx.telemetrySubscribers) {
+      this.ctx.telemetrySubscribers.forEach(item =>  item.unsubscribe());
+    }
   }
 
   clearRpcError() {

--- a/ui-ngx/src/app/modules/home/models/services.map.ts
+++ b/ui-ngx/src/app/modules/home/models/services.map.ts
@@ -39,6 +39,7 @@ import { OtaPackageService } from '@core/http/ota-package.service';
 import { AuthService } from '@core/auth/auth.service';
 import { ResourceService } from '@core/http/resource.service';
 import { TwoFactorAuthenticationService } from '@core/http/two-factor-authentication.service';
+import { TelemetryWebsocketService } from '@core/ws/telemetry-websocket.service';
 
 export const ServicesMap = new Map<string, Type<any>>(
   [
@@ -65,6 +66,7 @@ export const ServicesMap = new Map<string, Type<any>>(
    ['otaPackageService', OtaPackageService],
    ['authService', AuthService],
    ['resourceService', ResourceService],
-   ['twoFactorAuthenticationService', TwoFactorAuthenticationService]
+   ['twoFactorAuthenticationService', TwoFactorAuthenticationService],
+   ['telemetryWsService', TelemetryWebsocketService]
   ]
 );

--- a/ui-ngx/src/app/modules/home/models/widget-component.models.ts
+++ b/ui-ngx/src/app/modules/home/models/widget-component.models.ts
@@ -75,6 +75,7 @@ import { DialogService } from '@core/services/dialog.service';
 import { CustomDialogService } from '@home/components/widget/dialog/custom-dialog.service';
 import { AuthService } from '@core/auth/auth.service';
 import { ResourceService } from '@core/http/resource.service';
+import { TelemetryWebsocketService } from '@core/ws/telemetry-websocket.service';
 import { DatePipe } from '@angular/common';
 import { TranslateService } from '@ngx-translate/core';
 import { PageLink, TimePageLink } from '@shared/models/page/page-link';
@@ -87,6 +88,7 @@ import * as RxJSOperators from 'rxjs/operators';
 import { TbPopoverComponent } from '@shared/components/popover.component';
 import { EntityId } from '@shared/models/id/entity-id';
 import { AlarmQuery, AlarmSearchStatus, AlarmStatus} from '@app/shared/models/alarm.models';
+import { TelemetrySubscriber } from '@app/shared/public-api';
 
 export interface IWidgetAction {
   name: string;
@@ -177,6 +179,8 @@ export class WidgetContext {
   dialogs: DialogService;
   customDialog: CustomDialogService;
   resourceService: ResourceService;
+  telemetryWsService: TelemetryWebsocketService;
+  telemetrySubscribers?: TelemetrySubscriber[];
   date: DatePipe;
   translate: TranslateService;
   http: HttpClient;

--- a/ui-ngx/src/app/shared/components/phone-input.component.ts
+++ b/ui-ngx/src/app/shared/components/phone-input.component.ts
@@ -97,8 +97,9 @@ export class PhoneInputComponent implements OnInit, ControlValueAccessor, Valida
       if (this.defaultCountry) {
         this.getFlagAndPhoneNumberData(this.defaultCountry);
       }
-      if (this.phoneFormGroup) {
-        this.defineCountryFromNumber(this.phoneFormGroup.get('phoneNumber').value);
+      if (this.phoneFormGroup && this.phoneFormGroup.get('phoneNumber').value) {
+        const parsedPhoneNumber = this.parsePhoneNumberFromString(this.phoneFormGroup.get('phoneNumber').value);
+        this.defineCountryFromNumber(parsedPhoneNumber);
       }
     }
   }
@@ -110,7 +111,7 @@ export class PhoneInputComponent implements OnInit, ControlValueAccessor, Valida
   private countryCallingCode = '+';
   private modelValue: string;
   private changeSubscriptions: Subscription[] = [];
-  private validators: ValidatorFn[] = [(c: FormControl) => Validators.pattern(this.getPhoneNumberPattern())(c), this.validatePhoneNumber()];
+  private validators: ValidatorFn[] = [this.validatePhoneNumber()];
 
   private propagateChange = (v: any) => { };
 
@@ -133,8 +134,12 @@ export class PhoneInputComponent implements OnInit, ControlValueAccessor, Valida
     });
 
     this.changeSubscriptions.push(this.phoneFormGroup.get('phoneNumber').valueChanges.subscribe(value => {
-      this.updateModel();
-      this.defineCountryFromNumber(value);
+      let parsedPhoneNumber = null;
+      if (value && this.parsePhoneNumberFromString) {
+        parsedPhoneNumber = this.parsePhoneNumberFromString(value);
+        this.defineCountryFromNumber(parsedPhoneNumber);
+      }
+      this.updateModel(parsedPhoneNumber);
     }));
 
     this.changeSubscriptions.push(this.phoneFormGroup.get('country').valueChanges.subscribe(value => {
@@ -184,6 +189,10 @@ export class PhoneInputComponent implements OnInit, ControlValueAccessor, Valida
     return String.fromCodePoint(...countryCode.split('').map(country => this.baseCode + country.charCodeAt(0)));
   }
 
+  private updateModelValueInFormat(parsedPhoneNumber: any) {
+    this.modelValue = parsedPhoneNumber.format('E.164');
+  }
+
   validatePhoneNumber(): ValidatorFn {
     return (c: FormControl) => {
       const phoneNumber = c.value;
@@ -201,18 +210,11 @@ export class PhoneInputComponent implements OnInit, ControlValueAccessor, Valida
     };
   }
 
-  private defineCountryFromNumber(phoneNumber) {
-    if (phoneNumber && this.parsePhoneNumberFromString) {
-      const parsedPhoneNumber = this.parsePhoneNumberFromString(phoneNumber);
-      const country = this.phoneFormGroup.get('country').value;
-      if (parsedPhoneNumber?.country && parsedPhoneNumber?.country !== country) {
-        this.phoneFormGroup.get('country').patchValue(parsedPhoneNumber.country, {emitEvent: true});
-      }
+  private defineCountryFromNumber(parsedPhoneNumber) {
+    const country = this.phoneFormGroup.get('country').value;
+    if (parsedPhoneNumber?.country && parsedPhoneNumber?.country !== country) {
+      this.phoneFormGroup.get('country').patchValue(parsedPhoneNumber.country, {emitEvent: true});
     }
-  }
-
-  private getPhoneNumberPattern(): RegExp {
-    return new RegExp(`^${this.countryCallingCode.replace('+', '\\+')}$|^\\+[1-9]\\d{1,14}$`);
   }
 
   validate(): ValidationErrors | null {
@@ -247,6 +249,8 @@ export class PhoneInputComponent implements OnInit, ControlValueAccessor, Valida
       if (phoneNumber) {
         const parsedPhoneNumber = this.parsePhoneNumberFromString(phoneNumber);
         if (parsedPhoneNumber?.isValid() && parsedPhoneNumber?.isPossible()) {
+          country = parsedPhoneNumber?.country || this.defaultCountry;
+          this.updateModelValueInFormat(parsedPhoneNumber);
           this.isLegacy = false;
         } else {
           const validators = [Validators.maxLength(255)];
@@ -260,18 +264,19 @@ export class PhoneInputComponent implements OnInit, ControlValueAccessor, Valida
         this.isLegacy = false;
       }
       this.phoneFormGroup.updateValueAndValidity({emitEvent: false});
-      country = phoneNumber ? this.parsePhoneNumberFromString(phoneNumber)?.country || this.defaultCountry : this.defaultCountry;
       this.getFlagAndPhoneNumberData(country);
     }
     this.phoneFormGroup.reset({phoneNumber, country}, {emitEvent: false});
   }
 
-  private updateModel() {
+  private updateModel(parsedPhoneNumber?) {
     const phoneNumber = this.phoneFormGroup.get('phoneNumber');
     if (phoneNumber.value === '+' || phoneNumber.value === this.countryCallingCode) {
       this.propagateChange(null);
     } else if (phoneNumber.valid) {
-      this.modelValue = phoneNumber.value;
+      if (parsedPhoneNumber) {
+        this.updateModelValueInFormat(parsedPhoneNumber);
+      }
       this.propagateChange(this.modelValue);
     } else {
       this.propagateChange(null);


### PR DESCRIPTION
## Pull Request description

Description of problem is in #7258

With this PR I would receive continuous updates  in my custom widgets from all timeseries data keys without explicitly specifying them in widget configuration:
```
self.onInit = function() {
    let utils = self.ctx.$scope.$injector.get(self.ctx.servicesMap.get('utils'));

    utils.subscribeToEntityTelemetry(self.ctx).subscribe(
        data => console.log('Data: ', data),
        error => console.log('Error: ', error));
}
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



