### PR TITLE
[3.4.2] inactivity timeout fix

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -83,6 +84,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -152,6 +154,7 @@ public class DefaultDeviceStateService extends AbstractPartitionBasedService<Dev
 
     @Value("${state.defaultInactivityTimeoutInSec}")
     @Getter
+    @Setter
     private long defaultInactivityTimeoutInSec;
 
     @Value("${state.defaultStateCheckIntervalInSec}")
@@ -160,6 +163,7 @@ public class DefaultDeviceStateService extends AbstractPartitionBasedService<Dev
 
     @Value("${state.persistToTelemetry:false}")
     @Getter
+    @Setter
     private boolean persistToTelemetry;
 
     @Value("${state.initFetchPackSize:50000}")
@@ -634,7 +638,7 @@ public class DefaultDeviceStateService extends AbstractPartitionBasedService<Dev
 
     }
 
-    private DeviceStateData toDeviceStateData(EntityData ed, DeviceIdInfo deviceIdInfo) {
+    DeviceStateData toDeviceStateData(EntityData ed, DeviceIdInfo deviceIdInfo) {
         long lastActivityTime = getEntryValue(ed, getKeyType(), LAST_ACTIVITY_TIME, 0L);
         long inactivityAlarmTime = getEntryValue(ed, getKeyType(), INACTIVITY_ALARM_TIME, 0L);
         long inactivityTimeout = getEntryValue(ed, getKeyType(), INACTIVITY_TIMEOUT, TimeUnit.SECONDS.toMillis(defaultInactivityTimeoutInSec));
@@ -651,13 +655,32 @@ public class DefaultDeviceStateService extends AbstractPartitionBasedService<Dev
         TbMsgMetaData md = new TbMsgMetaData();
         md.putValue("deviceName", getEntryValue(ed, EntityKeyType.ENTITY_FIELD, "name", ""));
         md.putValue("deviceType", getEntryValue(ed, EntityKeyType.ENTITY_FIELD, "type", ""));
-        return DeviceStateData.builder()
+        DeviceStateData deviceStateData = DeviceStateData.builder()
                 .customerId(deviceIdInfo.getCustomerId())
                 .tenantId(deviceIdInfo.getTenantId())
                 .deviceId(deviceIdInfo.getDeviceId())
                 .deviceCreationTime(getEntryValue(ed, EntityKeyType.ENTITY_FIELD, "createdTime", 0L))
                 .metaData(md)
                 .state(deviceState).build();
+        transformInactivityTimeout(deviceStateData);
+        return deviceStateData;
+    }
+
+    private void transformInactivityTimeout(DeviceStateData deviceStateData) {
+        if (persistToTelemetry && deviceStateData.getState().getInactivityTimeout() == TimeUnit.SECONDS.toMillis(defaultInactivityTimeoutInSec)) {
+            log.trace("[{}] default value for inactivity timeout fetched {}, going to fetch inactivity timeout from attributes",
+                    deviceStateData.getDeviceId(), deviceStateData.getState().getInactivityTimeout());
+            try {
+                Optional<AttributeKvEntry> attributeOpt = attributesService.find(TenantId.SYS_TENANT_ID, deviceStateData.getDeviceId(), SERVER_SCOPE, INACTIVITY_TIMEOUT).get();
+                attributeOpt.flatMap(KvEntry::getLongValue).ifPresent((inactivityTimeout) -> {
+                    if (inactivityTimeout > 0) {
+                        deviceStateData.getState().setInactivityTimeout(inactivityTimeout);
+                    }
+                });
+            } catch (Exception e) {
+                log.warn("[{}] Failed to fetch inactivity timeout from attribute", deviceStateData.getDeviceId(), e);
+            }
+        }
     }
 
     private EntityKeyType getKeyType() {

--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -158,6 +158,8 @@ public class DefaultDeviceStateService extends AbstractPartitionBasedService<Dev
     private long defaultInactivityTimeoutInSec;
 
     @Value("#{${state.defaultInactivityTimeoutInSec} * 1000}")
+    @Getter
+    @Setter
     private long defaultInactivityTimeoutMs;
 
     @Value("${state.defaultStateCheckIntervalInSec}")

--- a/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
@@ -15,27 +15,45 @@
  */
 package org.thingsboard.server.service.state;
 
+import com.google.common.util.concurrent.Futures;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.thingsboard.server.cluster.TbClusterService;
+import org.thingsboard.server.common.data.DeviceIdInfo;
 import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.BaseAttributeKvEntry;
+import org.thingsboard.server.common.data.kv.LongDataEntry;
+import org.thingsboard.server.common.data.query.EntityData;
+import org.thingsboard.server.common.data.query.EntityKeyType;
+import org.thingsboard.server.common.data.query.TsValue;
 import org.thingsboard.server.dao.attributes.AttributesService;
 import org.thingsboard.server.dao.device.DeviceService;
 import org.thingsboard.server.dao.tenant.TenantService;
 import org.thingsboard.server.dao.timeseries.TimeseriesService;
 import org.thingsboard.server.queue.discovery.PartitionService;
-import org.thingsboard.server.cluster.TbClusterService;
 import org.thingsboard.server.queue.discovery.TbServiceInfoProvider;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.thingsboard.server.common.data.DataConstants.SERVER_SCOPE;
+import static org.thingsboard.server.service.state.DefaultDeviceStateService.INACTIVITY_TIMEOUT;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultDeviceStateServiceTest {
@@ -81,6 +99,27 @@ public class DefaultDeviceStateServiceTest {
         DeviceStateData deviceStateData = service.getOrFetchDeviceStateData(deviceId);
         assertThat(deviceStateData, is(deviceStateDataMock));
         Mockito.verify(service, times(1)).fetchDeviceStateDataUsingEntityDataQuery(deviceId);
+    }
+
+    @Test
+    public void givenPersistToTelemetryAndDefaultInactivityTimeoutFetched_whenTransformingToDeviceStateData_thenTryGetInactivityFromAttribute() {
+        var defaultInactivityTimeoutInSec = 60L;
+        service.setDefaultInactivityTimeoutInSec(defaultInactivityTimeoutInSec);
+        service.setPersistToTelemetry(true);
+
+        var deviceUuid = UUID.randomUUID();
+        var deviceId = new DeviceId(deviceUuid);
+
+        when(attributesService.find(any(), any(), anyString(), anyString()))
+                .thenReturn(Futures.immediateFuture(Optional.of(new BaseAttributeKvEntry(0, new LongDataEntry(INACTIVITY_TIMEOUT, 5000L)))));
+
+        var latest =
+                Map.of(EntityKeyType.TIME_SERIES, Map.of(INACTIVITY_TIMEOUT, new TsValue(0, Long.toString(defaultInactivityTimeoutInSec * 1000))));
+        DeviceStateData deviceStateData = service.toDeviceStateData(new EntityData(deviceId, latest, Map.of()), new DeviceIdInfo(TenantId.SYS_TENANT_ID.getId(), UUID.randomUUID(), deviceUuid));
+
+        Mockito.verify(attributesService, times(1)).find(TenantId.SYS_TENANT_ID, deviceId, SERVER_SCOPE, INACTIVITY_TIMEOUT);
+
+        Assert.assertEquals(5000L, deviceStateData.getState().getInactivityTimeout());
     }
 
 }

--- a/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
@@ -118,6 +118,7 @@ public class DefaultDeviceStateServiceTest {
 
     private void process(Map<EntityKeyType, Map<String, TsValue>> latest, long defaultInactivityTimeoutInSec) {
         service.setDefaultInactivityTimeoutInSec(defaultInactivityTimeoutInSec);
+        service.setDefaultInactivityTimeoutMs(defaultInactivityTimeoutInSec * 1000);
         service.setPersistToTelemetry(true);
 
         var deviceUuid = UUID.randomUUID();

--- a/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
@@ -15,7 +15,6 @@
  */
 package org.thingsboard.server.service.state;
 
-import com.google.common.util.concurrent.Futures;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,8 +26,6 @@ import org.thingsboard.server.cluster.TbClusterService;
 import org.thingsboard.server.common.data.DeviceIdInfo;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.TenantId;
-import org.thingsboard.server.common.data.kv.BaseAttributeKvEntry;
-import org.thingsboard.server.common.data.kv.LongDataEntry;
 import org.thingsboard.server.common.data.query.EntityData;
 import org.thingsboard.server.common.data.query.EntityKeyType;
 import org.thingsboard.server.common.data.query.TsValue;
@@ -40,19 +37,14 @@ import org.thingsboard.server.queue.discovery.PartitionService;
 import org.thingsboard.server.queue.discovery.TbServiceInfoProvider;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
-import static org.thingsboard.server.common.data.DataConstants.SERVER_SCOPE;
 import static org.thingsboard.server.service.state.DefaultDeviceStateService.INACTIVITY_TIMEOUT;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -104,20 +96,34 @@ public class DefaultDeviceStateServiceTest {
     @Test
     public void givenPersistToTelemetryAndDefaultInactivityTimeoutFetched_whenTransformingToDeviceStateData_thenTryGetInactivityFromAttribute() {
         var defaultInactivityTimeoutInSec = 60L;
+        var latest =
+                Map.of(
+                        EntityKeyType.TIME_SERIES, Map.of(INACTIVITY_TIMEOUT, new TsValue(0, Long.toString(defaultInactivityTimeoutInSec * 1000))),
+                        EntityKeyType.SERVER_ATTRIBUTE, Map.of(INACTIVITY_TIMEOUT, new TsValue(0, Long.toString(5000L)))
+                );
+
+        process(latest, defaultInactivityTimeoutInSec);
+    }
+
+    @Test
+    public void givenPersistToTelemetryAndNoInactivityTimeoutFetchedFromTimeSeries_whenTransformingToDeviceStateData_thenTryGetInactivityFromAttribute() {
+        var defaultInactivityTimeoutInSec = 60L;
+        var latest =
+                Map.of(
+                        EntityKeyType.SERVER_ATTRIBUTE, Map.of(INACTIVITY_TIMEOUT, new TsValue(0, Long.toString(5000L)))
+                );
+
+        process(latest, defaultInactivityTimeoutInSec);
+    }
+
+    private void process(Map<EntityKeyType, Map<String, TsValue>> latest, long defaultInactivityTimeoutInSec) {
         service.setDefaultInactivityTimeoutInSec(defaultInactivityTimeoutInSec);
         service.setPersistToTelemetry(true);
 
         var deviceUuid = UUID.randomUUID();
         var deviceId = new DeviceId(deviceUuid);
 
-        when(attributesService.find(any(), any(), anyString(), anyString()))
-                .thenReturn(Futures.immediateFuture(Optional.of(new BaseAttributeKvEntry(0, new LongDataEntry(INACTIVITY_TIMEOUT, 5000L)))));
-
-        var latest =
-                Map.of(EntityKeyType.TIME_SERIES, Map.of(INACTIVITY_TIMEOUT, new TsValue(0, Long.toString(defaultInactivityTimeoutInSec * 1000))));
         DeviceStateData deviceStateData = service.toDeviceStateData(new EntityData(deviceId, latest, Map.of()), new DeviceIdInfo(TenantId.SYS_TENANT_ID.getId(), UUID.randomUUID(), deviceUuid));
-
-        Mockito.verify(attributesService, times(1)).find(TenantId.SYS_TENANT_ID, deviceId, SERVER_SCOPE, INACTIVITY_TIMEOUT);
 
         Assert.assertEquals(5000L, deviceStateData.getState().getInactivityTimeout());
     }


### PR DESCRIPTION
## Pull Request description

Fix logic for inactivity timeout fetching to be in sync when **fetchDeviceStateDataUsingEntityDataQuery** is used on method **onAddedPartitions** execution.

Issue: https://github.com/thingsboard/thingsboard/issues/7545

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



