### PR TITLE
[3.4.2] Fix Cassandra prepared statement produces NullPointerException in some case

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDao.java
@@ -643,9 +643,9 @@ public class CassandraBaseTimeseriesDao extends AbstractCassandraBaseTimeseriesD
             stmtCreationLock.lock();
             try {
                 if (saveStmts == null) {
-                    saveStmts = new PreparedStatement[DataType.values().length];
+                    var stmts = new PreparedStatement[DataType.values().length];
                     for (DataType type : DataType.values()) {
-                        saveStmts[type.ordinal()] = prepare(INSERT_INTO + ModelConstants.TS_KV_CF +
+                        stmts[type.ordinal()] = prepare(INSERT_INTO + ModelConstants.TS_KV_CF +
                                 "(" + ModelConstants.ENTITY_TYPE_COLUMN +
                                 "," + ModelConstants.ENTITY_ID_COLUMN +
                                 "," + ModelConstants.KEY_COLUMN +
@@ -654,6 +654,7 @@ public class CassandraBaseTimeseriesDao extends AbstractCassandraBaseTimeseriesD
                                 "," + getColumnName(type) + ")" +
                                 " VALUES(?, ?, ?, ?, ?, ?)");
                     }
+                    saveStmts = stmts;
                 }
             } finally {
                 stmtCreationLock.unlock();
@@ -667,9 +668,9 @@ public class CassandraBaseTimeseriesDao extends AbstractCassandraBaseTimeseriesD
             stmtCreationLock.lock();
             try {
                 if (saveTtlStmts == null) {
-                    saveTtlStmts = new PreparedStatement[DataType.values().length];
+                    var stmts = new PreparedStatement[DataType.values().length];
                     for (DataType type : DataType.values()) {
-                        saveTtlStmts[type.ordinal()] = prepare(INSERT_INTO + ModelConstants.TS_KV_CF +
+                        stmts[type.ordinal()] = prepare(INSERT_INTO + ModelConstants.TS_KV_CF +
                                 "(" + ModelConstants.ENTITY_TYPE_COLUMN +
                                 "," + ModelConstants.ENTITY_ID_COLUMN +
                                 "," + ModelConstants.KEY_COLUMN +
@@ -678,6 +679,7 @@ public class CassandraBaseTimeseriesDao extends AbstractCassandraBaseTimeseriesD
                                 "," + getColumnName(type) + ")" +
                                 " VALUES(?, ?, ?, ?, ?, ?) USING TTL ?");
                     }
+                    saveTtlStmts = stmts;
                 }
             } finally {
                 stmtCreationLock.unlock();


### PR DESCRIPTION
## Fix Cassandra prepared statement produces NullPointerException in some case

Issue: https://github.com/thingsboard/thingsboard/issues/7551 
PE: https://github.com/thingsboard/thingsboard-pe/pull/1244

Simply build (assign) prepared statements array atomically

Tests OK:
![image](https://user-images.githubusercontent.com/79898499/199980222-43397845-77d5-409f-a03d-3233814ff8df.png)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



