### PR TITLE
[3.4.2] js-executor - improved lifecycle events and added kill for crash event

### DIFF
--- a/msa/js-executor/queue/kafkaTemplate.ts
+++ b/msa/js-executor/queue/kafkaTemplate.ts
@@ -30,6 +30,8 @@ import {
     TopicMessages
 } from 'kafkajs';
 
+import process, { kill, exit } from 'process';
+
 export class KafkaTemplate implements IQueue {
 
     private logger = _logger(`kafkaTemplate`);
@@ -122,6 +124,7 @@ export class KafkaTemplate implements IQueue {
             this.logger.error(`Got consumer CRASH event, should restart: ${e.payload.restart}`);
             if (!e.payload.restart) {
                 this.logger.error('Going to exit due to not retryable error!');
+                kill(process.pid, 'SIGTERM'); //sending signal to myself process to trigger the handler
                 await this.destroy();
             }
         });
@@ -253,6 +256,7 @@ export class KafkaTemplate implements IQueue {
             }
         }
         this.logger.info('Kafka resources stopped.');
+        exit(0); //same as in version before
     }
 
     private async disconnectProducer(): Promise<void> {

--- a/msa/js-executor/server.ts
+++ b/msa/js-executor/server.ts
@@ -81,15 +81,19 @@ process.on('exit', (code: number) => {
 
 async function exit(status: number) {
     logger.info('Exiting with status: %d ...', status);
-    if (httpServer) {
-        const _httpServer = httpServer;
-        httpServer = null;
-        await _httpServer.stop();
-    }
-    if (queues) {
-        const _queues = queues;
-        queues = null;
-        await _queues.destroy();
+    try {
+        if (httpServer) {
+            const _httpServer = httpServer;
+            httpServer = null;
+            await _httpServer.stop();
+        }
+        if (queues) {
+            const _queues = queues;
+            queues = null;
+            await _queues.destroy();
+        }
+    } catch (e) {
+        logger.error('Error on exit');
     }
     process.exit(status);
 }


### PR DESCRIPTION
## js-executor - improved lifecycle events and added kill for crash event

This is a quick fix for the situationthe  when js-executor node stops KafkaClient, but does not exit the main process.

The symptom may looks like a very uneven distribution of CPU load through the js-executors pods. And eventually the rule engine will end up with a lot of timeouts.

The fix is brutal but works fine for about 10 days with js-executors restarts when needed.

This PR needs to be improved by the very expert on node.js

The Grafana dashboard on JS-executors may looks like
![image](https://user-images.githubusercontent.com/79898499/200024637-88962b05-09e6-4e01-83dc-6f55d6c440f7.png)

You also may see no new logs for some time. Or see some weird errors like
```
2022-09-22 16:32:54,771 [kafkaTemplate] ERROR: Failed batch send to kafka, length: [3396], pending to reprocess msgs
2022-09-22 16:32:54,771 [kafkaTemplate] ERROR: TypeError: Cannot read properties of undefined (reading 'sendBatch')
    at KafkaTemplate.<anonymous> (/usr/share/tb-js-executor/queue/kafkaTemplate.js:177:41)
    at Generator.next (<anonymous>)
    at /usr/share/tb-js-executor/queue/kafkaTemplate.js:38:71
    at new Promise (<anonymous>)
    at __awaiter (/usr/share/tb-js-executor/queue/kafkaTemplate.js:34:12)
    at KafkaTemplate.sendMessagesAsBatch (/usr/share/tb-js-executor/queue/kafkaTemplate.js:168:16)
    at KafkaTemplate.<anonymous> (/usr/share/tb-js-executor/queue/kafkaTemplate.js:220:24)
    at Generator.next (<anonymous>)
    at /usr/share/tb-js-executor/queue/kafkaTemplate.js:38:71
    at new Promise (<anonymous>)
```
But the pods did not restarts

![image](https://user-images.githubusercontent.com/79898499/200026491-08a8c91a-a9a9-4d92-933f-d9ffd3007f7c.png)


After the fix, the distribution has to be even.

![image](https://user-images.githubusercontent.com/79898499/200025810-f5d02aaa-1320-4f3c-b350-8093fb2a10d7.png)



## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



