### PR TITLE
[3.4.2] Improve db calls stats printing

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/aspect/SqlDaoCallsAspect.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/aspect/SqlDaoCallsAspect.java
@@ -105,9 +105,6 @@ public class SqlDaoCallsAspect {
                 logTopNTenants(snapshots, Comparator.comparingInt(DbCallStatsSnapshot::getTotalFailure).reversed(), 10,
                         s -> logSnapshot(s, 10, Comparator.comparing(MethodCallStatsSnapshot::getFailures).reversed(), "failures", log::debug));
             } else if (log.isInfoEnabled()) {
-                log.info("Total calls statistics below:");
-                logTopNTenants(snapshots, Comparator.comparingInt(DbCallStatsSnapshot::getTotalCalls).reversed(), 3,
-                        s -> logSnapshot(s, 3, Comparator.comparing(MethodCallStatsSnapshot::getExecutions).reversed(), "executions", log::info));
                 log.info("Total timing statistics below:");
                 logTopNTenants(snapshots, Comparator.comparingLong(DbCallStatsSnapshot::getTotalTiming).reversed(), 3,
                         s -> logSnapshot(s, 3, Comparator.comparing(MethodCallStatsSnapshot::getTiming).reversed(), "timing", log::info));


### PR DESCRIPTION
## Pull Request description

Now, for `INFO` logging level, top **by timing** is printed, instead of top by failures.

Stats example for `INFO` logging level:
```
 Total timing statistics below:
 [ea076010-3d85-11ed-9200-77fc04fa14fa]: calls: 81, failures: 0, exec time: 284 
 [ea076010-3d85-11ed-9200-77fc04fa14fa] Top 3 methods by timing:
 [ea076010-3d85-11ed-9200-77fc04fa14fa]: method: JpaAbstractDao.findById(..), calls: 61, failures: 0, exec time: 180
 [ea076010-3d85-11ed-9200-77fc04fa14fa]: method: JpaRelationDao.findAllByFrom(..), calls: 2, failures: 0, exec time: 24
 [ea076010-3d85-11ed-9200-77fc04fa14fa]: method: JpaDeviceDao.findDeviceInfosByTenantId(..), calls: 1, failures: 0, exec time: 20
 [b7d45a20-3e26-11ed-9a91-2129c969dba6]: calls: 39, failures: 0, exec time: 149 
 [b7d45a20-3e26-11ed-9a91-2129c969dba6] Top 3 methods by timing:
 [b7d45a20-3e26-11ed-9a91-2129c969dba6]: method: JpaAbstractDao.findById(..), calls: 20, failures: 0, exec time: 67
 [b7d45a20-3e26-11ed-9a91-2129c969dba6]: method: JpaAbstractDao.save(..), calls: 1, failures: 0, exec time: 19
 [b7d45a20-3e26-11ed-9a91-2129c969dba6]: method: JpaRelationDao.findAllByFrom(..), calls: 1, failures: 0, exec time: 12
 [f53cdaf0-5f72-11ed-bd42-95eaa85af758]: calls: 34, failures: 0, exec time: 94 
 [f53cdaf0-5f72-11ed-bd42-95eaa85af758] Top 3 methods by timing:
 [f53cdaf0-5f72-11ed-bd42-95eaa85af758]: method: JpaAbstractDao.findById(..), calls: 18, failures: 0, exec time: 45
 [f53cdaf0-5f72-11ed-bd42-95eaa85af758]: method: JpaRelationDao.findAllByFrom(..), calls: 1, failures: 0, exec time: 11
 [f53cdaf0-5f72-11ed-bd42-95eaa85af758]: method: JpaWidgetsBundleDao.findAllTenantWidgetsBundlesByTenantId(..), calls: 1, failures: 0, exec time: 6
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



