### PR TITLE
[3.4.2] Bugfix of alarm count query with null sortOrder and textSearch specified.

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultAlarmQueryRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultAlarmQueryRepository.java
@@ -237,7 +237,7 @@ public class DefaultAlarmQueryRepository implements AlarmQueryRepository {
 
             String mainQuery = String.format("%s%s", selectPart, fromPart);
             if (textSearchQuery.isEmpty()) {
-                mainQuery += String.format("%s%s", joinPart, wherePart);
+                mainQuery = String.format("%s%s%s", mainQuery, joinPart, wherePart);
             } else {
                 mainQuery = String.format("select * from (%s%s) a %s WHERE %s", mainQuery, wherePart, joinPart, textSearchQuery);
             }


### PR DESCRIPTION
Issue: #7588 

query before:

```
select count(*)
from (select *
      from (select a.id                       as id,
                   a.created_time             as created_time,
                   a.ack_ts                   as ack_ts,
                   a.clear_ts                 as clear_ts,
                   a.additional_info          as additional_info,
                   a.end_ts                   as end_ts,
                   a.originator_id            as originator_id,
                   a.originator_type          as originator_type,
                   a.propagate                as propagate,
                   a.propagate_to_owner       as propagate_to_owner,
                   a.propagate_to_tenant      as propagate_to_tenant,
                   a.severity                 as severity,
                   a.start_ts                 as start_ts,
                   a.status                   as status,
                   a.tenant_id                as tenant_id,
                   a.customer_id              as customer_id,
                   a.propagate_relation_types as propagate_relation_types,
                   a.type                     as type,
                   COALESCE(CASE
                                WHEN a.originator_type = 0 THEN (select title from tenant where id = a.originator_id)
                                WHEN a.originator_type = 1 THEN (select title from customer where id = a.originator_id)
                                WHEN a.originator_type = 2 THEN (select email from tb_user where id = a.originator_id)
                                WHEN a.originator_type = 3 THEN (select title from dashboard where id = a.originator_id)
                                WHEN a.originator_type = 4 THEN (select name from asset where id = a.originator_id)
                                WHEN a.originator_type = 5 THEN (select name from device where id = a.originator_id)
                                WHEN a.originator_type = 9
                                    THEN (select name from entity_view where id = a.originator_id) END,
                            'Deleted')        as originator_name,
                   ea.entity_id               as entity_id
            from alarm a
                     inner join entity_alarm ea on a.id = ea.alarm_id
            where a.tenant_id = :permissions_tenant_id
              and ea.tenant_id = :permissions_tenant_id
              and a.created_time >= :startTime
              and ea.created_time >= :startTime
              and a.created_time <= :endTime
              and ea.created_time <= :endTime) a
               inner join (select *
                           from (VALUES (uuid('9c8a3e50-5f88-11ed-a915-8d3808f0f08c'), 0)) as e(id, priority)) e
                          on ea.entity_id = e.id
      WHERE LOWER(cast(created_time as varchar)) LIKE concat('%', :created_time_lowerSearchText, '%')
         or LOWER(cast(originator_name as varchar)) LIKE concat('%', :originator_name_lowerSearchText, '%')
         or LOWER(cast(type as varchar)) LIKE concat('%', :type_lowerSearchText, '%')
         or LOWER(cast(severity as varchar)) LIKE concat('%', :severity_lowerSearchText, '%')
         or LOWER(cast(status as varchar)) LIKE concat('%', :status_lowerSearchText, '%')) result
```

Query after:

```
select count(*)
from (select *
      from (select a.id                       as id,
                   a.created_time             as created_time,
                   a.ack_ts                   as ack_ts,
                   a.clear_ts                 as clear_ts,
                   a.additional_info          as additional_info,
                   a.end_ts                   as end_ts,
                   a.originator_id            as originator_id,
                   a.originator_type          as originator_type,
                   a.propagate                as propagate,
                   a.propagate_to_owner       as propagate_to_owner,
                   a.propagate_to_tenant      as propagate_to_tenant,
                   a.severity                 as severity,
                   a.start_ts                 as start_ts,
                   a.status                   as status,
                   a.tenant_id                as tenant_id,
                   a.customer_id              as customer_id,
                   a.propagate_relation_types as propagate_relation_types,
                   a.type                     as type,
                   COALESCE(CASE
                                WHEN a.originator_type = 0 THEN (select title from tenant where id = a.originator_id)
                                WHEN a.originator_type = 1 THEN (select title from customer where id = a.originator_id)
                                WHEN a.originator_type = 2 THEN (select email from tb_user where id = a.originator_id)
                                WHEN a.originator_type = 3 THEN (select title from dashboard where id = a.originator_id)
                                WHEN a.originator_type = 4 THEN (select name from asset where id = a.originator_id)
                                WHEN a.originator_type = 5 THEN (select name from device where id = a.originator_id)
                                WHEN a.originator_type = 9
                                    THEN (select name from entity_view where id = a.originator_id) END,
                            'Deleted')        as originator_name,
                   ea.entity_id               as entity_id
            from alarm a
                     inner join entity_alarm ea on a.id = ea.alarm_id
            where a.tenant_id = :permissions_tenant_id
              and ea.tenant_id = :permissions_tenant_id
              and a.created_time >= :startTime
              and ea.created_time >= :startTime
              and a.created_time <= :endTime
              and ea.created_time <= :endTime) a
               inner join (select *
                           from (VALUES (uuid('9c8a3e50-5f88-11ed-a915-8d3808f0f08c'), 0)) as e(id, priority)) e
                          on a.entity_id = e.id
      WHERE LOWER(cast(created_time as varchar)) LIKE concat('%', :created_time_lowerSearchText, '%')
         or LOWER(cast(originator_name as varchar)) LIKE concat('%', :originator_name_lowerSearchText, '%')
         or LOWER(cast(type as varchar)) LIKE concat('%', :type_lowerSearchText, '%')
         or LOWER(cast(severity as varchar)) LIKE concat('%', :severity_lowerSearchText, '%')
         or LOWER(cast(status as varchar)) LIKE concat('%', :status_lowerSearchText, '%')) result
```


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



