### PR TITLE
[3.4.2] RestClient updates. Remove default connection from RPC from device to push to cloud

### DIFF
--- a/application/src/main/data/json/tenant/edge_management/rule_chains/edge_root_rule_chain.json
+++ b/application/src/main/data/json/tenant/edge_management/rule_chains/edge_root_rule_chain.json
@@ -174,11 +174,6 @@
         "fromIndex": 3,
         "toIndex": 7,
         "type": "Timeseries Updated"
-      },
-      {
-        "fromIndex": 4,
-        "toIndex": 7,
-        "type": "Success"
       }
     ],
     "ruleChainConnections": null

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcSession.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcSession.java
@@ -244,7 +244,7 @@ public final class EdgeGrpcSession implements Closeable {
 
             @Override
             public void onFailure(Throwable t) {
-                String errorMsg = t.getMessage() != null ? t.getMessage() : "";
+                String errorMsg = EdgeUtils.createErrorMsgFromRootCauseAndStackTrace(t);
                 UplinkResponseMsg uplinkResponseMsg = UplinkResponseMsg.newBuilder()
                         .setUplinkMsgId(uplinkMsg.getUplinkMsgId())
                         .setSuccess(false).setErrorMsg(errorMsg).build();

--- a/common/data/src/main/java/org/thingsboard/server/common/data/EdgeUtils.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/EdgeUtils.java
@@ -16,6 +16,7 @@
 package org.thingsboard.server.common.data;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Throwables;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.server.common.data.edge.EdgeEvent;
 import org.thingsboard.server.common.data.edge.EdgeEventActionType;
@@ -28,6 +29,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
 public final class EdgeUtils {
+
+    private static final int STACK_TRACE_LIMIT = 10;
 
     private EdgeUtils() {
     }
@@ -92,5 +95,21 @@ public final class EdgeUtils {
         }
         edgeEvent.setBody(body);
         return edgeEvent;
+    }
+
+    public static String createErrorMsgFromRootCauseAndStackTrace(Throwable t) {
+        Throwable rootCause = Throwables.getRootCause(t);
+        StringBuilder errorMsg = new StringBuilder(rootCause.getMessage() != null ? rootCause.getMessage() : "");
+        if (rootCause.getStackTrace().length > 0) {
+            int idx = 0;
+            for (StackTraceElement stackTraceElement : rootCause.getStackTrace()) {
+                errorMsg.append("\n").append(stackTraceElement.toString());
+                idx++;
+                if (idx > STACK_TRACE_LIMIT) {
+                    break;
+                }
+            }
+        }
+        return errorMsg.toString();
     }
 }

--- a/rest-client/src/main/java/org/thingsboard/rest/client/RestClient.java
+++ b/rest-client/src/main/java/org/thingsboard/rest/client/RestClient.java
@@ -2032,10 +2032,15 @@ public class RestClient implements ClientHttpRequestInterceptor, Closeable {
     }
 
     public PageData<RuleChain> getRuleChains(PageLink pageLink) {
+        return getRuleChains(RuleChainType.CORE, pageLink);
+    }
+
+    public PageData<RuleChain> getRuleChains(RuleChainType ruleChainType, PageLink pageLink) {
         Map<String, String> params = new HashMap<>();
+        params.put("type", ruleChainType.name());
         addPageLinkToParam(params, pageLink);
         return restTemplate.exchange(
-                baseURL + "/api/ruleChains?" + getUrlParams(pageLink),
+                baseURL + "/api/ruleChains?type={type}&" + getUrlParams(pageLink),
                 HttpMethod.GET,
                 HttpEntity.EMPTY,
                 new ParameterizedTypeReference<PageData<RuleChain>>() {


### PR DESCRIPTION
## Pull Request description

Added method to fetch rule chains by type - to be able to fetch edge rule chains.
Remove a connection from 'RPC from device' to 'Push to cloud' node - it's already removed in PE in the last release, but forgotten in CE.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description contains human-readable scope of changes.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  