### PR TITLE
fix(sec): upgrade org.springframework.security:spring-security-oauth2-client to 5.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <spring-data.version>2.7.0</spring-data.version>
         <spring.version>5.3.20</spring.version>
         <spring-redis.version>5.5.12</spring-redis.version>
-        <spring-security.version>5.7.1</spring-security.version>
+        <spring-security.version>5.7.5</spring-security.version>
         <spring-data-redis.version>2.7.0</spring-data-redis.version>
         <jedis.version>3.7.1</jedis.version>
         <jjwt.version>0.7.0</jjwt.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.security:spring-security-oauth2-client 5.7.1
- [CVE-2022-31690](https://www.oscs1024.com/hd/CVE-2022-31690)


### What did I do？
Upgrade org.springframework.security:spring-security-oauth2-client from 5.7.1 to 5.7.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS