### PR TITLE
[3.4.2] Validation for entity's additionalInfo

### DIFF
--- a/common/data/src/main/java/org/thingsboard/server/common/data/SearchTextBasedWithAdditionalInfo.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/SearchTextBasedWithAdditionalInfo.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.server.common.data.id.UUIDBased;
+import org.thingsboard.server.common.data.validation.NoXss;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -36,6 +37,7 @@ import java.util.function.Consumer;
 public abstract class SearchTextBasedWithAdditionalInfo<I extends UUIDBased> extends SearchTextBased<I> implements HasAdditionalInfo {
 
     public static final ObjectMapper mapper = new ObjectMapper();
+    @NoXss
     private transient JsonNode additionalInfo;
     @JsonIgnore
     private byte[] additionalInfoBytes;

--- a/dao/src/main/java/org/thingsboard/server/dao/service/NoXssValidator.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/service/NoXssValidator.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.dao.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.extern.slf4j.Slf4j;
 import org.owasp.validator.html.AntiSamy;
 import org.owasp.validator.html.Policy;
@@ -48,12 +49,18 @@ public class NoXssValidator implements ConstraintValidator<NoXss, Object> {
 
     @Override
     public boolean isValid(Object value, ConstraintValidatorContext constraintValidatorContext) {
-        if (!(value instanceof String) || ((String) value).isEmpty()) {
+        String stringValue;
+        if (value instanceof CharSequence || value instanceof JsonNode) {
+            stringValue = value.toString();
+        } else {
+            return true;
+        }
+        if (stringValue.isEmpty()) {
             return true;
         }
 
         try {
-            return xssChecker.scan((String) value, xssPolicy).getNumberOfErrors() == 0;
+            return xssChecker.scan(stringValue, xssPolicy).getNumberOfErrors() == 0;
         } catch (ScanException | PolicyException e) {
             return false;
         }

--- a/dao/src/test/java/org/thingsboard/server/dao/service/NoXssValidatorTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/NoXssValidatorTest.java
@@ -15,23 +15,16 @@
  */
 package org.thingsboard.server.dao.service;
 
-import org.junit.jupiter.api.BeforeAll;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.asset.Asset;
 
-import javax.validation.ConstraintValidatorContext;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class NoXssValidatorTest {
-    private static NoXssValidator validator;
-
-    @BeforeAll
-    public static void beforeAll() {
-        validator = new NoXssValidator();
-        validator.initialize(null);
-    }
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -44,9 +37,25 @@ public class NoXssValidatorTest {
             "   <img src= \"http://site.com/\"  >  ",
             "123 <input type=text value=a onfocus=alert(1337) AUTOFOCUS>bebe"
     })
-    public void testIsNotValid(String stringWithXss) {
-        boolean isValid = validator.isValid(stringWithXss, mock(ConstraintValidatorContext.class));
-        assertFalse(isValid);
+    public void givenEntityWithMaliciousPropertyValue_thenReturnValidationError(String maliciousString) {
+        Asset invalidAsset = new Asset();
+        invalidAsset.setName(maliciousString);
+
+        assertThatThrownBy(() -> {
+            ConstraintValidator.validateFields(invalidAsset);
+        }).hasMessageContaining("field value is malformed");
+    }
+
+    @Test
+    public void givenEntityWithMaliciousValueInAdditionalInfo_thenReturnValidationError() {
+        Asset invalidAsset = new Asset();
+        String maliciousValue = "qwerty<script>alert(document.cookie)</script>qwerty";
+        invalidAsset.setAdditionalInfo(JacksonUtil.newObjectNode()
+                .set("description", new TextNode(maliciousValue)));
+
+        assertThatThrownBy(() -> {
+            ConstraintValidator.validateFields(invalidAsset);
+        }).hasMessageContaining("field value is malformed");
     }
 
 }


### PR DESCRIPTION
## Pull Request description

Added validation on xss for entity's additionalInfo.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
