### PR TITLE
Exclude node_modules' files from being watched

### DIFF
--- a/ui-ngx/extra-webpack.config.js
+++ b/ui-ngx/extra-webpack.config.js
@@ -58,6 +58,11 @@ module.exports = (config, options) => {
       contextRegExp: /moment$/,
     })
   );
+  config.watchOptions = {
+    ignored: [
+      "/node_modules/"
+    ]
+  };
 
   const index = config.plugins.findIndex(p => p instanceof ngWebpack.ivy.AngularWebpackPlugin || p instanceof ngWebpack.AngularWebpackPlugin);
   let angularWebpackPlugin = config.plugins[index];


### PR DESCRIPTION
## Pull Request description

currently webpack sets watchers for node_modules' files on start which is not a very good idea

The PR is to fix thingsboard issue https://github.com/thingsboard/thingsboard/issues/7513

