### PR TITLE
3.5 feature/redis sentinel support

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -484,6 +484,8 @@ redis:
   sentinel:
     # name of master node
     master: "${REDIS_MASTER}"
+    # comma-separated list of "host:port" pairs of sentinels
+    sentinels: "${REDIS_SENTINELS}"
   # db index
   db: "${REDIS_DB:0}"
   # db password

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -460,7 +460,7 @@ cache:
 spring.data.redis.repositories.enabled: false
 
 redis:
-  # standalone or cluster
+  # standalone or cluster or sentinel
   connection:
     type: "${REDIS_CONNECTION_TYPE:standalone}"
   standalone:
@@ -481,6 +481,9 @@ redis:
     # Maximum number of redirects to follow when executing commands across the cluster.
     max-redirects: "${REDIS_MAX_REDIRECTS:12}"
     useDefaultPoolConfig: "${REDIS_USE_DEFAULT_POOL_CONFIG:true}"
+  sentinel:
+    # name of master node
+    master: "${REDIS_MASTER}"
   # db index
   db: "${REDIS_DB:0}"
   # db password

--- a/common/cache/src/main/java/org/thingsboard/server/cache/TBRedisCacheConfiguration.java
+++ b/common/cache/src/main/java/org/thingsboard/server/cache/TBRedisCacheConfiguration.java
@@ -26,14 +26,19 @@ import org.springframework.core.convert.converter.ConverterRegistry;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisNode;
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.util.Assert;
+import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.id.EntityId;
 import redis.clients.jedis.JedisPoolConfig;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 @Configuration
 @ConditionalOnProperty(prefix = "cache", value = "type", havingValue = "redis")
@@ -76,6 +81,9 @@ public abstract class TBRedisCacheConfiguration {
 
     @Value("${redis.pool_config.blockWhenExhausted:true}")
     private boolean blockWhenExhausted;
+
+    private static final String COMMA = ",";
+    private static final String COLON = ":";
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -125,5 +133,20 @@ public abstract class TBRedisCacheConfiguration {
         poolConfig.setNumTestsPerEvictionRun(numberTestsPerEvictionRun);
         poolConfig.setBlockWhenExhausted(blockWhenExhausted);
         return poolConfig;
+    }
+
+    protected List<RedisNode> getNodes(String nodes) {
+        List<RedisNode> result;
+        if (StringUtils.isBlank(nodes)) {
+            result = Collections.emptyList();
+        } else {
+            result = new ArrayList<>();
+            for (String hostPort : nodes.split(COMMA)) {
+                String host = hostPort.split(COLON)[0];
+                int port = Integer.parseInt(hostPort.split(COLON)[1]);
+                result.add(new RedisNode(host, port));
+            }
+        }
+        return result;
     }
 }

--- a/common/cache/src/main/java/org/thingsboard/server/cache/TBRedisClusterConfiguration.java
+++ b/common/cache/src/main/java/org/thingsboard/server/cache/TBRedisClusterConfiguration.java
@@ -33,9 +33,6 @@ import java.util.List;
 @ConditionalOnProperty(prefix = "redis.connection", value = "type", havingValue = "cluster")
 public class TBRedisClusterConfiguration extends TBRedisCacheConfiguration {
 
-    private static final String COMMA = ",";
-    private static final String COLON = ":";
-
     @Value("${redis.cluster.nodes:}")
     private String clusterNodes;
 
@@ -48,11 +45,15 @@ public class TBRedisClusterConfiguration extends TBRedisCacheConfiguration {
     @Value("${redis.password:}")
     private String password;
 
+    @Value("${redis.username:}")
+    private String username;
+
     public JedisConnectionFactory loadFactory() {
         RedisClusterConfiguration clusterConfiguration = new RedisClusterConfiguration();
         clusterConfiguration.setClusterNodes(getNodes(clusterNodes));
         clusterConfiguration.setMaxRedirects(maxRedirects);
         clusterConfiguration.setPassword(password);
+        clusterConfiguration.setUsername(username);
         if (useDefaultPoolConfig) {
             return new JedisConnectionFactory(clusterConfiguration);
         } else {
@@ -60,18 +61,4 @@ public class TBRedisClusterConfiguration extends TBRedisCacheConfiguration {
         }
     }
 
-    private List<RedisNode> getNodes(String nodes) {
-        List<RedisNode> result;
-        if (StringUtils.isBlank(nodes)) {
-            result = Collections.emptyList();
-        } else {
-            result = new ArrayList<>();
-            for (String hostPort : nodes.split(COMMA)) {
-                String host = hostPort.split(COLON)[0];
-                Integer port = Integer.valueOf(hostPort.split(COLON)[1]);
-                result.add(new RedisNode(host, port));
-            }
-        }
-        return result;
-    }
 }

--- a/common/cache/src/main/java/org/thingsboard/server/cache/TbRedisSentinelConfiguration.java
+++ b/common/cache/src/main/java/org/thingsboard/server/cache/TbRedisSentinelConfiguration.java
@@ -22,21 +22,21 @@ public class TbRedisSentinelConfiguration extends TBRedisCacheConfiguration {
     @Value("${redis.sentinel.master:}")
     private String master;
 
-    @Value("${redis.sentinel.nodes:}")
-    private String clusterNodes;
+    @Value("${redis.cluster.nodes:}")
+    private String nodes;
 
-    @Value("${redis.sentinel.useDefaultPoolConfig:true}")
+    @Value("${redis.cluster.useDefaultPoolConfig:true}")
     private boolean useDefaultPoolConfig;
 
-    @Value("${redis.sentinel.database:0}")
+    @Value("${redis.database:}")
     private Integer database;
 
-    @Value("${redis.sentinel.password:}")
+    @Value("${redis.password:}")
     private String sentinelPassword;
 
     public JedisConnectionFactory loadFactory() {
         RedisSentinelConfiguration redisSentinelConfiguration = new RedisSentinelConfiguration();
-        redisSentinelConfiguration.setSentinels(getNodes(clusterNodes));
+        redisSentinelConfiguration.setSentinels(getNodes(nodes));
         redisSentinelConfiguration.setMaster(this.master);
         redisSentinelConfiguration.setDatabase(this.database);
         redisSentinelConfiguration.setSentinelPassword(sentinelPassword);

--- a/common/cache/src/main/java/org/thingsboard/server/cache/TbRedisSentinelConfiguration.java
+++ b/common/cache/src/main/java/org/thingsboard/server/cache/TbRedisSentinelConfiguration.java
@@ -22,13 +22,13 @@ public class TbRedisSentinelConfiguration extends TBRedisCacheConfiguration {
     @Value("${redis.sentinel.master:}")
     private String master;
 
-    @Value("${redis.cluster.nodes:}")
-    private String nodes;
+    @Value("${redis.sentinel.sentinels:}")
+    private String sentinels;
 
     @Value("${redis.cluster.useDefaultPoolConfig:true}")
     private boolean useDefaultPoolConfig;
 
-    @Value("${redis.database:}")
+    @Value("${redis.database:0}")
     private Integer database;
 
     @Value("${redis.password:}")
@@ -36,7 +36,7 @@ public class TbRedisSentinelConfiguration extends TBRedisCacheConfiguration {
 
     public JedisConnectionFactory loadFactory() {
         RedisSentinelConfiguration redisSentinelConfiguration = new RedisSentinelConfiguration();
-        redisSentinelConfiguration.setSentinels(getNodes(nodes));
+        redisSentinelConfiguration.setSentinels(getNodes(sentinels));
         redisSentinelConfiguration.setMaster(this.master);
         redisSentinelConfiguration.setDatabase(this.database);
         redisSentinelConfiguration.setSentinelPassword(sentinelPassword);

--- a/common/cache/src/main/java/org/thingsboard/server/cache/TbRedisSentinelConfiguration.java
+++ b/common/cache/src/main/java/org/thingsboard/server/cache/TbRedisSentinelConfiguration.java
@@ -1,0 +1,53 @@
+package org.thingsboard.server.cache;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+
+
+@Configuration
+@ConditionalOnMissingBean(TbCaffeineCacheConfiguration.class)
+@ConditionalOnProperty(prefix = "redis.connection", value = "type", havingValue = "sentinel")
+public class TbRedisSentinelConfiguration extends TBRedisCacheConfiguration {
+
+    @Value("${redis.username:}")
+    private String username;
+
+    @Value("${redis.password:}")
+    private String password;
+
+    @Value("${redis.sentinel.master:}")
+    private String master;
+
+    @Value("${redis.sentinel.nodes:}")
+    private String clusterNodes;
+
+    @Value("${redis.sentinel.useDefaultPoolConfig:true}")
+    private boolean useDefaultPoolConfig;
+
+    @Value("${redis.sentinel.database:0}")
+    private Integer database;
+
+    @Value("${redis.sentinel.password:}")
+    private String sentinelPassword;
+
+    public JedisConnectionFactory loadFactory() {
+        RedisSentinelConfiguration redisSentinelConfiguration = new RedisSentinelConfiguration();
+        redisSentinelConfiguration.setSentinels(getNodes(clusterNodes));
+        redisSentinelConfiguration.setMaster(this.master);
+        redisSentinelConfiguration.setDatabase(this.database);
+        redisSentinelConfiguration.setSentinelPassword(sentinelPassword);
+        redisSentinelConfiguration.setUsername(username);
+        redisSentinelConfiguration.setPassword(password);
+
+        if (useDefaultPoolConfig) {
+            return new JedisConnectionFactory(redisSentinelConfiguration);
+        } else {
+            return new JedisConnectionFactory(redisSentinelConfiguration, buildPoolConfig());
+        }
+    }
+
+}


### PR DESCRIPTION
Issue: https://github.com/thingsboard/thingsboard/issues/4728
Added new configuration for redis sentinel support, a bit refactored redis cluster configuration;
Provided similar pr for documentation: https://github.com/thingsboard/thingsboard.github.io/pull/921
Unit or integration tests makes no sense, as if anything works incorrect, the application would not start.


