### PR TITLE
[3.4.3] UI: Fixed validation in bulk import and improvement bulk import for Edge

### DIFF
--- a/ui-ngx/src/app/modules/home/components/import-export/import-export.models.ts
+++ b/ui-ngx/src/app/modules/home/components/import-export/import-export.models.ts
@@ -70,9 +70,6 @@ export enum ImportEntityColumnType {
   secret = 'SECRET'
 }
 
-export const importEntityObjectColumns =
-  [ImportEntityColumnType.name, ImportEntityColumnType.type, ImportEntityColumnType.accessToken];
-
 export const importEntityColumnTypeTranslations = new Map<ImportEntityColumnType, string>(
   [
     [ImportEntityColumnType.name, 'import.column-type.name'],

--- a/ui-ngx/src/app/modules/home/components/import-export/table-columns-assignment.component.html
+++ b/ui-ngx/src/app/modules/home/components/import-export/table-columns-assignment.component.html
@@ -49,7 +49,7 @@
       <mat-form-field floatLabel="always" hideRequiredMarker
                       *ngIf="isColumnTypeDiffers(column.type)">
         <mat-label></mat-label>
-        <input matInput required
+        <input matInput [required]="isColumnTypeDiffers(column.type)"
                [(ngModel)]="column.key" (ngModelChange)="columnsUpdated()"
                placeholder="{{ 'import.column-value' | translate }}"/>
       </mat-form-field>

--- a/ui-ngx/src/app/modules/home/components/import-export/table-columns-assignment.component.ts
+++ b/ui-ngx/src/app/modules/home/components/import-export/table-columns-assignment.component.ts
@@ -22,8 +22,7 @@ import { EntityType } from '@shared/models/entity-type.models';
 import {
   CsvColumnParam,
   ImportEntityColumnType,
-  importEntityColumnTypeTranslations,
-  importEntityObjectColumns
+  importEntityColumnTypeTranslations
 } from '@home/components/import-export/import-export.models';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { CollectionViewer, DataSource } from '@angular/cdk/collections';
@@ -117,7 +116,9 @@ export class TableColumnsAssignmentComponent implements OnInit, ControlValueAcce
       case EntityType.EDGE:
         this.columnTypes.push(
           { value: ImportEntityColumnType.routingKey },
-          { value: ImportEntityColumnType.secret }
+          { value: ImportEntityColumnType.secret },
+          { value: ImportEntityColumnType.serverAttribute },
+          { value: ImportEntityColumnType.timeseries }
         );
         break;
     }
@@ -143,8 +144,6 @@ export class TableColumnsAssignmentComponent implements OnInit, ControlValueAcce
     const isSelectType = this.columns.findIndex((column) => column.type === ImportEntityColumnType.type) > -1;
     const isSelectLabel = this.columns.findIndex((column) => column.type === ImportEntityColumnType.label) > -1;
     const isSelectDescription = this.columns.findIndex((column) => column.type === ImportEntityColumnType.description) > -1;
-    const isSelectRoutingKey = this.columns.findIndex((column) => column.type === ImportEntityColumnType.routingKey) > -1;
-    const isSelectSecret = this.columns.findIndex((column) => column.type === ImportEntityColumnType.secret) > -1;
     const hasInvalidColumn = this.columns.findIndex((column) => !this.columnValid(column)) > -1;
 
     this.valid = isSelectName && isSelectType && !hasInvalidColumn;
@@ -167,14 +166,16 @@ export class TableColumnsAssignmentComponent implements OnInit, ControlValueAcce
       });
     }
 
-    const routingKeyColumnType = this.columnTypes.find((columnType) => columnType.value === ImportEntityColumnType.routingKey);
-    if (routingKeyColumnType) {
-      routingKeyColumnType.disabled = isSelectRoutingKey;
+    if (this.entityType === EntityType.EDGE) {
+      const isSelectRoutingKey = this.columns.findIndex((column) => column.type === ImportEntityColumnType.routingKey) > -1;
+      const isSelectSecret = this.columns.findIndex((column) => column.type === ImportEntityColumnType.secret) > -1;
+
+      this.valid = this.valid && isSelectSecret && isSelectRoutingKey;
+
+      this.columnTypes.find((columnType) => columnType.value === ImportEntityColumnType.routingKey).disabled = isSelectRoutingKey;
+      this.columnTypes.find((columnType) => columnType.value === ImportEntityColumnType.secret).disabled = isSelectSecret;
     }
-    const secretColumnType = this.columnTypes.find((columnType) => columnType.value === ImportEntityColumnType.secret);
-    if (secretColumnType) {
-      secretColumnType.disabled = isSelectSecret;
-    }
+
     if (this.propagateChange) {
       this.propagateChange(this.columns);
     } else {
@@ -190,7 +191,7 @@ export class TableColumnsAssignmentComponent implements OnInit, ControlValueAcce
   }
 
   private columnValid(column: CsvColumnParam): boolean {
-    if (!importEntityObjectColumns.includes(column.type)) {
+    if (this.isColumnTypeDiffers(column.type)) {
       return column.key && column.key.trim().length > 0;
     } else {
       return true;


### PR DESCRIPTION
## Pull Request description

Fixed #7663.

This PR fixed the incorrect validation CSV mapping column when used without a header line.
Improvement validation and allow fields for Edge.

Before:
![image](https://user-images.githubusercontent.com/18036670/206420286-e7662a5a-ab0f-424e-a0ee-d16f77a390f0.png)

After:
![image](https://user-images.githubusercontent.com/18036670/206420137-8dca08f0-5921-44fa-9612-6306080720df.png)
 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



