### PR TITLE
[3.4.3] Fix no timeseries data in widget for entity view; fix State Chart invalid behavior

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbEntityDataSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbEntityDataSubscriptionService.java
@@ -562,8 +562,13 @@ public class DefaultTbEntityDataSubscriptionService implements TbEntityDataSubsc
                     if (queryResults != null) {
                         for (ReadTsKvQueryResult queryResult : queryResults) {
                             String queryKey = queriesKeys.get(queryResult.getQueryId());
-                            entityData.getTimeseries().put(queryKey, queryResult.toTsValues());
-                            lastTsMap.put(queryKey, queryResult.getLastEntryTs());
+                            if (queryKey != null) {
+                                entityData.getTimeseries().put(queryKey, queryResult.toTsValues());
+                                lastTsMap.put(queryKey, queryResult.getLastEntryTs());
+                            } else {
+                                log.warn("ReadTsKvQueryResult for {} {} has queryId not matching the initial query",
+                                        entityData.getEntityId().getEntityType(), entityData.getEntityId());
+                            }
                         }
                     }
                     // Populate with empty values if no data found.

--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbEntityDataSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbEntityDataSubscriptionService.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ArrayUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -563,8 +564,13 @@ public class DefaultTbEntityDataSubscriptionService implements TbEntityDataSubsc
                         for (ReadTsKvQueryResult queryResult : queryResults) {
                             String queryKey = queriesKeys.get(queryResult.getQueryId());
                             if (queryKey != null) {
-                                entityData.getTimeseries().put(queryKey, queryResult.toTsValues());
-                                lastTsMap.put(queryKey, queryResult.getLastEntryTs());
+                                TsValue[] tsValues = entityData.getTimeseries().get(queryKey);
+                                if (tsValues == null) {
+                                    tsValues = queryResult.toTsValues();
+                                } else {
+                                    tsValues = ArrayUtils.addAll(tsValues, queryResult.toTsValues());
+                                }
+                                entityData.getTimeseries().put(queryKey, tsValues);
                             } else {
                                 log.warn("ReadTsKvQueryResult for {} {} has queryId not matching the initial query",
                                         entityData.getEntityId().getEntityType(), entityData.getEntityId());

--- a/common/data/src/main/java/org/thingsboard/server/common/data/kv/BaseReadTsKvQuery.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/kv/BaseReadTsKvQuery.java
@@ -47,4 +47,12 @@ public class BaseReadTsKvQuery extends BaseTsKvQuery implements ReadTsKvQuery {
         this(key, startTs, endTs, endTs - startTs, limit, Aggregation.NONE, order);
     }
 
+    public BaseReadTsKvQuery(ReadTsKvQuery query, long startTs, long endTs) {
+        super(query.getId(), query.getKey(), startTs, endTs);
+        this.interval = query.getInterval();
+        this.limit = query.getLimit();
+        this.aggregation = query.getAggregation();
+        this.order = query.getOrder();
+    }
+
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/kv/BaseTsKvQuery.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/kv/BaseTsKvQuery.java
@@ -28,8 +28,12 @@ public class BaseTsKvQuery implements TsKvQuery {
     private final long endTs;
 
     public BaseTsKvQuery(String key, long startTs, long endTs) {
-        this.id = idSeq.get();
+        this(idSeq.get(), key, startTs, endTs);
         idSeq.set(id + 1);
+    }
+
+    protected BaseTsKvQuery(int id, String key, long startTs, long endTs) {
+        this.id = id;
         this.key = key;
         this.startTs = startTs;
         this.endTs = endTs;

--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/BaseTimeseriesService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/BaseTimeseriesService.java
@@ -234,7 +234,7 @@ public class BaseTimeseriesService implements TimeseriesService {
             } else {
                 endTs = query.getEndTs();
             }
-            return new BaseReadTsKvQuery(query.getKey(), startTs, endTs, query.getInterval(), query.getLimit(), query.getAggregation(), query.getOrder());
+            return new BaseReadTsKvQuery(query, startTs, endTs);
         }).collect(Collectors.toList());
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
@@ -35,6 +35,7 @@ import org.thingsboard.server.common.data.kv.DoubleDataEntry;
 import org.thingsboard.server.common.data.kv.KvEntry;
 import org.thingsboard.server.common.data.kv.LongDataEntry;
 import org.thingsboard.server.common.data.kv.ReadTsKvQuery;
+import org.thingsboard.server.common.data.kv.ReadTsKvQueryResult;
 import org.thingsboard.server.common.data.kv.StringDataEntry;
 import org.thingsboard.server.common.data.kv.TsKvEntry;
 import org.thingsboard.server.common.data.objects.TelemetryEntityView;
@@ -48,6 +49,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -342,6 +344,36 @@ public abstract class BaseTimeseriesServiceTest extends AbstractServiceTest {
         Assert.assertEquals(toTsEntry(TS - 1, stringKvEntry), entries.get(0));
         Assert.assertEquals(toTsEntry(TS - 2, stringKvEntry), entries.get(1));
         Assert.assertEquals(toTsEntry(TS - 3, stringKvEntry), entries.get(2));
+    }
+
+    @Test
+    public void testFindAllByQueries_verifyQueryId() throws Exception {
+        DeviceId deviceId = new DeviceId(Uuids.timeBased());
+        saveEntries(deviceId, TS);
+        saveEntries(deviceId, TS - 2);
+        saveEntries(deviceId, TS - 10);
+
+        BaseReadTsKvQuery query = new BaseReadTsKvQuery(STRING_KEY, TS - 10, TS + 1, 0, 1000, Aggregation.NONE, "DESC");
+        findAndVerifyQueryId(deviceId, query);
+    }
+
+    @Test
+    public void testFindAllByQueries_verifyQueryId_forEntityView() throws Exception {
+        DeviceId deviceId = new DeviceId(Uuids.timeBased());
+        saveEntries(deviceId, TS);
+        saveEntries(deviceId, TS - 2);
+        saveEntries(deviceId, TS - 12);
+
+        EntityView entityView = saveAndCreateEntityView(deviceId, List.of(LONG_KEY));
+
+        BaseReadTsKvQuery query = new BaseReadTsKvQuery(LONG_KEY, TS - 10, TS + 1, 0, 1000, Aggregation.NONE, "DESC");
+        findAndVerifyQueryId(entityView.getId(), query);
+    }
+
+    private void findAndVerifyQueryId(EntityId entityId, ReadTsKvQuery query) throws InterruptedException, ExecutionException, TimeoutException {
+        List<ReadTsKvQueryResult> results = tsService.findAllByQueries(tenantId, entityId, List.of(query)).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        assertThat(results).isNotEmpty();
+        assertThat(results).extracting(ReadTsKvQueryResult::getQueryId).containsOnly(query.getId());
     }
 
     @Test


### PR DESCRIPTION
## Pull Request description

This fixes the issues https://github.com/thingsboard/thingsboard/issues/7739 and https://github.com/thingsboard/thingsboard/issues/7742.

The root cause for no timeseries data for entity view was that in `BaseTimeseriesService`.`updateQueriesForEntityView` we were replacing initial `BaseReadTsKvQuery` with updated one with new id generated, and therefore returned `ReadTsKvQueryResult` had `queryId` not matching the initial query.

The cause for invalid State Chart behavior: when `fetchLatestPreviousPoint` in `GetTsCmd` is enabled, we are adding extra `BaseReadTsKvQuery` for same ts key, and then when processing the results, the result for the first query was rewritten by the result of the second one. 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
