### PR TITLE
[WIP][3.4.3] Feature: add originator label for alarms

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbAlarmDataSubCtx.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbAlarmDataSubCtx.java
@@ -219,7 +219,7 @@ public class TbAlarmDataSubCtx extends TbAbstractDataSubCtx<AlarmDataQuery> {
             boolean matchesFilter = filter(alarm);
             if (onCurrentPage) {
                 if (matchesFilter) {
-                    AlarmData updated = new AlarmData(alarm, current.getOriginatorName(), current.getEntityId());
+                    AlarmData updated = new AlarmData(alarm, current.getOriginatorName(), "", current.getEntityId());
                     updated.getLatest().putAll(current.getLatest());
                     alarmsMap.put(alarmId, updated);
                     sendWsMsg(new AlarmDataUpdate(cmdId, null, Collections.singletonList(updated), maxEntitiesPerAlarmSubscription, data.getTotalElements()));

--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbAlarmDataSubCtx.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbAlarmDataSubCtx.java
@@ -219,7 +219,7 @@ public class TbAlarmDataSubCtx extends TbAbstractDataSubCtx<AlarmDataQuery> {
             boolean matchesFilter = filter(alarm);
             if (onCurrentPage) {
                 if (matchesFilter) {
-                    AlarmData updated = new AlarmData(alarm, current.getOriginatorName(), "", current.getEntityId());
+                    AlarmData updated = new AlarmData(alarm, current.getOriginatorName(), current.getOriginatorLabel(), current.getEntityId());
                     updated.getLatest().putAll(current.getLatest());
                     alarmsMap.put(alarmId, updated);
                     sendWsMsg(new AlarmDataUpdate(cmdId, null, Collections.singletonList(updated), maxEntitiesPerAlarmSubscription, data.getTotalElements()));

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/entity/EntityService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/entity/EntityService.java
@@ -16,6 +16,7 @@
 package org.thingsboard.server.dao.entity;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import org.thingsboard.server.common.data.HasName;
 import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
@@ -27,6 +28,8 @@ import org.thingsboard.server.common.data.query.EntityDataQuery;
 public interface EntityService {
 
     ListenableFuture<String> fetchEntityNameAsync(TenantId tenantId, EntityId entityId);
+
+    ListenableFuture<? extends HasName> fetchEntityHasNameAsync(TenantId tenantId, EntityId entityId);
 
     CustomerId fetchEntityCustomerId(TenantId tenantId, EntityId entityId);
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/Device.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/Device.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 @ApiModel
 @EqualsAndHashCode(callSuper = true)
 @Slf4j
-public class Device extends SearchTextBasedWithAdditionalInfo<DeviceId> implements HasName, HasTenantId, HasCustomerId, HasOtaPackage, ExportableEntity<DeviceId> {
+public class Device extends SearchTextBasedWithAdditionalInfo<DeviceId> implements HasName, HasLabel, HasTenantId, HasCustomerId, HasOtaPackage, ExportableEntity<DeviceId> {
 
     private static final long serialVersionUID = 2807343040519543363L;
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/HasLabel.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/HasLabel.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.common.data;
+
+public interface HasLabel extends HasName {
+
+    String getLabel();
+
+}

--- a/common/data/src/main/java/org/thingsboard/server/common/data/alarm/AlarmInfo.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/alarm/AlarmInfo.java
@@ -25,6 +25,8 @@ public class AlarmInfo extends Alarm {
 
     @ApiModelProperty(position = 19, value = "Alarm originator name", example = "Thermostat")
     private String originatorName;
+    @ApiModelProperty(position = 20, value = "Alarm originator label", example = "Label")
+    private String originatorLabel;
 
     public AlarmInfo() {
         super();
@@ -34,9 +36,10 @@ public class AlarmInfo extends Alarm {
         super(alarm);
     }
 
-    public AlarmInfo(Alarm alarm, String originatorName) {
+    public AlarmInfo(Alarm alarm, String originatorName, String originatorLabel) {
         super(alarm);
         this.originatorName = originatorName;
+        this.originatorLabel = originatorLabel;
     }
 
     public String getOriginatorName() {
@@ -45,6 +48,14 @@ public class AlarmInfo extends Alarm {
 
     public void setOriginatorName(String originatorName) {
         this.originatorName = originatorName;
+    }
+
+    public String getOriginatorLabel() {
+        return originatorLabel;
+    }
+
+    public void setOriginatorLabel(String originatorLabel) {
+        this.originatorLabel = originatorLabel;
     }
 
     @Override

--- a/common/data/src/main/java/org/thingsboard/server/common/data/alarm/AlarmInfo.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/alarm/AlarmInfo.java
@@ -66,14 +66,21 @@ public class AlarmInfo extends Alarm {
 
         AlarmInfo alarmInfo = (AlarmInfo) o;
 
-        return originatorName != null ? originatorName.equals(alarmInfo.originatorName) : alarmInfo.originatorName == null;
-
+        if ((originatorName != null) & (originatorLabel != null)) {
+            return originatorName.equals(alarmInfo.originatorName) & originatorLabel.equals(alarmInfo.originatorLabel);
+        } else if (originatorName != null) {
+            return originatorName.equals(alarmInfo.originatorName);
+        } else if (originatorLabel != null) {
+            return originatorLabel.equals(alarmInfo.originatorLabel);
+        } else {
+            return true;
+        }
     }
 
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (originatorName != null ? originatorName.hashCode() : 0);
+        result = 31 * result + (originatorName != null ? originatorName.hashCode() : 0) + (originatorLabel != null ? originatorLabel.hashCode() : 0);
         return result;
     }
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/asset/Asset.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/asset/Asset.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.thingsboard.server.common.data.ExportableEntity;
 import org.thingsboard.server.common.data.HasCustomerId;
+import org.thingsboard.server.common.data.HasLabel;
 import org.thingsboard.server.common.data.HasName;
 import org.thingsboard.server.common.data.HasTenantId;
 import org.thingsboard.server.common.data.SearchTextBasedWithAdditionalInfo;
@@ -37,7 +38,7 @@ import java.util.Optional;
 
 @ApiModel
 @EqualsAndHashCode(callSuper = true)
-public class Asset extends SearchTextBasedWithAdditionalInfo<AssetId> implements HasName, HasTenantId, HasCustomerId, ExportableEntity<AssetId> {
+public class Asset extends SearchTextBasedWithAdditionalInfo<AssetId> implements HasName, HasLabel, HasTenantId, HasCustomerId, ExportableEntity<AssetId> {
 
     private static final long serialVersionUID = 2807343040519543363L;
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/edge/Edge.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/edge/Edge.java
@@ -21,6 +21,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Setter;
 import lombok.ToString;
 import org.thingsboard.server.common.data.HasCustomerId;
+import org.thingsboard.server.common.data.HasLabel;
 import org.thingsboard.server.common.data.HasName;
 import org.thingsboard.server.common.data.HasTenantId;
 import org.thingsboard.server.common.data.SearchTextBasedWithAdditionalInfo;
@@ -35,7 +36,7 @@ import org.thingsboard.server.common.data.validation.NoXss;
 @EqualsAndHashCode(callSuper = true)
 @ToString
 @Setter
-public class Edge extends SearchTextBasedWithAdditionalInfo<EdgeId> implements HasName, HasTenantId, HasCustomerId {
+public class Edge extends SearchTextBasedWithAdditionalInfo<EdgeId> implements HasName, HasLabel, HasTenantId, HasCustomerId {
 
     private static final long serialVersionUID = 4934987555236873728L;
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/query/AlarmData.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/query/AlarmData.java
@@ -31,8 +31,8 @@ public class AlarmData extends AlarmInfo {
     @Getter
     private final Map<EntityKeyType, Map<String, TsValue>> latest;
 
-    public AlarmData(Alarm alarm, String originatorName, EntityId entityId) {
-        super(alarm, originatorName);
+    public AlarmData(Alarm alarm, String originatorName, String originatorLabel, EntityId entityId) {
+        super(alarm, originatorName, originatorLabel);
         this.entityId = entityId;
         this.latest = new HashMap<>();
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/BaseEntityService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/BaseEntityService.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.thingsboard.server.common.data.HasCustomerId;
+import org.thingsboard.server.common.data.HasLabel;
 import org.thingsboard.server.common.data.HasName;
 import org.thingsboard.server.common.data.id.AlarmId;
 import org.thingsboard.server.common.data.id.AssetId;
@@ -129,7 +130,12 @@ public class BaseEntityService extends AbstractEntityService implements EntitySe
     @Override
     public ListenableFuture<String> fetchEntityNameAsync(TenantId tenantId, EntityId entityId) {
         log.trace("Executing fetchEntityNameAsync [{}]", entityId);
-        ListenableFuture<String> entityName;
+        return Futures.transform(fetchEntityHasNameAsync(tenantId, entityId), (Function<HasName, String>) hasName1 -> hasName1 != null ? hasName1.getName() : null, MoreExecutors.directExecutor());
+    }
+
+    @Override
+    public ListenableFuture<? extends HasName> fetchEntityHasNameAsync(TenantId tenantId, EntityId entityId) {
+        log.trace("Executing fetchEntityHasNamelAsync [{}]", entityId);
         ListenableFuture<? extends HasName> hasName;
         switch (entityId.getEntityType()) {
             case ASSET:
@@ -171,8 +177,8 @@ public class BaseEntityService extends AbstractEntityService implements EntitySe
             default:
                 throw new IllegalStateException("Not Implemented!");
         }
-        entityName = Futures.transform(hasName, (Function<HasName, String>) hasName1 -> hasName1 != null ? hasName1.getName() : null, MoreExecutors.directExecutor());
-        return entityName;
+        //entityName = Futures.transform(hasName, (Function<HasName, String>) hasName1 -> hasName1 != null ? hasName1.getName() : null, MoreExecutors.directExecutor());
+        return (ListenableFuture<? extends HasLabel>) hasName;
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/BaseEntityService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/BaseEntityService.java
@@ -177,8 +177,7 @@ public class BaseEntityService extends AbstractEntityService implements EntitySe
             default:
                 throw new IllegalStateException("Not Implemented!");
         }
-        //entityName = Futures.transform(hasName, (Function<HasName, String>) hasName1 -> hasName1 != null ? hasName1.getName() : null, MoreExecutors.directExecutor());
-        return (ListenableFuture<? extends HasLabel>) hasName;
+        return hasName;
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/model/ModelConstants.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/ModelConstants.java
@@ -283,6 +283,7 @@ public class ModelConstants {
     public static final String ALARM_DETAILS_PROPERTY = "details";
     public static final String ALARM_ORIGINATOR_ID_PROPERTY = "originator_id";
     public static final String ALARM_ORIGINATOR_NAME_PROPERTY = "originator_name";
+    public static final String ALARM_ORIGINATOR_LABEL_PROPERTY = "originator_label";
     public static final String ALARM_ORIGINATOR_TYPE_PROPERTY = "originator_type";
     public static final String ALARM_SEVERITY_PROPERTY = "severity";
     public static final String ALARM_STATUS_PROPERTY = "status";

--- a/dao/src/main/java/org/thingsboard/server/dao/model/sql/AlarmInfoEntity.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/model/sql/AlarmInfoEntity.java
@@ -24,6 +24,7 @@ import org.thingsboard.server.common.data.alarm.AlarmInfo;
 public class AlarmInfoEntity extends AbstractAlarmEntity<AlarmInfo> {
 
     private String originatorName;
+    private String originatorLabel;
 
     public AlarmInfoEntity() {
         super();
@@ -35,6 +36,6 @@ public class AlarmInfoEntity extends AbstractAlarmEntity<AlarmInfo> {
 
     @Override
     public AlarmInfo toData() {
-        return new AlarmInfo(super.toAlarm(), this.originatorName);
+        return new AlarmInfo(super.toAlarm(), this.originatorName, this.originatorLabel);
     }
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/AlarmDataAdapter.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/AlarmDataAdapter.java
@@ -105,7 +105,11 @@ public class AlarmDataAdapter {
         EntityId entityId = entityIdMap.get(entityUuid);
         Object originatorNameObj = row.get(ModelConstants.ALARM_ORIGINATOR_NAME_PROPERTY);
         String originatorName = originatorNameObj != null ? originatorNameObj.toString() : null;
-        return new AlarmData(alarm, originatorName, entityId);
+
+        //Object originatorLabelObj = row.get(ModelConstants.ALARM_ORIGINATOR_LABEL_PROPERTY);
+        //String originatorLabel = originatorLabelObj != null ? originatorLabelObj.toString() : null;
+
+        return new AlarmData(alarm, originatorName, "", entityId);
     }
 
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/AlarmDataAdapter.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/AlarmDataAdapter.java
@@ -105,11 +105,9 @@ public class AlarmDataAdapter {
         EntityId entityId = entityIdMap.get(entityUuid);
         Object originatorNameObj = row.get(ModelConstants.ALARM_ORIGINATOR_NAME_PROPERTY);
         String originatorName = originatorNameObj != null ? originatorNameObj.toString() : null;
-
-        //Object originatorLabelObj = row.get(ModelConstants.ALARM_ORIGINATOR_LABEL_PROPERTY);
-        //String originatorLabel = originatorLabelObj != null ? originatorLabelObj.toString() : null;
-
-        return new AlarmData(alarm, originatorName, "", entityId);
+        Object originatorLabelObj = row.get(ModelConstants.ALARM_ORIGINATOR_LABEL_PROPERTY);
+        String originatorLabel = originatorLabelObj != null ? originatorLabelObj.toString() : null;
+        return new AlarmData(alarm, originatorName, originatorLabel, entityId);
     }
 
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultAlarmQueryRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultAlarmQueryRepository.java
@@ -92,7 +92,7 @@ public class DefaultAlarmQueryRepository implements AlarmQueryRepository {
             " WHEN a.originator_type = " + EntityType.ASSET.ordinal() +
             " THEN (select label from asset where id = a.originator_id)" +
             " WHEN a.originator_type = " + EntityType.DEVICE.ordinal() +
-            " THEN (select name from device where id = a.originator_id)" +
+            " THEN (select label from device where id = a.originator_id)" +
             " END, '') as originator_label";
 
     private static final String FIELDS_SELECTION = "select a.id as id," +
@@ -112,7 +112,7 @@ public class DefaultAlarmQueryRepository implements AlarmQueryRepository {
             " a.tenant_id as tenant_id, " +
             " a.customer_id as customer_id, " +
             " a.propagate_relation_types as propagate_relation_types, " +
-            " a.type as type," + SELECT_ORIGINATOR_NAME + ", ";
+            " a.type as type," + SELECT_ORIGINATOR_NAME + ", " + SELECT_ORIGINATOR_LABEL + ", ";
 
     private static final String JOIN_ENTITY_ALARMS = "inner join entity_alarm ea on a.id = ea.alarm_id";
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultAlarmQueryRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultAlarmQueryRepository.java
@@ -68,6 +68,7 @@ public class DefaultAlarmQueryRepository implements AlarmQueryRepository {
         alarmFieldColumnMap.put("originatorId", ModelConstants.ALARM_ORIGINATOR_ID_PROPERTY);
         alarmFieldColumnMap.put("originatorType", ModelConstants.ALARM_ORIGINATOR_TYPE_PROPERTY);
         alarmFieldColumnMap.put("originator", "originator_name");
+        alarmFieldColumnMap.put("originatorLabel", ModelConstants.ALARM_ORIGINATOR_LABEL_PROPERTY);
     }
 
     private static final String SELECT_ORIGINATOR_NAME = " COALESCE(CASE" +
@@ -86,6 +87,13 @@ public class DefaultAlarmQueryRepository implements AlarmQueryRepository {
             " WHEN a.originator_type = " + EntityType.ENTITY_VIEW.ordinal() +
             " THEN (select name from entity_view where id = a.originator_id)" +
             " END, 'Deleted') as originator_name";
+
+    private static final String SELECT_ORIGINATOR_LABEL = " COALESCE(CASE" +
+            " WHEN a.originator_type = " + EntityType.ASSET.ordinal() +
+            " THEN (select label from asset where id = a.originator_id)" +
+            " WHEN a.originator_type = " + EntityType.DEVICE.ordinal() +
+            " THEN (select name from device where id = a.originator_id)" +
+            " END, '') as originator_label";
 
     private static final String FIELDS_SELECTION = "select a.id as id," +
             " a.created_time as created_time," +


### PR DESCRIPTION
## Pull Request description

issue: https://github.com/thingsboard/thingsboard/issues/7767

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



