### PR TITLE
[3.5] Bugfix: Node 'split array msg'. Empty array

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/transform/TbSplitArrayMsgNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/transform/TbSplitArrayMsgNode.java
@@ -40,7 +40,7 @@ import java.util.concurrent.ExecutionException;
         name = "split array msg",
         configClazz = EmptyNodeConfiguration.class,
         nodeDescription = "Split array message into several msgs",
-        nodeDetails = "Split the array fetched from the msg body. If the msg data is not a JSON object returns the "
+        nodeDetails = "Split the array fetched from the msg body. If the msg data is not a JSON array returns the "
                 + "incoming message as outbound message with <code>Failure</code> chain, otherwise returns "
                 + "inner objects of the extracted array as separate messages via <code>Success</code> chain.",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
@@ -61,7 +61,9 @@ public class TbSplitArrayMsgNode implements TbNode {
         JsonNode jsonNode = JacksonUtil.toJsonNode(msg.getData());
         if (jsonNode.isArray()) {
             ArrayNode data = (ArrayNode) jsonNode;
-            if (data.size() == 1) {
+            if (data.isEmpty()) {
+                ctx.ack(msg);
+            } else if (data.size() == 1) {
                 ctx.tellSuccess(TbMsg.transformMsg(msg, msg.getType(), msg.getOriginator(), msg.getMetaData(), JacksonUtil.toString(data.get(0))));
             } else {
                 TbMsgCallbackWrapper wrapper = new MultipleTbMsgsCallbackWrapper(data.size(), new TbMsgCallback() {


### PR DESCRIPTION
## Pull Request description

issue: https://github.com/thingsboard/thingsboard/issues/7790 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



