### PR TITLE
[3.7][WIP] RuleChainActorMessageProcessor: Split rule-chain without shadow checkpoints

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/ActorSystemContext.java
+++ b/application/src/main/java/org/thingsboard/server/actors/ActorSystemContext.java
@@ -409,6 +409,10 @@ public class ActorSystemContext {
     @Getter
     private long syncSessionTimeout;
 
+    @Value("${actors.rule.chain.checkpoint_on_split:true}")
+    @Getter
+    private boolean ruleChainCheckpointOnSplit;
+
     @Value("${actors.rule.chain.error_persist_frequency:3000}")
     @Getter
     private long ruleChainErrorPersistFrequency;

--- a/application/src/main/java/org/thingsboard/server/actors/ruleChain/RuleChainActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/ruleChain/RuleChainActorMessageProcessor.java
@@ -327,17 +327,18 @@ public class RuleChainActorMessageProcessor extends ComponentMsgProcessor<RuleCh
             } else {
                 // Will try to process many relations without shadow checkpoints.
                 // Failed rule node callback will do the checkpoint on the nearest split point.
-                log.trace("[{}][{}][{}] Pushing message to multiple targets: [{}]", tenantId, entityId, msg.getId(), relationsByTypes);
+                log.info("Pushing message to multiple targets: [{}][{}][{}] [{}]", tenantId, entityId, msg.getId(), relationsByTypes);
                 final RuleChainSplitPoint splitPoint = new RuleChainSplitPoint(msg.getCallback(), relationsCount);
                 for (RuleNodeRelation relation : relationsByTypes) {
                     //prepare callback in case of failure scenario
                     EntityId target = relation.getOut();
                     TbMsgCallback childTbMsgCallback = splitPoint.addChild(queueCallback -> {
                         //on failure msg callback will put to queue and consumed queueCallback will handle the result
+                        log.warn("Put to queue (shadow): [{}][{}][{}] [{}][{}]", tenantId, entityId, msg.getId(), target, msg);
                         putToQueue(tpi, msg, queueCallback, target);
                     });
 
-                    log.trace("[{}][{}][{}] Pushing message to target with split callback: [{}]", tenantId, entityId, msg.getId(), relation.getOut());
+                    log.info("Pushing to target with split callback: [{}][{}][{}] [{}]", tenantId, entityId, msg.getId(), relation.getOut());
                     TbMsg clonedMsg = TbMsg.newMsg(msg, childTbMsgCallback);
                     pushToTarget(tpi, clonedMsg, relation.getOut(), relation.getType());
                 }

--- a/application/src/main/java/org/thingsboard/server/service/queue/RuleChainSplitPoint.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/RuleChainSplitPoint.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.queue;
+
+import org.thingsboard.server.common.msg.queue.RuleEngineException;
+import org.thingsboard.server.common.msg.queue.TbMsgCallback;
+import org.thingsboard.server.queue.TbQueueCallback;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+
+public class RuleChainSplitPoint {
+    final TbMsgCallback parentCallback;
+    final List<SplitPointTbMsgCallback> childs;
+
+    final AtomicInteger countdown;
+    final int capacity;
+
+    volatile RuleEngineException exception = null;
+
+    public RuleChainSplitPoint(TbMsgCallback parentCallback, int capacity) {
+        assert capacity <= 0 : "positive capacity expected";
+        this.capacity = capacity;
+        this.childs = new ArrayList<>(capacity);
+        this.countdown = new AtomicInteger(capacity);
+        this.parentCallback = parentCallback;
+    }
+
+    // no need to be thread safe - all addition expected in the same thread for RuleChainActor
+    public SplitPointTbMsgCallback addChild(Consumer<TbQueueCallback> failureConsumer) {
+        assert childs.size() >= capacity : "callback list capacity exceeded";
+        SplitPointTbMsgCallback callback = new SplitPointTbMsgCallback(this, failureConsumer);
+        childs.add(callback);
+        return callback;
+    }
+
+    public void onSuccess() {
+        if (countdown.decrementAndGet() == 0) {
+            callbackParent();
+        }
+    }
+
+    public void onFailure(RuleEngineException t) {
+        this.exception = t;
+        if (countdown.decrementAndGet() == 0) {
+            callbackParent();
+        }
+    }
+
+    void callbackParent() {
+        if (exception == null) {
+            parentCallback.onSuccess();
+        } else {
+            parentCallback.onFailure(exception);
+        }
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/queue/SplitPointTbMsgCallback.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/SplitPointTbMsgCallback.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.queue;
+
+import lombok.RequiredArgsConstructor;
+import org.thingsboard.server.common.msg.queue.RuleEngineException;
+import org.thingsboard.server.common.msg.queue.TbMsgCallback;
+import org.thingsboard.server.queue.TbQueueCallback;
+import org.thingsboard.server.queue.TbQueueMsgMetadata;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+@RequiredArgsConstructor
+class SplitPointTbMsgCallback implements TbMsgCallback {
+
+    final AtomicBoolean runOnce = new AtomicBoolean();
+    final RuleChainSplitPoint splitPoint;
+    final Consumer<TbQueueCallback> failureConsumer;
+
+    @Override
+    public void onSuccess() {
+        if (runOnce.compareAndSet(false, true)) {
+            splitPoint.onSuccess();
+        }
+    }
+
+    @Override
+    public void onFailure(RuleEngineException e) {
+        if (runOnce.compareAndSet(false, true)) {
+            TbQueueCallback tbQueueCallback = new SplitPointTbQueueCallback();
+            failureConsumer.accept(tbQueueCallback);
+        }
+    }
+
+    private class SplitPointTbQueueCallback implements TbQueueCallback {
+        @Override
+        public void onSuccess(TbQueueMsgMetadata metadata) {
+            splitPoint.onSuccess();
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            splitPoint.onFailure(new RuleEngineException(t.getMessage()));
+        }
+    }
+}

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -357,6 +357,7 @@ actors:
     # Specify thread pool size for external call service
     external_call_thread_pool_size: "${ACTORS_RULE_EXTERNAL_CALL_THREAD_POOL_SIZE:50}"
     chain:
+      checkpoint_on_split: "${ACTORS_RULE_CHAIN_CHECKPOINT_ON_SPLIT:true}"
       # Errors for particular actor are persisted once per specified amount of milliseconds
       error_persist_frequency: "${ACTORS_RULE_CHAIN_ERROR_FREQUENCY:3000}"
       debug_mode_rate_limits_per_tenant:

--- a/common/message/src/main/java/org/thingsboard/server/common/msg/TbMsg.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/TbMsg.java
@@ -27,7 +27,6 @@ import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.EntityIdFactory;
-import org.thingsboard.server.common.data.id.QueueId;
 import org.thingsboard.server.common.data.id.RuleChainId;
 import org.thingsboard.server.common.data.id.RuleNodeId;
 import org.thingsboard.server.common.msg.gen.MsgProtos;
@@ -150,6 +149,12 @@ public final class TbMsg implements Serializable {
     public static TbMsg transformMsg(TbMsg tbMsg, RuleChainId ruleChainId, String queueName) {
         return new TbMsg(queueName, tbMsg.id, tbMsg.ts, tbMsg.type, tbMsg.originator, tbMsg.customerId, tbMsg.metaData, tbMsg.dataType,
                 tbMsg.data, ruleChainId, null, tbMsg.ctx.copy(), tbMsg.getCallback());
+    }
+
+    // used for SplitPoint with callback
+    public static TbMsg newMsg(TbMsg tbMsg, TbMsgCallback callback) {
+        return new TbMsg(tbMsg.queueName, UUID.randomUUID(), tbMsg.ts, tbMsg.type, tbMsg.originator, tbMsg.customerId, tbMsg.metaData.copy(), tbMsg.dataType,
+                tbMsg.data, tbMsg.ruleChainId, tbMsg.ruleNodeId, tbMsg.ctx.copy(), callback);
     }
 
     //used for enqueueForTellNext


### PR DESCRIPTION
# RuleChainActorMessageProcessor: Split rule-chain without shadow checkpoints

Will try to process many relations without shadow checkpoints. Failed rule node callback will do the checkpoint on the nearest split point.

The aim is to skip the shadow checkpoints when the rule chain splits into many targets.
Shadow checkpoint was implemented to guarantee consistency. 
The same guarantees remained in the PR based on callbacks.
Based on `RuleChainSplitPoint` and `SplitPointTbMsgCallback` that consumes fall-back lambda set by `RuleChainActorMessageProcessor`.

![image](https://user-images.githubusercontent.com/79898499/209159785-a22a5f75-466c-4d89-9842-b48059eab8ff.png)

### Benefits:
As 99,999% of messages come with no errors, much queue throughput will be saved.

The second benefit is to have a straight-forward rule chain run, near real-time execution. 

This really helps for a high load with lag accumulated, like 1M incoming messages:
 - Will not add another 12M to the end of the ques (for 12 branches as shown on the example rule chain)
 - Will produce results as soon as possible (immediately if there are no failures or timeouts)
 - Useful when the rule chain reads the state at the beginning, splits for many branches in the middle and saves the result at the end.
 - Especially useful for SequentialByOriginator-like queues performance as it saves roundtrips significantly.


### Downsides:

For batch timeout, it is nice to have onTimeout event that will save the unfinished chains at a safe point. 
Without such improvement, RuleChainActor will process messages even if message timeouts and probably will be retried from the beginning.

The current implementation does not show the rule-node first failure as the batch is considered successful if it passes the split point (see the log output, there is one failed on the next batch). The rule node will be executed at least twice! This might be unwanted behavior for the `Skip` strategy (at most one). The solution might be injecting another lambda for the Skip strategy batches (accessing through context)

### Processing  example
Here the only failed node branch was persisted (checkpoint). Others go straight-forward. 
Generally speaking, it avoids 11 of 12 messages to save with 3 avoided round trips to the queue for producer and consumer.

```
#########################  FIRST BATCH  #####################
2022-12-22 15:32:02,270 [rule-dispatcher-1-1] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing message to multiple targets: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][0a3b0325-c038-4017-9aa5-c388005a349d] [[RuleNodeRelation(in=12721f00-81eb-11ed-b3ac-0f69ad8878d5, out=127441e0-81eb-11ed-b3ac-0f69ad8878d5, type=Success), RuleNodeRelation(in=12721f00-81eb-11ed-b3ac-0f69ad8878d5, out=d37a7c20-81ef-11ed-92c7-6b7f1217da7d, type=Success)]]
2022-12-22 15:32:02,271 [rule-dispatcher-1-1] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][0a3b0325-c038-4017-9aa5-c388005a349d] [127441e0-81eb-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,272 [rule-dispatcher-1-1] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][0a3b0325-c038-4017-9aa5-c388005a349d] [d37a7c20-81ef-11ed-92c7-6b7f1217da7d]
2022-12-22 15:32:02,273 [rule-dispatcher-0-4] INFO  o.t.rule.engine.action.TbLogNode - 1B
2022-12-22 15:32:02,273 [rule-dispatcher-3-3] INFO  o.t.rule.engine.action.TbLogNode - 1A
2022-12-22 15:32:02,274 [rule-dispatcher-0-4] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing message to multiple targets: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][42940e20-c22e-4316-ba73-1977b0ffb756] [[RuleNodeRelation(in=127441e0-81eb-11ed-b3ac-0f69ad8878d5, out=d1f9fe00-81ec-11ed-b3ac-0f69ad8878d5, type=Success), RuleNodeRelation(in=127441e0-81eb-11ed-b3ac-0f69ad8878d5, out=d1fa9a40-81ec-11ed-b3ac-0f69ad8878d5, type=Success), RuleNodeRelation(in=127441e0-81eb-11ed-b3ac-0f69ad8878d5, out=d1fae860-81ec-11ed-b3ac-0f69ad8878d5, type=Success)]]
2022-12-22 15:32:02,274 [rule-dispatcher-0-4] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][42940e20-c22e-4316-ba73-1977b0ffb756] [d1f9fe00-81ec-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,274 [rule-dispatcher-0-4] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][42940e20-c22e-4316-ba73-1977b0ffb756] [d1fa9a40-81ec-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,274 [rule-dispatcher-0-4] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][42940e20-c22e-4316-ba73-1977b0ffb756] [d1fae860-81ec-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,275 [tbel-executor-43-3] INFO  o.t.rule.engine.action.TbLogNode - 2A
2022-12-22 15:32:02,275 [tbel-executor-57-1] INFO  o.t.rule.engine.action.TbLogNode - 1B-2single
2022-12-22 15:32:02,275 [tbel-executor-50-2] INFO  o.t.rule.engine.action.TbLogNode - 2B
2022-12-22 15:32:02,275 [rule-dispatcher-2-2] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing message to multiple targets: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][54aa6bba-4713-427c-9cfe-e2d85f5272a0] [[RuleNodeRelation(in=d1f9fe00-81ec-11ed-b3ac-0f69ad8878d5, out=d1fb3680-81ec-11ed-b3ac-0f69ad8878d5, type=Success), RuleNodeRelation(in=d1f9fe00-81ec-11ed-b3ac-0f69ad8878d5, out=d1fbabb0-81ec-11ed-b3ac-0f69ad8878d5, type=Success), RuleNodeRelation(in=d1f9fe00-81ec-11ed-b3ac-0f69ad8878d5, out=d1fbd2c0-81ec-11ed-b3ac-0f69ad8878d5, type=Success), RuleNodeRelation(in=d1f9fe00-81ec-11ed-b3ac-0f69ad8878d5, out=d1fc20e0-81ec-11ed-b3ac-0f69ad8878d5, type=Success), RuleNodeRelation(in=d1f9fe00-81ec-11ed-b3ac-0f69ad8878d5, out=d1fc6f00-81ec-11ed-b3ac-0f69ad8878d5, type=Success), RuleNodeRelation(in=d1f9fe00-81ec-11ed-b3ac-0f69ad8878d5, out=d1fce430-81ec-11ed-b3ac-0f69ad8878d5, type=Success), RuleNodeRelation(in=d1f9fe00-81ec-11ed-b3ac-0f69ad8878d5, out=d1fd5960-81ec-11ed-b3ac-0f69ad8878d5, type=Success)]]
2022-12-22 15:32:02,275 [rule-dispatcher-2-2] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][54aa6bba-4713-427c-9cfe-e2d85f5272a0] [d1fb3680-81ec-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,275 [rule-dispatcher-2-2] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][54aa6bba-4713-427c-9cfe-e2d85f5272a0] [d1fbabb0-81ec-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,275 [rule-dispatcher-2-2] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][54aa6bba-4713-427c-9cfe-e2d85f5272a0] [d1fbd2c0-81ec-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,275 [tbel-executor-50-2] INFO  o.t.rule.engine.action.TbLogNode - 2C
2022-12-22 15:32:02,275 [rule-dispatcher-2-2] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][54aa6bba-4713-427c-9cfe-e2d85f5272a0] [d1fc20e0-81ec-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,275 [rule-dispatcher-2-2] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][54aa6bba-4713-427c-9cfe-e2d85f5272a0] [d1fc6f00-81ec-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,275 [rule-dispatcher-2-2] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][54aa6bba-4713-427c-9cfe-e2d85f5272a0] [d1fce430-81ec-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,275 [rule-dispatcher-2-2] INFO  o.t.s.a.r.RuleChainActorMessageProcessor - Pushing to target with split callback: [fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][54aa6bba-4713-427c-9cfe-e2d85f5272a0] [d1fd5960-81ec-11ed-b3ac-0f69ad8878d5]
2022-12-22 15:32:02,275 [tbel-executor-50-2] INFO  o.t.rule.engine.action.TbLogNode - 3A
2022-12-22 15:32:02,275 [tbel-executor-57-1] INFO  o.t.rule.engine.action.TbLogNode - 3C
2022-12-22 15:32:02,276 [tbel-executor-50-2] INFO  o.t.rule.engine.action.TbLogNode - 3B
2022-12-22 15:32:02,276 [tbel-executor-57-1] INFO  o.t.rule.engine.action.TbLogNode - 3E
2022-12-22 15:32:02,276 [rule-dispatcher-3-3] INFO  o.t.rule.engine.action.TbLogNode - 3F
2022-12-22 15:32:02,276 [tbel-executor-50-2] INFO  o.t.rule.engine.action.TbLogNode - 3G-twice-hit
2022-12-22 15:32:02,276 [rule-dispatcher-2-2] INFO  o.t.rule.engine.action.TbLogNode - 3G-twice-hit
2022-12-22 15:32:02,298 [tbel-executor-57-1] WARN  o.t.s.a.AbstractScriptInvokeService - Script has exception counter 1 on disabledFunctions for id 68b3caee-7782-41cd-89b5-d3ed25d40436, exception java.lang.RuntimeException: Script memory overflow!
2022-12-22 15:32:02,300 [rule-dispatcher-3-3] WARN  o.t.s.a.r.RuleChainActorMessageProcessor - Put to queue (shadow): 
#########################  NEXT BATCH  #####################
[fa611bd0-81e7-11ed-90b5-5d800e929b01][fa611bd0-81e7-11ed-90b5-5d800e929b01][54aa6bba-4713-427c-9cfe-e2d85f5272a0] [d1fd5960-81ec-11ed-b3ac-0f69ad8878d5][TbMsg(queueName=Main, id=54aa6bba-4713-427c-9cfe-e2d85f5272a0, ts=1671719522192, type=POST_TELEMETRY_REQUEST, originator=fa611bd0-81e7-11ed-90b5-5d800e929b01, customerId=null, metaData=TbMsgMetaData(data={data=40}), dataType=JSON, data={"temp":42,"humidity":77}, ruleChainId=b8bdf2e0-81ea-11ed-b3ac-0f69ad8878d5, ruleNodeId=12721f00-81eb-11ed-b3ac-0f69ad8878d5, ctx=org.thingsboard.server.common.msg.TbMsgProcessingCtx@39a3d886, callback=org.thingsboard.server.service.queue.SplitPointTbMsgCallback@2f0891c9)]
2022-12-22 15:32:02,313 [tbel-executor-57-1] WARN  o.t.s.a.AbstractScriptInvokeService - Script has exception counter 2 on disabledFunctions for id 68b3caee-7782-41cd-89b5-d3ed25d40436, exception java.lang.RuntimeException: Script memory overflow!
2022-12-22 15:32:02,314 [tb-rule-engine-consumer-51-thread-30 | QK(Main,TB_RULE_ENGINE,system)-1] INFO  o.t.s.s.q.DefaultTbRuleEngineConsumerService - Failed to process [1] messages
2022-12-22 15:32:02,314 [tb-rule-engine-consumer-51-thread-30 | QK(Main,TB_RULE_ENGINE,system)-1] INFO  o.t.s.s.q.DefaultTbRuleEngineConsumerService - [fa611bd0-81e7-11ed-90b5-5d800e929b01] Failed to process message: TbMsg(queueName=Main, id=6d2fa86e-6dc5-4a13-ad81-d1ea680c1028, ts=1671719522192, type=POST_TELEMETRY_REQUEST, originator=fa611bd0-81e7-11ed-90b5-5d800e929b01, customerId=null, metaData=TbMsgMetaData(data={data=40}), dataType=JSON, data={"temp":42,"humidity":77}, ruleChainId=b8bdf2e0-81ea-11ed-b3ac-0f69ad8878d5, ruleNodeId=d1fd5960-81ec-11ed-b3ac-0f69ad8878d5, ctx=org.thingsboard.server.common.msg.TbMsgProcessingCtx@7e77b9f5, callback=org.thingsboard.server.common.msg.queue.TbMsgCallback$1@5f343e24), Last Rule Node: [RuleChain: tree|RuleNode: error1-2-3-four(d1fd5960-81ec-11ed-b3ac-0f69ad8878d5)]
```


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



