### PR TITLE
Exclude specified subtypes from autocomplete widget.

### DIFF
--- a/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
@@ -342,12 +342,9 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
       map((data) => {
         if (data) {
           if (this.excludeEntityIds && this.excludeEntityIds.length) {
+            const excludeEntityIdsSet = new Set(this.excludeEntityIds);
             const entities: Array<BaseData<EntityId>> = [];
-            data.forEach((entity) => {
-              if (this.excludeEntityIds.indexOf(entity.id.id) === -1) {
-                entities.push(entity);
-              }
-            });
+            data.forEach(entity => !excludeEntityIdsSet.has(entity.id.id) && entities.push(entity));
             return entities;
           } else {
             return data;

--- a/ui-ngx/src/app/shared/components/entity/entity-subtype-autocomplete.component.html
+++ b/ui-ngx/src/app/shared/components/entity/entity-subtype-autocomplete.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<mat-form-field [formGroup]="subTypeFormGroup" class="mat-block">
+<mat-form-field [formGroup]="subTypeFormGroup" class="mat-block" [appearance]="appearance">
   <mat-label>{{ entitySubtypeText | translate }}</mat-label>
   <input matInput type="text" placeholder="{{ selectEntitySubtypeText | translate }}"
          #subTypeInput

--- a/ui-ngx/src/app/shared/components/entity/entity-subtype-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-subtype-autocomplete.component.ts
@@ -37,6 +37,7 @@ import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { AssetService } from '@core/http/asset.service';
 import { EntityViewService } from '@core/http/entity-view.service';
 import { EdgeService } from '@core/http/edge.service';
+import { MatFormFieldAppearance } from '@angular/material/form-field/form-field';
 
 @Component({
   selector: 'tb-entity-subtype-autocomplete',
@@ -70,6 +71,12 @@ export class EntitySubTypeAutocompleteComponent implements ControlValueAccessor,
 
   @Input()
   disabled: boolean;
+
+  @Input()
+  excludeSubTypes: Array<string>;
+
+  @Input()
+  appearance: MatFormFieldAppearance = 'legacy';
 
   @ViewChild('subTypeInput', {static: true}) subTypeInput: ElementRef;
 
@@ -238,9 +245,14 @@ export class EntitySubTypeAutocompleteComponent implements ControlValueAccessor,
           break;
       }
       if (subTypesObservable) {
+        const excludeSubTypesSet = new Set(this.excludeSubTypes);
         this.subTypes = subTypesObservable.pipe(
           catchError(() => of([] as Array<EntitySubtype>)),
-          map(subTypes => subTypes.map(subType => subType.type)),
+          map(subTypes => {
+            const filteredSubTypes: Array<string> = [];
+            subTypes.forEach(subType => !excludeSubTypesSet.has(subType.type) && filteredSubTypes.push(subType.type));
+            return filteredSubTypes;
+          }),
           publishReplay(1),
           refCount()
         );


### PR DESCRIPTION
In our projects we are trying to reuse TB code widgets as much as possible. The `tb-entity-autocomplete` widget provides useful filtering feature by setting property called `excludeEntityIds`.

This PR adds the same functionality but for the `tb-entity-subtype-autocomplete` widget by setting properties called `excludeSubTypes`. Angular's `appearance` property was added as well.