### PR TITLE
Queue autocomplete add input hint

### DIFF
--- a/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.html
+++ b/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.html
@@ -16,7 +16,6 @@
 
 -->
 <mat-form-field [formGroup]="selectQueueFormGroup"
-                [ngStyle] = "autocompleteHint ? {'padding-bottom': '16px'} : {}"
                 class="mat-block autocomplete-queue">
   <input matInput type="text" placeholder="{{ 'queue.queue-name' | translate }}"
          #queueInput

--- a/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.html
+++ b/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.html
@@ -15,7 +15,9 @@
     limitations under the License.
 
 -->
-<mat-form-field [formGroup]="selectQueueFormGroup" class="mat-block autocomplete-queue">
+<mat-form-field [formGroup]="selectQueueFormGroup"
+                [ngStyle] = "autocompleteHint ? {'padding-bottom': '16px'} : {}"
+                class="mat-block autocomplete-queue">
   <input matInput type="text" placeholder="{{ 'queue.queue-name' | translate }}"
          #queueInput
          formControlName="queueName"
@@ -50,6 +52,7 @@
       </div>
     </mat-option>
   </mat-autocomplete>
+  <mat-hint *ngIf = "autocompleteHint">{{autocompleteHint | translate}}</mat-hint>
   <mat-error *ngIf="selectQueueFormGroup.get('queueName').hasError('required')">
     {{ 'queue.queue-required' | translate }}
   </mat-error>

--- a/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.html
+++ b/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.html
@@ -52,7 +52,7 @@
       </div>
     </mat-option>
   </mat-autocomplete>
-  <mat-hint *ngIf = "autocompleteHint">{{autocompleteHint | translate}}</mat-hint>
+  <mat-hint *ngIf = "autocompleteHint">{{ autocompleteHint | translate }}</mat-hint>
   <mat-error *ngIf="selectQueueFormGroup.get('queueName').hasError('required')">
     {{ 'queue.queue-required' | translate }}
   </mat-error>

--- a/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.scss
+++ b/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.scss
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-:host ::ng-deep {
+::ng-deep {
   .queue-option {
     .mat-option-text {
       display: inline;
     }
+
     .queue-option-description {
       display: block;
       overflow: hidden;
@@ -26,7 +27,9 @@
       white-space: nowrap;
     }
   }
+}
 
+:host ::ng-deep {
   .mat-form-field {
     .mat-form-field-wrapper {
       padding-bottom: 0px;

--- a/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.scss
+++ b/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-::ng-deep {
+:host ::ng-deep {
   .queue-option {
     .mat-option-text {
       display: inline;
@@ -24,6 +24,28 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+  }
+
+  .mat-form-field {
+    .mat-form-field-wrapper {
+      padding-bottom: 0px;
+
+      .mat-form-field-underline {
+        position: initial !important;
+        display: block;
+        margin-top: -1px;
+      }
+
+      .mat-form-field-subscript-wrapper,
+      .mat-form-field-ripple {
+        position: initial !important;
+        display: table;
+      }
+
+      .mat-form-field-subscript-wrapper {
+        min-height: calc(1em + 1px);
+      }
     }
   }
 }

--- a/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.ts
@@ -61,7 +61,6 @@ export class QueueAutocompleteComponent implements ControlValueAccessor, OnInit 
   get required(): boolean {
     return this.requiredValue;
   }
-
   @Input()
   set required(value: boolean) {
     this.requiredValue = coerceBooleanProperty(value);

--- a/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.ts
@@ -54,19 +54,12 @@ export class QueueAutocompleteComponent implements ControlValueAccessor, OnInit 
   @Input()
   requiredText: string;
 
-  private hint: string;
+  @Input()
+  autocompleteHint: string;
+
   private requiredValue: boolean;
   get required(): boolean {
     return this.requiredValue;
-  }
-
-  @Input()
-  set autocompleteHint(value) {
-    this.hint = value;
-  }
-
-  get autocompleteHint() {
-    return this.hint;
   }
 
   @Input()

--- a/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/queue/queue-autocomplete.component.ts
@@ -54,10 +54,21 @@ export class QueueAutocompleteComponent implements ControlValueAccessor, OnInit 
   @Input()
   requiredText: string;
 
+  private hint: string;
   private requiredValue: boolean;
   get required(): boolean {
     return this.requiredValue;
   }
+
+  @Input()
+  set autocompleteHint(value) {
+    this.hint = value;
+  }
+
+  get autocompleteHint() {
+    return this.hint;
+  }
+
   @Input()
   set required(value: boolean) {
     this.requiredValue = coerceBooleanProperty(value);


### PR DESCRIPTION
## Pull Request description

Added Input for hint in the queue-autocomplete component. 
This  change was added for this task: https://github.com/thingsboard/thingsboard-rule-config-ui-ngx/pull/108
UI example: 
![image](https://user-images.githubusercontent.com/43555187/212687549-632228da-72e0-45c2-a49c-aa905fb1f761.png)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x]  PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



