### PR TITLE
[WIP][3.5] Feature: new node 'device state'

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/ruleChain/DefaultTbContext.java
+++ b/application/src/main/java/org/thingsboard/server/actors/ruleChain/DefaultTbContext.java
@@ -29,6 +29,7 @@ import org.thingsboard.rule.engine.api.RuleEngineAlarmService;
 import org.thingsboard.rule.engine.api.RuleEngineApiUsageStateService;
 import org.thingsboard.rule.engine.api.RuleEngineAssetProfileCache;
 import org.thingsboard.rule.engine.api.RuleEngineDeviceProfileCache;
+import org.thingsboard.rule.engine.api.RuleEngineDeviceStateService;
 import org.thingsboard.rule.engine.api.RuleEngineRpcService;
 import org.thingsboard.rule.engine.api.RuleEngineTelemetryService;
 import org.thingsboard.rule.engine.api.ScriptEngine;
@@ -780,6 +781,11 @@ class DefaultTbContext implements TbContext {
     @Override
     public RuleEngineApiUsageStateService getRuleEngineApiUsageStateService() {
         return mainCtx.getApiUsageStateService();
+    }
+
+    @Override
+    public RuleEngineDeviceStateService getRuleEngineDeviceStateService() {
+        return mainCtx.getDeviceStateService();
     }
 
     private TbMsgMetaData getActionMetaData(RuleNodeId ruleNodeId) {

--- a/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/RuleEngineDeviceStateService.java
+++ b/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/RuleEngineDeviceStateService.java
@@ -13,21 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.service.state;
+package org.thingsboard.rule.engine.api;
 
-import org.springframework.context.ApplicationListener;
-import org.thingsboard.rule.engine.api.RuleEngineDeviceStateService;
-import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.TenantId;
-import org.thingsboard.server.queue.discovery.event.PartitionChangeEvent;
-import org.thingsboard.server.gen.transport.TransportProtos;
-import org.thingsboard.server.common.msg.queue.TbCallback;
 
-/**
- * Created by ashvayka on 01.05.18.
- */
-public interface DeviceStateService extends RuleEngineDeviceStateService, ApplicationListener<PartitionChangeEvent> {
+public interface RuleEngineDeviceStateService {
 
     void onDeviceConnect(TenantId tenantId, DeviceId deviceId);
 
@@ -36,7 +27,5 @@ public interface DeviceStateService extends RuleEngineDeviceStateService, Applic
     void onDeviceDisconnect(TenantId tenantId, DeviceId deviceId);
 
     void onDeviceInactivityTimeoutUpdate(TenantId tenantId, DeviceId deviceId, long inactivityTimeout);
-
-    void onQueueMsg(TransportProtos.DeviceStateServiceMsgProto proto, TbCallback bytes);
 
 }

--- a/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/TbContext.java
+++ b/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/TbContext.java
@@ -329,4 +329,6 @@ public interface TbContext {
     WidgetTypeService getWidgetTypeService();
 
     RuleEngineApiUsageStateService getRuleEngineApiUsageStateService();
+
+    RuleEngineDeviceStateService getRuleEngineDeviceStateService();
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgDeviceStateNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgDeviceStateNode.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.telemetry;
+
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.rule.engine.api.RuleNode;
+import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.rule.engine.api.TbNode;
+import org.thingsboard.rule.engine.api.TbNodeConfiguration;
+import org.thingsboard.rule.engine.api.TbNodeException;
+import org.thingsboard.rule.engine.api.util.TbNodeUtils;
+import org.thingsboard.server.common.data.DataConstants;
+import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.plugin.ComponentType;
+import org.thingsboard.server.common.msg.TbMsg;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+@Slf4j
+@RuleNode(
+        type = ComponentType.ACTION,
+        name = "device state",
+        configClazz = TbMsgDeviceStateNodeConfiguration.class,
+        nodeDescription = "Initializing device connectivity events",
+        nodeDetails = "Triggering the device connectivity events that are pushed to the <b>Rule Engine</b>. " +
+                "If msg originator is not a device, incoming message routes via <code>Failure</code> chain, " +
+                "otherwise <code>Success</code> chain is used." +
+                "<br/><br/>" +
+                "Supported events are:" +
+                "<br/>  - <b>Connect event<b>" +
+                "<br/>  - <b>Disconnect event<b>" +
+                "<br/>  - <b>Activity event<b>" +
+                "<br/>  - <b>Inactivity event<b>",
+        uiResources = {"static/rulenode/rulenode-core-config.js"},
+        configDirective = "tbActionNodeDeviceStateConfig"
+)
+public class TbMsgDeviceStateNode implements TbNode {
+
+    private TbMsgDeviceStateNodeConfiguration config;
+    private String event;
+
+    @Override
+    public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
+        this.config = TbNodeUtils.convert(configuration, TbMsgDeviceStateNodeConfiguration.class);
+        this.event = config.getEvent();
+        checkConfig();
+    }
+
+    @Override
+    public void onMsg(TbContext ctx, TbMsg msg) throws ExecutionException, InterruptedException, TbNodeException {
+        if (!msg.getOriginator().getEntityType().equals(EntityType.DEVICE)) {
+            throw new TbNodeException("Unsupported entity type: " + msg.getOriginator().getEntityType());
+        }
+        if (event.equals(DataConstants.ACTIVITY_EVENT)) {
+            ctx.getRuleEngineDeviceStateService().onDeviceActivity(ctx.getTenantId(), (DeviceId) msg.getOriginator(), System.currentTimeMillis());
+        } else if (event.equals(DataConstants.CONNECT_EVENT)) {
+            ctx.getRuleEngineDeviceStateService().onDeviceConnect(ctx.getTenantId(), (DeviceId) msg.getOriginator());
+        } else if (event.equals(DataConstants.INACTIVITY_EVENT)) {
+            ctx.getRuleEngineDeviceStateService().onDeviceInactivityTimeoutUpdate(ctx.getTenantId(), (DeviceId) msg.getOriginator(), 0);
+        } else if (event.equals(DataConstants.DISCONNECT_EVENT)) {
+            ctx.getRuleEngineDeviceStateService().onDeviceDisconnect(ctx.getTenantId(), (DeviceId) msg.getOriginator());
+        }
+        ctx.tellSuccess(msg);
+    }
+
+    private void checkConfig() {
+        List<String> avaliableEvents = List.of(
+                DataConstants.CONNECT_EVENT,
+                DataConstants.INACTIVITY_EVENT,
+                DataConstants.ACTIVITY_EVENT,
+                DataConstants.DISCONNECT_EVENT
+        );
+        if (!avaliableEvents.contains(this.event)) {
+            throw new IllegalArgumentException("Unsupported event: " + this.event);
+        }
+    }
+
+}

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgDeviceStateNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgDeviceStateNodeConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.telemetry;
+
+import lombok.Data;
+import org.thingsboard.rule.engine.api.NodeConfiguration;
+import org.thingsboard.server.common.data.DataConstants;
+
+@Data
+public class TbMsgDeviceStateNodeConfiguration implements NodeConfiguration<TbMsgDeviceStateNodeConfiguration> {
+
+    private String event;
+
+    @Override
+    public TbMsgDeviceStateNodeConfiguration defaultConfiguration() {
+        TbMsgDeviceStateNodeConfiguration configuration = new TbMsgDeviceStateNodeConfiguration();
+        configuration.setEvent(DataConstants.ACTIVITY_EVENT);
+        return configuration;
+    }
+}

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/telemetry/TbMsgDeviceStateNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/telemetry/TbMsgDeviceStateNodeTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.telemetry;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.rule.engine.api.RuleEngineDeviceStateService;
+import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.rule.engine.api.TbNodeConfiguration;
+import org.thingsboard.rule.engine.api.TbNodeException;
+import org.thingsboard.server.common.data.DataConstants;
+import org.thingsboard.server.common.data.id.CustomerId;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.msg.TbMsg;
+import org.thingsboard.server.common.msg.TbMsgMetaData;
+import org.thingsboard.server.common.msg.queue.TbMsgCallback;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TbMsgDeviceStateNodeTest {
+
+    TenantId tenantId;
+    DeviceId deviceId;
+    TbContext ctx;
+    TbMsgDeviceStateNode node;
+    TbMsgDeviceStateNodeConfiguration config;
+    TbMsgCallback callback;
+    RuleEngineDeviceStateService ruleEngineDeviceStateService;
+
+    @BeforeEach
+    void setUp() {
+        tenantId = new TenantId(UUID.randomUUID());
+        deviceId = new DeviceId(UUID.randomUUID());
+        callback = mock(TbMsgCallback.class);
+
+        //node
+        config = new TbMsgDeviceStateNodeConfiguration().defaultConfiguration();
+        node = spy(new TbMsgDeviceStateNode());
+
+        //init mock
+        ctx = mock(TbContext.class);
+        ruleEngineDeviceStateService = mock(RuleEngineDeviceStateService.class);
+
+        when(ctx.getTenantId()).thenReturn(tenantId);
+        when(ctx.getRuleEngineDeviceStateService()).thenReturn(ruleEngineDeviceStateService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        node.destroy();
+    }
+
+    @Test
+    void checkConfigNode_whenInit_thenFail() {
+        assertThatThrownBy(() -> node.init(ctx, getNodeConfiguration(DataConstants.ENTITY_CREATED))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void checkConfigNode_whenOriginatorNotDevice_thenFail() throws TbNodeException, ExecutionException, InterruptedException {
+        CustomerId customerId = new CustomerId(UUID.randomUUID());
+        node.init(ctx, getNodeConfiguration(DataConstants.ACTIVITY_EVENT));
+
+        assertThatThrownBy(() -> node.onMsg(ctx, getTbMsg(customerId, "{}"))).isInstanceOf(TbNodeException.class);
+    }
+
+    @Test
+    void givenMsg_whenOnMsg_then_activityEvent() throws TbNodeException, ExecutionException, InterruptedException {
+        verifyOnMs_Node(DataConstants.ACTIVITY_EVENT);
+    }
+
+    @Test
+    void givenMsg_whenOnMsg_then_connectEvent() throws TbNodeException, ExecutionException, InterruptedException {
+        verifyOnMs_Node(DataConstants.CONNECT_EVENT);
+    }
+
+    @Test
+    void givenMsg_whenOnMsg_then_inactivityEvent() throws TbNodeException, ExecutionException, InterruptedException {
+        verifyOnMs_Node(DataConstants.INACTIVITY_EVENT);
+    }
+
+    @Test
+    void givenMsg_whenOnMsg_then_disconnectEvent() throws TbNodeException, ExecutionException, InterruptedException {
+        verifyOnMs_Node(DataConstants.DISCONNECT_EVENT);
+    }
+
+    private void verifyOnMs_Node(String event) throws TbNodeException, ExecutionException, InterruptedException {
+        node.init(ctx, getNodeConfiguration(event));
+        node.onMsg(ctx, getTbMsg(deviceId, "{}"));
+
+        ArgumentCaptor<TbMsg> newMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        verify(ctx, times(1)).tellSuccess(newMsgCaptor.capture());
+        verify(ctx, never()).tellFailure(any(), any());
+
+        if (event.equals(DataConstants.ACTIVITY_EVENT)) {
+            verify(ruleEngineDeviceStateService, times(1)).onDeviceActivity(eq(tenantId), eq(deviceId), anyLong());
+        } else if (event.equals(DataConstants.CONNECT_EVENT)) {
+            verify(ruleEngineDeviceStateService, times(1)).onDeviceConnect(tenantId, deviceId);
+        } else if (event.equals(DataConstants.INACTIVITY_EVENT)) {
+            verify(ruleEngineDeviceStateService, times(1)).onDeviceInactivityTimeoutUpdate(tenantId, deviceId, 0);
+        } else if (event.equals(DataConstants.DISCONNECT_EVENT)) {
+            verify(ruleEngineDeviceStateService, times(1)).onDeviceDisconnect(tenantId, deviceId);
+        }
+
+        TbMsg newMsg = newMsgCaptor.getValue();
+        assertThat(newMsg).isNotNull();
+    }
+
+    private TbNodeConfiguration getNodeConfiguration(String event) {
+        config.setEvent(event);
+        return new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+    }
+
+    private TbMsg getTbMsg(EntityId entityId, String data) {
+        final Map<String, String> mdMap = Map.of(
+                "TestKey_1", "Test",
+                "country", "US",
+                "voltageDataValue", "220",
+                "city", "NY"
+        );
+        return TbMsg.newMsg("POST_ATTRIBUTES_REQUEST", entityId, new TbMsgMetaData(mdMap), data, callback);
+    }
+}


### PR DESCRIPTION
## Pull Request description

issue: https://github.com/thingsboard/thingsboard/issues/7954  

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



