### PR TITLE
[3.5] Feature: new nodes 'asset type switch' & 'device type switch'

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAbstractTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAbstractTypeSwitchNode.java
@@ -28,7 +28,7 @@ import org.thingsboard.server.common.msg.TbMsg;
 @Slf4j
 public abstract class TbAbstractTypeSwitchNode implements TbNode {
 
-    protected EmptyNodeConfiguration config;
+    private EmptyNodeConfiguration config;
 
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAbstractTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAbstractTypeSwitchNode.java
@@ -36,10 +36,10 @@ public abstract class TbAbstractTypeSwitchNode implements TbNode {
     }
 
     @Override
-    public void onMsg(TbContext ctx, TbMsg msg) {
+    public void onMsg(TbContext ctx, TbMsg msg) throws TbNodeException {
         ctx.tellNext(msg, getRelationType(ctx, msg.getOriginator()));
     }
 
-    protected abstract String getRelationType(TbContext ctx, EntityId originator);
+    protected abstract String getRelationType(TbContext ctx, EntityId originator) throws TbNodeException;
 
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAbstractTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAbstractTypeSwitchNode.java
@@ -40,10 +40,6 @@ public abstract class TbAbstractTypeSwitchNode implements TbNode {
         ctx.tellNext(msg, getRelationType(ctx, msg.getOriginator()));
     }
 
-    @Override
-    public void destroy() {
-    }
-
     protected abstract String getRelationType(TbContext ctx, EntityId originator);
 
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAbstractTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAbstractTypeSwitchNode.java
@@ -16,39 +16,34 @@
 package org.thingsboard.rule.engine.filter;
 
 import lombok.extern.slf4j.Slf4j;
-import org.thingsboard.rule.engine.api.RuleNode;
+import org.thingsboard.rule.engine.api.EmptyNodeConfiguration;
 import org.thingsboard.rule.engine.api.TbContext;
 import org.thingsboard.rule.engine.api.TbNode;
 import org.thingsboard.rule.engine.api.TbNodeConfiguration;
 import org.thingsboard.rule.engine.api.TbNodeException;
 import org.thingsboard.rule.engine.api.util.TbNodeUtils;
-import org.thingsboard.server.common.data.EntityType;
-import org.thingsboard.server.common.data.plugin.ComponentType;
+import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.msg.TbMsg;
 
 @Slf4j
-@RuleNode(
-        type = ComponentType.FILTER,
-        name = "entity type",
-        configClazz = TbOriginatorTypeFilterNodeConfiguration.class,
-        relationTypes = {"True", "False"},
-        nodeDescription = "Filter incoming messages by message Originator Type",
-        nodeDetails = "If the entity type of the incoming message originator is expected - send Message via <b>True</b> chain, otherwise <b>False</b> chain is used.",
-        uiResources = {"static/rulenode/rulenode-core-config.js"},
-        configDirective = "tbFilterNodeOriginatorTypeConfig")
-public class TbOriginatorTypeFilterNode implements TbNode {
+public abstract class TbAbstractTypeSwitchNode implements TbNode {
 
-    TbOriginatorTypeFilterNodeConfiguration config;
+    protected EmptyNodeConfiguration config;
 
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
-        this.config = TbNodeUtils.convert(configuration, TbOriginatorTypeFilterNodeConfiguration.class);
+        this.config = TbNodeUtils.convert(configuration, EmptyNodeConfiguration.class);
     }
 
     @Override
     public void onMsg(TbContext ctx, TbMsg msg) {
-        EntityType originatorType = msg.getOriginator().getEntityType();
-        ctx.tellNext(msg, config.getOriginatorTypes().contains(originatorType) ? "True" : "False");
+        ctx.tellNext(msg, getRelationType(ctx, msg.getOriginator()));
     }
+
+    @Override
+    public void destroy() {
+    }
+
+    protected abstract String getRelationType(TbContext ctx, EntityId originator);
 
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNode.java
@@ -40,11 +40,11 @@ public class TbAssetTypeSwitchNode extends TbAbstractTypeSwitchNode {
 
     protected String getRelationType(TbContext ctx, EntityId originator) {
         if (!EntityType.ASSET.equals(originator.getEntityType())) {
-            throw new RuntimeException("Unsupported originator type: " + originator.getEntityType() + "!");
+            throw new RuntimeException("Unsupported originator type: " + originator.getEntityType() + "! Only 'ASSET' type is allowed.");
         }
         AssetProfile assetProfile = ctx.getAssetProfileCache().get(ctx.getTenantId(), (AssetId) originator);
         if (assetProfile == null) {
-            throw new RuntimeException("Asset profile with entity id: " + originator.getId() + " wasn't found!");
+            throw new RuntimeException("Asset profile for entity id: " + originator.getId() + " wasn't found!");
         }
         return assetProfile.getName();
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNode.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.rule.engine.api.EmptyNodeConfiguration;
+import org.thingsboard.rule.engine.api.RuleNode;
+import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.id.AssetId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.plugin.ComponentType;
+
+@Slf4j
+@RuleNode(
+        type = ComponentType.FILTER,
+        name = "asset type switch",
+        customRelations = true,
+        relationTypes = {},
+        configClazz = EmptyNodeConfiguration.class,
+        nodeDescription = "Route incoming messages by Asset Type",
+        nodeDetails = "Routes messages to chain according to the asset type",
+        uiResources = {"static/rulenode/rulenode-core-config.js"},
+        configDirective = "tbNodeEmptyConfig")
+public class TbAssetTypeSwitchNode extends TbAbstractTypeSwitchNode {
+
+    protected String getRelationType(TbContext ctx, EntityId originator) {
+        if (!EntityType.ASSET.equals(originator.getEntityType())) {
+            throw new RuntimeException("Unsupported originator type: " + originator.getEntityType() + "!");
+        }
+        return ctx.getAssetProfileCache().get(ctx.getTenantId(), (AssetId) originator).getName();
+    }
+
+}

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNode.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.rule.engine.api.EmptyNodeConfiguration;
 import org.thingsboard.rule.engine.api.RuleNode;
 import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.rule.engine.api.TbNodeException;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.asset.AssetProfile;
 import org.thingsboard.server.common.data.id.AssetId;
@@ -32,19 +33,20 @@ import org.thingsboard.server.common.data.plugin.ComponentType;
         customRelations = true,
         relationTypes = {},
         configClazz = EmptyNodeConfiguration.class,
-        nodeDescription = "Route incoming messages by Asset Type",
-        nodeDetails = "Routes messages to chain according to the asset type",
+        nodeDescription = "Route incoming messages based on the name of the asset profile",
+        nodeDetails = "Route incoming messages based on the name of the asset profile. The asset profile name is case-sensitive",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
         configDirective = "tbNodeEmptyConfig")
 public class TbAssetTypeSwitchNode extends TbAbstractTypeSwitchNode {
 
-    protected String getRelationType(TbContext ctx, EntityId originator) {
+    @Override
+    protected String getRelationType(TbContext ctx, EntityId originator) throws TbNodeException {
         if (!EntityType.ASSET.equals(originator.getEntityType())) {
-            throw new RuntimeException("Unsupported originator type: " + originator.getEntityType() + "! Only 'ASSET' type is allowed.");
+            throw new TbNodeException("Unsupported originator type: " + originator.getEntityType() + "! Only 'ASSET' type is allowed.");
         }
         AssetProfile assetProfile = ctx.getAssetProfileCache().get(ctx.getTenantId(), (AssetId) originator);
         if (assetProfile == null) {
-            throw new RuntimeException("Asset profile for entity id: " + originator.getId() + " wasn't found!");
+            throw new TbNodeException("Asset profile for entity id: " + originator.getId() + " wasn't found!");
         }
         return assetProfile.getName();
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNode.java
@@ -20,6 +20,7 @@ import org.thingsboard.rule.engine.api.EmptyNodeConfiguration;
 import org.thingsboard.rule.engine.api.RuleNode;
 import org.thingsboard.rule.engine.api.TbContext;
 import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.asset.AssetProfile;
 import org.thingsboard.server.common.data.id.AssetId;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.plugin.ComponentType;
@@ -41,7 +42,11 @@ public class TbAssetTypeSwitchNode extends TbAbstractTypeSwitchNode {
         if (!EntityType.ASSET.equals(originator.getEntityType())) {
             throw new RuntimeException("Unsupported originator type: " + originator.getEntityType() + "!");
         }
-        return ctx.getAssetProfileCache().get(ctx.getTenantId(), (AssetId) originator).getName();
+        AssetProfile assetProfile = ctx.getAssetProfileCache().get(ctx.getTenantId(), (AssetId) originator);
+        if (assetProfile == null) {
+            throw new RuntimeException("Asset profile with entity id: " + originator.getId() + " doesn't not found!");
+        }
+        return assetProfile.getName();
     }
 
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNode.java
@@ -44,7 +44,7 @@ public class TbAssetTypeSwitchNode extends TbAbstractTypeSwitchNode {
         }
         AssetProfile assetProfile = ctx.getAssetProfileCache().get(ctx.getTenantId(), (AssetId) originator);
         if (assetProfile == null) {
-            throw new RuntimeException("Asset profile with entity id: " + originator.getId() + " doesn't not found!");
+            throw new RuntimeException("Asset profile with entity id: " + originator.getId() + " wasn't found!");
         }
         return assetProfile.getName();
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNode.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.rule.engine.api.EmptyNodeConfiguration;
 import org.thingsboard.rule.engine.api.RuleNode;
 import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.rule.engine.api.TbNodeException;
 import org.thingsboard.server.common.data.DeviceProfile;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.id.DeviceId;
@@ -30,21 +31,22 @@ import org.thingsboard.server.common.data.plugin.ComponentType;
         type = ComponentType.FILTER,
         name = "device type switch",
         customRelations = true,
-        relationTypes = {},
+        relationTypes = {"default"},
         configClazz = EmptyNodeConfiguration.class,
-        nodeDescription = "Route incoming messages by Device Type",
-        nodeDetails = "Routes messages to chain according to the device type",
+        nodeDescription = "Route incoming messages based on the name of the device profile",
+        nodeDetails = "Route incoming messages based on the name of the device profile. The device profile name is case-sensitive",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
         configDirective = "tbNodeEmptyConfig")
 public class TbDeviceTypeSwitchNode extends TbAbstractTypeSwitchNode {
 
-    protected String getRelationType(TbContext ctx, EntityId originator) {
+    @Override
+    protected String getRelationType(TbContext ctx, EntityId originator) throws TbNodeException {
         if (!EntityType.DEVICE.equals(originator.getEntityType())) {
-            throw new RuntimeException("Unsupported originator type: " + originator.getEntityType() + "! Only 'DEVICE' type is allowed.");
+            throw new TbNodeException("Unsupported originator type: " + originator.getEntityType() + "! Only 'DEVICE' type is allowed.");
         }
         DeviceProfile deviceProfile = ctx.getDeviceProfileCache().get(ctx.getTenantId(), (DeviceId) originator);
         if (deviceProfile == null) {
-            throw new RuntimeException("Device profile for entity id: " + originator.getId() + " wasn't found!");
+            throw new TbNodeException("Device profile for entity id: " + originator.getId() + " wasn't found!");
         }
         return deviceProfile.getName();
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNode.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.rule.engine.api.EmptyNodeConfiguration;
 import org.thingsboard.rule.engine.api.RuleNode;
 import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.server.common.data.DeviceProfile;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.EntityId;
@@ -41,7 +42,11 @@ public class TbDeviceTypeSwitchNode extends TbAbstractTypeSwitchNode {
         if (!EntityType.DEVICE.equals(originator.getEntityType())) {
             throw new RuntimeException("Unsupported originator type: " + originator.getEntityType() + "!");
         }
-        return ctx.getDeviceProfileCache().get(ctx.getTenantId(), (DeviceId) originator).getName();
+        DeviceProfile deviceProfile = ctx.getDeviceProfileCache().get(ctx.getTenantId(), (DeviceId) originator);
+        if (deviceProfile == null) {
+            throw new RuntimeException("Device profile with entity id: " + originator.getId() + " doesn't not found!");
+        }
+        return deviceProfile.getName();
     }
 
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNode.java
@@ -44,7 +44,7 @@ public class TbDeviceTypeSwitchNode extends TbAbstractTypeSwitchNode {
         }
         DeviceProfile deviceProfile = ctx.getDeviceProfileCache().get(ctx.getTenantId(), (DeviceId) originator);
         if (deviceProfile == null) {
-            throw new RuntimeException("Device profile with entity id: " + originator.getId() + " doesn't not found!");
+            throw new RuntimeException("Device profile with entity id: " + originator.getId() + " wasn't found!");
         }
         return deviceProfile.getName();
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNode.java
@@ -40,11 +40,11 @@ public class TbDeviceTypeSwitchNode extends TbAbstractTypeSwitchNode {
 
     protected String getRelationType(TbContext ctx, EntityId originator) {
         if (!EntityType.DEVICE.equals(originator.getEntityType())) {
-            throw new RuntimeException("Unsupported originator type: " + originator.getEntityType() + "!");
+            throw new RuntimeException("Unsupported originator type: " + originator.getEntityType() + "! Only 'DEVICE' type is allowed.");
         }
         DeviceProfile deviceProfile = ctx.getDeviceProfileCache().get(ctx.getTenantId(), (DeviceId) originator);
         if (deviceProfile == null) {
-            throw new RuntimeException("Device profile with entity id: " + originator.getId() + " wasn't found!");
+            throw new RuntimeException("Device profile for entity id: " + originator.getId() + " wasn't found!");
         }
         return deviceProfile.getName();
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNode.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.rule.engine.api.EmptyNodeConfiguration;
+import org.thingsboard.rule.engine.api.RuleNode;
+import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.plugin.ComponentType;
+
+@Slf4j
+@RuleNode(
+        type = ComponentType.FILTER,
+        name = "device type switch",
+        customRelations = true,
+        relationTypes = {},
+        configClazz = EmptyNodeConfiguration.class,
+        nodeDescription = "Route incoming messages by Device Type",
+        nodeDetails = "Routes messages to chain according to the device type",
+        uiResources = {"static/rulenode/rulenode-core-config.js"},
+        configDirective = "tbNodeEmptyConfig")
+public class TbDeviceTypeSwitchNode extends TbAbstractTypeSwitchNode {
+
+    protected String getRelationType(TbContext ctx, EntityId originator) {
+        if (!EntityType.DEVICE.equals(originator.getEntityType())) {
+            throw new RuntimeException("Unsupported originator type: " + originator.getEntityType() + "!");
+        }
+        return ctx.getDeviceProfileCache().get(ctx.getTenantId(), (DeviceId) originator).getName();
+    }
+
+}

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbOriginatorTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbOriginatorTypeSwitchNode.java
@@ -30,11 +30,11 @@ import org.thingsboard.server.common.msg.TbMsg;
 @Slf4j
 @RuleNode(
         type = ComponentType.FILTER,
-        name = "originator type switch",
+        name = "entity type switch",
         configClazz = EmptyNodeConfiguration.class,
         relationTypes = {"Device", "Asset", "Alarm", "Entity View", "Tenant", "Customer", "User", "Dashboard", "Rule chain", "Rule node"},
         nodeDescription = "Route incoming messages by Message Originator Type",
-        nodeDetails = "Routes messages to chain according to the originator type ('Device', 'Asset', etc.).",
+        nodeDetails = "Routes messages to chain according to the entity type ('Device', 'Asset', etc.).",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
         configDirective = "tbNodeEmptyConfig")
 public class TbOriginatorTypeSwitchNode implements TbNode {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbOriginatorTypeSwitchNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbOriginatorTypeSwitchNode.java
@@ -19,13 +19,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.rule.engine.api.EmptyNodeConfiguration;
 import org.thingsboard.rule.engine.api.RuleNode;
 import org.thingsboard.rule.engine.api.TbContext;
-import org.thingsboard.rule.engine.api.TbNode;
-import org.thingsboard.rule.engine.api.TbNodeConfiguration;
 import org.thingsboard.rule.engine.api.TbNodeException;
-import org.thingsboard.rule.engine.api.util.TbNodeUtils;
 import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.plugin.ComponentType;
-import org.thingsboard.server.common.msg.TbMsg;
 
 @Slf4j
 @RuleNode(
@@ -37,19 +34,12 @@ import org.thingsboard.server.common.msg.TbMsg;
         nodeDetails = "Routes messages to chain according to the entity type ('Device', 'Asset', etc.).",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
         configDirective = "tbNodeEmptyConfig")
-public class TbOriginatorTypeSwitchNode implements TbNode {
-
-    EmptyNodeConfiguration config;
+public class TbOriginatorTypeSwitchNode extends TbAbstractTypeSwitchNode {
 
     @Override
-    public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
-        this.config = TbNodeUtils.convert(configuration, EmptyNodeConfiguration.class);
-    }
-
-    @Override
-    public void onMsg(TbContext ctx, TbMsg msg) throws TbNodeException {
+    protected String getRelationType(TbContext ctx, EntityId originator) throws TbNodeException {
         String relationType;
-        EntityType originatorType = msg.getOriginator().getEntityType();
+        EntityType originatorType = originator.getEntityType();
         switch (originatorType) {
             case TENANT:
                 relationType = "Tenant";
@@ -87,7 +77,7 @@ public class TbOriginatorTypeSwitchNode implements TbNode {
             default:
                 throw new TbNodeException("Unsupported originator type: " + originatorType);
         }
-        ctx.tellNext(msg, relationType);
+        return relationType;
     }
 
 }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNodeTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.filter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.rule.engine.api.EmptyNodeConfiguration;
+import org.thingsboard.rule.engine.api.RuleEngineAssetProfileCache;
+import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.rule.engine.api.TbNodeConfiguration;
+import org.thingsboard.rule.engine.api.TbNodeException;
+import org.thingsboard.server.common.data.asset.AssetProfile;
+import org.thingsboard.server.common.data.id.AssetId;
+import org.thingsboard.server.common.data.id.CustomerId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.msg.TbMsg;
+import org.thingsboard.server.common.msg.TbMsgMetaData;
+import org.thingsboard.server.common.msg.queue.TbMsgCallback;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TbAssetTypeSwitchNodeTest {
+
+    TenantId tenantId;
+    AssetId assetId;
+    AssetProfile assetProfile;
+    TbContext ctx;
+    TbAssetTypeSwitchNode node;
+    EmptyNodeConfiguration config;
+    TbMsgCallback callback;
+    RuleEngineAssetProfileCache assetProfileCache;
+
+    @BeforeEach
+    void setUp() throws TbNodeException {
+        tenantId = new TenantId(UUID.randomUUID());
+        assetId = new AssetId(UUID.randomUUID());
+
+        assetProfile = new AssetProfile();
+        assetProfile.setTenantId(tenantId);
+        assetProfile.setName("TestAssetProfile");
+
+        //node
+        config = new EmptyNodeConfiguration();
+        node = spy(new TbAssetTypeSwitchNode());
+        node.init(ctx, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        //init mock
+        ctx = mock(TbContext.class);
+        assetProfileCache = mock(RuleEngineAssetProfileCache.class);
+        callback = mock(TbMsgCallback.class);
+
+        when(ctx.getTenantId()).thenReturn(tenantId);
+        when(ctx.getAssetProfileCache()).thenReturn(assetProfileCache);
+
+        doReturn(assetProfile).when(assetProfileCache).get(tenantId, assetId);
+    }
+
+    @AfterEach
+    void tearDown() {
+        node.destroy();
+    }
+
+    @Test
+    void givenMsg_whenOnMsg_then_Fail() {
+        CustomerId customerId = new CustomerId(UUID.randomUUID());
+        assertThatThrownBy(() -> node.onMsg(ctx, getTbMsg(customerId, "{}"))).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void givenMsg_whenOnMsg_then_Success() {
+        TbMsg msg = getTbMsg(assetId, "{}");
+        node.onMsg(ctx, msg);
+
+        ArgumentCaptor<TbMsg> newMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        verify(ctx, times(1)).tellNext(newMsgCaptor.capture(), eq("TestAssetProfile"));
+        verify(ctx, never()).tellFailure(any(), any());
+
+        TbMsg newMsg = newMsgCaptor.getValue();
+        assertThat(newMsg).isNotNull();
+        assertThat(newMsg).isSameAs(msg);
+    }
+
+    private TbMsg getTbMsg(EntityId entityId, String data) {
+        final Map<String, String> mdMap = Map.of(
+                "TestKey_1", "Test",
+                "country", "US",
+                "voltageDataValue", "220",
+                "city", "NY"
+        );
+        return TbMsg.newMsg("POST_ATTRIBUTES_REQUEST", entityId, new TbMsgMetaData(mdMap), data, callback);
+    }
+}

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNodeTest.java
@@ -94,16 +94,20 @@ class TbAssetTypeSwitchNodeTest {
     @Test
     void givenMsg_whenOnMsg_then_Fail() {
         CustomerId customerId = new CustomerId(UUID.randomUUID());
-        assertThatThrownBy(() -> node.onMsg(ctx, getTbMsg(customerId))).isInstanceOf(RuntimeException.class);
+        assertThatThrownBy(() -> {
+            node.onMsg(ctx, getTbMsg(customerId));
+        }).isInstanceOf(TbNodeException.class).hasMessageContaining("Unsupported originator type");
     }
 
     @Test
     void givenMsg_whenOnMsg_EntityIdDeleted_then_Fail() {
-        assertThatThrownBy(() -> node.onMsg(ctx, getTbMsg(assetIdDeleted))).isInstanceOf(RuntimeException.class);
+        assertThatThrownBy(() -> {
+            node.onMsg(ctx, getTbMsg(assetIdDeleted));
+        }).isInstanceOf(TbNodeException.class).hasMessageContaining("Asset profile for entity id");
     }
 
     @Test
-    void givenMsg_whenOnMsg_then_Success() {
+    void givenMsg_whenOnMsg_then_Success() throws TbNodeException {
         TbMsg msg = getTbMsg(assetId);
         node.onMsg(ctx, msg);
 

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNodeTest.java
@@ -34,7 +34,6 @@ import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
 import org.thingsboard.server.common.msg.queue.TbMsgCallback;
 
-import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -95,16 +94,20 @@ class TbDeviceTypeSwitchNodeTest {
     @Test
     void givenMsg_whenOnMsg_then_Fail() {
         CustomerId customerId = new CustomerId(UUID.randomUUID());
-        assertThatThrownBy(() -> node.onMsg(ctx, getTbMsg(customerId))).isInstanceOf(RuntimeException.class);
+        assertThatThrownBy(() -> {
+            node.onMsg(ctx, getTbMsg(customerId));
+        }).isInstanceOf(TbNodeException.class).hasMessageContaining("Unsupported originator type");
     }
 
     @Test
     void givenMsg_whenOnMsg_EntityIdDeleted_then_Fail() {
-        assertThatThrownBy(() -> node.onMsg(ctx, getTbMsg(deviceIdDeleted))).isInstanceOf(RuntimeException.class);
+        assertThatThrownBy(() -> {
+            node.onMsg(ctx, getTbMsg(deviceIdDeleted));
+        }).isInstanceOf(TbNodeException.class).hasMessageContaining("Device profile for entity id");
     }
 
     @Test
-    void givenMsg_whenOnMsg_then_Success() {
+    void givenMsg_whenOnMsg_then_Success() throws TbNodeException {
         TbMsg msg = getTbMsg(deviceId);
         node.onMsg(ctx, msg);
 

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNodeTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright © 2016-2022 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.filter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.rule.engine.api.EmptyNodeConfiguration;
+import org.thingsboard.rule.engine.api.RuleEngineDeviceProfileCache;
+import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.rule.engine.api.TbNodeConfiguration;
+import org.thingsboard.rule.engine.api.TbNodeException;
+import org.thingsboard.server.common.data.DeviceProfile;
+import org.thingsboard.server.common.data.id.CustomerId;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.msg.TbMsg;
+import org.thingsboard.server.common.msg.TbMsgMetaData;
+import org.thingsboard.server.common.msg.queue.TbMsgCallback;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TbDeviceTypeSwitchNodeTest {
+
+    TenantId tenantId;
+    DeviceId deviceId;
+    DeviceProfile deviceProfile;
+    TbContext ctx;
+    TbDeviceTypeSwitchNode node;
+    EmptyNodeConfiguration config;
+    TbMsgCallback callback;
+    RuleEngineDeviceProfileCache deviceProfileCache;
+
+    @BeforeEach
+    void setUp() throws TbNodeException {
+        tenantId = new TenantId(UUID.randomUUID());
+        deviceId = new DeviceId(UUID.randomUUID());
+
+        deviceProfile = new DeviceProfile();
+        deviceProfile.setTenantId(tenantId);
+        deviceProfile.setName("TestDeviceProfile");
+
+        //node
+        config = new EmptyNodeConfiguration();
+        node = spy(new TbDeviceTypeSwitchNode());
+        node.init(ctx, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        //init mock
+        ctx = mock(TbContext.class);
+        deviceProfileCache = mock(RuleEngineDeviceProfileCache.class);
+        callback = mock(TbMsgCallback.class);
+
+        when(ctx.getTenantId()).thenReturn(tenantId);
+        when(ctx.getDeviceProfileCache()).thenReturn(deviceProfileCache);
+
+        doReturn(deviceProfile).when(deviceProfileCache).get(tenantId, deviceId);
+    }
+
+    @AfterEach
+    void tearDown() {
+        node.destroy();
+    }
+
+    @Test
+    void givenMsg_whenOnMsg_then_Fail() {
+        CustomerId customerId = new CustomerId(UUID.randomUUID());
+        assertThatThrownBy(() -> node.onMsg(ctx, getTbMsg(customerId, "{}"))).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void givenMsg_whenOnMsg_then_Success() {
+        TbMsg msg = getTbMsg(deviceId, "{}");
+        node.onMsg(ctx, msg);
+
+        ArgumentCaptor<TbMsg> newMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        verify(ctx, times(1)).tellNext(newMsgCaptor.capture(), eq("TestDeviceProfile"));
+        verify(ctx, never()).tellFailure(any(), any());
+
+        TbMsg newMsg = newMsgCaptor.getValue();
+        assertThat(newMsg).isNotNull();
+        assertThat(newMsg).isSameAs(msg);
+    }
+
+    private TbMsg getTbMsg(EntityId entityId, String data) {
+        final Map<String, String> mdMap = Map.of(
+                "TestKey_1", "Test",
+                "country", "US",
+                "voltageDataValue", "220",
+                "city", "NY"
+        );
+        return TbMsg.newMsg("POST_ATTRIBUTES_REQUEST", entityId, new TbMsgMetaData(mdMap), data, callback);
+    }
+}

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNodeTest.java
@@ -44,7 +44,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,6 +52,7 @@ class TbDeviceTypeSwitchNodeTest {
 
     TenantId tenantId;
     DeviceId deviceId;
+    DeviceId deviceIdDeleted;
     DeviceProfile deviceProfile;
     TbContext ctx;
     TbDeviceTypeSwitchNode node;
@@ -64,6 +64,7 @@ class TbDeviceTypeSwitchNodeTest {
     void setUp() throws TbNodeException {
         tenantId = new TenantId(UUID.randomUUID());
         deviceId = new DeviceId(UUID.randomUUID());
+        deviceIdDeleted = new DeviceId(UUID.randomUUID());
 
         deviceProfile = new DeviceProfile();
         deviceProfile.setTenantId(tenantId);
@@ -71,7 +72,7 @@ class TbDeviceTypeSwitchNodeTest {
 
         //node
         config = new EmptyNodeConfiguration();
-        node = spy(new TbDeviceTypeSwitchNode());
+        node = new TbDeviceTypeSwitchNode();
         node.init(ctx, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
 
         //init mock
@@ -83,6 +84,7 @@ class TbDeviceTypeSwitchNodeTest {
         when(ctx.getDeviceProfileCache()).thenReturn(deviceProfileCache);
 
         doReturn(deviceProfile).when(deviceProfileCache).get(tenantId, deviceId);
+        doReturn(null).when(deviceProfileCache).get(tenantId, deviceIdDeleted);
     }
 
     @AfterEach
@@ -93,12 +95,17 @@ class TbDeviceTypeSwitchNodeTest {
     @Test
     void givenMsg_whenOnMsg_then_Fail() {
         CustomerId customerId = new CustomerId(UUID.randomUUID());
-        assertThatThrownBy(() -> node.onMsg(ctx, getTbMsg(customerId, "{}"))).isInstanceOf(RuntimeException.class);
+        assertThatThrownBy(() -> node.onMsg(ctx, getTbMsg(customerId))).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void givenMsg_whenOnMsg_EntityIdDeleted_then_Fail() {
+        assertThatThrownBy(() -> node.onMsg(ctx, getTbMsg(deviceIdDeleted))).isInstanceOf(RuntimeException.class);
     }
 
     @Test
     void givenMsg_whenOnMsg_then_Success() {
-        TbMsg msg = getTbMsg(deviceId, "{}");
+        TbMsg msg = getTbMsg(deviceId);
         node.onMsg(ctx, msg);
 
         ArgumentCaptor<TbMsg> newMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
@@ -110,13 +117,7 @@ class TbDeviceTypeSwitchNodeTest {
         assertThat(newMsg).isSameAs(msg);
     }
 
-    private TbMsg getTbMsg(EntityId entityId, String data) {
-        final Map<String, String> mdMap = Map.of(
-                "TestKey_1", "Test",
-                "country", "US",
-                "voltageDataValue", "220",
-                "city", "NY"
-        );
-        return TbMsg.newMsg("POST_ATTRIBUTES_REQUEST", entityId, new TbMsgMetaData(mdMap), data, callback);
+    private TbMsg getTbMsg(EntityId entityId) {
+        return TbMsg.newMsg("POST_ATTRIBUTES_REQUEST", entityId, new TbMsgMetaData(), "{}", callback);
     }
 }


### PR DESCRIPTION
## Pull Request description

issue: https://github.com/thingsboard/thingsboard/issues/7975

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



