### PR TITLE
Fixed applying custom translation to labels of latest data keys in timeseries widgets

### DIFF
--- a/ui-ngx/src/app/core/api/widget-subscription.ts
+++ b/ui-ngx/src/app/core/api/widget-subscription.ts
@@ -1402,6 +1402,7 @@ export class WidgetSubscription implements IWidgetSubscription {
     }));
     if (datasource.latestDataKeys) {
       datasourceDataArray = datasourceDataArray.concat(datasource.latestDataKeys.map((dataKey, latestKeyIndex) => {
+        dataKey.label = this.ctx.utils.customTranslation(dataKey.label, dataKey.label);
         const datasourceData: DatasourceData = {
           datasource,
           dataKey,


### PR DESCRIPTION
## Pull Request description

{i18n:variable-name} displayed instead of human-readable text.  
Fixed #8011 

Timeseries table data keys configuration
![image](https://user-images.githubusercontent.com/17936317/215526987-88405190-ecd9-4865-91ca-3e84dcbb6d9a.png)

![image](https://user-images.githubusercontent.com/17936317/215527167-1b33f3c0-2bcf-47f0-a40d-f750b5e369c9.png)

Before:
![image](https://user-images.githubusercontent.com/17936317/215527404-b9256893-e496-4620-b1fa-952cc569a0c8.png)

After:
![image](https://user-images.githubusercontent.com/17936317/215527491-e7ddbfc0-74ed-46bb-9ac9-d38c01ce888a.png)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



