### PR TITLE
Fix loading widget resources, when one of the resources is marked as module

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/widget-component.service.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-component.service.ts
@@ -340,7 +340,7 @@ export class WidgetComponentService {
               factories: modulesWithFactoriesList.map(mf => mf.factories).flat()
             };
             if (modules && modules.length) {
-              resModulesWithFactories.modules.concat(modules);
+              resModulesWithFactories.modules = resModulesWithFactories.modules.concat(modules);
             }
             return resModulesWithFactories;
           }


### PR DESCRIPTION
## Pull Request description
In case '_**is module**_' is checked for one of the widget resources, basic modules (SharedModule, WidgetComponentsModule, HomeComponentsModule) won't be included.
This could lead to errors like on the screenshot below.

 ![image](https://user-images.githubusercontent.com/17936317/216622992-594a281b-0dde-42fb-93dd-a3b7fe0ab26f.png)
 
![image](https://user-images.githubusercontent.com/17936317/216635638-281f85c8-5582-4f68-bb83-56797f4d0b58.png)

 After the change missed components will be included to widget resources. The widget will be loaded without errors. 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




