### PR TITLE
Leave only lower bould for widget's height in mobile mode.

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/widget-config.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-config.component.html
@@ -508,7 +508,7 @@
                 </mat-form-field>
                 <mat-form-field fxFlex>
                   <mat-label translate>widget-config.height</mat-label>
-                  <input matInput formControlName="mobileHeight" type="number" min="1" max="10" step="1">
+                  <input matInput formControlName="mobileHeight" type="number" min="1" step="1">
                 </mat-form-field>
               </div>
             </ng-template>

--- a/ui-ngx/src/app/modules/home/components/widget/widget-config.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-config.component.ts
@@ -255,7 +255,7 @@ export class WidgetConfigComponent extends PageComponent implements OnInit, Cont
     });
     this.layoutSettings = this.fb.group({
       mobileOrder: [null, [Validators.pattern(/^-?[0-9]+$/)]],
-      mobileHeight: [null, [Validators.min(1), Validators.max(10), Validators.pattern(/^\d*$/)]],
+      mobileHeight: [null, [Validators.min(1), Validators.pattern(/^\d*$/)]],
       mobileHide: [false],
       desktopHide: [false]
     });


### PR DESCRIPTION
There are some cases in dashboard development when you need to have little mobile row height (e.g., 25px), but at the same time some widgets on the same dashboard state should higher than 250 px (10 * 25px), where 10 - is upper value of multiplier for widget height in mobile mode.

This PR is to get rid of upper bound (upper value of multiplier).