### PR TITLE
[3.7][WIP] SQL load balancing for Postgresql pool (PgPool-II)

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -548,6 +548,8 @@ spring.servlet.multipart.max-request-size: "50MB"
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation: "true"
 # Note: as for current Spring JPA version, custom NullHandling for the Sort.Order is ignored and this parameter is used
 spring.jpa.properties.hibernate.order_by.default_null_ordering: "${SPRING_JPA_PROPERTIES_HIBERNATE_ORDER_BY_DEFAULT_NULL_ORDERING:last}"
+# Load balancing feature for PgPool-II based on comments added to SQL. By default, the feature is disabled. To enable use SPRING_JPA_PROPERTIES_HIBERNATE_SESSION_FACTORY_STATEMENT_INSPECTOR=org.thingsboard.server.dao.loadbalance.LoadBalancerStatementInspector
+spring.jpa.properties.hibernate.session_factory.statement_inspector: "${SPRING_JPA_PROPERTIES_HIBERNATE_SESSION_FACTORY_STATEMENT_INSPECTOR:org.thingsboard.server.dao.loadbalance.NoOpStatementInspector}"
 
 # SQL DAO Configuration
 spring:

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/loadbalance/LoadBalancerConstants.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/loadbalance/LoadBalancerConstants.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.loadbalance;
+
+public interface LoadBalancerConstants {
+    String masterPrefix = "/*MASTER*/ "; // Will be added to regular queries to route the query to the master (findById, etc.).
+    String replicaPrefix = "/*REPLICA*/ "; // A query intended for LoadBalancer is expected to startsWith this replicaPrefix. This prefix will be removed from queries to route to a replica
+}

--- a/dao/src/main/java/org/thingsboard/server/dao/loadbalance/LoadBalancerStatementInspector.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/loadbalance/LoadBalancerStatementInspector.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.loadbalance;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+
+public class LoadBalancerStatementInspector implements StatementInspector {
+
+    @Override
+    public String inspect(String sql) {
+        if (sql.startsWith(LoadBalancerConstants.replicaPrefix)) {
+            return sql.substring(LoadBalancerConstants.replicaPrefix.length());
+        }
+        return LoadBalancerConstants.masterPrefix.concat(sql);
+    }
+
+}

--- a/dao/src/main/java/org/thingsboard/server/dao/loadbalance/NoOpStatementInspector.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/loadbalance/NoOpStatementInspector.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.loadbalance;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+
+public class NoOpStatementInspector implements StatementInspector {
+
+    @Override
+    public String inspect(String sql) {
+        return sql;
+    }
+
+}

--- a/dao/src/test/java/org/thingsboard/server/dao/loadbalance/LoadBalancerStatementInspectorTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/loadbalance/LoadBalancerStatementInspectorTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.loadbalance;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoadBalancerStatementInspectorTest {
+
+    StatementInspector inspector;
+
+    @BeforeEach
+    void setUp() {
+        inspector = new LoadBalancerStatementInspector();
+    }
+
+    @Test
+    void testMasterIntendedQuery() {
+        String sql = "SELECT * from device d;";
+        assertThat(inspector.inspect(sql)).isEqualTo(LoadBalancerConstants.masterPrefix + sql);
+    }
+
+    @Test
+    void testReplicaIntendedQuery() {
+        String sql = "SELECT * from device d;";
+        assertThat(inspector.inspect(LoadBalancerConstants.replicaPrefix + sql)).isEqualTo(sql);
+    }
+
+}

--- a/dao/src/test/java/org/thingsboard/server/dao/loadbalance/NoOpStatementInspectorTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/loadbalance/NoOpStatementInspectorTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.loadbalance;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoOpStatementInspectorTest {
+
+    @Test
+    void testNoChanges() {
+        final String sql = "SELECT * from device d;";
+        StatementInspector inspector = new NoOpStatementInspector();
+
+        assertThat(inspector.inspect(null)).isEqualTo(null);
+        assertThat(inspector.inspect("")).isEqualTo("");
+        assertThat(inspector.inspect(sql)).isEqualTo(sql);
+        assertThat(inspector.inspect(LoadBalancerConstants.replicaPrefix + sql)).isEqualTo(LoadBalancerConstants.replicaPrefix + sql);
+        assertThat(inspector.inspect(LoadBalancerConstants.masterPrefix + sql)).isEqualTo(LoadBalancerConstants.masterPrefix + sql);
+    }
+
+}


### PR DESCRIPTION
## SQL load balancing for Postgresql pool (PgPool-II)

Load balancing feature for PgPool-II based on comments added to SQL. By default, the feature is disabled. 
To enable use `SPRING_JPA_PROPERTIES_HIBERNATE_SESSION_FACTORY_STATEMENT_INSPECTOR=org.thingsboard.server.dao.loadbalance.LoadBalancerStatementInspector`

The implementation added  the `/*MASTER*/ `comment to any hibernate SQL query that does not starts with `/*REPLICA*/ ` comment. Any comment will by recognized by PgPool-II as a marker to pass the query for the master node only. This done because some short queries needs to be run right after update on master.  
If The `/*REPLICA*/ ` comment found, it removed and SQL running without any comment (allowed to run on replica node)

Note: The row queries fired by `jdbcTemplate` are not a part of Hibernate and not passed to the `StatementInspector`. So those queries are effectively allowed to run on replica node (like EntityDataQueryRepository, etc)

To see the effect of this feature on Hibernate query, please, use the SQL log on your test environment 
`<logger name="org.hibernate.SQL" level="DEBUG" />`

Link to the PgPool-II load balancing documentation https://www.pgpool.net/docs/42/en/html/runtime-config-load-balancing.html

Usage of the `StatementInspector` was  inspired by this article: https://vladmihalcea.com/hibernate-statementinspector

![image](https://user-images.githubusercontent.com/79898499/217556796-5e64fb42-b6cd-413b-b870-6ec3b95b21df.png)

Statictics shows that query are distributed as designed:
```
SELECT mean_exec_time, calls, * FROM public.pg_stat_statements
ORDER BY mean_exec_time DESC, calls DESC LIMIT 100;
```
replica:
![image](https://user-images.githubusercontent.com/79898499/217600377-22cd12ea-d61d-4535-84cc-a86611902a2b.png)
master:
![image](https://user-images.githubusercontent.com/79898499/217600471-0a08e84f-2f7b-4b6b-8039-a2fb0ac2c422.png)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



