### PR TITLE
[3.5] UI: Use entity's label (if set) in select entity dialog.

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/maps/dialogs/select-entity-dialog.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/maps/dialogs/select-entity-dialog.component.html
@@ -31,7 +31,7 @@
       <mat-label translate>entity.entity</mat-label>
       <mat-select formControlName="entity">
         <mat-option *ngFor="let entity of data.entities" [value]="entity">
-          {{ entity.entityLabel || entity.entityName }}
+          {{ data.showEntityLabel && entity.entityLabel ? entity.entityLabel : entity.entityName }}
         </mat-option>
       </mat-select>
     </mat-form-field>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/maps/dialogs/select-entity-dialog.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/maps/dialogs/select-entity-dialog.component.html
@@ -31,7 +31,7 @@
       <mat-label translate>entity.entity</mat-label>
       <mat-select formControlName="entity">
         <mat-option *ngFor="let entity of data.entities" [value]="entity">
-          {{ entity.entityName }}
+          {{ entity.entityLabel || entity.entityName }}
         </mat-option>
       </mat-select>
     </mat-form-field>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/maps/dialogs/select-entity-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/maps/dialogs/select-entity-dialog.component.ts
@@ -25,6 +25,7 @@ import { FormattedData } from '@shared/models/widget.models';
 
 export interface SelectEntityDialogData {
   entities: FormattedData[];
+  showEntityLabel?: boolean;
 }
 
 @Component({

--- a/ui-ngx/src/app/modules/home/components/widget/lib/maps/leaflet-map.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/maps/leaflet-map.ts
@@ -205,7 +205,8 @@ export default abstract class LeafletMap {
           disableClose: true,
           panelClass: ['tb-dialog', 'tb-fullscreen-dialog'],
           data: {
-            entities
+            entities,
+            showEntityLabel: this.options.useLabelForDragSelection
           }
         }).afterClosed();
     }
@@ -217,40 +218,41 @@ export default abstract class LeafletMap {
           this.toggleDrawMode(type);
           let tooltipText;
           let customTranslation;
+          const entityName = this.options.useLabelForDragSelection && data.entityLabel ? data.entityLabel : data.entityName;
           switch (type) {
             case 'tbMarker':
-              tooltipText = this.translateService.instant('widgets.maps.tooltips.placeMarker', {entityName: data.entityName});
+              tooltipText = this.translateService.instant('widgets.maps.tooltips.placeMarker', {entityName: entityName});
               // @ts-ignore
               this.map.pm.Draw.tbMarker._hintMarker.setTooltipContent(tooltipText);
               break;
             case 'tbCircle':
-              tooltipText = this.translateService.instant('widgets.maps.tooltips.startCircle', {entityName: data.entityName});
+              tooltipText = this.translateService.instant('widgets.maps.tooltips.startCircle', {entityName: entityName});
               // @ts-ignore
               this.map.pm.Draw.tbCircle._hintMarker.setTooltipContent(tooltipText);
               customTranslation = {
                 tooltips: {
-                  finishCircle: this.translateService.instant('widgets.maps.tooltips.finishCircle', {entityName: data.entityName})
+                  finishCircle: this.translateService.instant('widgets.maps.tooltips.finishCircle', {entityName: entityName})
                 }
               };
               break;
             case 'tbRectangle':
-              tooltipText = this.translateService.instant('widgets.maps.tooltips.firstVertex', {entityName: data.entityName});
+              tooltipText = this.translateService.instant('widgets.maps.tooltips.firstVertex', {entityName: entityName});
               // @ts-ignore
               this.map.pm.Draw.tbRectangle._hintMarker.setTooltipContent(tooltipText);
               customTranslation = {
                 tooltips: {
-                  finishRect: this.translateService.instant('widgets.maps.tooltips.finishRect', {entityName: data.entityName})
+                  finishRect: this.translateService.instant('widgets.maps.tooltips.finishRect', {entityName: entityName})
                 }
               };
               break;
             case 'tbPolygon':
-              tooltipText = this.translateService.instant('widgets.maps.tooltips.firstVertex', {entityName: data.entityName});
+              tooltipText = this.translateService.instant('widgets.maps.tooltips.firstVertex', {entityName: entityName});
               // @ts-ignore
               this.map.pm.Draw.tbPolygon._hintMarker.setTooltipContent(tooltipText);
               customTranslation = {
                 tooltips: {
-                  continueLine: this.translateService.instant('widgets.maps.tooltips.continueLine', {entityName: data.entityName}),
-                  finishPoly: this.translateService.instant('widgets.maps.tooltips.finishPoly', {entityName: data.entityName})
+                  continueLine: this.translateService.instant('widgets.maps.tooltips.continueLine', {entityName: entityName}),
+                  finishPoly: this.translateService.instant('widgets.maps.tooltips.finishPoly', {entityName: entityName})
                 }
               };
               break;

--- a/ui-ngx/src/app/modules/home/components/widget/lib/maps/map-models.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/maps/map-models.ts
@@ -302,6 +302,7 @@ export interface MarkersSettings {
   markerOffsetY: number;
   posFunction?: string;
   draggableMarker: boolean;
+  useLabelForDragSelection: boolean;
   showLabel: boolean;
   useLabelFunction: boolean;
   label?: string;
@@ -340,6 +341,7 @@ export const defaultMarkersSettings: MarkersSettings = {
   markerOffsetY: 1,
   posFunction: 'return {x: origXPos, y: origYPos};',
   draggableMarker: false,
+  useLabelForDragSelection: false,
   showLabel: true,
   useLabelFunction: false,
   label: '${entityName}',

--- a/ui-ngx/src/app/modules/home/components/widget/lib/maps/map-widget2.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/maps/map-widget2.ts
@@ -266,6 +266,9 @@ export class MapWidgetController implements MapWidgetInterface {
         if (isEditMap && !settings.hasOwnProperty('draggableMarker')) {
           parsedOptions.draggableMarker = true;
         }
+        if (isEditMap && !settings.hasOwnProperty('useLabelForDragSelection')) {
+          parsedOptions.useLabelForDragSelection = false;
+        }
         if (isEditMap && !settings.hasOwnProperty('editablePolygon')) {
           parsedOptions.editablePolygon = true;
         }

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/map/markers-settings.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/map/markers-settings.component.html
@@ -36,9 +36,14 @@
                 functionTitle="{{ 'widgets.maps.position-function' | translate }}"
                 helpId="widget/lib/map/position_fn">
     </tb-js-func>
-    <mat-checkbox formControlName="draggableMarker" style="margin-bottom: 16px;">
-      {{ 'widgets.maps.draggable-marker' | translate }}
-    </mat-checkbox>
+    <section fxLayout="column" fxLayout.gt-xs="row" fxLayoutGap.gt-xs="8px" style="margin-bottom: 16px;">
+      <mat-checkbox formControlName="draggableMarker">
+        {{ 'widgets.maps.draggable-marker' | translate }}
+      </mat-checkbox>
+      <mat-slide-toggle formControlName="useLabelForDragSelection" [fxShow]="markersSettingsFormGroup.get('draggableMarker').value">
+        {{ 'widgets.maps.use-label-for-drag-selection' | translate }}
+      </mat-slide-toggle>
+    </section>
     <fieldset class="fields-group fields-group-slider">
       <legend class="group-title" translate>widgets.maps.label</legend>
       <mat-expansion-panel class="tb-settings" [expanded]="markersSettingsFormGroup.get('showLabel').value">

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/map/markers-settings.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/map/markers-settings.component.ts
@@ -86,6 +86,7 @@ export class MarkersSettingsComponent extends PageComponent implements OnInit, C
       markerOffsetY: [null, []],
       posFunction: [null, []],
       draggableMarker: [null, []],
+      useLabelForDragSelection: [null, []],
       showLabel: [null, []],
       useLabelFunction: [null, []],
       label: [null, []],

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -4540,6 +4540,7 @@
             "marker-offset-y": "Marker Y offset relative to position multiplied by marker height",
             "position-function": "Position conversion function, should return x,y coordinates as double from 0 to 1 each",
             "draggable-marker": "Draggable marker",
+            "use-label-for-drag-selection": "Use entity label for drag selection",
             "label": "Label",
             "show-label": "Show label",
             "use-label-function": "Use label function",


### PR DESCRIPTION
In some cases entity name is not human readable (serial number or UUID), so it would be useful to display entity's label if it is set.