### PR TITLE
Optionally update dashboard state when using navigate back API.

### DIFF
--- a/ui-ngx/src/app/modules/home/components/dashboard-page/states/default-state-controller.component.ts
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/states/default-state-controller.component.ts
@@ -168,10 +168,15 @@ export class DefaultStateControllerComponent extends StateControllerComponent im
     }
   }
 
-  public navigatePrevState(index: number): void {
-    if (index < this.stateObject.length - 1) {
-      this.stateObject.splice(index + 1, this.stateObject.length - index - 1);
-      this.gotoState(this.stateObject[this.stateObject.length - 1].id, true);
+  public navigatePrevState(index: number, params?: StateParams): void {
+    let lastIndex: number = this.stateObject.length - 1;
+    if (index < lastIndex) {
+      this.stateObject.splice(index + 1, lastIndex - 1);
+      lastIndex = this.stateObject.length - 1;
+      if (params) {
+        this.stateObject[lastIndex].params = params;
+      }
+      this.gotoState(this.stateObject[lastIndex].id, true);
     }
   }
 

--- a/ui-ngx/src/app/modules/home/components/dashboard-page/states/entity-state-controller.component.ts
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/states/entity-state-controller.component.ts
@@ -195,11 +195,14 @@ export class EntityStateControllerComponent extends StateControllerComponent imp
     }
   }
 
-  public navigatePrevState(index: number): void {
+  public navigatePrevState(index: number, params?: StateParams): void {
     if (index < this.stateObject.length - 1) {
       this.stateObject.splice(index + 1, this.stateObject.length - index - 1);
       this.selectedStateIndex = this.stateObject.length - 1;
-      this.gotoState(this.stateObject[this.stateObject.length - 1].id, true);
+      if (params) {
+        this.stateObject[this.selectedStateIndex].params = params;
+      }
+      this.gotoState(this.stateObject[this.selectedStateIndex].id, true);
     }
   }
 

--- a/ui-ngx/src/app/modules/home/components/dashboard-page/states/state-controller.component.ts
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/states/state-controller.component.ts
@@ -199,7 +199,7 @@ export abstract class StateControllerComponent implements IStateControllerCompon
 
   public abstract getStateParamsByStateId(stateId: string): StateParams;
 
-  public abstract navigatePrevState(index: number): void;
+  public abstract navigatePrevState(index: number, params?: StateParams): void;
 
   public abstract openState(id: string, params?: StateParams, openRightLayout?: boolean): void;
 


### PR DESCRIPTION
This PR a bit simplifies dashboard state management in case of "dynamic navigation". 

Our approach in dashboard development is to have single dashboard what covers all type of devices. But user/customer should see only that types what he/she wants or buys. We called it "dynamic navigation". So to have smooth navigation experience, we need to pass additional information in dashboard state.
