### PR TITLE
[3.5] UI tests stability improvements

### DIFF
--- a/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/TestProperties.java
+++ b/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/TestProperties.java
@@ -16,6 +16,7 @@
 package org.thingsboard.server.msa;
 
 import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.DockerClientFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,7 +42,9 @@ public class TestProperties {
 
     public static String getBaseUiUrl() {
         if (instance.isActive()) {
-            return "https://host.docker.internal";
+            //return "https://host.docker.internal" // this alternative requires docker-selenium.yml extra_hosts: - "host.docker.internal:host-gateway"
+            //return "https://" + DockerClientFactory.instance().dockerHostIpAddress(); //this alternative will get Docker IP from testcontainers
+            return "https://haproxy"; //communicate inside current docker-compose network to the load balancer container
         }
         return getProperties().getProperty("tb.baseUiUrl");
     }

--- a/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/ui/base/AbstractBasePage.java
+++ b/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/ui/base/AbstractBasePage.java
@@ -32,9 +32,11 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 abstract public class AbstractBasePage {
+    public static final long WAIT_TIMEOUT = TimeUnit.SECONDS.toMillis(30);
     protected WebDriver driver;
     protected WebDriverWait wait;
     protected Actions actions;
@@ -43,7 +45,7 @@ abstract public class AbstractBasePage {
 
     public AbstractBasePage(WebDriver driver) {
         this.driver = driver;
-        this.wait = new WebDriverWait(driver, Duration.ofMillis(8000));
+        this.wait = new WebDriverWait(driver, Duration.ofMillis(WAIT_TIMEOUT));
         this.actions = new Actions(driver);
         this.js = (JavascriptExecutor) driver;
     }

--- a/msa/black-box-tests/src/test/resources/docker-selenium.yml
+++ b/msa/black-box-tests/src/test/resources/docker-selenium.yml
@@ -32,6 +32,4 @@ services:
       SE_SCREEN_DEPTH: 24
       SE_SCREEN_DPI: 74
     extra_hosts:
-      - "host.docker.internal:172.17.0.1"
-
-
+      - "host.docker.internal:host-gateway"

--- a/msa/black-box-tests/src/test/resources/docker-selenium.yml
+++ b/msa/black-box-tests/src/test/resources/docker-selenium.yml
@@ -31,5 +31,6 @@ services:
       SE_SCREEN_HEIGHT: 1080
       SE_SCREEN_DEPTH: 24
       SE_SCREEN_DPI: 74
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+# Alternative way how to connect to the host address
+#    extra_hosts:
+#      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
## UI tests stability improvements

PE: https://github.com/thingsboard/thingsboard-pe/pull/1484

- fixed hardcoded IP '172.17.0.1' in docker-compose selenium - `host.docker.internal:host-gateway` (outdated)
- wait timeout increased up to 30 sec for slow or busy environments

- host-gateway replaced with the simple call **https://haproxy** as the selenium runs within the same network with load balancer and can reach it by service name

The problem was the hardcoded IP address in tests for the docker host machine.
For the TeamCity build agent in docker, the address is different `'172.18.0.1'`, so the fix required
![image](https://user-images.githubusercontent.com/79898499/221274068-b26b541b-5c6c-4ff3-a25d-e7c68467ca11.png)

The result during the build with `host-gateway` is on the screenshot below:
![image](https://user-images.githubusercontent.com/79898499/221274139-934b7583-eb30-45bd-b522-d4fcdede6598.png)
 
# Alternative approach with CLI
```
docker exec -it teamcity-agent bash
user@581c32d7ebdd:/# docker run alpine:3.16 sh -c "ip route|awk '/default/ { print $3 }'"
Unable to find image 'alpine:3.16' locally
3.16: Pulling from library/alpine
ef5531b6e74e: Pull complete 
Digest: sha256:1bd67c81e4ad4b8f4a5c1c914d7985336f130e5cefb3e323654fd09d6bcdbbe2
Status: Downloaded newer image for alpine:3.16
default via 172.18.0.1 dev eth0
```
# Alternative approach DockerClient from testcontainers
```
           Optional<String> defaultGatewayDockerClient = DockerClientConfigUtils.getDefaultGateway();
            log.warn("DockerClient defaultGatewayDockerClient [{}] ", defaultGatewayDockerClient);
            log.warn("DockerClient host IP address is [{}]", DockerClientFactory.instance().dockerHostIpAddress());
```            

Output:
```
2023-02-25 13:19:29,205 [main] WARN  o.t.server.msa.TestProperties - DockerClient default gateway (constant) [host.docker.internal]

[14:19:29 ](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_Build/34829?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=34829_65069_65069&logFilter=debug&logView=linear)
  2023-02-25 13:19:29,207 [main] INFO     [alpine:3.14] - Pulling docker image: alpine:3.14. Please be patient; this may take some time but only needs to be done once.

[14:19:31 ](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_Build/34829?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=34829_65070_65070&logFilter=debug&logView=linear)
  2023-02-25 13:19:31,344 [docker-java-stream-1035501547] INFO     [alpine:3.14] - Starting to pull image

[14:19:31 ](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_Build/34829?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=34829_65071_65071&logFilter=debug&logView=linear)
  2023-02-25 13:19:31,344 [docker-java-stream-1035501547] INFO     [alpine:3.14] - Pulling image layers:  0 pending,  0 downloaded,  0 extracted, (0 bytes/0 bytes)

[14:19:33 ](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_Build/34829?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=34829_65072_65072&logFilter=debug&logView=linear)
  2023-02-25 13:19:32,997 [docker-java-stream-1035501547] INFO     [alpine:3.14] - Pulling image layers:  0 pending,  1 downloaded,  0 extracted, (1 MB/2 MB)

[14:19:33 ](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_Build/34829?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=34829_65073_65073&logFilter=debug&logView=linear)
  2023-02-25 13:19:33,093 [docker-java-stream-1035501547] INFO     [alpine:3.14] - Pulling image layers:  0 pending,  1 downloaded,  1 extracted, (2 MB/2 MB)

[14:19:33 ](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_Build/34829?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=34829_65074_65074&logFilter=debug&logView=linear)
  2023-02-25 13:19:33,114 [docker-java-stream-1035501547] INFO     [alpine:3.14] - Pull complete. 1 layers, pulled in 1s (downloaded 2 MB at 2 MB/s)

[14:19:34 ](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_Build/34829?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=34829_65075_65075&logFilter=debug&logView=linear)
  2023-02-25 13:19:33,905 [main] WARN  o.t.server.msa.TestProperties - DockerClient defaultGatewayDockerClient [Optional[172.18.0.1]]

[14:19:34 ](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_Build/34829?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=34829_65076_65076&logFilter=debug&logView=linear)
  2023-02-25 13:19:33,906 [main] WARN  o.t.server.msa.TestProperties - DockerClient host IP address is [172.18.0.1]
```

The best approach to define the host address is considered `DockerClientFactory.instance().dockerHostIpAddress()`.

The simplest way - https://haproxy

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



