### PR TITLE
Core: Filter alarms by customer ownership.

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/query/DefaultEntityQueryService.java
+++ b/application/src/main/java/org/thingsboard/server/service/query/DefaultEntityQueryService.java
@@ -181,6 +181,7 @@ public class DefaultEntityQueryService implements EntityQueryService {
 
     @Override
     public PageData<AlarmData> findAlarmDataByQuery(SecurityUser securityUser, AlarmDataQuery query) {
+        query.setCustomerId(securityUser.getCustomerId());
         EntityDataQuery entityDataQuery = this.buildEntityDataQuery(query);
         PageData<EntityData> entities = entityService.findEntityDataByQuery(securityUser.getTenantId(),
                 securityUser.getCustomerId(), entityDataQuery);

--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbAlarmDataSubCtx.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbAlarmDataSubCtx.java
@@ -109,6 +109,7 @@ public class TbAlarmDataSubCtx extends TbAbstractDataSubCtx<AlarmDataQuery> {
         AlarmDataUpdate update;
         if (!entitiesMap.isEmpty()) {
             long start = System.currentTimeMillis();
+            query.setCustomerId(getCustomerId());
             PageData<AlarmData> alarms = alarmService.findAlarmDataByQueryForEntities(getTenantId(), query, getOrderedEntityIds());
             long end = System.currentTimeMillis();
             stats.getAlarmQueryInvocationCnt().incrementAndGet();

--- a/common/data/src/main/java/org/thingsboard/server/common/data/query/AlarmDataQuery.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/query/AlarmDataQuery.java
@@ -17,7 +17,9 @@ package org.thingsboard.server.common.data.query;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+import org.thingsboard.server.common.data.id.CustomerId;
 
 import java.util.List;
 
@@ -27,6 +29,11 @@ public class AlarmDataQuery extends AbstractDataQuery<AlarmDataPageLink> {
     @Getter
     protected List<EntityKey> alarmFields;
 
+    @Getter
+    @Setter
+    @JsonIgnore
+    protected CustomerId customerId;
+
     public AlarmDataQuery() {
     }
 
@@ -34,13 +41,14 @@ public class AlarmDataQuery extends AbstractDataQuery<AlarmDataPageLink> {
         super(entityFilter, keyFilters);
     }
 
-    public AlarmDataQuery(EntityFilter entityFilter, AlarmDataPageLink pageLink, List<EntityKey> entityFields, List<EntityKey> latestValues, List<KeyFilter> keyFilters, List<EntityKey> alarmFields) {
+    public AlarmDataQuery(EntityFilter entityFilter, AlarmDataPageLink pageLink, List<EntityKey> entityFields, List<EntityKey> latestValues, List<KeyFilter> keyFilters, List<EntityKey> alarmFields, CustomerId customerId) {
         super(entityFilter, pageLink, entityFields, latestValues, keyFilters);
         this.alarmFields = alarmFields;
+        this.customerId = customerId;
     }
 
     @JsonIgnore
     public AlarmDataQuery next() {
-        return new AlarmDataQuery(getEntityFilter(), getPageLink().nextPageLink(), entityFields, latestValues, keyFilters, alarmFields);
+        return new AlarmDataQuery(getEntityFilter(), getPageLink().nextPageLink(), entityFields, latestValues, keyFilters, alarmFields, customerId);
     }
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/AlarmDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/AlarmDao.java
@@ -44,6 +44,8 @@ public interface AlarmDao extends Dao<Alarm> {
 
     Alarm findLatestByOriginatorAndType(TenantId tenantId, EntityId originator, String type);
 
+    Alarm findCustomerLatestByOriginatorAndType(CustomerId customerId, EntityId originator, String type);
+
     ListenableFuture<Alarm> findLatestByOriginatorAndTypeAsync(TenantId tenantId, EntityId originator, String type);
 
     Alarm findAlarmById(TenantId tenantId, UUID key);

--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
@@ -115,7 +115,10 @@ public class BaseAlarmService extends AbstractEntityService implements AlarmServ
             }
             alarm.setCustomerId(entityService.fetchEntityCustomerId(alarm.getTenantId(), alarm.getOriginator()));
             if (alarm.getId() == null) {
-                Alarm existing = alarmDao.findLatestByOriginatorAndType(alarm.getTenantId(), alarm.getOriginator(), alarm.getType());
+                boolean isCustomer = !EntityId.NULL_UUID.equals(alarm.getCustomerId().getId());
+                Alarm existing = isCustomer ?
+                        alarmDao.findCustomerLatestByOriginatorAndType(alarm.getCustomerId(), alarm.getOriginator(), alarm.getType()) :
+                        alarmDao.findLatestByOriginatorAndType(alarm.getTenantId(), alarm.getOriginator(), alarm.getType());
                 if (existing == null || existing.getStatus().isCleared()) {
                     if (!alarmCreationEnabled) {
                         throw new ApiUsageLimitsExceededException("Alarms creation is disabled");

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/AlarmRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/AlarmRepository.java
@@ -38,6 +38,16 @@ public interface AlarmRepository extends JpaRepository<AlarmEntity, UUID> {
     List<AlarmEntity> findLatestByOriginatorAndType(@Param("originatorId") UUID originatorId,
                                                     @Param("alarmType") String alarmType,
                                                     Pageable pageable);
+    @Query("SELECT a " +
+           "FROM AlarmEntity a " +
+           "WHERE a.customerId = :customerId " +
+           "AND a.originatorId = :originatorId " +
+           "AND a.type = :alarmType " +
+           "ORDER BY a.startTs DESC")
+    List<AlarmEntity> findCustomerLatestByOriginatorAndType(@Param("customerId") UUID customerId,
+                                                            @Param("originatorId") UUID originatorId,
+                                                            @Param("alarmType") String alarmType,
+                                                            Pageable pageable);
 
     @Query(value = "SELECT new org.thingsboard.server.dao.model.sql.AlarmInfoEntity(a) FROM AlarmEntity a " +
             "LEFT JOIN EntityAlarmEntity ea ON a.id = ea.alarmId " +

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/JpaAlarmDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/JpaAlarmDao.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
+import org.thingsboard.server.common.data.Customer;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.alarm.Alarm;
 import org.thingsboard.server.common.data.alarm.AlarmInfo;
@@ -81,6 +82,16 @@ public class JpaAlarmDao extends JpaAbstractDao<AlarmEntity, Alarm> implements A
     @Override
     public Alarm findLatestByOriginatorAndType(TenantId tenantId, EntityId originator, String type) {
         List<AlarmEntity> latest = alarmRepository.findLatestByOriginatorAndType(
+                originator.getId(),
+                type,
+                PageRequest.of(0, 1));
+        return latest.isEmpty() ? null : DaoUtil.getData(latest.get(0));
+    }
+
+    @Override
+    public Alarm findCustomerLatestByOriginatorAndType(CustomerId customerId, EntityId originator, String type) {
+        List<AlarmEntity> latest = alarmRepository.findCustomerLatestByOriginatorAndType(
+                customerId.getId(),
                 originator.getId(),
                 type,
                 PageRequest.of(0, 1));

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultAlarmQueryRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultAlarmQueryRepository.java
@@ -24,6 +24,7 @@ import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.alarm.AlarmSearchStatus;
 import org.thingsboard.server.common.data.alarm.AlarmSeverity;
 import org.thingsboard.server.common.data.alarm.AlarmStatus;
+import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.page.PageData;
@@ -138,6 +139,10 @@ public class DefaultAlarmQueryRepository implements AlarmQueryRepository {
                 addAnd = true;
             } else {
                 selectPart.append(" a.originator_id as entity_id ");
+                if (query.getCustomerId() != null && !EntityId.NULL_UUID.equals(query.getCustomerId().getId())) {
+                    wherePart.append(buildPermissionsQuery(query.getCustomerId(), ctx));
+                    addAnd = true;
+                }
             }
             EntityDataSortOrder sortOrder = pageLink.getSortOrder();
             String textSearchQuery = buildTextSearchQuery(ctx, query.getAlarmFields(), pageLink.getTextSearch());
@@ -292,6 +297,13 @@ public class DefaultAlarmQueryRepository implements AlarmQueryRepository {
         StringBuilder permissionsQuery = new StringBuilder();
         ctx.addUuidParameter("permissions_tenant_id", tenantId.getId());
         permissionsQuery.append(" a.tenant_id = :permissions_tenant_id and ea.tenant_id = :permissions_tenant_id ");
+        return permissionsQuery.toString();
+    }
+
+    private String buildPermissionsQuery(CustomerId customerId, QueryContext ctx) {
+        StringBuilder permissionsQuery = new StringBuilder();
+        ctx.addUuidParameter("permissions_customer_id", customerId.getId());
+        permissionsQuery.append(" a.customer_id = :permissions_customer_id ");
         return permissionsQuery.toString();
     }
 


### PR DESCRIPTION
I am not sure, that my PR covers all cases. At least, I put several _FIXME_ in code. So I am opened for a discussion.
Here is a [bug](https://github.com/thingsboard/thingsboard/issues/7701)

Steps to reproduce:
1. Assign a device to first customer.
2. Generate alarm.
3. Ensure alarm is visible for the first customer.
4. Re-assign the device to second customer.
5. The generated alarm is visible for the second customer.

*Expected behaviour*
The second customer should see only that alarms that happened during his/her ownership.