### PR TITLE
[3.5] lwm2m lifecycle refactor

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
@@ -70,7 +70,7 @@ import org.thingsboard.server.service.telemetry.cmd.v2.LatestValueCmd;
 import org.thingsboard.server.transport.AbstractTransportIntegrationTest;
 import org.thingsboard.server.transport.lwm2m.client.LwM2MTestClient;
 import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClientContext;
-import org.thingsboard.server.transport.lwm2m.server.uplink.DefaultLwM2mUplinkMsgHandler;
+import org.thingsboard.server.transport.lwm2m.server.uplink.LwM2mUplinkMsgHandler;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -108,7 +108,7 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfil
 public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportIntegrationTest {
 
     @SpyBean
-    DefaultLwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandlerTest;
+    LwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandlerTest;
 
     @Autowired
     private LwM2mClientContext clientContextTest;

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
@@ -45,7 +45,7 @@ import org.junit.Assert;
 import org.mockito.Mockito;
 import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient;
 import org.thingsboard.server.transport.lwm2m.server.client.LwM2mClientContext;
-import org.thingsboard.server.transport.lwm2m.server.uplink.DefaultLwM2mUplinkMsgHandler;
+import org.thingsboard.server.transport.lwm2m.server.uplink.LwM2mUplinkMsgHandler;
 import org.thingsboard.server.transport.lwm2m.utils.LwM2mValueConverterImpl;
 
 import java.io.IOException;
@@ -109,12 +109,12 @@ public class LwM2MTestClient {
     private LwM2MLocationParams locationParams;
     private LwM2mTemperatureSensor lwM2MTemperatureSensor;
     private Set<LwM2MClientState> clientStates;
-    private DefaultLwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandlerTest;
+    private LwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandlerTest;
     private LwM2mClientContext clientContext;
 
     public void init(Security security, Configuration coapConfig, int port, boolean isRpc, boolean isBootstrap,
                      int shortServerId, int shortServerIdBs, Security securityBs,
-                     DefaultLwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandler,
+                     LwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandler,
                      LwM2mClientContext clientContext) throws InvalidDDFFileException, IOException {
         Assert.assertNull("client already initialized", leshanClient);
         this.defaultLwM2mUplinkMsgHandlerTest = defaultLwM2mUplinkMsgHandler;

--- a/application/src/test/resources/logback-test.xml
+++ b/application/src/test/resources/logback-test.xml
@@ -21,6 +21,11 @@
     <!-- mute TelemetryEdgeSqlTest that causes a lot of randomly generated errors -->
     <logger name="org.thingsboard.server.service.edge.rpc.EdgeGrpcSession" level="OFF"/>
 
+    <!--    LwM2m lifecycle debug for the test scope -->
+    <logger name="org.thingsboard.server.transport.lwm2m.server.downlink.DefaultLwM2mDownlinkMsgHandler" level="TRACE"/>
+    <logger name="org.thingsboard.server.transport.lwm2m.server.uplink.DefaultLwM2mUplinkMsgHandler" level="TRACE"/>
+    <logger name="org.thingsboard.server.transport.lwm2m.server.ota.DefaultLwM2MOtaUpdateService" level="TRACE"/>
+
     <root level="WARN">
         <appender-ref ref="console"/>
     </root>

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
@@ -25,6 +25,7 @@ import org.eclipse.leshan.core.node.codec.DefaultLwM2mEncoder;
 import org.eclipse.leshan.server.californium.LeshanServer;
 import org.eclipse.leshan.server.californium.LeshanServerBuilder;
 import org.eclipse.leshan.server.californium.registration.CaliforniumRegistrationStore;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 import org.thingsboard.server.cache.ota.OtaPackageDataCache;
 import org.thingsboard.server.common.data.DataConstants;
@@ -35,7 +36,7 @@ import org.thingsboard.server.transport.lwm2m.config.LwM2MTransportServerConfig;
 import org.thingsboard.server.transport.lwm2m.secure.TbLwM2MAuthorizer;
 import org.thingsboard.server.transport.lwm2m.secure.TbLwM2MDtlsCertificateVerifier;
 import org.thingsboard.server.transport.lwm2m.server.store.TbSecurityStore;
-import org.thingsboard.server.transport.lwm2m.server.uplink.DefaultLwM2mUplinkMsgHandler;
+import org.thingsboard.server.transport.lwm2m.server.uplink.LwM2mUplinkMsgHandler;
 import org.thingsboard.server.transport.lwm2m.utils.LwM2mValueConverterImpl;
 
 import javax.annotation.PreDestroy;
@@ -56,6 +57,7 @@ import static org.thingsboard.server.transport.lwm2m.server.ota.DefaultLwM2MOtaU
 
 @Slf4j
 @Component
+@DependsOn({"lwM2mDownlinkMsgHandler", "lwM2mUplinkMsgHandler"})
 @TbLwM2mTransportComponent
 @RequiredArgsConstructor
 public class DefaultLwM2mTransportService implements LwM2MTransportService {
@@ -66,7 +68,7 @@ public class DefaultLwM2mTransportService implements LwM2MTransportService {
     private final LwM2mTransportContext context;
     private final LwM2MTransportServerConfig config;
     private final OtaPackageDataCache otaPackageDataCache;
-    private final DefaultLwM2mUplinkMsgHandler handler;
+    private final LwM2mUplinkMsgHandler handler;
     private final CaliforniumRegistrationStore registrationStore;
     private final TbSecurityStore securityStore;
     private final TbLwM2MDtlsCertificateVerifier certificateVerifier;

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClientContextImpl.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClientContextImpl.java
@@ -42,7 +42,7 @@ import org.thingsboard.server.transport.lwm2m.server.ota.LwM2MOtaUpdateService;
 import org.thingsboard.server.transport.lwm2m.server.session.LwM2MSessionManager;
 import org.thingsboard.server.transport.lwm2m.server.store.TbLwM2MClientStore;
 import org.thingsboard.server.transport.lwm2m.server.store.TbMainSecurityStore;
-import org.thingsboard.server.transport.lwm2m.server.uplink.DefaultLwM2mUplinkMsgHandler;
+import org.thingsboard.server.transport.lwm2m.server.uplink.LwM2mUplinkMsgHandler;
 import org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil;
 
 import java.util.Arrays;
@@ -75,7 +75,7 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
 
     @Autowired
     @Lazy
-    private DefaultLwM2mUplinkMsgHandler defaultLwM2MUplinkMsgHandler;
+    private LwM2mUplinkMsgHandler defaultLwM2MUplinkMsgHandler;
     @Autowired
     @Lazy
     private LwM2MOtaUpdateService otaUpdateService;

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/DefaultLwM2mDownlinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/downlink/DefaultLwM2mDownlinkMsgHandler.java
@@ -103,7 +103,7 @@ import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.ge
 import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.validateVersionedId;
 
 @Slf4j
-@Service
+@Service("lwM2mDownlinkMsgHandler")
 @TbLwM2mTransportComponent
 @RequiredArgsConstructor
 public class DefaultLwM2mDownlinkMsgHandler extends LwM2MExecutorAwareService implements LwM2mDownlinkMsgHandler {
@@ -124,6 +124,7 @@ public class DefaultLwM2mDownlinkMsgHandler extends LwM2MExecutorAwareService im
 
     @PreDestroy
     public void destroy() {
+        log.trace("Destroying {}", getClass().getSimpleName());
         super.destroy();
     }
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/DefaultLwM2MOtaUpdateService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/DefaultLwM2MOtaUpdateService.java
@@ -146,6 +146,7 @@ public class DefaultLwM2MOtaUpdateService extends LwM2MExecutorAwareService impl
 
     @PreDestroy
     public void destroy() {
+        log.info("Destroying {}", getClass().getSimpleName());
         super.destroy();
     }
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/DefaultLwM2MOtaUpdateService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/DefaultLwM2MOtaUpdateService.java
@@ -146,7 +146,7 @@ public class DefaultLwM2MOtaUpdateService extends LwM2MExecutorAwareService impl
 
     @PreDestroy
     public void destroy() {
-        log.info("Destroying {}", getClass().getSimpleName());
+        log.trace("Destroying {}", getClass().getSimpleName());
         super.destroy();
     }
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/DefaultLwM2mUplinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/DefaultLwM2mUplinkMsgHandler.java
@@ -20,6 +20,8 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.model.ObjectModel;
@@ -32,6 +34,7 @@ import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
+import org.eclipse.leshan.core.node.codec.LwM2mValueConverter;
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.request.*;
 import org.eclipse.leshan.core.request.WriteRequest.Mode;
@@ -122,69 +125,41 @@ import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.fr
 
 
 @Slf4j
-@Service
+@Service("lwM2mUplinkMsgHandler")
 @TbLwM2mTransportComponent
+@RequiredArgsConstructor
 public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService implements LwM2mUplinkMsgHandler {
 
-    public LwM2mValueConverterImpl converter;
+    @Getter
+    private final LwM2mValueConverter converter = LwM2mValueConverterImpl.getInstance();;
 
     private final TransportService transportService;
     private final LwM2mTransportContext context;
+    @Lazy
     private final LwM2MAttributesService attributesService;
     private final LwM2MSessionManager sessionManager;
+    @Lazy
     private final LwM2MOtaUpdateService otaService;
     private final LwM2MTransportServerConfig config;
     private final LwM2MTelemetryLogService logService;
     private final LwM2mTransportServerHelper helper;
     private final TbLwM2MDtlsSessionStore sessionStore;
     private final LwM2mClientContext clientContext;
-    private final LwM2mDownlinkMsgHandler defaultLwM2MDownlinkMsgHandler;
+    private final LwM2mDownlinkMsgHandler defaultLwM2MDownlinkMsgHandler; //Do not use Lazy because we need live executor to handle msgs
     private final LwM2mVersionedModelProvider modelProvider;
     private final RegistrationStore registrationStore;
     private final TbLwM2mSecurityStore securityStore;
     private final LwM2MModelConfigService modelConfigService;
 
-    public DefaultLwM2mUplinkMsgHandler(TransportService transportService,
-                                        LwM2MTransportServerConfig config,
-                                        LwM2mTransportServerHelper helper,
-                                        LwM2mClientContext clientContext,
-                                        LwM2MTelemetryLogService logService,
-                                        LwM2MSessionManager sessionManager,
-                                        @Lazy LwM2MOtaUpdateService otaService,
-                                        @Lazy LwM2MAttributesService attributesService,
-                                        @Lazy LwM2mDownlinkMsgHandler defaultLwM2MDownlinkMsgHandler,
-                                        LwM2mTransportContext context,
-                                        TbLwM2MDtlsSessionStore sessionStore,
-                                        LwM2mVersionedModelProvider modelProvider,
-                                        RegistrationStore registrationStore,
-                                        TbLwM2mSecurityStore securityStore,
-                                        LwM2MModelConfigService modelConfigService) {
-        this.transportService = transportService;
-        this.sessionManager = sessionManager;
-        this.attributesService = attributesService;
-        this.otaService = otaService;
-        this.config = config;
-        this.helper = helper;
-        this.clientContext = clientContext;
-        this.logService = logService;
-        this.defaultLwM2MDownlinkMsgHandler = defaultLwM2MDownlinkMsgHandler;
-        this.context = context;
-        this.sessionStore = sessionStore;
-        this.modelProvider = modelProvider;
-        this.registrationStore = registrationStore;
-        this.securityStore = securityStore;
-        this.modelConfigService = modelConfigService;
-    }
-
     @PostConstruct
     public void init() {
         super.init();
         this.context.getScheduler().scheduleAtFixedRate(this::reportActivity, new Random().nextInt((int) config.getSessionReportTimeout()), config.getSessionReportTimeout(), TimeUnit.MILLISECONDS);
-        this.converter = LwM2mValueConverterImpl.getInstance();
     }
 
     @PreDestroy
     public void destroy() {
+        log.trace("Destroying {}", getClass().getSimpleName());
         super.destroy();
     }
 
@@ -955,6 +930,7 @@ public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService impl
      *
      * @param lwM2MClient - LwM2M Client
      */
+    @Override
     public void initAttributes(LwM2mClient lwM2MClient, boolean logFailedUpdateOfNonChangedValue) {
         Map<String, String> keyNamesMap = this.getNamesFromProfileForSharedAttributes(lwM2MClient);
         if (!keyNamesMap.isEmpty()) {

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/LwM2mUplinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/LwM2mUplinkMsgHandler.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.transport.lwm2m.server.uplink;
 
+import org.eclipse.leshan.core.node.codec.LwM2mValueConverter;
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.request.CreateRequest;
 import org.eclipse.leshan.core.request.SendRequest;
@@ -69,5 +70,10 @@ public interface LwM2mUplinkMsgHandler {
 
     void onToTransportUpdateCredentials(TransportProtos.SessionInfoProto sessionInfo, TransportProtos.ToTransportUpdateCredentialsProto updateCredentials);
 
+    void initAttributes(LwM2mClient lwM2MClient, boolean logFailedUpdateOfNonChangedValue);
+
     LwM2MTransportServerConfig getConfig();
+
+    LwM2mValueConverter getConverter();
+
 }

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
@@ -52,7 +52,7 @@ import org.thingsboard.server.transport.lwm2m.server.ota.firmware.FirmwareUpdate
 import org.thingsboard.server.transport.lwm2m.server.ota.firmware.FirmwareUpdateState;
 import org.thingsboard.server.transport.lwm2m.server.ota.software.SoftwareUpdateResult;
 import org.thingsboard.server.transport.lwm2m.server.ota.software.SoftwareUpdateState;
-import org.thingsboard.server.transport.lwm2m.server.uplink.DefaultLwM2mUplinkMsgHandler;
+import org.thingsboard.server.transport.lwm2m.server.uplink.LwM2mUplinkMsgHandler;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -289,12 +289,12 @@ public class LwM2MTransportUtil {
      * Attribute pmax = new Attribute(MAXIMUM_PERIOD, "60");
      * Attribute [] attrs = {gt, st};
      */
-    public static SimpleDownlinkRequest createWriteAttributeRequest(String target, Object params, DefaultLwM2mUplinkMsgHandler serviceImpl) {
+    public static SimpleDownlinkRequest createWriteAttributeRequest(String target, Object params, LwM2mUplinkMsgHandler serviceImpl) {
         AttributeSet attrSet = new AttributeSet(createWriteAttributes(params, serviceImpl, target));
         return attrSet.getAttributes().size() > 0 ? new WriteAttributesRequest(target, attrSet) : null;
     }
 
-    private static Attribute[] createWriteAttributes(Object params, DefaultLwM2mUplinkMsgHandler serviceImpl, String target) {
+    private static Attribute[] createWriteAttributes(Object params, LwM2mUplinkMsgHandler serviceImpl, String target) {
         List<Attribute> attributeLists = new ArrayList<>();
         Map<String, Object> map = JacksonUtil.convertValue(params, new TypeReference<>() {
         });
@@ -366,19 +366,19 @@ public class LwM2MTransportUtil {
         return newValues;
     }
 
-    public static Object convertWriteAttributes(String type, Object value, DefaultLwM2mUplinkMsgHandler serviceImpl, String target) {
+    public static Object convertWriteAttributes(String type, Object value, LwM2mUplinkMsgHandler serviceImpl, String target) {
         switch (type) {
             /** Integer [0:255]; */
             case DIMENSION:
-                Long dim = (Long) serviceImpl.converter.convertValue(value, equalsResourceTypeGetSimpleName(value), INTEGER, new LwM2mPath(target));
+                Long dim = (Long) serviceImpl.getConverter().convertValue(value, equalsResourceTypeGetSimpleName(value), INTEGER, new LwM2mPath(target));
                 return dim >= 0 && dim <= 255 ? dim : null;
             /**String;*/
             case OBJECT_VERSION:
-                return serviceImpl.converter.convertValue(value, equalsResourceTypeGetSimpleName(value), STRING, new LwM2mPath(target));
+                return serviceImpl.getConverter().convertValue(value, equalsResourceTypeGetSimpleName(value), STRING, new LwM2mPath(target));
             /**INTEGER */
             case MINIMUM_PERIOD:
             case MAXIMUM_PERIOD:
-                return serviceImpl.converter.convertValue(value, equalsResourceTypeGetSimpleName(value), INTEGER, new LwM2mPath(target));
+                return serviceImpl.getConverter().convertValue(value, equalsResourceTypeGetSimpleName(value), INTEGER, new LwM2mPath(target));
             /**Float; */
             case GREATER_THAN:
             case LESSER_THAN:
@@ -386,7 +386,7 @@ public class LwM2MTransportUtil {
                 if (value.getClass().getSimpleName().equals("String")) {
                     value = Double.valueOf((String) value);
                 }
-                return serviceImpl.converter.convertValue(value, equalsResourceTypeGetSimpleName(value), FLOAT, new LwM2mPath(target));
+                return serviceImpl.getConverter().convertValue(value, equalsResourceTypeGetSimpleName(value), FLOAT, new LwM2mPath(target));
             default:
                 return null;
         }


### PR DESCRIPTION
## Pull Request description

lwm2m lifecycle refactor.

This fixes the lifecycle issue that sometimes fires during integration tests.
The cause is the Downlink handler was destroyed earlier than the server. That causes `onCancel` event that trying to send to the client. But the executor is not able anymore, and the exception is thrown. Exception handler is also trying to execute some code in the same dead executor and fires exception.

1. Removed `@Lazy` from `LwM2mDownlinkMsgHandler` in `DefaultLwM2mUplinkMsgHandler`
2. `DefaultLwM2mTransportService` `@DependsOn({"lwM2mDownlinkMsgHandler", "lwM2mUplinkMsgHandler"})`
3. Dependencies refactored: implementations replaced with interfaces. Some public methods are extracted to interfaces.
4. `DefaultLwM2mDownlinkMsgHandler` - wrapped any exceptions on `handleDownlinkError` that may fire and prevent graceful server shutdown
5. Trace logs added to follow lifecycle, test log back config enabled trace logs for classes that extend `LwM2MExecutorAwareService`.

Test affected that expected to be fixed:
![image](https://user-images.githubusercontent.com/79898499/224303539-6d3d88f8-7869-4927-bfb6-e1ab7176add2.png)

The log of failed build right before failed tests
```log
[17:06:42] :	 [Step 5/9] 2023-03-09 16:06:42,307 [main] INFO  o.e.l.c.californium.LeshanClient - Destroying Leshan client ...
[17:06:42] :	 [Step 5/9] 2023-03-09 16:06:42,307 [main] INFO  o.e.l.c.e.DefaultRegistrationEngine - Trying to deregister to coap://localhost:5685 ...
[17:06:42] :	 [Step 5/9] 2023-03-09 16:06:42,309 [main] INFO  o.e.l.c.e.DefaultRegistrationEngine - De-register response DELETED(202) null.
[17:06:42] :	 [Step 5/9] 2023-03-09 16:06:42,310 [main] INFO  o.e.l.c.californium.LeshanClient - Leshan client destroyed.
[17:06:42] :	 [Step 5/9] 2023-03-09 16:06:42,591 [main] INFO  o.t.s.controller.AbstractWebTest - Executed web test teardown
[17:06:42] :	 [Step 5/9] 2023-03-09 16:06:42,594 [main] INFO  o.t.s.controller.AbstractWebTest - Finished test: testExecuteSecurityObjectById_Result_NOT_FOUND
[17:06:42] :	 [Step 5/9] 2023-03-09 16:06:42,968 [main] ERROR o.t.s.t.l.s.DefaultLwM2mTransportService - Failed to gracefully stop the LwM2M transport server!
[17:06:42] :	 [Step 5/9] java.util.concurrent.RejectedExecutionException: null
[17:06:42] :	 [Step 5/9] 	at java.base/java.util.concurrent.ForkJoinPool.externalPush(ForkJoinPool.java:1880)
[17:06:42] :	 [Step 5/9] 	at java.base/java.util.concurrent.ForkJoinPool.externalSubmit(ForkJoinPool.java:1921)
[17:06:42] :	 [Step 5/9] 	at java.base/java.util.concurrent.ForkJoinPool.submit(ForkJoinPool.java:2497)
[17:06:42] :	 [Step 5/9] 	at java.base/java.util.concurrent.ForkJoinPool.submit(ForkJoinPool.java:178)
[17:06:42] :	 [Step 5/9] 	at org.thingsboard.server.transport.lwm2m.server.downlink.DefaultLwM2mDownlinkMsgHandler.handleDownlinkError(DefaultLwM2mDownlinkMsgHandler.java:540)
[17:06:42] :	 [Step 5/9] 	at org.thingsboard.server.transport.lwm2m.server.downlink.DefaultLwM2mDownlinkMsgHandler.lambda$sendRequest$7(DefaultLwM2mDownlinkMsgHandler.java:503)
[17:06:42] :	 [Step 5/9] 	at org.eclipse.leshan.core.californium.CoapAsyncRequestObserver.onCancel(CoapAsyncRequestObserver.java:135)
[17:06:42] :	 [Step 5/9] 	at org.eclipse.californium.core.coap.Message.setCanceled(Message.java:942)
[17:06:42] :	 [Step 5/9] 	at org.eclipse.californium.core.coap.Request.setCanceled(Request.java:1024)
[17:06:42] :	 [Step 5/9] 	at org.eclipse.californium.core.network.InMemoryMessageExchangeStore.stop(InMemoryMessageExchangeStore.java:448)
[17:06:42] :	 [Step 5/9] 	at org.eclipse.californium.core.network.BaseMatcher.stop(BaseMatcher.java:158)
[17:06:42] :	 [Step 5/9] 	at org.eclipse.californium.core.network.CoapEndpoint.stop(CoapEndpoint.java:505)
[17:06:42] :	 [Step 5/9] 	at org.eclipse.californium.core.network.CoapEndpoint.destroy(CoapEndpoint.java:517)
[17:06:42] :	 [Step 5/9] 	at org.eclipse.californium.core.CoapServer.destroy(CoapServer.java:332)
[17:06:42] :	 [Step 5/9] 	at org.eclipse.leshan.server.californium.LeshanServer.destroy(LeshanServer.java:412)
[17:06:42] :	 [Step 5/9] 	at org.thingsboard.server.transport.lwm2m.server.DefaultLwM2mTransportService.shutdown(DefaultLwM2mTransportService.java:124)
```

After that issue the application init can't bind the port

```
[17:06:49] :	 [Step 5/9] 2023-03-09 16:06:49,364 [main] ERROR o.e.californium.core.CoapServer - cannot start server endpoint [0.0.0.0/0.0.0.0:0]
[17:06:49] :	 [Step 5/9] java.net.BindException: Address already in use (Bind failed)
[17:06:49] :	 [Step 5/9] 	at java.base/java.net.PlainDatagramSocketImpl.bind0(Native Method)
[17:06:49] :	 [Step 5/9] 	at java.base/java.net.AbstractPlainDatagramSocketImpl.bind(AbstractPlainDatagramSocketImpl.java:135)
[17:06:49] :	 [Step 5/9] 	at java.base/java.net.DatagramSocket.bind(DatagramSocket.java:394)
[17:06:49] :	 [Step 5/9] 	at org.eclipse.californium.scandium.DTLSConnector.init(DTLSConnector.java:895)
[17:06:49] :	 [Step 5/9] 	at org.eclipse.californium.scandium.DTLSConnector.start(DTLSConnector.java:847)
[17:06:49] :	 [Step 5/9] 	at org.eclipse.californium.scandium.DTLSConnector.start(DTLSConnector.java:813)
[17:06:49] :	 [Step 5/9] 	at org.eclipse.californium.core.network.CoapEndpoint.start(CoapEndpoint.java:478)
[17:06:49] :	 [Step 5/9] 	at org.eclipse.californium.core.CoapServer.start(CoapServer.java:279)
[17:06:49] :	 [Step 5/9] 	at org.eclipse.leshan.server.californium.LeshanServer.start(LeshanServer.java:375)
[17:06:49] :	 [Step 5/9] 	at org.thingsboard.server.transport.lwm2m.server.DefaultLwM2mTransportService.startLhServer(DefaultLwM2mTransportService.java:111)
[17:06:49] :	 [Step 5/9] 	at org.thingsboard.server.transport.lwm2m.server.DefaultLwM2mTransportService.init(DefaultLwM2mTransportService.java:106)

```

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



