### PR TITLE
[3.5] Rule ExpectedException refactored with AssertJ Exception Assertions

### DIFF
--- a/application/src/test/java/org/thingsboard/server/service/resource/sql/BaseTbResourceServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/resource/sql/BaseTbResourceServiceTest.java
@@ -19,10 +19,8 @@ import com.datastax.oss.driver.api.core.uuid.Uuids;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.ExpectedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.thingsboard.server.common.data.EntityInfo;
 import org.thingsboard.server.common.data.ResourceType;
@@ -46,6 +44,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DaoSqlTest
@@ -116,10 +115,6 @@ public class BaseTbResourceServiceTest extends AbstractControllerTest {
                 .andExpect(status().isOk());
     }
 
-    @SuppressWarnings("deprecation")
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void testSaveResourceWithMaxSumDataSizeOutOfLimit() throws Exception {
         loginSysAdmin();
@@ -138,9 +133,9 @@ public class BaseTbResourceServiceTest extends AbstractControllerTest {
         Assert.assertEquals(1, resourceService.sumDataSizeByTenantId(tenantId));
 
         try {
-            thrown.expect(DataValidationException.class);
-            thrown.expectMessage(String.format("Failed to create the tb resource, files size limit is exhausted %d bytes!", limit));
-            createResource("test1", 1 + DEFAULT_FILE_NAME);
+            assertThatThrownBy(() -> createResource("test1", 1 + DEFAULT_FILE_NAME))
+                    .isInstanceOf(DataValidationException.class)
+                    .hasMessageContaining("Failed to create the tb resource, files size limit is exhausted %d bytes!", limit);
         } finally {
             defaultTenantProfile.getProfileData().setConfiguration(DefaultTenantProfileConfiguration.builder().maxResourcesInBytes(0).build());
             loginSysAdmin();

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseDeviceServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseDeviceServiceTest.java
@@ -19,10 +19,8 @@ import com.datastax.oss.driver.api.core.uuid.Uuids;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.ExpectedException;
 import org.thingsboard.server.common.data.Customer;
 import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.DeviceInfo;
@@ -47,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.thingsboard.server.common.data.ota.OtaPackageType.FIRMWARE;
 import static org.thingsboard.server.dao.model.ModelConstants.NULL_UUID;
 
@@ -71,10 +70,6 @@ public abstract class BaseDeviceServiceTest extends AbstractServiceTest {
         tenantProfileService.deleteTenantProfiles(tenantId);
         tenantProfileService.deleteTenantProfiles(anotherTenantId);
     }
-
-    @SuppressWarnings("deprecation")
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testSaveDevicesWithoutMaxDeviceLimit() {
@@ -244,9 +239,9 @@ public abstract class BaseDeviceServiceTest extends AbstractServiceTest {
 
         savedDevice.setFirmwareId(savedFirmware.getId());
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("Can't assign firmware with different deviceProfile!");
-        deviceService.saveDevice(savedDevice);
+        assertThatThrownBy(() -> deviceService.saveDevice(savedDevice))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("Can't assign firmware with different deviceProfile!");
     }
 
     @Test

--- a/dao/src/test/java/org/thingsboard/server/dao/service/BaseOtaPackageServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/BaseOtaPackageServiceTest.java
@@ -19,9 +19,7 @@ import com.datastax.oss.driver.api.core.uuid.Uuids;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.DeviceProfile;
@@ -44,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.thingsboard.server.common.data.ota.OtaPackageType.FIRMWARE;
 
 public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
@@ -78,10 +77,6 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         deviceProfileId = savedDeviceProfile.getId();
     }
 
-    @SuppressWarnings("deprecation")
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @After
     public void after() {
         tenantService.deleteTenant(tenantId);
@@ -99,9 +94,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         createAndSaveFirmware(tenantId, "1");
         Assert.assertEquals(1, otaPackageService.sumDataSizeByTenantId(tenantId));
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage(String.format("Failed to create the ota package, files size limit is exhausted %d bytes!", DATA_SIZE));
-        createAndSaveFirmware(tenantId, "2");
+        assertThatThrownBy(() -> createAndSaveFirmware(tenantId, "2"))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("Failed to create the ota package, files size limit is exhausted %d bytes!", DATA_SIZE);
     }
 
     @Test
@@ -243,9 +238,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmware.setChecksum(CHECKSUM);
         firmware.setData(DATA);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("OtaPackage should be assigned to tenant!");
-        otaPackageService.saveOtaPackage(firmware);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackage(firmware))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("OtaPackage should be assigned to tenant!");
     }
 
     @Test
@@ -261,9 +256,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmware.setChecksum(CHECKSUM);
         firmware.setData(DATA);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("Type should be specified!");
-        otaPackageService.saveOtaPackage(firmware);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackage(firmware))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("Type should be specified!");
     }
 
     @Test
@@ -279,9 +274,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmware.setChecksum(CHECKSUM);
         firmware.setData(DATA);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("OtaPackage title should be specified!");
-        otaPackageService.saveOtaPackage(firmware);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackage(firmware))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("OtaPackage title should be specified!");
     }
 
     @Test
@@ -297,9 +292,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmware.setChecksum(CHECKSUM);
         firmware.setData(DATA);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("OtaPackage file name should be specified!");
-        otaPackageService.saveOtaPackage(firmware);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackage(firmware))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("OtaPackage file name should be specified!");
     }
 
     @Test
@@ -315,9 +310,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmware.setChecksum(CHECKSUM);
         firmware.setData(DATA);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("OtaPackage content type should be specified!");
-        otaPackageService.saveOtaPackage(firmware);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackage(firmware))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("OtaPackage content type should be specified!");
     }
 
     @Test
@@ -333,9 +328,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmware.setChecksumAlgorithm(CHECKSUM_ALGORITHM);
         firmware.setChecksum(CHECKSUM);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("OtaPackage data should be specified!");
-        otaPackageService.saveOtaPackage(firmware);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackage(firmware))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("OtaPackage data should be specified!");
     }
 
     @Test
@@ -352,9 +347,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmware.setChecksum(CHECKSUM);
         firmware.setData(DATA);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("OtaPackage is referencing to non-existent tenant!");
-        otaPackageService.saveOtaPackage(firmware);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackage(firmware))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("OtaPackage is referencing to non-existent tenant!");
     }
 
     @Test
@@ -371,9 +366,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmware.setChecksum(CHECKSUM);
         firmware.setData(DATA);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("OtaPackage is referencing to non-existent device profile!");
-        otaPackageService.saveOtaPackage(firmware);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackage(firmware))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("OtaPackage is referencing to non-existent device profile!");
     }
 
     @Test
@@ -389,9 +384,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmware.setChecksumAlgorithm(CHECKSUM_ALGORITHM);
         firmware.setData(DATA);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("OtaPackage checksum should be specified!");
-        otaPackageService.saveOtaPackage(firmware);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackage(firmware))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("OtaPackage checksum should be specified!");
     }
 
     @Test
@@ -411,17 +406,17 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         newFirmwareInfo.setTitle(TITLE);
         newFirmwareInfo.setVersion(VERSION);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("OtaPackage with such title and version already exists!");
-        otaPackageService.saveOtaPackageInfo(newFirmwareInfo, false);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackageInfo(newFirmwareInfo, false))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("OtaPackage with such title and version already exists!");
     }
 
     @Test
     public void testSaveFirmwareWithExistingTitleAndVersion() {
         createAndSaveFirmware(tenantId, VERSION);
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("OtaPackage with such title and version already exists!");
-        createAndSaveFirmware(tenantId, VERSION);
+        assertThatThrownBy(() -> createAndSaveFirmware(tenantId, VERSION))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("OtaPackage with such title and version already exists!");
     }
 
     @Test
@@ -436,9 +431,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         Device savedDevice = deviceService.saveDevice(device);
 
         try {
-            thrown.expect(DataValidationException.class);
-            thrown.expectMessage("The otaPackage referenced by the devices cannot be deleted!");
-            otaPackageService.deleteOtaPackage(tenantId, savedFirmware.getId());
+            assertThatThrownBy(() -> otaPackageService.deleteOtaPackage(tenantId, savedFirmware.getId()))
+                    .isInstanceOf(DataValidationException.class)
+                    .hasMessageContaining("The otaPackage referenced by the devices cannot be deleted!");
         } finally {
             deviceService.deleteDevice(tenantId, savedDevice.getId());
             otaPackageService.deleteOtaPackage(tenantId, savedFirmware.getId());
@@ -448,12 +443,12 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
     @Test
     public void testUpdateDeviceProfileId() {
         OtaPackage savedFirmware = createAndSaveFirmware(tenantId, VERSION);
+        savedFirmware.setDeviceProfileId(null);
 
         try {
-            thrown.expect(DataValidationException.class);
-            thrown.expectMessage("Updating otaPackage deviceProfile is prohibited!");
-            savedFirmware.setDeviceProfileId(null);
-            otaPackageService.saveOtaPackage(savedFirmware);
+            assertThatThrownBy(() -> otaPackageService.saveOtaPackage(savedFirmware))
+                    .isInstanceOf(DataValidationException.class)
+                    .hasMessageContaining("Updating otaPackage deviceProfile is prohibited!");
         } finally {
             otaPackageService.deleteOtaPackage(tenantId, savedFirmware.getId());
         }
@@ -482,9 +477,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         deviceProfileService.saveDeviceProfile(savedDeviceProfile);
 
         try {
-            thrown.expect(DataValidationException.class);
-            thrown.expectMessage("The otaPackage referenced by the device profile cannot be deleted!");
-            otaPackageService.deleteOtaPackage(tenantId, savedFirmware.getId());
+            assertThatThrownBy(() -> otaPackageService.deleteOtaPackage(tenantId, savedFirmware.getId()))
+                    .isInstanceOf(DataValidationException.class)
+                    .hasMessageContaining("The otaPackage referenced by the device profile cannot be deleted!");
         } finally {
             deviceProfileService.deleteDeviceProfile(tenantId, savedDeviceProfile.getId());
         }
@@ -636,12 +631,18 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmwareInfo.setType(FIRMWARE);
         firmwareInfo.setTitle(TITLE);
         firmwareInfo.setVersion(VERSION);
+
         firmwareInfo.setUrl("   ");
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("Ota package URL should be specified!");
-        otaPackageService.saveOtaPackageInfo(firmwareInfo, true);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackageInfo(firmwareInfo, true))
+                .as("firmwareInfo url set whitespaces")
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("Ota package URL should be specified!");
+
         firmwareInfo.setUrl("");
-        otaPackageService.saveOtaPackageInfo(firmwareInfo, true);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackageInfo(firmwareInfo, true))
+                .as("firmwareInfo url is empty")
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("Ota package URL should be specified!");
     }
 
     @Test
@@ -655,12 +656,10 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmwareInfo.setTenantId(tenantId);
 
         OtaPackageInfo savedFirmwareInfo = otaPackageService.saveOtaPackageInfo(firmwareInfo, true);
-
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("Updating otaPackage URL is prohibited!");
-
         savedFirmwareInfo.setUrl("https://newurl.com");
-        otaPackageService.saveOtaPackageInfo(savedFirmwareInfo, true);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackageInfo(savedFirmwareInfo, true))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("Updating otaPackage URL is prohibited!");
     }
 
     @Test
@@ -673,10 +672,9 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmwareInfo.setUrl(URL);
         firmwareInfo.setTenantId(tenantId);
 
-        thrown.expect(DataValidationException.class);
-        thrown.expectMessage("title length must be equal or less than 255");
-
-        otaPackageService.saveOtaPackageInfo(firmwareInfo, true);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackageInfo(firmwareInfo, true))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("title length must be equal or less than 255");
     }
 
     @Test
@@ -687,11 +685,11 @@ public abstract class BaseOtaPackageServiceTest extends AbstractServiceTest {
         firmwareInfo.setUrl(URL);
         firmwareInfo.setTenantId(tenantId);
         firmwareInfo.setTitle(TITLE);
-
         firmwareInfo.setVersion(StringUtils.random(257));
-        thrown.expectMessage("version length must be equal or less than 255");
 
-        otaPackageService.saveOtaPackageInfo(firmwareInfo, true);
+        assertThatThrownBy(() -> otaPackageService.saveOtaPackageInfo(firmwareInfo, true))
+                .isInstanceOf(DataValidationException.class)
+                .hasMessageContaining("version length must be equal or less than 255");
     }
 
     private OtaPackage createAndSaveFirmware(TenantId tenantId, String version) {


### PR DESCRIPTION
## Pull Request description
Rule ExpectedException refactored with AssertJ Exception Assertions

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



