### PR TITLE
[3.5] added assignee check for alarm

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/AlarmController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/AlarmController.java
@@ -139,6 +139,9 @@ public class AlarmController extends BaseController {
         checkNotNull(alarm.getOriginator());
         checkEntity(alarm.getId(), alarm, Resource.ALARM);
         checkEntityId(alarm.getOriginator(), Operation.READ);
+        if (alarm.getAssigneeId() != null) {
+            checkUserId(alarm.getAssigneeId(), Operation.READ);
+        }
         return tbAlarmService.save(alarm, getCurrentUser());
     }
 

--- a/application/src/main/java/org/thingsboard/server/service/entitiy/alarm/DefaultTbAlarmService.java
+++ b/application/src/main/java/org/thingsboard/server/service/entitiy/alarm/DefaultTbAlarmService.java
@@ -70,7 +70,7 @@ public class DefaultTbAlarmService extends AbstractTbEntityService implements Tb
             UserId newAssignee = alarm.getAssigneeId();
             UserId curAssignee = resultAlarm.getAssigneeId();
             if (newAssignee != null && !newAssignee.equals(curAssignee)) {
-                resultAlarm = assign(alarm, newAssignee, alarm.getAssignTs(), user);
+                resultAlarm = assign(resultAlarm, newAssignee, alarm.getAssignTs(), user);
             } else if (newAssignee == null && curAssignee != null) {
                 resultAlarm = unassign(alarm, alarm.getAssignTs(), user);
             }

--- a/application/src/test/java/org/thingsboard/server/controller/AbstractWebTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/AbstractWebTest.java
@@ -352,6 +352,7 @@ public abstract class AbstractWebTest extends AbstractInMemoryStorageTest {
     protected Tenant savedDifferentTenant;
     protected User savedDifferentTenantUser;
     private Customer savedDifferentCustomer;
+    protected User differentCustomerUser;
 
     protected void loginDifferentTenant() throws Exception {
         if (savedDifferentTenant != null) {
@@ -379,7 +380,7 @@ public abstract class AbstractWebTest extends AbstractInMemoryStorageTest {
             createDifferentCustomer();
 
             loginTenantAdmin();
-            User differentCustomerUser = new User();
+            differentCustomerUser = new User();
             differentCustomerUser.setAuthority(Authority.CUSTOMER_USER);
             differentCustomerUser.setTenantId(tenantId);
             differentCustomerUser.setCustomerId(savedDifferentCustomer.getId());

--- a/application/src/test/java/org/thingsboard/server/controller/BaseAlarmControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/BaseAlarmControllerTest.java
@@ -656,4 +656,38 @@ public abstract class BaseAlarmControllerTest extends AbstractControllerTest {
 
         return foundAlarm;
     }
+
+
+    @Test
+    public void testCreateAlarmWithOtherTenantsAssignee() throws Exception {
+        loginDifferentTenant();
+        loginTenantAdmin();
+
+        Alarm alarm = Alarm.builder()
+                .tenantId(tenantId)
+                .customerId(customerId)
+                .originator(customerDevice.getId())
+                .severity(AlarmSeverity.CRITICAL)
+                .assigneeId(savedDifferentTenantUser.getId())
+                .build();
+
+        doPost("/api/alarm", alarm).andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void testCreateAlarmWithOtherCustomerAsAssignee() throws Exception {
+        loginDifferentCustomer();
+        loginCustomerUser();
+
+        Alarm alarm = Alarm.builder()
+                .tenantId(tenantId)
+                .customerId(customerId)
+                .originator(customerDevice.getId())
+                .severity(AlarmSeverity.CRITICAL)
+                .assigneeId(differentCustomerUser.getId())
+                .build();
+
+        doPost("/api/alarm", alarm).andExpect(status().isForbidden());
+    }
+
 }


### PR DESCRIPTION
## Pull Request description

before, we could save alarm with assigne Id that references user from another tenant. fixed this 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



