### PR TITLE
UI: Fix labelText and InputText to entity autocomplete

### DIFF
--- a/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.html
+++ b/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.html
@@ -16,7 +16,7 @@
 
 -->
 <mat-form-field [formGroup]="selectEntityFormGroup" class="mat-block" [appearance]="appearance">
-  <mat-label>{{ entityText | translate }}</mat-label>
+  <mat-label>{{ label | translate }}</mat-label>
   <input matInput type="text"
          #entityInput
          formControlName="entity"
@@ -42,6 +42,6 @@
     </mat-option>
   </mat-autocomplete>
   <mat-error *ngIf="selectEntityFormGroup.get('entity').hasError('required')">
-    {{ entityRequiredText | translate }}
+    {{ requiredErrorText | translate }}
   </mat-error>
 </mat-form-field>

--- a/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
@@ -61,6 +61,24 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
 
   entitySubtypeValue: string;
 
+  entityText: string;
+
+  noEntitiesMatchingText: string;
+
+  entityRequiredText: string;
+
+  filteredEntities: Observable<Array<BaseData<EntityId>>>;
+
+  searchText = '';
+
+  private requiredValue: boolean;
+
+  private dirty = false;
+
+  private refresh$ = new Subject<Array<BaseData<EntityId>>>();
+
+  private propagateChange = (v: any) => { };
+
   @Input()
   set entityType(entityType: EntityType) {
     if (this.entityTypeValue !== entityType) {
@@ -71,6 +89,7 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
       this.dirty = true;
     }
   }
+
   @Input()
   set entitySubtype(entitySubtype: string) {
     if (this.entitySubtypeValue !== entitySubtype) {
@@ -99,13 +118,12 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
   @Input()
   appearance: MatFormFieldAppearance = 'fill';
 
-  private requiredValue: boolean;
-  get required(): boolean {
-    return this.requiredValue;
-  }
   @Input()
   set required(value: boolean) {
     this.requiredValue = coerceBooleanProperty(value);
+  }
+  get required(): boolean {
+    return this.requiredValue;
   }
 
   @Input()
@@ -116,19 +134,20 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
 
   @ViewChild('entityInput', {static: true}) entityInput: ElementRef;
 
-  entityText: string;
-  noEntitiesMatchingText: string;
-  entityRequiredText: string;
+  get requiredErrorText(): string {
+    if (this.requiredText && this.requiredText.length) {
+      return this.requiredText;
+    }
+    return this.entityRequiredText;
+  }
 
-  filteredEntities: Observable<Array<BaseData<EntityId>>>;
+  get label(): string {
+    if (this.labelText && this.labelText.length) {
+      return this.labelText;
+    }
+    return this.entityText;
+  }
 
-  searchText = '';
-
-  private dirty = false;
-
-  private refresh$ = new Subject<Array<BaseData<EntityId>>>();
-
-  private propagateChange = (v: any) => { };
 
   constructor(private store: Store<AppState>,
               public translate: TranslateService,
@@ -376,19 +395,5 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
       }
     }
     return entityType;
-  }
-
-  get label(): string {
-    if (this.labelText && this.labelText.length) {
-      return this.labelText;
-    }
-    return this.entityText;
-  }
-
-  get requiredErrorText(): string {
-    if (this.requiredText && this.requiredText.length) {
-      return this.requiredText;
-    }
-    return this.entityRequiredText;
   }
 }

--- a/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
@@ -71,7 +71,6 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
       this.dirty = true;
     }
   }
-
   @Input()
   set entitySubtype(entitySubtype: string) {
     if (this.entitySubtypeValue !== entitySubtype) {
@@ -249,12 +248,6 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
           break;
       }
     }
-    if (this.labelText && this.labelText.length) {
-      this.entityText = this.labelText;
-    }
-    if (this.requiredText && this.requiredText.length) {
-      this.entityRequiredText = this.requiredText;
-    }
     const currentEntity = this.getCurrentEntity();
     if (currentEntity) {
       const currentEntityType = currentEntity.id.entityType;
@@ -383,5 +376,19 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
       }
     }
     return entityType;
+  }
+
+  get label(): string {
+    if (this.labelText && this.labelText.length) {
+      return this.labelText;
+    }
+    return this.entityText;
+  }
+
+  get requiredErrorText(): string {
+    if (this.requiredText && this.requiredText.length) {
+      return this.requiredText;
+    }
+    return this.entityRequiredText;
   }
 }


### PR DESCRIPTION
## Pull Request description
Issue: https://github.com/thingsboard/thingsboard/pull/8044

This sample code did not work because requiredText and labelText property are used after entityType property.
<tb-entity-autocomplete
    fxFlex
    [required]="required"
    (entityChanged)="entityLoaded($event)"
    [entityType]="EntityType.DEVICE "
    [requiredText]="requiredText"
    [labelText]="labelText"
    formControlName="entityId">
</tb-entity-autocomplete>

Changed visualization logic of requiredText and labelText so now that don`t need input`s special sequence.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



