### PR TITLE
[3.7] Cache transactional event listener with fallback

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/asset/AssetCacheEvictEvent.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/asset/AssetCacheEvictEvent.java
@@ -16,12 +16,10 @@
 package org.thingsboard.server.dao.asset;
 
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import org.thingsboard.server.common.data.id.TenantId;
 
 @Data
-@RequiredArgsConstructor
-class AssetCacheEvictEvent {
+public class AssetCacheEvictEvent {
 
     private final TenantId tenantId;
     private final String newName;

--- a/dao/src/main/java/org/thingsboard/server/dao/asset/AssetProfileServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/asset/AssetProfileServiceImpl.java
@@ -18,6 +18,8 @@ package org.thingsboard.server.dao.asset;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -70,6 +72,7 @@ public class AssetProfileServiceImpl extends AbstractCachedEntityService<AssetPr
     private DataValidator<AssetProfile> assetProfileValidator;
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(AssetProfileEvictEvent event) {
         List<AssetProfileCacheKey> keys = new ArrayList<>(2);

--- a/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
@@ -83,7 +83,7 @@ public class BaseAssetService extends AbstractCachedEntityService<AssetCacheKey,
     @Autowired
     private DataValidator<Asset> assetValidator;
 
-    @TransactionalEventListener(classes = AssetCacheEvictEvent.class)
+    @TransactionalEventListener(fallbackExecution = true)
     @Override
     public void handleEvictEvent(AssetCacheEvictEvent event) {
         List<AssetCacheKey> keys = new ArrayList<>(2);
@@ -150,7 +150,7 @@ public class BaseAssetService extends AbstractCachedEntityService<AssetCacheKey,
             }
             asset.setType(assetProfile.getName());
             savedAsset = assetDao.saveAndFlush(asset.getTenantId(), asset);
-            publishEvictEvent(evictEvent);
+            eventPublisher.publishEvent(evictEvent);
         } catch (Exception t) {
             handleEvictEvent(evictEvent);
             checkConstraintViolation(t,
@@ -188,7 +188,7 @@ public class BaseAssetService extends AbstractCachedEntityService<AssetCacheKey,
             throw new DataValidationException("Can't delete asset that has entity views!");
         }
 
-        publishEvictEvent(new AssetCacheEvictEvent(asset.getTenantId(), asset.getName(), null));
+        eventPublisher.publishEvent(new AssetCacheEvictEvent(asset.getTenantId(), asset.getName(), null));
 
         assetDao.removeById(tenantId, assetId.getId());
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
@@ -21,6 +21,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -84,6 +86,7 @@ public class BaseAssetService extends AbstractCachedEntityService<AssetCacheKey,
     private DataValidator<Asset> assetValidator;
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(AssetCacheEvictEvent event) {
         List<AssetCacheKey> keys = new ArrayList<>(2);

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceCredentialsEvictEvent.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceCredentialsEvictEvent.java
@@ -18,7 +18,7 @@ package org.thingsboard.server.dao.device;
 import lombok.Data;
 
 @Data
-class DeviceCredentialsEvictEvent {
+public class DeviceCredentialsEvictEvent {
 
     private final String newCedentialsId;
     private final String oldCredentialsId;

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceCredentialsServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceCredentialsServiceImpl.java
@@ -22,6 +22,8 @@ import org.eclipse.leshan.core.SecurityMode;
 import org.eclipse.leshan.core.util.SecurityUtil;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +64,7 @@ public class DeviceCredentialsServiceImpl extends AbstractCachedEntityService<St
     private DataValidator<DeviceCredentials> credentialsValidator;
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(DeviceCredentialsEvictEvent event) {
         cache.evict(event.getNewCedentialsId());

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceProfileServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceProfileServiceImpl.java
@@ -19,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -80,6 +82,7 @@ public class DeviceProfileServiceImpl extends AbstractCachedEntityService<Device
     private QueueService queueService;
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(DeviceProfileEvictEvent event) {
         List<DeviceProfileCacheKey> keys = new ArrayList<>(2);

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
@@ -21,6 +21,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -246,6 +248,7 @@ public class DeviceServiceImpl extends AbstractCachedEntityService<DeviceCacheKe
     }
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(DeviceCacheEvictEvent event) {
         List<DeviceCacheKey> keys = new ArrayList<>(3);

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
@@ -234,7 +234,7 @@ public class DeviceServiceImpl extends AbstractCachedEntityService<DeviceCacheKe
             device.setType(deviceProfile.getName());
             device.setDeviceData(syncDeviceData(deviceProfile, device.getDeviceData()));
             Device result = deviceDao.saveAndFlush(device.getTenantId(), device);
-            publishEvictEvent(deviceCacheEvictEvent);
+            eventPublisher.publishEvent(deviceCacheEvictEvent);
             return result;
         } catch (Exception t) {
             handleEvictEvent(deviceCacheEvictEvent);
@@ -245,7 +245,7 @@ public class DeviceServiceImpl extends AbstractCachedEntityService<DeviceCacheKe
         }
     }
 
-    @TransactionalEventListener(classes = DeviceCacheEvictEvent.class)
+    @TransactionalEventListener(fallbackExecution = true)
     @Override
     public void handleEvictEvent(DeviceCacheEvictEvent event) {
         List<DeviceCacheKey> keys = new ArrayList<>(3);
@@ -327,7 +327,7 @@ public class DeviceServiceImpl extends AbstractCachedEntityService<DeviceCacheKe
 
         deviceDao.removeById(tenantId, deviceId.getId());
 
-        publishEvictEvent(deviceCacheEvictEvent);
+        eventPublisher.publishEvent(deviceCacheEvictEvent);
     }
 
 
@@ -561,8 +561,8 @@ public class DeviceServiceImpl extends AbstractCachedEntityService<DeviceCacheKe
 
         // explicitly remove device with previous tenant id from cache
         // result device object will have different tenant id and will not remove entity from cache
-        publishEvictEvent(oldTenantEvent);
-        publishEvictEvent(newTenantEvent);
+        eventPublisher.publishEvent(oldTenantEvent);
+        eventPublisher.publishEvent(newTenantEvent);
 
         return savedDevice;
     }
@@ -610,7 +610,7 @@ public class DeviceServiceImpl extends AbstractCachedEntityService<DeviceCacheKe
             }
         }
 
-        publishEvictEvent(new DeviceCacheEvictEvent(savedDevice.getTenantId(), savedDevice.getId(), provisionRequest.getDeviceName(), null));
+        eventPublisher.publishEvent(new DeviceCacheEvictEvent(savedDevice.getTenantId(), savedDevice.getId(), provisionRequest.getDeviceName(), null));
         return savedDevice;
     }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeCacheEvictEvent.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeCacheEvictEvent.java
@@ -16,12 +16,10 @@
 package org.thingsboard.server.dao.edge;
 
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import org.thingsboard.server.common.data.id.TenantId;
 
 @Data
-@RequiredArgsConstructor
-class EdgeCacheEvictEvent {
+public class EdgeCacheEvictEvent {
 
     private final TenantId tenantId;
     private final String newName;

--- a/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
@@ -105,7 +105,7 @@ public class EdgeServiceImpl extends AbstractCachedEntityService<EdgeCacheKey, E
     @Getter
     private boolean edgesEnabled;
 
-    @TransactionalEventListener(classes = EdgeCacheEvictEvent.class)
+    @TransactionalEventListener(fallbackExecution = true)
     @Override
     public void handleEvictEvent(EdgeCacheEvictEvent event) {
         List<EdgeCacheKey> keys = new ArrayList<>(2);
@@ -160,7 +160,7 @@ public class EdgeServiceImpl extends AbstractCachedEntityService<EdgeCacheKey, E
         EdgeCacheEvictEvent evictEvent = new EdgeCacheEvictEvent(edge.getTenantId(), edge.getName(), oldEdge != null ? oldEdge.getName() : null);
         try {
             var savedEdge = edgeDao.save(edge.getTenantId(), edge);
-            publishEvictEvent(evictEvent);
+            eventPublisher.publishEvent(evictEvent);
             return savedEdge;
         } catch (Exception t) {
             handleEvictEvent(evictEvent);
@@ -202,7 +202,7 @@ public class EdgeServiceImpl extends AbstractCachedEntityService<EdgeCacheKey, E
 
         edgeDao.removeById(tenantId, edgeId.getId());
 
-        publishEvictEvent(new EdgeCacheEvictEvent(edge.getTenantId(), edge.getName(), null));
+        eventPublisher.publishEvent(new EdgeCacheEvictEvent(edge.getTenantId(), edge.getName(), null));
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
@@ -26,6 +26,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -106,6 +108,7 @@ public class EdgeServiceImpl extends AbstractCachedEntityService<EdgeCacheKey, E
     private boolean edgesEnabled;
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(EdgeCacheEvictEvent event) {
         List<EdgeCacheKey> keys = new ArrayList<>(2);

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractCachedEntityService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractCachedEntityService.java
@@ -17,7 +17,6 @@ package org.thingsboard.server.dao.entity;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.thingsboard.server.cache.TbTransactionalCache;
 
 import java.io.Serializable;
@@ -28,15 +27,7 @@ public abstract class AbstractCachedEntityService<K extends Serializable, V exte
     protected TbTransactionalCache<K, V> cache;
 
     @Autowired
-    private ApplicationEventPublisher eventPublisher;
-
-    protected void publishEvictEvent(E event) {
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
-            eventPublisher.publishEvent(event);
-        } else {
-            handleEvictEvent(event);
-        }
-    }
+    protected ApplicationEventPublisher eventPublisher;
 
     public abstract void handleEvictEvent(E event);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractCachedService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractCachedService.java
@@ -17,7 +17,6 @@ package org.thingsboard.server.dao.entity;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.thingsboard.server.cache.TbTransactionalCache;
 
 import java.io.Serializable;
@@ -28,15 +27,7 @@ public abstract class AbstractCachedService<K extends Serializable, V extends Se
     protected TbTransactionalCache<K, V> cache;
 
     @Autowired
-    private ApplicationEventPublisher eventPublisher;
-
-    protected void publishEvictEvent(E event) {
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
-            eventPublisher.publishEvent(event);
-        } else {
-            handleEvictEvent(event);
-        }
-    }
+    protected ApplicationEventPublisher eventPublisher;
 
     public abstract void handleEvictEvent(E event);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewEvictEvent.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewEvictEvent.java
@@ -16,14 +16,12 @@
 package org.thingsboard.server.dao.entityview;
 
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.EntityViewId;
 import org.thingsboard.server.common.data.id.TenantId;
 
 @Data
-@RequiredArgsConstructor
-class EntityViewEvictEvent {
+public class EntityViewEvictEvent {
 
     private final TenantId tenantId;
     private final EntityViewId id;

--- a/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
@@ -21,6 +21,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -82,6 +84,7 @@ public class EntityViewServiceImpl extends AbstractCachedEntityService<EntityVie
     protected JpaExecutorService service;
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(EntityViewEvictEvent event) {
         List<EntityViewCacheKey> keys = new ArrayList<>(5);

--- a/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entityview/EntityViewServiceImpl.java
@@ -81,7 +81,7 @@ public class EntityViewServiceImpl extends AbstractCachedEntityService<EntityVie
     @Autowired
     protected JpaExecutorService service;
 
-    @TransactionalEventListener(classes = EntityViewEvictEvent.class)
+    @TransactionalEventListener(fallbackExecution = true)
     @Override
     public void handleEvictEvent(EntityViewEvictEvent event) {
         List<EntityViewCacheKey> keys = new ArrayList<>(5);
@@ -103,7 +103,7 @@ public class EntityViewServiceImpl extends AbstractCachedEntityService<EntityVie
         EntityView old = entityViewValidator.validate(entityView, EntityView::getTenantId);
         try {
             EntityView saved = entityViewDao.save(entityView.getTenantId(), entityView);
-            publishEvictEvent(new EntityViewEvictEvent(saved.getTenantId(), saved.getId(), saved.getEntityId(), old != null ? old.getEntityId() : null, saved.getName(), old != null ? old.getName() : null));
+            eventPublisher.publishEvent(new EntityViewEvictEvent(saved.getTenantId(), saved.getId(), saved.getEntityId(), old != null ? old.getEntityId() : null, saved.getName(), old != null ? old.getName() : null));
             return saved;
         } catch (Exception t) {
             checkConstraintViolation(t,
@@ -304,7 +304,7 @@ public class EntityViewServiceImpl extends AbstractCachedEntityService<EntityVie
         deleteEntityRelations(tenantId, entityViewId);
         EntityView entityView = entityViewDao.findById(tenantId, entityViewId.getId());
         entityViewDao.removeById(tenantId, entityViewId.getId());
-        publishEvictEvent(new EntityViewEvictEvent(entityView.getTenantId(), entityView.getId(), entityView.getEntityId(), null, entityView.getName(), null));
+        eventPublisher.publishEvent(new EntityViewEvictEvent(entityView.getTenantId(), entityView.getId(), entityView.getEntityId(), null, entityView.getName(), null));
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/notification/DefaultNotificationRuleService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/notification/DefaultNotificationRuleService.java
@@ -53,7 +53,7 @@ public class DefaultNotificationRuleService extends AbstractCachedEntityService<
         }
         try {
             notificationRule = notificationRuleDao.saveAndFlush(tenantId, notificationRule);
-            publishEvictEvent(notificationRule);
+            eventPublisher.publishEvent(notificationRule);
         } catch (Exception e) {
             handleEvictEvent(notificationRule);
             checkConstraintViolation(e, Map.of(
@@ -99,7 +99,7 @@ public class DefaultNotificationRuleService extends AbstractCachedEntityService<
     @Override
     public void deleteNotificationRuleById(TenantId tenantId, NotificationRuleId id) {
         NotificationRule notificationRule = findNotificationRuleById(tenantId, id);
-        publishEvictEvent(notificationRule);
+        eventPublisher.publishEvent(notificationRule);
         notificationRuleDao.removeById(tenantId, id.getId());
     }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/ota/BaseOtaPackageService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/ota/BaseOtaPackageService.java
@@ -61,7 +61,7 @@ public class BaseOtaPackageService extends AbstractCachedEntityService<OtaPackag
     private final DataValidator<OtaPackageInfo> otaPackageInfoValidator;
     private final DataValidator<OtaPackage> otaPackageValidator;
 
-    @TransactionalEventListener(classes = OtaPackageCacheEvictEvent.class)
+    @TransactionalEventListener(fallbackExecution = true)
     @Override
     public void handleEvictEvent(OtaPackageCacheEvictEvent event) {
         cache.evict(new OtaPackageCacheKey(event.getId()));
@@ -79,7 +79,7 @@ public class BaseOtaPackageService extends AbstractCachedEntityService<OtaPackag
         try {
             var result = otaPackageInfoDao.save(otaPackageInfo.getTenantId(), otaPackageInfo);
             if (otaPackageId != null) {
-                publishEvictEvent(new OtaPackageCacheEvictEvent(otaPackageId));
+                eventPublisher.publishEvent(new OtaPackageCacheEvictEvent(otaPackageId));
             }
             return result;
         } catch (Exception t) {
@@ -103,7 +103,7 @@ public class BaseOtaPackageService extends AbstractCachedEntityService<OtaPackag
         try {
             var result = otaPackageDao.save(otaPackage.getTenantId(), otaPackage);
             if (otaPackageId != null) {
-                publishEvictEvent(new OtaPackageCacheEvictEvent(otaPackageId));
+                eventPublisher.publishEvent(new OtaPackageCacheEvictEvent(otaPackageId));
             }
             return result;
         } catch (Exception t) {
@@ -194,7 +194,7 @@ public class BaseOtaPackageService extends AbstractCachedEntityService<OtaPackag
         validateId(otaPackageId, INCORRECT_OTA_PACKAGE_ID + otaPackageId);
         try {
             otaPackageDao.removeById(tenantId, otaPackageId.getId());
-            publishEvictEvent(new OtaPackageCacheEvictEvent(otaPackageId));
+            eventPublisher.publishEvent(new OtaPackageCacheEvictEvent(otaPackageId));
         } catch (Exception t) {
             ConstraintViolationException e = extractConstraintViolationException(t).orElse(null);
             if (e != null && e.getConstraintName() != null && e.getConstraintName().equalsIgnoreCase("fk_firmware_device")) {

--- a/dao/src/main/java/org/thingsboard/server/dao/ota/BaseOtaPackageService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/ota/BaseOtaPackageService.java
@@ -21,6 +21,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.thingsboard.server.cache.ota.OtaPackageDataCache;
@@ -62,6 +64,7 @@ public class BaseOtaPackageService extends AbstractCachedEntityService<OtaPackag
     private final DataValidator<OtaPackage> otaPackageValidator;
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(OtaPackageCacheEvictEvent event) {
         cache.evict(new OtaPackageCacheKey(event.getId()));

--- a/dao/src/main/java/org/thingsboard/server/dao/ota/OtaPackageCacheEvictEvent.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/ota/OtaPackageCacheEvictEvent.java
@@ -16,12 +16,10 @@
 package org.thingsboard.server.dao.ota;
 
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 import org.thingsboard.server.common.data.id.OtaPackageId;
 
 @Data
-@RequiredArgsConstructor
-class OtaPackageCacheEvictEvent {
+public class OtaPackageCacheEvictEvent {
 
     private final OtaPackageId id;
 

--- a/dao/src/main/java/org/thingsboard/server/dao/relation/BaseRelationService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/relation/BaseRelationService.java
@@ -26,6 +26,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -112,6 +114,7 @@ public class BaseRelationService implements RelationService {
     }
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     public void handleEvictEvent(EntityRelationEvent event) {
         List<RelationCacheKey> keys = new ArrayList<>(5);
         keys.add(new RelationCacheKey(event.getFrom(), event.getTo(), event.getType(), event.getTypeGroup()));

--- a/dao/src/main/java/org/thingsboard/server/dao/relation/EntityRelationEvent.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/relation/EntityRelationEvent.java
@@ -15,21 +15,17 @@
  */
 package org.thingsboard.server.dao.relation;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.Data;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.relation.EntityRelation;
 import org.thingsboard.server.common.data.relation.RelationTypeGroup;
 
-@RequiredArgsConstructor
+@Data
 public class EntityRelationEvent {
-    @Getter
+
     private final EntityId from;
-    @Getter
     private final EntityId to;
-    @Getter
     private final String type;
-    @Getter
     private final RelationTypeGroup typeGroup;
 
     public static EntityRelationEvent from(EntityRelation relation) {

--- a/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantProfileServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantProfileServiceImpl.java
@@ -18,6 +18,8 @@ package org.thingsboard.server.dao.tenant;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.thingsboard.server.common.data.EntityInfo;
@@ -57,6 +59,7 @@ public class TenantProfileServiceImpl extends AbstractCachedEntityService<Tenant
     private DataValidator<TenantProfile> tenantProfileValidator;
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(TenantProfileEvictEvent event) {
         List<TenantProfileCacheKey> keys = new ArrayList<>(2);

--- a/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/tenant/TenantServiceImpl.java
@@ -19,6 +19,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -147,6 +149,7 @@ public class TenantServiceImpl extends AbstractCachedEntityService<TenantId, Ten
     protected TbTransactionalCache<TenantId, Boolean> existsTenantCache;
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(TenantEvictEvent event) {
         TenantId tenantId = event.getTenantId();

--- a/dao/src/main/java/org/thingsboard/server/dao/user/UserSettingsServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/user/UserSettingsServiceImpl.java
@@ -105,7 +105,7 @@ public class UserSettingsServiceImpl extends AbstractCachedService<UserId, UserS
         try {
             validateJsonKeys(userSettings.getSettings());
             UserSettings saved = userSettingsDao.save(tenantId, userSettings);
-            publishEvictEvent(new UserSettingsEvictEvent(userSettings.getUserId()));
+            eventPublisher.publishEvent(new UserSettingsEvictEvent(userSettings.getUserId()));
             return saved;
         } catch (Exception t) {
             handleEvictEvent(new UserSettingsEvictEvent(userSettings.getUserId()));
@@ -113,7 +113,7 @@ public class UserSettingsServiceImpl extends AbstractCachedService<UserId, UserS
         }
     }
 
-    @TransactionalEventListener(classes = UserSettingsEvictEvent.class)
+    @TransactionalEventListener(fallbackExecution = true)
     @Override
     public void handleEvictEvent(UserSettingsEvictEvent event) {
         List<UserId> keys = new ArrayList<>();

--- a/dao/src/main/java/org/thingsboard/server/dao/user/UserSettingsServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/user/UserSettingsServiceImpl.java
@@ -26,6 +26,8 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.thingsboard.common.util.JacksonUtil;
@@ -114,6 +116,7 @@ public class UserSettingsServiceImpl extends AbstractCachedService<UserId, UserS
     }
 
     @TransactionalEventListener(fallbackExecution = true)
+    @Order(Ordered.HIGHEST_PRECEDENCE)
     @Override
     public void handleEvictEvent(UserSettingsEvictEvent event) {
         List<UserId> keys = new ArrayList<>();

--- a/dao/src/test/java/org/thingsboard/server/dao/TestEventSourcingListener.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/TestEventSourcingListener.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.thingsboard.server.cache.device.DeviceCacheEvictEvent;
+import org.thingsboard.server.dao.asset.AssetCacheEvictEvent;
+import org.thingsboard.server.dao.asset.AssetProfileEvictEvent;
+import org.thingsboard.server.dao.device.DeviceCredentialsEvictEvent;
+import org.thingsboard.server.dao.device.DeviceProfileEvictEvent;
+import org.thingsboard.server.dao.edge.EdgeCacheEvictEvent;
+import org.thingsboard.server.dao.entityview.EntityViewEvictEvent;
+import org.thingsboard.server.dao.ota.OtaPackageCacheEvictEvent;
+import org.thingsboard.server.dao.relation.EntityRelationEvent;
+import org.thingsboard.server.dao.tenant.TenantEvictEvent;
+import org.thingsboard.server.dao.tenant.TenantProfileEvictEvent;
+import org.thingsboard.server.dao.user.UserSettingsEvictEvent;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * The purpose of this class is to log or set a checkpoint during debug
+ * */
+
+@Component
+@Slf4j
+public class TestEventSourcingListener {
+
+    @PostConstruct
+    public void init() {
+        log.debug("EventSourcingListener initiated");
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(AssetProfileEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(AssetCacheEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(DeviceCredentialsEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(DeviceProfileEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(DeviceCacheEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(EdgeCacheEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(EntityViewEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(OtaPackageCacheEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(EntityRelationEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(TenantProfileEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(TenantEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+    @TransactionalEventListener(fallbackExecution = true)
+    public void handleEvent(UserSettingsEvictEvent event){
+        log.debug("event called: {}", event);
+    }
+
+}


### PR DESCRIPTION
## Cache transactional event listener with fallback

Cache evict event publishing refactored as `@TransactionalEventListener(fallbackExecution = true)` instead of custom transaction detection code.

This relay on default transaction management and open the way to adding more listeners to the same event.

For cache listeners, the order is set as `@Order(Ordered.HIGHEST_PRECEDENCE)`

Reference:

See `TransactionalApplicationListenerMethodAdapter` that is responsible for handling `@TransactionalEventListener`

```
	@Override
	public void onApplicationEvent(ApplicationEvent event) {
		if (TransactionSynchronizationManager.isSynchronizationActive() &&
				TransactionSynchronizationManager.isActualTransactionActive()) {
			TransactionSynchronizationManager.registerSynchronization(
					new TransactionalApplicationListenerSynchronization<>(event, this, this.callbacks));
		}
		else if (this.annotation.fallbackExecution()) {
			if (this.annotation.phase() == TransactionPhase.AFTER_ROLLBACK && logger.isWarnEnabled()) {
				logger.warn("Processing " + event + " as a fallback execution on AFTER_ROLLBACK phase");
			}
			processEvent(event);
		}
		else {
			// No transactional event execution at all
			if (logger.isDebugEnabled()) {
				logger.debug("No transaction is active - skipping " + event);
			}
		}
	}
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] PR name contains fix version. For example, "[3.3.4] Hotfix of some UI component" or "[3.4] New Super Feature".
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



