### PR TITLE
[3.5] Edge processor - delete attribute msg is not properly handled for non device type

### DIFF
--- a/application/src/test/java/org/thingsboard/server/edge/BaseTelemetryEdgeTest.java
+++ b/application/src/test/java/org/thingsboard/server/edge/BaseTelemetryEdgeTest.java
@@ -17,10 +17,7 @@ package org.thingsboard.server.edge;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import com.google.protobuf.AbstractMessage;
 import org.awaitility.Awaitility;
 import org.junit.Assert;
@@ -271,10 +268,7 @@ abstract public class BaseTelemetryEdgeTest extends AbstractEdgeTest {
                 .setEntityType(savedAsset.getId().getEntityType().name());
         AttributeDeleteMsg.Builder attributeDeleteMsg = AttributeDeleteMsg.newBuilder();
         attributeDeleteMsg.setScope(DataConstants.SERVER_SCOPE);
-        ArrayNode arrayNode = JacksonUtil.OBJECT_MAPPER.createArrayNode();
-        arrayNode.add(attributeKey);
-        List<String> keys = new Gson().fromJson(arrayNode.toString(), new TypeToken<>(){}.getType());
-        attributeDeleteMsg.addAllAttributeNames(keys);
+        attributeDeleteMsg.addAllAttributeNames(List.of(attributeKey));
         attributeDeleteMsg.build();
         builder.setAttributeDeleteMsg(attributeDeleteMsg);
         UplinkMsg.Builder uplinkMsgBuilder = UplinkMsg.newBuilder();

--- a/application/src/test/java/org/thingsboard/server/edge/BaseTelemetryEdgeTest.java
+++ b/application/src/test/java/org/thingsboard/server/edge/BaseTelemetryEdgeTest.java
@@ -15,11 +15,20 @@
  */
 package org.thingsboard.server.edge;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.google.protobuf.AbstractMessage;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Test;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.DataConstants;
 import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.asset.Asset;
 import org.thingsboard.server.common.data.edge.EdgeEvent;
 import org.thingsboard.server.common.data.edge.EdgeEventActionType;
 import org.thingsboard.server.common.data.edge.EdgeEventType;
@@ -27,9 +36,11 @@ import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.gen.edge.v1.AttributeDeleteMsg;
 import org.thingsboard.server.gen.edge.v1.DeviceUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.EntityDataProto;
+import org.thingsboard.server.gen.edge.v1.UplinkMsg;
 import org.thingsboard.server.gen.transport.TransportProtos;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 abstract public class BaseTelemetryEdgeTest extends AbstractEdgeTest {
 
@@ -231,6 +242,55 @@ abstract public class BaseTelemetryEdgeTest extends AbstractEdgeTest {
         TransportProtos.KeyValueProto keyValueProto = attributesUpdatedMsg.getKv(0);
         Assert.assertEquals("key1", keyValueProto.getKey());
         Assert.assertEquals("value1", keyValueProto.getStringV());
+    }
+
+    @Test
+    public void testSendAttributesDeleteRequestToCloud_nonDeviceEntity() throws Exception {
+        edgeImitator.expectMessageAmount(2);
+        Asset savedAsset = saveAsset("Delete Attribute Test");
+        doPost("/api/edge/" + edge.getUuidId() + "/asset/" + savedAsset.getUuidId(), Asset.class);
+        Assert.assertTrue(edgeImitator.waitForMessages());
+
+        final String attributeKey = "key1";
+        ObjectNode attributesData = JacksonUtil.OBJECT_MAPPER.createObjectNode();
+        attributesData.put(attributeKey, "value1");
+        doPost("/api/plugins/telemetry/ASSET/" + savedAsset.getId() + "/attributes/" + DataConstants.SERVER_SCOPE, attributesData);
+
+        // Wait before device attributes saved to database before deleting them
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> {
+                    String urlTemplate = "/api/plugins/telemetry/ASSET/" + savedAsset.getId() + "/keys/attributes/" + DataConstants.SERVER_SCOPE;
+                    List<String> actualKeys = doGetAsyncTyped(urlTemplate, new TypeReference<>() {});
+                    return actualKeys != null && !actualKeys.isEmpty() && actualKeys.contains(attributeKey);
+                });
+
+        EntityDataProto.Builder builder = EntityDataProto.newBuilder()
+                .setEntityIdMSB(savedAsset.getUuidId().getMostSignificantBits())
+                .setEntityIdLSB(savedAsset.getUuidId().getLeastSignificantBits())
+                .setEntityType(savedAsset.getId().getEntityType().name());
+        AttributeDeleteMsg.Builder attributeDeleteMsg = AttributeDeleteMsg.newBuilder();
+        attributeDeleteMsg.setScope(DataConstants.SERVER_SCOPE);
+        ArrayNode arrayNode = JacksonUtil.OBJECT_MAPPER.createArrayNode();
+        arrayNode.add(attributeKey);
+        List<String> keys = new Gson().fromJson(arrayNode.toString(), new TypeToken<>(){}.getType());
+        attributeDeleteMsg.addAllAttributeNames(keys);
+        attributeDeleteMsg.build();
+        builder.setAttributeDeleteMsg(attributeDeleteMsg);
+        UplinkMsg.Builder uplinkMsgBuilder = UplinkMsg.newBuilder();
+        uplinkMsgBuilder.addEntityData(builder.build());
+
+        edgeImitator.expectResponsesAmount(1);
+        edgeImitator.sendUplinkMsg(uplinkMsgBuilder.build());
+        Assert.assertTrue(edgeImitator.waitForResponses());
+
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> {
+                    String urlTemplate = "/api/plugins/telemetry/ASSET/" + savedAsset.getId() + "/keys/attributes/" + DataConstants.SERVER_SCOPE;
+                    List<String> actualKeys = doGetAsyncTyped(urlTemplate, new TypeReference<>() {});
+                    return actualKeys != null && actualKeys.isEmpty();
+                });
     }
 
 }


### PR DESCRIPTION
## Pull Request description

In case attribute was deleted for non device type - incorrect future completion, and as a result error messages in the logs.

Scope of changes:
* properly return future and finish it for non device types
* added test to validate it

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



