### PR TITLE
Fix for no users matching assignment user

### DIFF
--- a/ui-ngx/src/app/modules/home/components/alarm/alarm-assignee-panel.component.html
+++ b/ui-ngx/src/app/modules/home/components/alarm/alarm-assignee-panel.component.html
@@ -22,7 +22,7 @@
          (focusin)="onFocus()"
          [matAutocomplete]="userAutocomplete">
   <mat-icon matSuffix>search</mat-icon>
-  <mat-autocomplete class="tb-assignee-autocomplete"
+  <mat-autocomplete class="tb-assignee-autocomplete tb-autocomplete"
                     #userAutocomplete="matAutocomplete"
                     [displayWith]="displayUserFn"
                     (optionSelected)="selected($event)">
@@ -41,10 +41,12 @@
         <span [innerHTML]="user.email | highlight:searchText"></span>
       </div>
     </mat-option>
-    <mat-option *ngIf="!(filteredUsers | async)?.length" [value]="null">
-      <span style="white-space: normal">
-          {{ translate.get('user.no-users-matching', {entity: searchText}) | async }}
-      </span>
+    <mat-option *ngIf="!(filteredUsers | async)?.length" [value]="null" class="tb-not-found">
+      <div class="tb-not-found-content" (click)="$event.stopPropagation()">
+        <span style="white-space: normal">
+            {{ translate.get('user.no-users-matching', {entity: searchText}) | async }}
+        </span>
+      </div>
     </mat-option>
   </mat-autocomplete>
 </mat-form-field>


### PR DESCRIPTION
## Pull Request description

Before fix: after selecting option - no users matching, autocomplete tries to select the null user and gets an error.
![image](https://user-images.githubusercontent.com/83352633/230637335-a9829336-30a6-4c1e-8418-2ba10ca10042.png)
After fix: Added stop Propagation for click action and fixed CSS layout for it.
![image](https://user-images.githubusercontent.com/83352633/230637494-8406a30d-55de-4a65-bffb-02fb44af42e9.png)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



