### PR TITLE
[WIP] Added new Azure iot hub external node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <pubsub.client.version>1.105.0</pubsub.client.version>
         <google.common.protos.version>2.1.0</google.common.protos.version> <!-- required by io.grpc:grpc-protobuf:1.38.0-->
         <azure-servicebus.version>3.2.0</azure-servicebus.version>
+        <azure-iot-service-client.version>1.13.0</azure-iot-service-client.version>
         <passay.version>1.5.0</passay.version>
         <ua-parser.version>1.5.4</ua-parser.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -1836,6 +1837,11 @@
                 <groupId>com.microsoft.azure</groupId>
                 <artifactId>azure-servicebus</artifactId>
                 <version>${azure-servicebus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure.sdk.iot</groupId>
+                <artifactId>iot-service-client</artifactId>
+                <version>${azure-iot-service-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.passay</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <pubsub.client.version>1.105.0</pubsub.client.version>
         <google.common.protos.version>2.1.0</google.common.protos.version> <!-- required by io.grpc:grpc-protobuf:1.38.0-->
         <azure-servicebus.version>3.2.0</azure-servicebus.version>
-        <azure-iot-service-client.version>1.13.0</azure-iot-service-client.version>
+        <azure-iot-device-client.version>2.1.5</azure-iot-device-client.version>
         <passay.version>1.5.0</passay.version>
         <ua-parser.version>1.5.4</ua-parser.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -1840,8 +1840,8 @@
             </dependency>
             <dependency>
                 <groupId>com.microsoft.azure.sdk.iot</groupId>
-                <artifactId>iot-service-client</artifactId>
-                <version>${azure-iot-service-client.version}</version>
+                <artifactId>iot-device-client</artifactId>
+                <version>${azure-iot-device-client.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.passay</groupId>

--- a/rule-engine/rule-engine-components/pom.xml
+++ b/rule-engine/rule-engine-components/pom.xml
@@ -154,6 +154,10 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure.sdk.iot</groupId>
+            <artifactId>iot-service-client</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/rule-engine/rule-engine-components/pom.xml
+++ b/rule-engine/rule-engine-components/pom.xml
@@ -156,7 +156,7 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.sdk.iot</groupId>
-            <artifactId>iot-service-client</artifactId>
+            <artifactId>iot-device-client</artifactId>
         </dependency>
     </dependencies>
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNode.java
@@ -39,14 +39,13 @@ import javax.net.ssl.SSLException;
 @Slf4j
 @RuleNode(
         type = ComponentType.EXTERNAL,
-        name = "azure iot hub",
+        name = "azure iot hub (deprecated)",
         configClazz = TbAzureIotHubNodeConfiguration.class,
         nodeDescription = "Publish messages to the Azure IoT Hub",
         nodeDetails = "Will publish message payload to the Azure IoT Hub with QoS <b>AT_LEAST_ONCE</b>.",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
         configDirective = "tbExternalNodeAzureIotHubConfig"
 )
-@Deprecated
 public class TbAzureIotHubNode extends TbMqttNode {
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNode.java
@@ -46,6 +46,7 @@ import javax.net.ssl.SSLException;
         uiResources = {"static/rulenode/rulenode-core-config.js"},
         configDirective = "tbExternalNodeAzureIotHubConfig"
 )
+@Deprecated
 public class TbAzureIotHubNode extends TbMqttNode {
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNodeConfigurationV2.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNodeConfigurationV2.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.mqtt.azure;
+
+import lombok.Data;
+import org.thingsboard.rule.engine.api.NodeConfiguration;
+
+@Data
+public class TbAzureIotHubNodeConfigurationV2 implements NodeConfiguration<TbAzureIotHubNodeConfigurationV2> {
+
+    private String connString;
+    private String deviceId;
+
+    @Override
+    public TbAzureIotHubNodeConfigurationV2 defaultConfiguration() {
+        TbAzureIotHubNodeConfigurationV2 configuration = new TbAzureIotHubNodeConfigurationV2();
+        configuration.setConnString("<iot-hub-name>");
+        configuration.setDeviceId("<device-id>");
+        return configuration;
+    }
+}

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNodeConfigurationV2.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNodeConfigurationV2.java
@@ -27,7 +27,7 @@ public class TbAzureIotHubNodeConfigurationV2 implements NodeConfiguration<TbAzu
     @Override
     public TbAzureIotHubNodeConfigurationV2 defaultConfiguration() {
         TbAzureIotHubNodeConfigurationV2 configuration = new TbAzureIotHubNodeConfigurationV2();
-        configuration.setConnString("<iot-hub-name>");
+        configuration.setConnString("<iot-hub-connection-string>");
         configuration.setDeviceId("<device-id>");
         return configuration;
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNodeConfigurationV2.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNodeConfigurationV2.java
@@ -21,14 +21,12 @@ import org.thingsboard.rule.engine.api.NodeConfiguration;
 @Data
 public class TbAzureIotHubNodeConfigurationV2 implements NodeConfiguration<TbAzureIotHubNodeConfigurationV2> {
 
-    private String connString;
-    private String deviceId;
+    private String deviceConnString;
 
     @Override
     public TbAzureIotHubNodeConfigurationV2 defaultConfiguration() {
         TbAzureIotHubNodeConfigurationV2 configuration = new TbAzureIotHubNodeConfigurationV2();
-        configuration.setConnString("<iot-hub-connection-string>");
-        configuration.setDeviceId("<device-id>");
+        configuration.setDeviceConnString("<device-connection-string>");
         return configuration;
     }
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNodeV2.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNodeV2.java
@@ -38,7 +38,7 @@ import java.util.concurrent.Executors;
 @Slf4j
 @RuleNode(
         type = ComponentType.EXTERNAL,
-        name = "azure iot hub V2",
+        name = "azure iot hub",
         configClazz = TbAzureIotHubNodeConfigurationV2.class,
         nodeDescription = "Publish messages to the Azure IoT Hub (Recommended)",
         nodeDetails = "Will publish message payload to the Azure IoT Hub with AMQP sender </b>.",

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNodeV2.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/TbAzureIotHubNodeV2.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.mqtt.azure;
+
+import com.microsoft.azure.sdk.iot.service.DeliveryAcknowledgement;
+import com.microsoft.azure.sdk.iot.service.IotHubServiceClientProtocol;
+import com.microsoft.azure.sdk.iot.service.Message;
+import com.microsoft.azure.sdk.iot.service.ServiceClient;
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.rule.engine.api.RuleNode;
+import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.rule.engine.api.TbNode;
+import org.thingsboard.rule.engine.api.TbNodeConfiguration;
+import org.thingsboard.rule.engine.api.TbNodeException;
+import org.thingsboard.rule.engine.api.util.TbNodeUtils;
+import org.thingsboard.server.common.data.plugin.ComponentType;
+import org.thingsboard.server.common.msg.TbMsg;
+import org.thingsboard.server.common.msg.TbMsgMetaData;
+import org.thingsboard.server.common.msg.queue.PartitionChangeMsg;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@RuleNode(
+        type = ComponentType.EXTERNAL,
+        name = "azure iot hub V2",
+        configClazz = TbAzureIotHubNodeConfigurationV2.class,
+        nodeDescription = "Publish messages to the Azure IoT Hub (Recommended)",
+        nodeDetails = "Will publish message payload to the Azure IoT Hub with AMQP sender </b>.",
+        uiResources = {"static/rulenode/rulenode-core-config.js"},
+        configDirective = "tbExternalNodeAzureIotHubConfigV2"
+)
+public class TbAzureIotHubNodeV2 implements TbNode {
+    private static final String ERROR = "error";
+    private TbAzureIotHubNodeConfigurationV2 config;
+    private ServiceClient serviceClient;
+
+    @Override
+    public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
+        this.config = TbNodeUtils.convert(configuration, TbAzureIotHubNodeConfigurationV2.class);
+        this.config = new TbAzureIotHubNodeConfigurationV2().defaultConfiguration();
+        try {
+            serviceClient = ServiceClient.createFromConnectionString(this.config.getConnString(), IotHubServiceClientProtocol.AMQPS);
+            serviceClient.open();
+        } catch (Exception e) {
+            throw new TbNodeException(e);
+        }
+    }
+
+    @Override
+    public void onMsg(TbContext ctx, TbMsg msg) throws ExecutionException, InterruptedException, TbNodeException {
+        publishMessageAsync(ctx, msg);
+    }
+
+    private void publishMessageAsync(TbContext ctx, TbMsg msg) {
+        ctx.getExternalCallExecutor().executeAsync(() -> publishMessage(ctx, msg));
+    }
+
+    private void publishMessage(TbContext ctx, TbMsg msg) {
+        try {
+            Message message = new Message(msg.getData());
+            message.setDeliveryAcknowledgement(DeliveryAcknowledgement.Full);
+            message.setMessageId(UUID.randomUUID().toString());
+            message.getProperties().put("content-type", "JSON");
+            CompletableFuture<Void> future = serviceClient.sendAsync(config.getDeviceId(), message);
+            future.whenCompleteAsync((success, err) -> {
+                if (err != null) {
+                    TbMsg next = processException(ctx, msg, err);
+                    ctx.tellFailure(next, err);
+                } else {
+                    ctx.tellSuccess(msg);
+                }
+            }, Executors.newCachedThreadPool());
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        try {
+            serviceClient.close();
+        } catch (IOException e) {
+        }
+        TbNode.super.destroy();
+    }
+
+    @Override
+    public void onPartitionChangeMsg(TbContext ctx, PartitionChangeMsg msg) {
+        TbNode.super.onPartitionChangeMsg(ctx, msg);
+    }
+
+    private TbMsg processException(TbContext ctx, TbMsg origMsg, Throwable t) {
+        TbMsgMetaData metaData = origMsg.getMetaData().copy();
+        metaData.putValue(ERROR, t.getClass() + ": " + t.getMessage());
+        return ctx.transformMsg(origMsg, origMsg.getType(), origMsg.getOriginator(), metaData, origMsg.getData());
+    }
+}
+


### PR DESCRIPTION
## Pull Request description

We have already external node to publish to Azure iot hub, but it is implemented using mqtt protocol directly and causes issues from time to time while publishing. ("Channel is closed" is produced by Azure when two or more devices are using the same device Id credentials). To avoid such issues alternative node was implemented using iot hub sdk. The old node is being deprecated now.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



