### PR TITLE
Feature/alarm tenant id active idx

### DIFF
--- a/application/src/main/data/upgrade/3.4.4/schema_update.sql
+++ b/application/src/main/data/upgrade/3.4.4/schema_update.sql
@@ -47,10 +47,14 @@ UPDATE alarm SET acknowledged = true, cleared = false WHERE status = 'ACTIVE_ACK
 UPDATE alarm SET acknowledged = false, cleared = true WHERE status = 'CLEARED_UNACK';
 UPDATE alarm SET acknowledged = false, cleared = false WHERE status = 'ACTIVE_UNACK';
 
--- Drop index by 'status' column and replace with new one that has only active alarms;
+-- Drop index by 'status' column and replace with new indexes that has only active alarms;
 DROP INDEX IF EXISTS idx_alarm_originator_alarm_type_active;
 CREATE INDEX IF NOT EXISTS idx_alarm_originator_alarm_type_active
     ON alarm USING btree (originator_id, type) WHERE cleared = false;
+
+DROP INDEX IF EXISTS idx_alarm_tenant_alarm_type_active;
+CREATE INDEX IF NOT EXISTS idx_alarm_tenant_alarm_type_active
+    ON alarm USING btree (tenant_id, type) WHERE cleared = false;
 
 -- Cover index by alarm type to optimize propagated alarm queries;
 DROP INDEX IF EXISTS idx_entity_alarm_entity_id_alarm_type_created_time_alarm_id;

--- a/dao/src/main/resources/sql/schema-entities-idx.sql
+++ b/dao/src/main/resources/sql/schema-entities-idx.sql
@@ -20,9 +20,12 @@ CREATE INDEX IF NOT EXISTS idx_alarm_originator_created_time ON alarm(originator
 
 CREATE INDEX IF NOT EXISTS idx_alarm_tenant_created_time ON alarm(tenant_id, created_time DESC);
 
--- Drop index by 'status' column and replace with new one that has only active alarms;
+-- Drop index by 'status' column and replace with new indexes that has only active alarms;
 CREATE INDEX IF NOT EXISTS idx_alarm_originator_alarm_type_active
     ON alarm USING btree (originator_id, type) WHERE cleared = false;
+
+CREATE INDEX IF NOT EXISTS idx_alarm_tenant_alarm_type_active
+    ON alarm USING btree (tenant_id, type) WHERE cleared = false;
 
 CREATE INDEX IF NOT EXISTS idx_alarm_tenant_alarm_type_created_time ON alarm(tenant_id, type, created_time DESC);
 


### PR DESCRIPTION
## Pull Request description

Put your PR description here instead of this sentence.   

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



