### PR TITLE
Event table fixed width for cell with copy button

### DIFF
--- a/ui-ngx/src/app/modules/home/components/event/event-table-config.ts
+++ b/ui-ngx/src/app/modules/home/components/event/event-table-config.ts
@@ -243,7 +243,8 @@ export class EventTableConfig extends EntityTableConfig<Event, TimePageLink> {
               padding: '0 12px 0 0'
             })),
           new EntityTableColumn<Event>('entityId', 'event.entity-id', '85px',
-            (entity) => `${entity.body.entityId.substring(0, 6)}…`, () => ({
+            (entity) => `<span style="display: inline-block; width: 7ch">${entity.body.entityId.substring(0, 6)}…</span>`,
+            () => ({
               padding: '0 12px 0 0'
             }), false, () => ({
               padding: '0 12px 0 0'
@@ -261,7 +262,8 @@ export class EventTableConfig extends EntityTableConfig<Event, TimePageLink> {
               type: CellActionDescriptorType.COPY_BUTTON
             }),
           new EntityTableColumn<Event>('msgId', 'event.message-id', '85px',
-            (entity) => `${entity.body.msgId.substring(0, 6)}…`, () => ({
+            (entity) => `<span style="display: inline-block; width: 7ch">${entity.body.msgId.substring(0, 6)}…</span>`,
+            () => ({
               padding: '0 12px 0 0'
             }), false, () => ({
               padding: '0 12px 0 0'


### PR DESCRIPTION
## Pull Request description

Add fixed width for event table cell with copy button (Entity Id, Message Id) that gives the ability to align copy button in one line.

Before fix:
![image](https://user-images.githubusercontent.com/83352633/236209913-5a4cf9ba-9ad9-48b0-96d0-ac52148033e3.png)
After fix:
![image](https://user-images.githubusercontent.com/83352633/236211951-cf5b0ace-f249-4baf-8350-2fbad08c2618.png)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


