### PR TITLE
Bug/Yml cannot scan a double-quoted scalar on Windows

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -132,7 +132,7 @@ security:
     githubMapper:
       emailUrl: "${SECURITY_OAUTH2_GITHUB_MAPPER_EMAIL_URL_KEY:https://api.github.com/user/emails}"
   java_cacerts:
-    path: "${SECURITY_JAVA_CACERTS_PATH:${java.home}${file.separator}lib${file.separator}security${file.separator}cacerts}"
+    path: "${SECURITY_JAVA_CACERTS_PATH:${java.home}/lib/security/cacerts}"
     password: "${SECURITY_JAVA_CACERTS_PASSWORD:changeit}"
 
 # Usage statistics parameters


### PR DESCRIPTION
## Pull Request description

_Issue:_ On Windows, ${file.separator} for JavaCacerts path is replaced with "backslash", which cannot be parsed by yml file, so the application cannot be built and run fails.

_Error message:_ 
org.thingsboard.server.ThingsboardServerApplication
2023-05-04 15:37:58,122 [main] ERROR o.s.boot.SpringApplication - Application run failed
org.yaml.snakeyaml.scanner.ScannerException: while scanning a double-quoted scalar
 in 'reader', line 150, column 11:
        path: "${SECURITY_JAVA_CACERTS_PATH:${ ... 
              ^
found unknown escape character l(108)
 in 'reader', line 150, column 54:
     ... _JAVA_CACERTS_PATH:${java.home}\lib\security\cacerts}"


_Fix:_ Replace fetching ${file.separator} from System.properties with hardcoded "forward slash".  

Windows could process request with a forward slash:
![image](https://user-images.githubusercontent.com/50847617/236221225-09bb63b4-55a0-4ca6-9994-cf0187882588.png)





