### PR TITLE
Minor noification improvement

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/notification/sent/sent-notification-dialog.component.html
+++ b/ui-ngx/src/app/modules/home/pages/notification/sent/sent-notification-dialog.component.html
@@ -198,6 +198,11 @@
                   <mat-error *ngIf="webTemplateForm.get('additionalConfig.actionButtonConfig.text').hasError('required')">
                     {{ 'notification.button-text-required' | translate }}
                   </mat-error>
+                  <mat-error *ngIf="webTemplateForm.get('additionalConfig.actionButtonConfig.text').hasError('maxlength')">
+                    {{ 'notification.button-text-max-length' | translate :
+                    {length: webTemplateForm.get('additionalConfig.actionButtonConfig.text').getError('maxlength').requiredLength}
+                    }}
+                  </mat-error>
                 </mat-form-field>
               </div>
               <div fxLayout="row" fxLayoutGap.gt-xs="8px" fxLayout.xs="column">

--- a/ui-ngx/src/app/modules/home/pages/notification/template/template-configuration.ts
+++ b/ui-ngx/src/app/modules/home/pages/notification/template/template-configuration.ts
@@ -99,7 +99,7 @@ export abstract class TemplateConfiguration<T, R = any> extends DialogComponent<
         }),
         actionButtonConfig: this.fb.group({
           enabled: [false],
-          text: [{value: '', disabled: true}, Validators.required],
+          text: [{value: '', disabled: true}, [Validators.required, Validators.maxLength(50)]],
           linkType: [ActionButtonLinkType.LINK],
           link: [{value: '', disabled: true}, Validators.required],
           dashboardId: [{value: null, disabled: true}, Validators.required],

--- a/ui-ngx/src/app/modules/home/pages/notification/template/template-notification-dialog.component.html
+++ b/ui-ngx/src/app/modules/home/pages/notification/template/template-notification-dialog.component.html
@@ -126,6 +126,11 @@
                   <mat-error *ngIf="webTemplateForm.get('additionalConfig.actionButtonConfig.text').hasError('required')">
                     {{ 'notification.button-text-required' | translate }}
                   </mat-error>
+                  <mat-error *ngIf="webTemplateForm.get('additionalConfig.actionButtonConfig.text').hasError('maxlength')">
+                    {{ 'notification.button-text-max-length' | translate :
+                    {length: webTemplateForm.get('additionalConfig.actionButtonConfig.text').getError('maxlength').requiredLength}
+                    }}
+                  </mat-error>
                 </mat-form-field>
               </div>
               <div fxLayout="row" fxLayoutGap.gt-xs="8px" fxLayout.xs="column">
@@ -189,7 +194,7 @@
           <mat-label class="tb-title tb-required"
                      [ngClass]="{'tb-error': (emailStep.interacted || emailTemplateForm.get('body').dirty) && emailTemplateForm.get('body').hasError('required')}"
                      translate>notification.message</mat-label>
-          <editor [init]="tinyMceOptions" matInput formControlName="body"></editor>
+          <editor [init]="tinyMceOptions" formControlName="body"></editor>
           <mat-error class="tb-mat-error"
             *ngIf="(emailStep.interacted || emailTemplateForm.get('body').dirty) && emailTemplateForm.get('body').hasError('required')">
             {{ 'notification.message-required' | translate }}

--- a/ui-ngx/src/app/shared/components/notification/notification.component.scss
+++ b/ui-ngx/src/app/shared/components/notification/notification.component.scss
@@ -44,6 +44,8 @@
     .button {
       margin-top: 12px;
       border-color: initial;
+      height: fit-content;
+      line-height: 2;
     }
   }
 

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -2808,6 +2808,7 @@
         "basic-settings": "Basic settings",
         "button-text": "Button text",
         "button-text-required": "Button text is required",
+        "button-text-max-length": "Button text should be less than or equal to {{ length }} characters",
         "compose": "Compose",
         "conversation": "Conversation",
         "conversation-required": "Conversation is required",


### PR DESCRIPTION
## Pull Request description
Fixed notification button size.
Added notification action button text validator for a max length.

Before:
![image](https://user-images.githubusercontent.com/18036670/236774960-9eacaf21-2f30-4b3d-868d-146234e908f3.png)

After:
![image](https://user-images.githubusercontent.com/18036670/236775035-5933682a-5c09-4281-9aca-95c88bcb669c.png)
![image](https://user-images.githubusercontent.com/18036670/236775139-3cd3b889-a3bb-411f-9fa7-09bab8320ab7.png)

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



