### PR TITLE
Fixed incorrect updated dataSource validator when changing dataSource type

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/widget-config.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-config.component.html
@@ -156,7 +156,7 @@
                                           [widgetType]="widgetType"
                                           [datasourceType]="datasourceControl.get('type').value"
                                           [maxDataKeys]="modelValue?.typeParameters?.maxDataKeys"
-                                          [optDataKeys]="dataKeysOptional(datasourceControl.value)"
+                                          [optDataKeys]="dataKeysOptional(datasourceControl.get('type').value)"
                                           [aliasController]="aliasController"
                                           [datakeySettingsSchema]="modelValue?.dataKeySettingsSchema"
                                           [dataKeySettingsDirective]="modelValue?.dataKeySettingsDirective"

--- a/ui-ngx/src/app/modules/home/components/widget/widget-config.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-config.component.ts
@@ -538,17 +538,17 @@ export class WidgetConfigComponent extends PageComponent implements OnInit, Cont
     }
   }
 
-  public dataKeysOptional(datasource?: Datasource): boolean {
+  public dataKeysOptional(type?: DatasourceType): boolean {
     if (this.widgetType === widgetType.timeseries && this.modelValue?.typeParameters?.hasAdditionalLatestDataKeys) {
       return true;
     } else {
       return this.modelValue.typeParameters && this.modelValue.typeParameters.dataKeysOptional
-        && datasource?.type !== DatasourceType.entityCount && datasource?.type !== DatasourceType.alarmCount;
+        && type !== DatasourceType.entityCount && type !== DatasourceType.alarmCount;
     }
   }
 
   private buildDatasourceForm(datasource?: Datasource): UntypedFormGroup {
-    const dataKeysRequired = !this.dataKeysOptional(datasource);
+    const dataKeysRequired = !this.dataKeysOptional(datasource?.type);
     const datasourceFormGroup = this.fb.group(
       {
         type: [datasource ? datasource.type : null, [Validators.required]],
@@ -569,7 +569,7 @@ export class WidgetConfigComponent extends PageComponent implements OnInit, Cont
       datasourceFormGroup.get('entityAliasId').setValidators(
         (type === DatasourceType.entity || type === DatasourceType.entityCount) ? [Validators.required] : []
       );
-      const newDataKeysRequired = !this.dataKeysOptional(datasourceFormGroup.value);
+      const newDataKeysRequired = !this.dataKeysOptional(type);
       datasourceFormGroup.get('dataKeys').setValidators(newDataKeysRequired ? [Validators.required] : []);
       datasourceFormGroup.get('entityAliasId').updateValueAndValidity();
       datasourceFormGroup.get('dataKeys').updateValueAndValidity();


### PR DESCRIPTION
## Pull Request description

When we change the widget dataSource type from required data keys (Screen 1) to optional data keys (Screen 2), there are no updated validators in dataSource data keys.

_Screen 1_
![image](https://user-images.githubusercontent.com/18036670/236853450-25e9ad0f-ddca-4461-aa34-231480e4610c.png)

Before:
_Screen 2_
![image](https://user-images.githubusercontent.com/18036670/236853517-67efcf82-722d-45db-a489-148801291e94.png)

After:
_Screen 2_
![image](https://user-images.githubusercontent.com/18036670/236853686-3c26f1df-0fdd-4b4f-b038-8471d2127180.png)


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



