### PR TITLE
Fixed mat suffix icon tooltip

### DIFF
--- a/ui-ngx/src/styles.scss
+++ b/ui-ngx/src/styles.scss
@@ -567,6 +567,10 @@ mat-label {
     }
   }
 
+  .mat-mdc-form-field-icon-prefix, .mat-mdc-form-field-icon-suffix {
+    z-index: 1;
+  }
+
   .mat-toolbar.mat-mdc-table-toolbar .mat-mdc-form-field.mat-form-field-appearance-fill,
   .mat-mdc-form-field.mat-form-field-appearance-fill.tb-appearance-transparent {
     .mdc-text-field--filled {


### PR DESCRIPTION
## Pull Request description

Issue: [#8530](https://github.com/thingsboard/thingsboard/issues/8530).

After fixing all of the material icons with the attribute matSuffix starts to show tooltip.
![image](https://github.com/thingsboard/thingsboard/assets/83352633/6504547d-d569-472f-8a4c-de937bc228a0)

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



