### PR TITLE
Fixed Api usage widget fill color

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/api-usage/api_usage_json.raw
+++ b/ui-ngx/src/app/modules/home/pages/api-usage/api_usage_json.raw
@@ -32,8 +32,8 @@
                   "units": null,
                   "decimals": null,
                   "funcBody": null,
-                  "usePostProcessing": null,
-                  "postFuncBody": null
+                  "usePostProcessing": true,
+                  "postFuncBody": "return value ? value : 'ENABLED';"
                 },
                 {
                   "name": "jsExecutionLimit",
@@ -72,7 +72,7 @@
                   "decimals": null,
                   "funcBody": null,
                   "usePostProcessing": true,
-                  "postFuncBody": "return value ? value.toLowerCase() : '';"
+                  "postFuncBody": "return value ? value.toLowerCase() : 'enabled';"
                 },
                 {
                   "name": "jsExecutionApiState",
@@ -190,8 +190,8 @@
                   "units": null,
                   "decimals": null,
                   "funcBody": null,
-                  "usePostProcessing": null,
-                  "postFuncBody": null
+                  "usePostProcessing": true,
+                  "postFuncBody": "return value ? value : 'ENABLED';"
                 },
                 {
                   "name": "storageDataPointsLimit",
@@ -230,7 +230,7 @@
                   "decimals": null,
                   "funcBody": null,
                   "usePostProcessing": true,
-                  "postFuncBody": "return value ? value.toLowerCase() : '';"
+                  "postFuncBody": "return value ? value.toLowerCase() : 'enabled';"
                 },
                 {
                   "name": "dbApiState",
@@ -348,8 +348,8 @@
                   "units": null,
                   "decimals": null,
                   "funcBody": null,
-                  "usePostProcessing": null,
-                  "postFuncBody": null
+                  "usePostProcessing": true,
+                  "postFuncBody": "return value ? value : 'ENABLED';"
                 },
                 {
                   "name": "ruleEngineExecutionLimit",
@@ -388,7 +388,7 @@
                   "decimals": null,
                   "funcBody": null,
                   "usePostProcessing": true,
-                  "postFuncBody": "return value ? value.toLowerCase() : '';"
+                  "postFuncBody": "return value ? value.toLowerCase() : 'enabled';"
                 },
                 {
                   "name": "ruleEngineApiState",
@@ -516,8 +516,8 @@
                   "units": null,
                   "decimals": null,
                   "funcBody": null,
-                  "usePostProcessing": null,
-                  "postFuncBody": null
+                  "usePostProcessing": true,
+                  "postFuncBody": "return value ? value : 'ENABLED';"
                 },
                 {
                   "name": "transportMsgLimit",
@@ -556,7 +556,7 @@
                   "decimals": null,
                   "funcBody": null,
                   "usePostProcessing": true,
-                  "postFuncBody": "return value ? value.toLowerCase() : '';"
+                  "postFuncBody": "return value ? value.toLowerCase() : 'enabled';"
                 },
                 {
                   "name": "transportApiState",
@@ -687,8 +687,8 @@
                   "units": null,
                   "decimals": null,
                   "funcBody": null,
-                  "usePostProcessing": null,
-                  "postFuncBody": null
+                  "usePostProcessing": true,
+                  "postFuncBody": "return value ? value : 'ENABLED';"
                 },
                 {
                   "name": "createdAlarmsLimit",
@@ -727,7 +727,7 @@
                   "decimals": null,
                   "funcBody": null,
                   "usePostProcessing": true,
-                  "postFuncBody": "return value ? value.toLowerCase() : '';"
+                  "postFuncBody": "return value ? value.toLowerCase() : 'enabled';"
                 },
                 {
                   "name": "alarmApiState",


### PR DESCRIPTION
## Pull Request description
Fixed: [#8545](https://github.com/thingsboard/thingsboard/issues/8545)

Fixed fill color for Api usage widget.
![image](https://github.com/thingsboard/thingsboard/assets/83352633/4173fde5-123c-4602-af35-8d40e2aec0af)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



