### PR TITLE
[hotfix][3.5.0] DeviceActivityTriggerProcessor hotfix: filter by EntityType type DEVICE

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/notification/rule/trigger/DeviceActivityTriggerProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/notification/rule/trigger/DeviceActivityTriggerProcessor.java
@@ -20,6 +20,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.springframework.stereotype.Service;
 import org.thingsboard.server.common.data.DataConstants;
 import org.thingsboard.server.common.data.DeviceProfile;
+import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.notification.info.DeviceActivityNotificationInfo;
@@ -45,6 +46,11 @@ public class DeviceActivityTriggerProcessor implements RuleEngineMsgNotification
         if (!triggerConfig.getNotifyOn().contains(event)) {
             return false;
         }
+
+        if (trigger.getMsg().getOriginator().getEntityType() != EntityType.DEVICE) {
+            return false;
+        }
+
         DeviceId deviceId = (DeviceId) trigger.getMsg().getOriginator();
         if (CollectionUtils.isNotEmpty(triggerConfig.getDevices())) {
             return triggerConfig.getDevices().contains(deviceId.getId());


### PR DESCRIPTION
## Pull Request description

DeviceActivityTriggerProcessor hotfix: filter by EntityType type DEVICE

```
2023-05-16 06:31:31,757 [NotificationExecutorService-10-10] ERROR o.t.s.s.n.r.DefaultNotificationRuleProcessor - Failed to process notification rule 6a069c90-f343-11ed-89eb-5787fa419f0f for trigger type DEVICE_ACTIVITY with trigger object RuleEngineMsgTrigger(tenantId=4360dc00-849b-11ea-b908-fb276498eb8c, msg=TbMsg(queueName=LoRaGateway, id=b85b13c3-dd1c-4e83-a9fa-87933f93973f, ts=1684171903980, type=INACTIVITY_EVENT, originator=7d0c2420-b115-11ec-a169-3d932e51a05e, customerId=null, metaData=TbMsgMetaData(data={}), dataType=JSON, data={"trigger":true}, ruleChainId=bfb1c7c0-34ce-11ed-8f1a-4175fe0a3632, ruleNodeId=bfc7c0c1-34ce-11ed-8f1a-4175fe0a3632, ctx=org.thingsboard.server.common.msg.TbMsgProcessingCtx@16370071, deadline=1200260531337493, callback=org.thingsboard.server.service.queue.TbMsgPackCallback@75a34068))
java.lang.ClassCastException: class org.thingsboard.server.common.data.id.AssetId cannot be cast to class org.thingsboard.server.common.data.id.DeviceId (org.thingsboard.server.common.data.id.AssetId and org.thingsboard.server.common.data.id.DeviceId are in unnamed module of loader org.springframework.boot.loader.LaunchedURLClassLoader @76b0bfab)
	at org.thingsboard.server.service.notification.rule.trigger.DeviceActivityTriggerProcessor.matchesFilter(DeviceActivityTriggerProcessor.java:63)
	at org.thingsboard.server.service.notification.rule.trigger.DeviceActivityTriggerProcessor.matchesFilter(DeviceActivityTriggerProcessor.java:51)
	at org.thingsboard.server.service.notification.rule.DefaultNotificationRuleProcessor.matchesFilter(DefaultNotificationRuleProcessor.java:201)
	at org.thingsboard.server.service.notification.rule.DefaultNotificationRuleProcessor.processNotificationRule(DefaultNotificationRuleProcessor.java:155)
	at org.thingsboard.server.service.notification.rule.DefaultNotificationRuleProcessor.lambda$process$0(DefaultNotificationRuleProcessor.java:119)
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



