### PR TITLE
[hotfix][3.5.0] SqlPartitioningRepository hotfix: partition already pending detach in partitioned table

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/sqlts/insert/sql/SqlPartitioningRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sqlts/insert/sql/SqlPartitioningRepository.java
@@ -110,9 +110,12 @@ public class SqlPartitioningRepository {
 
         String tablePartition = table + "_" + partitionTs;
         String detachPsqlStmtStr = "ALTER TABLE " + table + " DETACH PARTITION " + tablePartition;
-        if (getCurrentServerVersion() >= PSQL_VERSION_14) {
-            detachPsqlStmtStr += " CONCURRENTLY";
-        }
+
+        // hotfix of ERROR: partition "integration_debug_event_1678323600000" already pending detach in partitioned table "public.integration_debug_event"
+        // https://github.com/thingsboard/thingsboard/issues/8271
+        // if (getCurrentServerVersion() >= PSQL_VERSION_14) {
+        //    detachPsqlStmtStr += " CONCURRENTLY";
+        // }
 
         String dropStmtStr = "DROP TABLE " + tablePartition;
         try {


### PR DESCRIPTION

## Pull Request description

SqlPartitioningRepository hotfix: partition already pending detach in a partitioned table

This is a quick workaround for disabling the Postgres 15 feature. 

This is related to the issue https://github.com/thingsboard/thingsboard/issues/8271

This is **not a solution** but a workaround. The only reason is to release **disk space** for **Postgresql 15** instances.

![image](https://github.com/thingsboard/thingsboard/assets/79898499/ef46d750-7e0e-4e4f-8d7c-d6970768f38e)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



