### PR TITLE
Added columns visibility for Timeseries table

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-key-settings.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-key-settings.component.html
@@ -66,4 +66,29 @@
       </ng-template>
     </mat-expansion-panel>
   </fieldset>
+  <mat-form-field fxFlex class="mat-block">
+    <mat-label translate>widgets.table.default-column-visibility</mat-label>
+    <mat-select formControlName="defaultColumnVisibility">
+      <mat-option [value]="'visible'">
+        {{ 'widgets.table.column-visibility-visible' | translate }}
+      </mat-option>
+      <mat-option [value]="'hidden'">
+        {{ 'widgets.table.column-visibility-hidden' | translate }}
+      </mat-option>
+      <mat-option [value]="'hidden-mobile'">
+        {{ 'widgets.table.column-visibility-hidden-mobile' | translate }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+  <mat-form-field fxFlex class="mat-block">
+    <mat-label translate>widgets.table.column-selection-to-display</mat-label>
+    <mat-select formControlName="columnSelectionToDisplay">
+      <mat-option [value]="'enabled'">
+        {{ 'widgets.table.column-selection-to-display-enabled' | translate }}
+      </mat-option>
+      <mat-option [value]="'disabled'">
+        {{ 'widgets.table.column-selection-to-display-disabled' | translate }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
 </section>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-key-settings.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-key-settings.component.ts
@@ -43,7 +43,9 @@ export class TimeseriesTableKeySettingsComponent extends WidgetSettingsComponent
       useCellStyleFunction: false,
       cellStyleFunction: '',
       useCellContentFunction: false,
-      cellContentFunction: ''
+      cellContentFunction: '',
+      defaultColumnVisibility: 'visible',
+      columnSelectionToDisplay: 'enabled'
     };
   }
 
@@ -53,6 +55,8 @@ export class TimeseriesTableKeySettingsComponent extends WidgetSettingsComponent
       cellStyleFunction: [settings.cellStyleFunction, [Validators.required]],
       useCellContentFunction: [settings.useCellContentFunction, []],
       cellContentFunction: [settings.cellContentFunction, [Validators.required]],
+      defaultColumnVisibility: [settings.defaultColumnVisibility, []],
+      columnSelectionToDisplay: [settings.columnSelectionToDisplay, []],
     });
   }
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-latest-key-settings.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-latest-key-settings.component.html
@@ -73,4 +73,29 @@
       </ng-template>
     </mat-expansion-panel>
   </fieldset>
+  <mat-form-field fxFlex class="mat-block">
+    <mat-label translate>widgets.table.default-column-visibility</mat-label>
+    <mat-select formControlName="defaultColumnVisibility">
+      <mat-option [value]="'visible'">
+        {{ 'widgets.table.column-visibility-visible' | translate }}
+      </mat-option>
+      <mat-option [value]="'hidden'">
+        {{ 'widgets.table.column-visibility-hidden' | translate }}
+      </mat-option>
+      <mat-option [value]="'hidden-mobile'">
+        {{ 'widgets.table.column-visibility-hidden-mobile' | translate }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
+  <mat-form-field fxFlex class="mat-block">
+    <mat-label translate>widgets.table.column-selection-to-display</mat-label>
+    <mat-select formControlName="columnSelectionToDisplay">
+      <mat-option [value]="'enabled'">
+        {{ 'widgets.table.column-selection-to-display-enabled' | translate }}
+      </mat-option>
+      <mat-option [value]="'disabled'">
+        {{ 'widgets.table.column-selection-to-display-disabled' | translate }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
 </section>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-latest-key-settings.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-latest-key-settings.component.ts
@@ -44,7 +44,9 @@ export class TimeseriesTableLatestKeySettingsComponent extends WidgetSettingsCom
       useCellStyleFunction: false,
       cellStyleFunction: '',
       useCellContentFunction: false,
-      cellContentFunction: ''
+      cellContentFunction: '',
+      defaultColumnVisibility: 'visible',
+      columnSelectionToDisplay: 'enabled'
     };
   }
 
@@ -56,6 +58,8 @@ export class TimeseriesTableLatestKeySettingsComponent extends WidgetSettingsCom
       cellStyleFunction: [settings.cellStyleFunction, [Validators.required]],
       useCellContentFunction: [settings.useCellContentFunction, []],
       cellContentFunction: [settings.cellContentFunction, [Validators.required]],
+      defaultColumnVisibility: [settings.defaultColumnVisibility, []],
+      columnSelectionToDisplay: [settings.columnSelectionToDisplay, []],
     });
   }
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-widget-settings.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-widget-settings.component.html
@@ -23,6 +23,9 @@
         <mat-checkbox formControlName="enableSearch">
           {{ 'widgets.table.enable-search' | translate }}
         </mat-checkbox>
+        <mat-checkbox formControlName="enableSelectColumnDisplay">
+          {{ 'widgets.table.enable-select-column-display' | translate }}
+        </mat-checkbox>
       </section>
       <section fxLayout="column" fxFlex>
         <mat-checkbox formControlName="enableStickyHeader">

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-widget-settings.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/timeseries-table-widget-settings.component.ts
@@ -41,6 +41,7 @@ export class TimeseriesTableWidgetSettingsComponent extends WidgetSettingsCompon
   protected defaultSettings(): WidgetSettings {
     return {
       enableSearch: true,
+      enableSelectColumnDisplay: true,
       enableStickyHeader: true,
       enableStickyAction: true,
       reserveSpaceForHiddenAction: 'true',
@@ -59,6 +60,7 @@ export class TimeseriesTableWidgetSettingsComponent extends WidgetSettingsCompon
   protected onSettingsSet(settings: WidgetSettings) {
     this.timeseriesTableWidgetSettingsForm = this.fb.group({
       enableSearch: [settings.enableSearch, []],
+      enableSelectColumnDisplay: [settings.enableSelectColumnDisplay, []],
       enableStickyHeader: [settings.enableStickyHeader, []],
       enableStickyAction: [settings.enableStickyAction, []],
       reserveSpaceForHiddenAction: [settings.reserveSpaceForHiddenAction, []],

--- a/ui-ngx/src/app/modules/home/components/widget/lib/table-widget.models.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/table-widget.models.ts
@@ -31,6 +31,7 @@ type ColumnSelectionOptions = 'enabled' | 'disabled';
 
 export interface TableWidgetSettings {
   enableSearch: boolean;
+  enableSelectColumnDisplay: boolean;
   enableStickyAction: boolean;
   enableStickyHeader: boolean;
   displayPagination: boolean;


### PR DESCRIPTION
## Pull Request description
Issue: [#8570](https://github.com/thingsboard/thingsboard/issues/8570)

Added columns visibility for Timeseries table with support of multiple datasources with timeseries and latest data columns.
![image](https://github.com/thingsboard/thingsboard/assets/83352633/775b0876-d4fc-42c7-ac56-486faa79ce4f)
![image](https://github.com/thingsboard/thingsboard/assets/83352633/daae5e17-cf29-4075-85d4-b7c1e21e4f8e)
Timeseries data key 
![image](https://github.com/thingsboard/thingsboard/assets/83352633/04e528e5-8249-44e1-aa51-920e14f95ef3)
Latest data key
![image](https://github.com/thingsboard/thingsboard/assets/83352633/1718c65b-f1a1-4b87-8831-0f38f87e0bac)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


