### PR TITLE
Fixed XML External Entity Injection (XXE Injection) vulnerability

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/resource/DefaultTbResourceService.java
+++ b/application/src/main/java/org/thingsboard/server/service/resource/DefaultTbResourceService.java
@@ -16,8 +16,6 @@
 package org.thingsboard.server.service.resource;
 
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.leshan.core.model.DDFFileParser;
-import org.eclipse.leshan.core.model.DefaultDDFFileValidator;
 import org.springframework.stereotype.Service;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.ResourceType;
@@ -53,11 +51,9 @@ import static org.thingsboard.server.utils.LwM2mObjectModelUtils.toLwm2mResource
 public class DefaultTbResourceService extends AbstractTbEntityService implements TbResourceService {
 
     private final ResourceService resourceService;
-    private final DDFFileParser ddfFileParser;
 
     public DefaultTbResourceService(ResourceService resourceService) {
         this.resourceService = resourceService;
-        this.ddfFileParser = new DDFFileParser(new DefaultDDFFileValidator());
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/server/utils/LwM2mObjectModelUtils.java
+++ b/application/src/main/java/org/thingsboard/server/utils/LwM2mObjectModelUtils.java
@@ -25,7 +25,7 @@ import org.thingsboard.server.common.data.exception.ThingsboardException;
 import org.thingsboard.server.common.data.lwm2m.LwM2mInstance;
 import org.thingsboard.server.common.data.lwm2m.LwM2mObject;
 import org.thingsboard.server.common.data.lwm2m.LwM2mResourceObserve;
-import org.thingsboard.server.common.data.util.TBDDFFileParser;
+import org.thingsboard.server.common.data.util.TbDDFFileParser;
 import org.thingsboard.server.dao.exception.DataValidationException;
 
 import java.io.ByteArrayInputStream;
@@ -40,7 +40,7 @@ import static org.thingsboard.server.common.data.lwm2m.LwM2mConstants.LWM2M_SEPA
 @Slf4j
 public class LwM2mObjectModelUtils {
     
-    private static final TBDDFFileParser ddfFileParser = new TBDDFFileParser();
+    private static final TbDDFFileParser ddfFileParser = new TbDDFFileParser();
     
     public static void toLwm2mResource (TbResource resource) throws ThingsboardException {
         try {

--- a/application/src/main/java/org/thingsboard/server/utils/LwM2mObjectModelUtils.java
+++ b/application/src/main/java/org/thingsboard/server/utils/LwM2mObjectModelUtils.java
@@ -16,8 +16,6 @@
 package org.thingsboard.server.utils;
 
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.leshan.core.model.DDFFileParser;
-import org.eclipse.leshan.core.model.DefaultDDFFileValidator;
 import org.eclipse.leshan.core.model.InvalidDDFFileException;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.thingsboard.server.common.data.ResourceType;
@@ -27,6 +25,7 @@ import org.thingsboard.server.common.data.exception.ThingsboardException;
 import org.thingsboard.server.common.data.lwm2m.LwM2mInstance;
 import org.thingsboard.server.common.data.lwm2m.LwM2mObject;
 import org.thingsboard.server.common.data.lwm2m.LwM2mResourceObserve;
+import org.thingsboard.server.common.data.util.TBDDFFileParser;
 import org.thingsboard.server.dao.exception.DataValidationException;
 
 import java.io.ByteArrayInputStream;
@@ -41,7 +40,7 @@ import static org.thingsboard.server.common.data.lwm2m.LwM2mConstants.LWM2M_SEPA
 @Slf4j
 public class LwM2mObjectModelUtils {
     
-    private static final DDFFileParser ddfFileParser = new DDFFileParser(new DefaultDDFFileValidator());
+    private static final TBDDFFileParser ddfFileParser = new TBDDFFileParser();
     
     public static void toLwm2mResource (TbResource resource) throws ThingsboardException {
         try {

--- a/common/data/pom.xml
+++ b/common/data/pom.xml
@@ -116,6 +116,11 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.leshan</groupId>
+            <artifactId>leshan-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common/data/src/main/java/org/thingsboard/server/common/data/util/TBDDFFileParser.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/util/TBDDFFileParser.java
@@ -1,0 +1,273 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.common.data.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.leshan.core.LwM2m;
+import org.eclipse.leshan.core.model.DDFFileValidator;
+import org.eclipse.leshan.core.model.DefaultDDFFileValidator;
+import org.eclipse.leshan.core.model.InvalidDDFFileException;
+import org.eclipse.leshan.core.model.ObjectModel;
+import org.eclipse.leshan.core.model.ResourceModel;
+import org.eclipse.leshan.core.util.StringUtils;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+public class TBDDFFileParser {
+    private static final DDFFileValidator ddfFileValidator = new DefaultDDFFileValidator();
+
+    public List<ObjectModel> parse(InputStream inputStream, String streamName)
+            throws InvalidDDFFileException, IOException {
+        streamName = streamName == null ? "" : streamName;
+
+        log.debug("Parsing DDF file {}", streamName);
+
+        try {
+            // Parse XML file
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document document = builder.parse(inputStream);
+
+            // Get DDF file validator
+            LwM2m.LwM2mVersion lwm2mVersion = null;
+            ddfFileValidator.validate(document);
+
+            // Build list of ObjectModel
+            ArrayList<ObjectModel> objects = new ArrayList<>();
+            NodeList nodeList = document.getDocumentElement().getElementsByTagName("Object");
+            for (int i = 0; i < nodeList.getLength(); i++) {
+                objects.add(parseObject(nodeList.item(i), streamName, lwm2mVersion, true));
+            }
+            return objects;
+        } catch (InvalidDDFFileException | SAXException e) {
+            throw new InvalidDDFFileException(e, "Invalid DDF file %s", streamName);
+        }
+        catch (ParserConfigurationException e) {
+            throw new IllegalStateException("Unable to create Document Builder", e);
+        }
+    }
+
+    private ObjectModel parseObject(Node object, String streamName, LwM2m.LwM2mVersion schemaVersion, boolean validate)
+            throws InvalidDDFFileException {
+
+        Node objectType = object.getAttributes().getNamedItem("ObjectType");
+        if (validate && (objectType == null || !"MODefinition".equals(objectType.getTextContent()))) {
+            throw new InvalidDDFFileException(
+                    "Object element in %s MUST have a ObjectType attribute equals to 'MODefinition'.", streamName);
+        }
+
+        Integer id = null;
+        String name = null;
+        String description = null;
+        String version = ObjectModel.DEFAULT_VERSION;
+        Boolean multiple = null;
+        Boolean mandatory = null;
+        Map<Integer, ResourceModel> resources = new HashMap<>();
+        String urn = null;
+        String description2 = null;
+        String lwm2mVersion = ObjectModel.DEFAULT_VERSION;
+
+        for (int i = 0; i < object.getChildNodes().getLength(); i++) {
+            Node field = object.getChildNodes().item(i);
+            if (field.getNodeType() != Node.ELEMENT_NODE)
+                continue;
+
+            switch (field.getNodeName()) {
+                case "ObjectID":
+                    id = Integer.valueOf(field.getTextContent());
+                    break;
+                case "Name":
+                    name = field.getTextContent();
+                    break;
+                case "Description1":
+                    description = field.getTextContent();
+                    break;
+                case "ObjectVersion":
+                    if (!StringUtils.isEmpty(field.getTextContent())) {
+                        version = field.getTextContent();
+                    }
+                    break;
+                case "MultipleInstances":
+                    if ("Multiple".equals(field.getTextContent())) {
+                        multiple = true;
+                    } else if ("Single".equals(field.getTextContent())) {
+                        multiple = false;
+                    }
+                    break;
+                case "Mandatory":
+                    if ("Mandatory".equals(field.getTextContent())) {
+                        mandatory = true;
+                    } else if ("Optional".equals(field.getTextContent())) {
+                        mandatory = false;
+                    }
+                    break;
+                case "Resources":
+                    for (int j = 0; j < field.getChildNodes().getLength(); j++) {
+                        Node item = field.getChildNodes().item(j);
+                        if (item.getNodeType() != Node.ELEMENT_NODE)
+                            continue;
+
+                        if (item.getNodeName().equals("Item")) {
+                            ResourceModel resource = parseResource(item, streamName);
+                            if (validate && resources.containsKey(resource.id)) {
+                                throw new InvalidDDFFileException(
+                                        "Object %s in %s contains at least 2 resources with same id %s.",
+                                        id != null ? id : "", streamName, resource.id);
+                            } else {
+                                resources.put(resource.id, resource);
+                            }
+                        }
+                    }
+                    break;
+                case "ObjectURN":
+                    urn = field.getTextContent();
+                    break;
+                case "LWM2MVersion":
+                    if (!StringUtils.isEmpty(field.getTextContent())) {
+                        lwm2mVersion = field.getTextContent();
+                        if (schemaVersion != null && !schemaVersion.toString().equals(lwm2mVersion)) {
+                            throw new InvalidDDFFileException(
+                                    "LWM2MVersion is not consistent with xml shema(xsi:noNamespaceSchemaLocation) in %s : %s  expected but was %s.",
+                                    streamName, schemaVersion, lwm2mVersion);
+                        }
+                    }
+                    break;
+                case "Description2":
+                    description2 = field.getTextContent();
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return new ObjectModel(id, name, description, version, multiple, mandatory, resources.values(), urn,
+                lwm2mVersion, description2);
+
+    }
+
+    private ResourceModel parseResource(Node item, String streamName) throws DOMException, InvalidDDFFileException {
+
+        Integer id = Integer.valueOf(item.getAttributes().getNamedItem("ID").getTextContent());
+        String name = null;
+        ResourceModel.Operations operations = null;
+        Boolean multiple = false;
+        Boolean mandatory = false;
+        ResourceModel.Type type = null;
+        String rangeEnumeration = null;
+        String units = null;
+        String description = null;
+
+        for (int i = 0; i < item.getChildNodes().getLength(); i++) {
+            Node field = item.getChildNodes().item(i);
+            if (field.getNodeType() != Node.ELEMENT_NODE)
+                continue;
+
+            switch (field.getNodeName()) {
+                case "Name":
+                    name = field.getTextContent();
+                    break;
+                case "Operations":
+                    String strOp = field.getTextContent();
+                    if (strOp != null && !strOp.isEmpty()) {
+                        operations = ResourceModel.Operations.valueOf(strOp);
+                    } else {
+                        operations = ResourceModel.Operations.NONE;
+                    }
+                    break;
+                case "MultipleInstances":
+                    if ("Multiple".equals(field.getTextContent())) {
+                        multiple = true;
+                    } else if ("Single".equals(field.getTextContent())) {
+                        multiple = false;
+                    }
+                    break;
+                case "Mandatory":
+                    if ("Mandatory".equals(field.getTextContent())) {
+                        mandatory = true;
+                    } else if ("Optional".equals(field.getTextContent())) {
+                        mandatory = false;
+                    }
+                    break;
+                case "Type":
+                    switch (field.getTextContent()) {
+                        case "String":
+                            type = ResourceModel.Type.STRING;
+                            break;
+                        case "Integer":
+                            type = ResourceModel.Type.INTEGER;
+                            break;
+                        case "Float":
+                            type = ResourceModel.Type.FLOAT;
+                            break;
+                        case "Boolean":
+                            type = ResourceModel.Type.BOOLEAN;
+                            break;
+                        case "Opaque":
+                            type = ResourceModel.Type.OPAQUE;
+                            break;
+                        case "Time":
+                            type = ResourceModel.Type.TIME;
+                            break;
+                        case "Objlnk":
+                            type = ResourceModel.Type.OBJLNK;
+                            break;
+                        case "Unsigned Integer":
+                            type = ResourceModel.Type.UNSIGNED_INTEGER;
+                            break;
+                        case "Corelnk":
+                            type = ResourceModel.Type.CORELINK;
+                            break;
+                        case "":
+                            type = ResourceModel.Type.NONE;
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
+                case "RangeEnumeration":
+                    rangeEnumeration = field.getTextContent();
+                    break;
+                case "Units":
+                    units = field.getTextContent();
+                    break;
+                case "Description":
+                    description = field.getTextContent();
+                    break;
+                default:
+                    break;
+            }
+        }
+        return new ResourceModel(id, name, operations, multiple, mandatory, type, rangeEnumeration, units, description);
+    }
+}

--- a/common/data/src/main/java/org/thingsboard/server/common/data/util/TbDDFFileParser.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/util/TbDDFFileParser.java
@@ -28,7 +28,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -41,7 +40,7 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-public class TBDDFFileParser {
+public class TbDDFFileParser {
     private static final DDFFileValidator ddfFileValidator = new DefaultDDFFileValidator();
 
     public List<ObjectModel> parse(InputStream inputStream, String streamName)

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportServerHelper.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportServerHelper.java
@@ -25,6 +25,7 @@ import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.springframework.stereotype.Component;
+import org.thingsboard.server.common.data.util.TBDDFFileParser;
 import org.thingsboard.server.common.transport.TransportServiceCallback;
 import org.thingsboard.server.common.transport.auth.ValidateDeviceCredentialsResponse;
 import org.thingsboard.server.gen.transport.TransportProtos;
@@ -142,9 +143,9 @@ public class LwM2mTransportServerHelper {
                 .build();
     }
 
-    public ObjectModel parseFromXmlToObjectModel(byte[] xmlByte, String streamName, DefaultDDFFileValidator ddfValidator) {
+    public ObjectModel parseFromXmlToObjectModel(byte[] xmlByte, String streamName) {
         try {
-            DDFFileParser ddfFileParser = new DDFFileParser(ddfValidator);
+            TBDDFFileParser ddfFileParser = new TBDDFFileParser();
             return ddfFileParser.parse(new ByteArrayInputStream(xmlByte), streamName).get(0);
         } catch (IOException | InvalidDDFFileException e) {
             log.error("Could not parse the XML file [{}]", streamName, e);

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportServerHelper.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportServerHelper.java
@@ -18,14 +18,12 @@ package org.thingsboard.server.transport.lwm2m.server;
 import com.google.gson.JsonParser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.leshan.core.model.DDFFileParser;
-import org.eclipse.leshan.core.model.DefaultDDFFileValidator;
 import org.eclipse.leshan.core.model.InvalidDDFFileException;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.springframework.stereotype.Component;
-import org.thingsboard.server.common.data.util.TBDDFFileParser;
+import org.thingsboard.server.common.data.util.TbDDFFileParser;
 import org.thingsboard.server.common.transport.TransportServiceCallback;
 import org.thingsboard.server.common.transport.auth.ValidateDeviceCredentialsResponse;
 import org.thingsboard.server.gen.transport.TransportProtos;
@@ -145,7 +143,7 @@ public class LwM2mTransportServerHelper {
 
     public ObjectModel parseFromXmlToObjectModel(byte[] xmlByte, String streamName) {
         try {
-            TBDDFFileParser ddfFileParser = new TBDDFFileParser();
+            TbDDFFileParser ddfFileParser = new TbDDFFileParser();
             return ddfFileParser.parse(new ByteArrayInputStream(xmlByte), streamName).get(0);
         } catch (IOException | InvalidDDFFileException e) {
             log.error("Could not parse the XML file [{}]", streamName, e);

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mVersionedModelProvider.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mVersionedModelProvider.java
@@ -154,8 +154,7 @@ public class LwM2mVersionedModelProvider implements LwM2mModelProvider {
             Optional<TbResource> tbResource = context.getTransportResourceCache().get(this.tenantId, LWM2M_MODEL, key);
             return tbResource.map(resource -> helper.parseFromXmlToObjectModel(
                     Base64.getDecoder().decode(resource.getData()),
-                    key + ".xml",
-                    new DefaultDDFFileValidator())).orElse(null);
+                    key + ".xml")).orElse(null);
         }
     }
 }


### PR DESCRIPTION
## Pull Request description

Issue was reported by security researcher from [huntr.dev](http://huntr.dev/).
Fixed potential XXE vulnerability in thingsboard while uploading xml files in "Resources library" section by disallowing doctype in xml file.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



