### PR TITLE
Adding "hintMode" for the help-popup component

### DIFF
--- a/ui-ngx/src/app/modules/home/components/relation/relation-filters.component.scss
+++ b/ui-ngx/src/app/modules/home/components/relation/relation-filters.component.scss
@@ -39,7 +39,7 @@
           border: 1px solid #E0E0E0;
           width: 100%;
           border-radius: 6px;
-          padding: 24px;
+          padding: 22px;
           align-items: center;
         }
       }

--- a/ui-ngx/src/app/shared/components/help-popup.component.html
+++ b/ui-ngx/src/app/shared/components/help-popup.component.html
@@ -32,17 +32,21 @@
 </fieldset>
 <fieldset class="tb-help-popup-button-container" *ngIf="textMode">
   <div #toggleHelpTextButton
+       [ngClass] = "{'hint-button': hintMode}"
        (click)="toggleHelp()">
     <button mat-button
             color="primary"
             class="tb-help-popup-text-button"
-            [ngClass]="{'mat-mdc-outlined-button mdc-button--outlined': popoverVisible && popoverReady}">
+            [ngClass]="{'mat-mdc-outlined-button mdc-button--outlined': popoverVisible && popoverReady,
+                        'tb-standard-help-popup-text-button': !hintMode,
+                        'tb-hint-help-popup-text-button': hintMode}">
       <span>
         <ng-container *ngIf="triggerSafeHtml">
           <span [style]="triggerStyle" [innerHTML]="triggerSafeHtml"></span>
         </ng-container>
-        <mat-icon *ngIf="!popoverVisible || popoverReady" class="tb-mat-16">open_in_new</mat-icon>
-        <mat-spinner *ngIf="popoverVisible && !popoverReady" mode="indeterminate" diameter="16" strokeWidth="2"></mat-spinner>
+        <mat-icon *ngIf="(!popoverVisible || popoverReady)"
+                  [ngClass]="{'tb-mat-16': !hintMode,'tb-mat-12': hintMode}">open_in_new</mat-icon>
+        <mat-spinner *ngIf="popoverVisible && !popoverReady" mode="indeterminate" [diameter]="hintMode ? 12 : 16" strokeWidth="2"></mat-spinner>
       </span>
     </button>
   </div>

--- a/ui-ngx/src/app/shared/components/help-popup.component.html
+++ b/ui-ngx/src/app/shared/components/help-popup.component.html
@@ -38,14 +38,13 @@
             color="primary"
             class="tb-help-popup-text-button"
             [ngClass]="{'mat-mdc-outlined-button mdc-button--outlined': popoverVisible && popoverReady,
-                        'tb-standard-help-popup-text-button': !hintMode,
                         'tb-hint-help-popup-text-button': hintMode}">
       <span>
         <ng-container *ngIf="triggerSafeHtml">
           <span [style]="triggerStyle" [innerHTML]="triggerSafeHtml"></span>
         </ng-container>
         <mat-icon *ngIf="(!popoverVisible || popoverReady)"
-                  [ngClass]="{'tb-mat-16': !hintMode,'tb-mat-12': hintMode}">open_in_new</mat-icon>
+                  [ngClass]="hintMode ? 'tb-mat-12' : 'tb-mat-16'">open_in_new</mat-icon>
         <mat-spinner *ngIf="popoverVisible && !popoverReady" mode="indeterminate" [diameter]="hintMode ? 12 : 16" strokeWidth="2"></mat-spinner>
       </span>
     </button>

--- a/ui-ngx/src/app/shared/components/help-popup.component.scss
+++ b/ui-ngx/src/app/shared/components/help-popup.component.scss
@@ -13,10 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 .tb-help-popup-button-container {
   width: initial;
   display: inline-block;
   vertical-align: middle;
+  .hint-button {
+    line-height: 1;
+  }
 }
 
 .tb-help-popup-button {
@@ -42,12 +46,29 @@
   }
 }
 
-.tb-help-popup-text-button.mat-mdc-button.mat-mdc-button-base {
-  position: relative;
+.tb-hint-help-popup-text-button.mat-mdc-button.mat-mdc-button-base {
+  padding: 0 3px;
+  line-height: 1;
+  &.mat-mdc-outlined-button {
+    padding: 0 2px;
+  }
+  .mdc-button__label > span {
+    .mat-icon {
+      vertical-align: bottom;
+      margin-right: 0;
+    }
+    .mat-mdc-progress-spinner {
+      vertical-align: bottom;
+    }
+  }
+  .mat-mdc-button-touch-target {
+    height: 14px;
+  }
+}
+
+.tb-standard-help-popup-text-button.mat-mdc-button.mat-mdc-button-base {
   padding: 0 2px 0 8px;
   line-height: 28px;
-  height: auto;
-  transition: border 0s;
   &.mat-mdc-outlined-button {
     padding: 0 1px 0 7px;
     line-height: 26px;
@@ -55,14 +76,26 @@
   .mdc-button__label > span {
     .mat-icon {
       vertical-align: middle;
+    }
+    .mat-mdc-progress-spinner {
+      margin-right: 5px;
+      vertical-align: middle;
+    }
+  }
+}
+
+.tb-help-popup-text-button.mat-mdc-button.mat-mdc-button-base {
+  position: relative;
+  height: auto;
+  transition: border 0s;
+  .mdc-button__label > span {
+    .mat-icon {
       padding-left: 4px;
       box-sizing: initial;
     }
     .mat-mdc-progress-spinner {
       display: inline-block;
       margin-left: 4px;
-      margin-right: 5px;
-      vertical-align: middle;
     }
   }
 }

--- a/ui-ngx/src/app/shared/components/help-popup.component.scss
+++ b/ui-ngx/src/app/shared/components/help-popup.component.scss
@@ -46,27 +46,10 @@
   }
 }
 
-.tb-hint-help-popup-text-button.mat-mdc-button.mat-mdc-button-base {
-  padding: 0 3px;
-  line-height: 1;
-  &.mat-mdc-outlined-button {
-    padding: 0 2px;
-  }
-  .mdc-button__label > span {
-    .mat-icon {
-      vertical-align: bottom;
-      margin-right: 0;
-    }
-    .mat-mdc-progress-spinner {
-      vertical-align: bottom;
-    }
-  }
-  .mat-mdc-button-touch-target {
-    height: 14px;
-  }
-}
-
-.tb-standard-help-popup-text-button.mat-mdc-button.mat-mdc-button-base {
+.tb-help-popup-text-button.mat-mdc-button.mat-mdc-button-base {
+  position: relative;
+  height: auto;
+  transition: border 0s;
   padding: 0 2px 0 8px;
   line-height: 28px;
   &.mat-mdc-outlined-button {
@@ -76,26 +59,36 @@
   .mdc-button__label > span {
     .mat-icon {
       vertical-align: middle;
-    }
-    .mat-mdc-progress-spinner {
-      margin-right: 5px;
-      vertical-align: middle;
-    }
-  }
-}
-
-.tb-help-popup-text-button.mat-mdc-button.mat-mdc-button-base {
-  position: relative;
-  height: auto;
-  transition: border 0s;
-  .mdc-button__label > span {
-    .mat-icon {
       padding-left: 4px;
       box-sizing: initial;
     }
     .mat-mdc-progress-spinner {
       display: inline-block;
       margin-left: 4px;
+      margin-right: 5px;
+      vertical-align: middle;
     }
+  }
+}
+
+.tb-hint-help-popup-text-button.mat-mdc-button.mat-mdc-button-base {
+  padding: 0 3px;
+  line-height: 1;
+  &.mat-mdc-outlined-button {
+    padding: 0 2px;
+    line-height: 1;
+  }
+  .mdc-button__label > span {
+    .mat-icon {
+      vertical-align: bottom;
+      margin-right: 0;
+    }
+    .mat-mdc-progress-spinner {
+      margin-right: 0;
+      vertical-align: bottom;
+    }
+  }
+  .mat-mdc-button-touch-target {
+    height: 14px;
   }
 }

--- a/ui-ngx/src/app/shared/components/help-popup.component.ts
+++ b/ui-ngx/src/app/shared/components/help-popup.component.ts
@@ -28,6 +28,7 @@ import { TbPopoverService } from '@shared/components/popover.service';
 import { PopoverPlacement } from '@shared/components/popover.models';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { isDefinedAndNotNull } from '@core/utils';
+import { coerceBoolean } from '@shared/decorators/coercion';
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -58,6 +59,10 @@ export class HelpPopupComponent implements OnChanges, OnDestroy {
 
   // eslint-disable-next-line @angular-eslint/no-input-rename
   @Input('tb-help-popup-style') helpPopupStyle: { [klass: string]: any } = {};
+
+  @Input()
+  @coerceBoolean()
+  hintMode = false;
 
   popoverVisible = false;
   popoverReady = true;

--- a/ui-ngx/src/styles.scss
+++ b/ui-ngx/src/styles.scss
@@ -829,6 +829,9 @@ mat-label {
     svg {
       vertical-align: inherit;
     }
+    &.tb-mat-12 {
+      @include tb-mat-icon-size(12);
+    }
     &.tb-mat-16 {
       @include tb-mat-icon-size(16);
     }


### PR DESCRIPTION
To the 'help-popup.component' added a special mode that changes styles to implement it inside hints:
![image](https://github.com/thingsboard/thingsboard/assets/43555187/181e7425-8c25-43dd-9e4a-ff648724cb8c)
![image](https://github.com/thingsboard/thingsboard/assets/43555187/ca11ecb5-1ed1-4ecd-a308-9a25b66a3f05)




