### PR TITLE
fix: Slow RabbitMQ message polling

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -1117,6 +1117,7 @@ queue:
     automatic_recovery_enabled: "${TB_QUEUE_RABBIT_MQ_AUTOMATIC_RECOVERY_ENABLED:false}"
     connection_timeout: "${TB_QUEUE_RABBIT_MQ_CONNECTION_TIMEOUT:60000}"
     handshake_timeout: "${TB_QUEUE_RABBIT_MQ_HANDSHAKE_TIMEOUT:10000}"
+    max_poll_messages: "${TB_QUEUE_RABBIT_MQ_MAX_POLL_MESSAGES:1}"
     queue-properties:
       rule-engine: "${TB_QUEUE_RABBIT_MQ_RE_QUEUE_PROPERTIES:x-max-length-bytes:1048576000;x-message-ttl:604800000}"
       core: "${TB_QUEUE_RABBIT_MQ_CORE_QUEUE_PROPERTIES:x-max-length-bytes:1048576000;x-message-ttl:604800000}"

--- a/common/queue/src/main/java/org/thingsboard/server/queue/rabbitmq/TbRabbitMqSettings.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/rabbitmq/TbRabbitMqSettings.java
@@ -47,6 +47,8 @@ public class TbRabbitMqSettings {
     private int connectionTimeout;
     @Value("${queue.rabbitmq.handshake_timeout:}")
     private int handshakeTimeout;
+    @Value("${queue.rabbitmq.max_poll_messages:1}")
+    private int maxPollMessages;
 
     private ConnectionFactory connectionFactory;
 

--- a/common/queue/src/test/java/org/thingsboard/server/queue/rabbitmq/TbRabbitMqConsumerTemplateTest.java
+++ b/common/queue/src/test/java/org/thingsboard/server/queue/rabbitmq/TbRabbitMqConsumerTemplateTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.queue.rabbitmq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.GetResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
+import org.thingsboard.server.queue.TbQueueAdmin;
+import org.thingsboard.server.queue.TbQueueMsgDecoder;
+import org.thingsboard.server.queue.common.DefaultTbQueueMsg;
+
+@ExtendWith(MockitoExtension.class)
+class TbRabbitMqConsumerTemplateTest {
+
+  private static final String TOPIC = "some-topic";
+
+  @Mock
+  private TbQueueAdmin admin;
+
+  @Mock
+  private ConnectionFactory connectionFactory;
+
+  @Mock
+  private TbQueueMsgDecoder<DefaultTbQueueMsg> decoder;
+
+  @Mock
+  private Connection connection;
+
+  @Mock
+  private Channel channel;
+
+  @Mock
+  private TopicPartitionInfo partition;
+
+  @Mock
+  private GetResponse getResponse;
+
+  private TbRabbitMqConsumerTemplate<DefaultTbQueueMsg> consumer;
+
+  private void setUpConsumerWithMaxPollMessages(int maxPollMessages) throws Exception {
+    when(connectionFactory.newConnection()).thenReturn(connection);
+    when(connection.createChannel()).thenReturn(channel);
+    TbRabbitMqSettings settings = new TbRabbitMqSettings();
+    settings.setMaxPollMessages(maxPollMessages);
+    settings.setConnectionFactory(connectionFactory);
+
+    consumer = new TbRabbitMqConsumerTemplate<>(admin, settings, TOPIC, decoder);
+    when(partition.getFullTopicName()).thenReturn(TOPIC);
+    consumer.subscribe(Set.of(partition));
+  }
+
+  @Test
+  void pollWithMax5PollMessagesReturnsEmptyListIfNoMessages() throws Exception {
+    setUpConsumerWithMaxPollMessages(5);
+    when(channel.basicGet(anyString(), anyBoolean())).thenReturn(null);
+
+    assertThat(consumer.poll(0L)).isEmpty();
+
+    verify(channel).basicGet(anyString(), anyBoolean());
+  }
+
+  @Test
+  void pollWithMax5PollMessagesReturns5MessagesIfQueueContains5() throws Exception {
+    setUpConsumerWithMaxPollMessages(5);
+    when(getResponse.getBody()).thenReturn(newMessageBody());
+    when(channel.basicGet(anyString(), anyBoolean())).thenReturn(getResponse);
+
+    assertThat(consumer.poll(0L)).hasSize(5);
+
+    verify(channel, times(5)).basicGet(anyString(), anyBoolean());
+  }
+
+  @Test
+  void pollWithMax1PollMessageReturns1MessageIfQueueContainsMore() throws Exception {
+    setUpConsumerWithMaxPollMessages(1);
+    when(getResponse.getBody()).thenReturn(newMessageBody());
+    when(channel.basicGet(anyString(), anyBoolean())).thenReturn(getResponse);
+
+    assertThat(consumer.poll(0L)).hasSize(1);
+
+    verify(channel).basicGet(anyString(), anyBoolean());
+  }
+
+  @Test
+  void pollWithMax3PollMessagesReturns2MessagesIfQueueContains2() throws Exception {
+    setUpConsumerWithMaxPollMessages(3);
+    when(getResponse.getBody()).thenReturn(newMessageBody());
+    when(channel.basicGet(anyString(), anyBoolean())).thenReturn(getResponse, getResponse, null);
+
+    assertThat(consumer.poll(0L)).hasSize(2);
+
+    verify(channel, times(3)).basicGet(anyString(), anyBoolean());
+  }
+
+  private byte[] newMessageBody() {
+    return ("{\"key\": \"" + UUID.randomUUID() + "\"}").getBytes(StandardCharsets.UTF_8);
+  }
+
+}


### PR DESCRIPTION
Configurable RabbitMQ polling in order that more messages can be obtained from the queue during a poll.

Fixes #8445

## Pull Request description

A new RabbitMQ specific configuration property has been added that allows users to specify how many messages per queue should be retrieved during a single poll.
This could help to increase throughput when there are many messages on a queue and the polling happens to slow, causing delays in further message processing. (Prerequisite is that the system is properly seized to cope with the higher number of messages).

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
**Documentation should mention `TB_QUEUE_RABBIT_MQ_MAX_POLL_MESSAGES` and `queue.rabbitmq.max_poll_messages`**
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.




