### PR TITLE
Fixed 'Notify again' dialog in notification center

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/notification/sent/sent-notification-dialog.componet.ts
+++ b/ui-ngx/src/app/modules/home/pages/notification/sent/sent-notification-dialog.componet.ts
@@ -154,6 +154,7 @@ export class SentNotificationDialogComponent extends
       let useTemplate = true;
       if (isDefinedAndNotNull(this.data.request.template)) {
         useTemplate = false;
+        this.refreshAllowDeliveryMethod();
         // eslint-disable-next-line guard-for-in
         for (const method in this.data.request.template.configuration.deliveryMethodsTemplates) {
           this.deliveryMethodFormsMap.get(NotificationDeliveryMethod[method])
@@ -162,8 +163,6 @@ export class SentNotificationDialogComponent extends
       }
       this.notificationRequestForm.get('useTemplate').setValue(useTemplate, {onlySelf : true});
     }
-
-    this.refreshAllowDeliveryMethod();
   }
 
   ngOnDestroy() {
@@ -343,13 +342,15 @@ export class SentNotificationDialogComponent extends
   }
 
   private updateDeliveryMethodsDisableState() {
-    this.notificationDeliveryMethods.forEach(method => {
-      if (this.allowNotificationDeliveryMethods.includes(method)) {
-        this.getDeliveryMethodsTemplatesControl(method).enable({emitEvent: true});
-      } else {
-        this.getDeliveryMethodsTemplatesControl(method).disable({emitEvent: true});
-        this.getDeliveryMethodsTemplatesControl(method).setValue(false, {emitEvent: true}); //used for notify again
-      }
-    });
+    if (this.allowNotificationDeliveryMethods) {
+      this.notificationDeliveryMethods.forEach(method => {
+        if (this.allowNotificationDeliveryMethods.includes(method)) {
+          this.getDeliveryMethodsTemplatesControl(method).enable({emitEvent: true});
+        } else {
+          this.getDeliveryMethodsTemplatesControl(method).disable({emitEvent: true});
+          this.getDeliveryMethodsTemplatesControl(method).setValue(false, {emitEvent: true}); //used for notify again
+        }
+      });
+    }
   }
 }

--- a/ui-ngx/src/app/modules/home/pages/notification/sent/sent-notification-dialog.componet.ts
+++ b/ui-ngx/src/app/modules/home/pages/notification/sent/sent-notification-dialog.componet.ts
@@ -154,7 +154,6 @@ export class SentNotificationDialogComponent extends
       let useTemplate = true;
       if (isDefinedAndNotNull(this.data.request.template)) {
         useTemplate = false;
-        this.refreshAllowDeliveryMethod();
         // eslint-disable-next-line guard-for-in
         for (const method in this.data.request.template.configuration.deliveryMethodsTemplates) {
           this.deliveryMethodFormsMap.get(NotificationDeliveryMethod[method])
@@ -163,6 +162,7 @@ export class SentNotificationDialogComponent extends
       }
       this.notificationRequestForm.get('useTemplate').setValue(useTemplate, {onlySelf : true});
     }
+    this.refreshAllowDeliveryMethod();
   }
 
   ngOnDestroy() {
@@ -336,8 +336,10 @@ export class SentNotificationDialogComponent extends
   refreshAllowDeliveryMethod() {
     this.notificationService.getAvailableDeliveryMethods({ignoreLoading: true}).subscribe(allowMethods => {
       this.allowNotificationDeliveryMethods = allowMethods;
-      this.updateDeliveryMethodsDisableState();
-      this.showRefresh = (this.notificationDeliveryMethods.length !== allowMethods.length);
+      if (!this.notificationRequestForm.get('useTemplate').value) {
+        this.updateDeliveryMethodsDisableState();
+        this.showRefresh = (this.notificationDeliveryMethods.length !== allowMethods.length);
+      }
     });
   }
 


### PR DESCRIPTION
## Pull Request description

Fixed: [#8783](https://github.com/thingsboard/thingsboard/issues/8783)

Before fix: 'Notify again' dialog with template when you click 'Next' stays in the “Compose” tab, and the “Review” tab doesn’t appear.

After fix: everything works fine and tab 'Review' opens.
![image](https://github.com/thingsboard/thingsboard/assets/83352633/c963e330-2ce4-45ae-8a3e-c341176c91d9)
![image](https://github.com/thingsboard/thingsboard/assets/83352633/92bb916b-aa31-4c6b-b833-98cf084b620f)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



