### PR TITLE
Fixed dashboard state selection in toolbar on mobile view

### DIFF
--- a/ui-ngx/src/app/modules/home/components/dashboard-page/dashboard-toolbar.component.scss
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/dashboard-toolbar.component.scss
@@ -163,7 +163,8 @@ tb-dashboard-toolbar {
                   }
                 }
 
-                tb-states-component {
+                tb-states-component,
+                tb-entity-state-controller {
                   pointer-events: all;
                 }
               }


### PR DESCRIPTION
## Pull Request description
Fixed #8813 

Before:
It is not possible to navigate to a previous dashboard state on mobile view by selecting the target state in the dashboard toolbar.
The list of previous states does not appear on clicking the current state name.
![image](https://github.com/thingsboard/thingsboard/assets/17936317/5ba23955-ddcf-4055-9923-c5c567f77aa9)

After:
The list of previous states does appear, and navigation is possible in this way.
![image](https://github.com/thingsboard/thingsboard/assets/17936317/f956da85-a0b8-4cec-b35b-893362bf63b7)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



