### PR TITLE
[3.5.2] TbDate toISOString sync as SimpleDateFormat required 

### DIFF
--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbDate.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbDate.java
@@ -73,7 +73,9 @@ public class TbDate extends Date {
     }
 
     public String toISOString() {
-        return isoDateFormat.format(this);
+        synchronized (TbDate.class) {
+            return isoDateFormat.format(this);
+        }
     }
 
     public String toLocaleString(String locale) {

--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbDate.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbDate.java
@@ -35,7 +35,8 @@ public class TbDate extends Date {
     private static final DateTimeFormatter isoDateFormatter = DateTimeFormatter.ofPattern(
             "yyyy-MM-dd[[ ]['T']HH:mm[:ss[.SSS]][ ][XXX][Z][z][VV][O]]").withZone(ZoneId.systemDefault());
 
-    private static final DateFormat isoDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    private static final ThreadLocal<DateFormat> isoDateFormat = ThreadLocal.withInitial(() ->
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
 
     public TbDate() {
         super();
@@ -73,9 +74,7 @@ public class TbDate extends Date {
     }
 
     public String toISOString() {
-        synchronized (TbDate.class) {
-            return isoDateFormat.format(this);
-        }
+        return isoDateFormat.get().format(this);
     }
 
     public String toLocaleString(String locale) {

--- a/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbDateTest.java
+++ b/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbDateTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.script.api.tbel;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Slf4j
+class TbDateTest {
+
+    ListeningExecutorService executor;
+
+    @AfterEach
+    void tearDown() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    /**
+     * Note: This test simulated the high concurrency calls.
+     * But it not always fails before as the concurrency issue happens far away from the test subject, inside the SimpleDateFormat class.
+     * Few calls later after latch open, the concurrency issue is not well reproduced.
+     * Depends on environment some failure may happen each 2 or 100 runs.
+     * To be highly confident run this test in a ForkMode=method, repeat 100 times. This will provide about 99 failures per 100 runs.
+     * The value of this test is *never* to fail when isoDateFormat.format(this) is properly synchronized
+     * If this test fails time-to-time -- it is a sign that isoDateFormat.format() called concurrently and have to be fixed (synchronized)
+     * The expected exception example:
+     *   Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 14 out of bounds for length 13
+     * 	     at java.base/sun.util.calendar.BaseCalendar.getCalendarDateFromFixedDate(BaseCalendar.java:457)
+     * 	     at java.base/java.util.GregorianCalendar.computeFields(GregorianCalendar.java:2394)
+     * 	     at java.base/java.util.GregorianCalendar.computeFields(GregorianCalendar.java:2309)
+     * 	     at java.base/java.util.Calendar.setTimeInMillis(Calendar.java:1834)
+     * 	     at java.base/java.util.Calendar.setTime(Calendar.java:1800)
+     * 	     at java.base/java.text.SimpleDateFormat.format(SimpleDateFormat.java:974)
+     */
+    @Test
+    void testToISOStringConcurrently() throws ExecutionException, InterruptedException, TimeoutException {
+        int threads = 5;
+        executor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(threads));
+        for (int j = 0; j < 1000; j++) {
+            final int iteration = j;
+            CountDownLatch readyLatch = new CountDownLatch(threads);
+            CountDownLatch latch = new CountDownLatch(1);
+            long now = 1709217342000L;
+            List<ListenableFuture<String>> futures = new ArrayList<>(threads);
+            for (int i = 0; i < threads; i++) {
+                long ts = now + TimeUnit.DAYS.toMillis(i * 366) + TimeUnit.MINUTES.toMillis(iteration) + TimeUnit.SECONDS.toMillis(iteration) + iteration;
+                TbDate tbDate = new TbDate(ts);
+                futures.add(executor.submit(() -> {
+                    readyLatch.countDown();
+                    if (!latch.await(30, TimeUnit.SECONDS)) {
+                        throw new RuntimeException("await timeout");
+                    }
+                    return tbDate.toISOString();
+                }));
+            }
+            ListenableFuture<List<String>> future = Futures.allAsList(futures);
+            Futures.addCallback(future, new FutureCallback<List<String>>() {
+                @Override
+                public void onSuccess(List<String> result) {
+
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
+                    log.error("Failure happens on iteration {}", iteration);
+                }
+            }, MoreExecutors.directExecutor());
+            readyLatch.await(30, TimeUnit.SECONDS);
+            latch.countDown();
+            future.get(30, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
## TbDate toISOString sync as SimpleDateFormat required 

The issue with full description: https://github.com/thingsboard/thingsboard/issues/8872

![image](https://github.com/thingsboard/thingsboard/assets/79898499/018549a5-4b6f-4710-b068-60f9c5de93e3)

Upd: [TbDate isoDateFormat is ThreadLocal instead synchronization](https://github.com/thingsboard/thingsboard/pull/8873/commits/2a683f9977b4acb5bd9551406e7f0f4e688c46a3)

![image](https://github.com/thingsboard/thingsboard/assets/79898499/7d935b16-03d8-40c5-b7d6-27c4143c426d)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



