### PR TITLE
Update cource Decorators

### DIFF
--- a/ui-ngx/src/app/shared/decorators/coercion.ts
+++ b/ui-ngx/src/app/shared/decorators/coercion.ts
@@ -22,21 +22,29 @@ import {
   coerceStringArray as coerceStringArrayAngular
 } from '@angular/cdk/coercion';
 
-export const coerceBoolean = () => (target: any, key: string): void => {
-  const getter = function() {
-    return this['__' + key];
-  };
+export const coerceBoolean = () => (target: any, key: string, propertyDescriptor?: PropertyDescriptor): void => {
+  if (!!propertyDescriptor && !!propertyDescriptor.set) {
+    const original = propertyDescriptor.set;
 
-  const setter = function(next: any) {
-    this['__' + key] = coerceBooleanProperty(next);
-  };
+    propertyDescriptor.set = function(next) {
+      original.apply(this, [coerceBooleanProperty(next)]);
+    };
+  } else {
+    const getter = function() {
+      return this['__' + key];
+    };
 
-  Object.defineProperty(target, key, {
-    get: getter,
-    set: setter,
-    enumerable: true,
-    configurable: true,
-  });
+    const setter = function(next: any) {
+      this['__' + key] = coerceBooleanProperty(next);
+    };
+
+    Object.defineProperty(target, key, {
+      get: getter,
+      set: setter,
+      enumerable: true,
+      configurable: true,
+    });
+  }
 };
 
 export const coerceNumber = () => (target: any, key: string): void => {

--- a/ui-ngx/src/app/shared/decorators/coercion.ts
+++ b/ui-ngx/src/app/shared/decorators/coercion.ts
@@ -47,70 +47,103 @@ export const coerceBoolean = () => (target: any, key: string, propertyDescriptor
   }
 };
 
-export const coerceNumber = () => (target: any, key: string): void => {
-  const getter = function(): number {
-    return this['__' + key];
-  };
+export const coerceNumber = () => (target: any, key: string, propertyDescriptor?: PropertyDescriptor): void => {
+  if (!!propertyDescriptor && !!propertyDescriptor.set) {
+    const original = propertyDescriptor.set;
 
-  const setter = function(next: any) {
-    this['__' + key] = coerceNumberProperty(next);
-  };
+    propertyDescriptor.set = function(next) {
+      original.apply(this, [coerceNumberProperty(next)]);
+    };
+  } else {
+    const getter = function() {
+      return this['__' + key];
+    };
 
-  Object.defineProperty(target, key, {
-    get: getter,
-    set: setter,
-    enumerable: true,
-    configurable: true,
-  });
+    const setter = function(next: any) {
+      this['__' + key] = coerceNumberProperty(next);
+    };
+
+    Object.defineProperty(target, key, {
+      get: getter,
+      set: setter,
+      enumerable: true,
+      configurable: true,
+    });
+  }
 };
 
-export const coerceCssPixelValue = () => (target: any, key: string): void => {
-  const getter = function(): string {
-    return this['__' + key];
-  };
+export const coerceCssPixelValue = () => (target: any, key: string, propertyDescriptor?: PropertyDescriptor): void => {
+  if (!!propertyDescriptor && !!propertyDescriptor.set) {
+    const original = propertyDescriptor.set;
 
-  const setter = function(next: any) {
-    this['__' + key] = coerceCssPixelValueAngular(next);
-  };
+    propertyDescriptor.set = function(next) {
+      original.apply(this, [coerceCssPixelValueAngular(next)]);
+    };
+  } else {
+    const getter = function() {
+      return this['__' + key];
+    };
 
-  Object.defineProperty(target, key, {
-    get: getter,
-    set: setter,
-    enumerable: true,
-    configurable: true,
-  });
+    const setter = function(next: any) {
+      this['__' + key] = coerceCssPixelValueAngular(next);
+    };
+
+    Object.defineProperty(target, key, {
+      get: getter,
+      set: setter,
+      enumerable: true,
+      configurable: true,
+    });
+  }
 };
 
-export const coerceArray = () => (target: any, key: string): void => {
-  const getter = function(): any[] {
-    return this['__' + key];
-  };
+export const coerceArray = () => (target: any, key: string, propertyDescriptor?: PropertyDescriptor): void => {
+  if (!!propertyDescriptor && !!propertyDescriptor.set) {
+    const original = propertyDescriptor.set;
 
-  const setter = function(next: any) {
-    this['__' + key] = coerceArrayAngular(next);
-  };
+    propertyDescriptor.set = function(next) {
+      original.apply(this, [coerceArrayAngular(next)]);
+    };
+  } else {
+    const getter = function() {
+      return this['__' + key];
+    };
 
-  Object.defineProperty(target, key, {
-    get: getter,
-    set: setter,
-    enumerable: true,
-    configurable: true,
-  });
+    const setter = function(next: any) {
+      this['__' + key] = coerceArrayAngular(next);
+    };
+
+    Object.defineProperty(target, key, {
+      get: getter,
+      set: setter,
+      enumerable: true,
+      configurable: true,
+    });
+  }
 };
 
-export const coerceStringArray = (separator?: string | RegExp) => (target: any, key: string): void => {
-  const getter = function(): string[] {
-    return this['__' + key];
-  };
+export const coerceStringArray = (separator?: string | RegExp) =>
+  (target: any, key: string, propertyDescriptor?: PropertyDescriptor): void => {
+  if (!!propertyDescriptor && !!propertyDescriptor.set) {
+    const original = propertyDescriptor.set;
 
-  const setter = function(next: any) {
-    this['__' + key] = coerceStringArrayAngular(next, separator);
-  };
+    propertyDescriptor.set = function(next) {
+      original.apply(this, [coerceStringArrayAngular(next, separator)]);
+    };
+  } else {
+    const getter = function() {
+      return this['__' + key];
+    };
 
-  Object.defineProperty(target, key, {
-    get: getter,
-    set: setter,
-    enumerable: true,
-    configurable: true,
-  });
+    const setter = function(next: any) {
+      this['__' + key] = coerceStringArrayAngular(next, separator);
+    };
+
+    Object.defineProperty(target, key, {
+      get: getter,
+      set: setter,
+      enumerable: true,
+      configurable: true,
+    });
+  }
 };


### PR DESCRIPTION
## Pull Request description
 
Cource decorators worked incorrectly with the following entry:
![image](https://github.com/thingsboard/thingsboard/assets/43555187/686ce8b5-1883-4963-977d-0f109bb01f7e)
this entry was parsed as 'required = false'

This PR fixing this problem.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



