### PR TITLE
Fixed device transport configuration with SNMP protocol enabled/disabled state

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/device/data/device-transport-configuration.component.ts
+++ b/ui-ngx/src/app/modules/home/pages/device/data/device-transport-configuration.component.ts
@@ -14,13 +14,13 @@
 /// limitations under the License.
 ///
 
-import { Component, forwardRef, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, forwardRef, Input, OnInit } from '@angular/core';
 import {
   ControlValueAccessor,
-  UntypedFormBuilder,
-  UntypedFormGroup,
   NG_VALIDATORS,
   NG_VALUE_ACCESSOR,
+  UntypedFormBuilder,
+  UntypedFormGroup,
   ValidationErrors,
   Validator,
   Validators
@@ -30,7 +30,6 @@ import { AppState } from '@app/core/core.state';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { DeviceTransportConfiguration, DeviceTransportType } from '@shared/models/device.models';
 import { deepClone } from '@core/utils';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'tb-device-transport-configuration',
@@ -105,9 +104,7 @@ export class DeviceTransportConfigurationComponent implements ControlValueAccess
     if (configuration) {
       delete configuration.type;
     }
-    // setTimeout(() => {
-      this.deviceTransportConfigurationFormGroup.patchValue({configuration}, {emitEvent: false});
-    // }, 0);
+    this.deviceTransportConfigurationFormGroup.patchValue({configuration}, {emitEvent: false});
   }
 
   validate(): ValidationErrors | null {

--- a/ui-ngx/src/app/modules/home/pages/device/data/device-transport-configuration.component.ts
+++ b/ui-ngx/src/app/modules/home/pages/device/data/device-transport-configuration.component.ts
@@ -14,7 +14,7 @@
 /// limitations under the License.
 ///
 
-import { Component, forwardRef, Input, OnInit } from '@angular/core';
+import { Component, forwardRef, Input, OnDestroy, OnInit } from '@angular/core';
 import {
   ControlValueAccessor,
   UntypedFormBuilder,
@@ -30,6 +30,7 @@ import { AppState } from '@app/core/core.state';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { DeviceTransportConfiguration, DeviceTransportType } from '@shared/models/device.models';
 import { deepClone } from '@core/utils';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'tb-device-transport-configuration',
@@ -104,9 +105,9 @@ export class DeviceTransportConfigurationComponent implements ControlValueAccess
     if (configuration) {
       delete configuration.type;
     }
-    setTimeout(() => {
+    // setTimeout(() => {
       this.deviceTransportConfigurationFormGroup.patchValue({configuration}, {emitEvent: false});
-    }, 0);
+    // }, 0);
   }
 
   validate(): ValidationErrors | null {

--- a/ui-ngx/src/app/modules/home/pages/device/data/snmp-device-transport-configuration.component.ts
+++ b/ui-ngx/src/app/modules/home/pages/device/data/snmp-device-transport-configuration.component.ts
@@ -127,6 +127,9 @@ export class SnmpDeviceTransportConfigurationComponent implements ControlValueAc
       this.snmpDeviceTransportConfigurationFormGroup.disable({emitEvent: false});
     } else {
       this.snmpDeviceTransportConfigurationFormGroup.enable({emitEvent: false});
+      this.updateDisabledFormValue(
+        this.snmpDeviceTransportConfigurationFormGroup.get('protocolVersion').value || SnmpDeviceProtocolVersion.V2C
+      );
     }
   }
 


### PR DESCRIPTION
## Pull Request description

Fixed: [#8883](https://github.com/thingsboard/thingsboard/issues/8883)

Before fix:
![image](https://github.com/thingsboard/thingsboard/assets/83352633/20283c10-772d-48a0-b240-c99733dde7d6)
![image](https://github.com/thingsboard/thingsboard/assets/83352633/521bfe56-b656-462a-afe7-efd5f4d7a054)
After fix:

![image](https://github.com/thingsboard/thingsboard/assets/83352633/093628a3-50a7-4e07-bf40-11ea1c585966)
![image](https://github.com/thingsboard/thingsboard/assets/83352633/1df05a0d-5c95-44a7-b74b-f545151d7512)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



