### PR TITLE
[WIP] Improvement for Add asset dialog

### DIFF
--- a/ui-ngx/src/app/modules/home/components/profile/asset-profile-autocomplete.component.html
+++ b/ui-ngx/src/app/modules/home/components/profile/asset-profile-autocomplete.component.html
@@ -43,6 +43,11 @@
           (click)="editAssetProfile($event)">
     <mat-icon class="material-icons">edit</mat-icon>
   </button>
+  <button mat-button color="primary" matSuffix
+          (click)="createAssetProfile($event, '')"
+          *ngIf="!selectAssetProfileFormGroup.get('assetProfile').value && !disabled && addNewProfile && showCreateNewButton">
+    <span style="white-space: nowrap">{{ 'notification.create-new' | translate }}</span>
+  </button>
   <mat-autocomplete
     class="tb-autocomplete"
     (closed)="onPanelClosed()"

--- a/ui-ngx/src/app/modules/home/components/profile/asset-profile-autocomplete.component.ts
+++ b/ui-ngx/src/app/modules/home/components/profile/asset-profile-autocomplete.component.ts
@@ -25,7 +25,7 @@ import {
   Output,
   ViewChild
 } from '@angular/core';
-import { ControlValueAccessor, UntypedFormBuilder, UntypedFormGroup, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { Observable, of } from 'rxjs';
 import { PageLink } from '@shared/models/page/page-link';
 import { Direction } from '@shared/models/page/sort-order';
@@ -33,7 +33,6 @@ import { catchError, debounceTime, distinctUntilChanged, map, share, switchMap, 
 import { Store } from '@ngrx/store';
 import { AppState } from '@app/core/core.state';
 import { TranslateService } from '@ngx-translate/core';
-import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { entityIdEquals } from '@shared/models/id/entity-id';
 import { TruncatePipe } from '@shared//pipe/truncate.pipe';
 import { ENTER } from '@angular/cdk/keycodes';
@@ -46,6 +45,7 @@ import { AssetProfile, AssetProfileInfo } from '@shared/models/asset.models';
 import { AssetProfileService } from '@core/http/asset-profile.service';
 import { AssetProfileDialogComponent, AssetProfileDialogData } from './asset-profile-dialog.component';
 import { SubscriptSizing } from '@angular/material/form-field';
+import { coerceBoolean } from '@shared/decorators/coercion';
 
 @Component({
   selector: 'tb-asset-profile-autocomplete',
@@ -82,16 +82,15 @@ export class AssetProfileAutocompleteComponent implements ControlValueAccessor, 
   addNewProfile = true;
 
   @Input()
+  @coerceBoolean()
+  showCreateNewButton = false;
+
+  @Input()
   showDetailsPageLink = false;
 
-  private requiredValue: boolean;
-  get required(): boolean {
-    return this.requiredValue;
-  }
   @Input()
-  set required(value: boolean) {
-    this.requiredValue = coerceBooleanProperty(value);
-  }
+  @coerceBoolean()
+  required = false;
 
   @Input()
   disabled: boolean;

--- a/ui-ngx/src/app/modules/home/components/wizard/device-wizard-dialog.component.html
+++ b/ui-ngx/src/app/modules/home/components/wizard/device-wizard-dialog.component.html
@@ -76,6 +76,7 @@
           </div>
           <tb-entity-autocomplete
             formControlName="customerId"
+            useFullEntityId
             labelText="device.wizard.customer-to-assign-device"
             [entityType]="entityType.CUSTOMER">
           </tb-entity-autocomplete>

--- a/ui-ngx/src/app/modules/home/components/wizard/device-wizard-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/wizard/device-wizard-dialog.component.ts
@@ -147,11 +147,8 @@ export class DeviceWizardDialogComponent extends DialogComponent<DeviceWizardDia
         overwriteActivityTime: this.deviceWizardFormGroup.get('overwriteActivityTime').value,
         description: this.deviceWizardFormGroup.get('description').value
       },
-      customerId: null
+      customerId: this.deviceWizardFormGroup.get('customerId').value
     };
-    if (this.deviceWizardFormGroup.get('customerId').value) {
-      device.customerId = new CustomerId(this.deviceWizardFormGroup.get('customerId').value);
-    }
     if (this.addDeviceWizardStepper.steps.last.completed || this.addDeviceWizardStepper.selectedIndex > 0) {
       return this.deviceService.saveDeviceWithCredentials(deepTrim(device), deepTrim(this.credentialsFormGroup.value.credential)).pipe(
         catchError((e: HttpErrorResponse) => {

--- a/ui-ngx/src/app/modules/home/pages/asset/asset.component.html
+++ b/ui-ngx/src/app/modules/home/pages/asset/asset.component.html
@@ -86,6 +86,13 @@
           {{ 'asset.name-max-length' | translate }}
         </mat-error>
       </mat-form-field>
+      <mat-form-field class="mat-block">
+        <mat-label translate>asset.label</mat-label>
+        <input matInput formControlName="label">
+        <mat-error *ngIf="entityForm.get('label').hasError('maxlength')">
+          {{ 'asset.label-max-length' | translate }}
+        </mat-error>
+      </mat-form-field>
       <tb-asset-profile-autocomplete
         [selectDefaultProfile]="isAdd"
         required
@@ -96,18 +103,11 @@
       </tb-asset-profile-autocomplete>
       <tb-entity-autocomplete
         *ngIf="isAdd"
-        returnFullId
+        useFullEntityId
         formControlName="customerId"
         labelText="asset.customer-to-assign-asset"
         [entityType]="entityType.CUSTOMER">
       </tb-entity-autocomplete>
-      <mat-form-field class="mat-block">
-        <mat-label translate>asset.label</mat-label>
-        <input matInput formControlName="label">
-        <mat-error *ngIf="entityForm.get('label').hasError('maxlength')">
-          {{ 'asset.label-max-length' | translate }}
-        </mat-error>
-      </mat-form-field>
       <div formGroupName="additionalInfo">
         <mat-form-field class="mat-block">
           <mat-label translate>asset.description</mat-label>

--- a/ui-ngx/src/app/modules/home/pages/asset/asset.component.html
+++ b/ui-ngx/src/app/modules/home/pages/asset/asset.component.html
@@ -89,10 +89,18 @@
       <tb-asset-profile-autocomplete
         [selectDefaultProfile]="isAdd"
         required
+        showCreateNewButton
         formControlName="assetProfileId"
         [showDetailsPageLink]="true"
         (assetProfileUpdated)="onAssetProfileUpdated()">
       </tb-asset-profile-autocomplete>
+      <tb-entity-autocomplete
+        *ngIf="isAdd"
+        returnFullId
+        formControlName="customerId"
+        labelText="asset.customer-to-assign-asset"
+        [entityType]="entityType.CUSTOMER">
+      </tb-entity-autocomplete>
       <mat-form-field class="mat-block">
         <mat-label translate>asset.label</mat-label>
         <input matInput formControlName="label">

--- a/ui-ngx/src/app/modules/home/pages/asset/asset.component.ts
+++ b/ui-ngx/src/app/modules/home/pages/asset/asset.component.ts
@@ -69,6 +69,7 @@ export class AssetComponent extends EntityComponent<AssetInfo> {
         name: [entity ? entity.name : '', [Validators.required, Validators.maxLength(255)]],
         assetProfileId: [entity ? entity.assetProfileId : null, [Validators.required]],
         label: [entity ? entity.label : '', Validators.maxLength(255)],
+        customerId: [entity ? entity.customerId : ''],
         additionalInfo: this.fb.group(
           {
             description: [entity && entity.additionalInfo ? entity.additionalInfo.description : ''],
@@ -81,6 +82,7 @@ export class AssetComponent extends EntityComponent<AssetInfo> {
   updateForm(entity: AssetInfo) {
     this.entityForm.patchValue({name: entity.name});
     this.entityForm.patchValue({assetProfileId: entity.assetProfileId});
+    this.entityForm.patchValue({customerId: entity.customerId});
     this.entityForm.patchValue({label: entity.label});
     this.entityForm.patchValue({additionalInfo: {description: entity.additionalInfo ? entity.additionalInfo.description : ''}});
   }

--- a/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
@@ -40,7 +40,6 @@ import { getCurrentAuthUser } from '@core/auth/auth.selectors';
 import { Authority } from '@shared/models/authority.enum';
 import { isDefinedAndNotNull, isEqual } from '@core/utils';
 import { coerceBoolean } from '@shared/decorators/coercion';
-import { CustomerId } from '@shared/models/id/customer-id';
 
 @Component({
   selector: 'tb-entity-autocomplete',
@@ -119,7 +118,7 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
 
   @Input()
   @coerceBoolean()
-  returnFullId = false;
+  useFullEntityId = false;
 
   @Input()
   @coerceBoolean()
@@ -176,7 +175,7 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
             if (typeof value === 'string' || !value) {
               modelValue = null;
             } else {
-              modelValue = value.id.id;
+              modelValue = this.useFullEntityId ? value.id : value.id.id;
             }
             this.updateView(modelValue, value);
             if (value === null) {
@@ -312,7 +311,7 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
       } catch (e) {
         this.propagateChange(null);
       }
-      this.modelValue = entity !== null ? entity.id.id : null;
+      this.modelValue = entity !== null ? this.useFullEntityId ? entity.id : entity.id.id : null;
       this.selectEntityFormGroup.get('entity').patchValue(entity !== null ? entity : '', {emitEvent: false});
       this.entityChanged.emit(entity);
     } else {
@@ -336,9 +335,6 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
   updateView(value: string | null, entity: BaseData<EntityId> | null) {
     if (!isEqual(this.modelValue, value)) {
       this.modelValue = value;
-      if (this.returnFullId && this.entityTypeValue === EntityType.CUSTOMER) {
-        this.modelValue = new CustomerId(this.modelValue);
-      }
       this.propagateChange(this.modelValue);
       this.entityChanged.emit(entity);
     }

--- a/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
@@ -311,7 +311,7 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
       } catch (e) {
         this.propagateChange(null);
       }
-      this.modelValue = entity !== null ? this.useFullEntityId ? entity.id : entity.id.id : null;
+      this.modelValue = entity !== null ? (this.useFullEntityId ? entity.id : entity.id.id) : null;
       this.selectEntityFormGroup.get('entity').patchValue(entity !== null ? entity : '', {emitEvent: false});
       this.entityChanged.emit(entity);
     } else {

--- a/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-autocomplete.component.ts
@@ -26,7 +26,7 @@ import {
   ViewChild
 } from '@angular/core';
 import { MatFormFieldAppearance } from '@angular/material/form-field';
-import { ControlValueAccessor, UntypedFormBuilder, UntypedFormGroup, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { merge, Observable, of, Subject } from 'rxjs';
 import { catchError, debounceTime, map, share, switchMap, tap } from 'rxjs/operators';
 import { Store } from '@ngrx/store';
@@ -40,6 +40,7 @@ import { getCurrentAuthUser } from '@core/auth/auth.selectors';
 import { Authority } from '@shared/models/authority.enum';
 import { isDefinedAndNotNull, isEqual } from '@core/utils';
 import { coerceBoolean } from '@shared/decorators/coercion';
+import { CustomerId } from '@shared/models/id/customer-id';
 
 @Component({
   selector: 'tb-entity-autocomplete',
@@ -55,7 +56,7 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
 
   selectEntityFormGroup: UntypedFormGroup;
 
-  modelValue: string | null;
+  modelValue: string | EntityId | null;
 
   entityTypeValue: EntityType | AliasEntityType;
 
@@ -115,6 +116,10 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
 
   @Input()
   appearance: MatFormFieldAppearance = 'fill';
+
+  @Input()
+  @coerceBoolean()
+  returnFullId = false;
 
   @Input()
   @coerceBoolean()
@@ -331,6 +336,9 @@ export class EntityAutocompleteComponent implements ControlValueAccessor, OnInit
   updateView(value: string | null, entity: BaseData<EntityId> | null) {
     if (!isEqual(this.modelValue, value)) {
       this.modelValue = value;
+      if (this.returnFullId && this.entityTypeValue === EntityType.CUSTOMER) {
+        this.modelValue = new CustomerId(this.modelValue);
+      }
       this.propagateChange(this.modelValue);
       this.entityChanged.emit(entity);
     }

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -685,7 +685,8 @@
         "unassign-asset-from-edge-text": "After the confirmation the asset will be unassigned and won't be accessible by the edge.",
         "unassign-assets-from-edge-title": "Are you sure you want to unassign { count, plural, =1 {1 asset} other {# assets} }?",
         "unassign-assets-from-edge-text": "After the confirmation all selected assets will be unassigned and won't be accessible by the edge.",
-        "selected-assets": "{ count, plural, =1 {1 asset} other {# assets} } selected"
+        "selected-assets": "{ count, plural, =1 {1 asset} other {# assets} } selected",
+        "customer-to-assign-asset": "Customer to assign the asset"
     },
     "attribute": {
         "attributes": "Attributes",


### PR DESCRIPTION
## Pull Request description

Improvement:
1. Add button 'Create new' for Asset profile autocomplete.
2. Add input 'Customer to assign the asset'.

![image](https://github.com/thingsboard/thingsboard/assets/83352633/e9a96f95-5cdb-45b9-92ef-fcab0302e01d)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




