### PR TITLE
[Hotfix] web socket synchronized fix

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/plugin/TbWebSocketHandler.java
+++ b/application/src/main/java/org/thingsboard/server/controller/plugin/TbWebSocketHandler.java
@@ -239,7 +239,7 @@ public class TbWebSocketHandler extends TextWebSocketHandler implements WebSocke
             this.lastActivityTime = System.currentTimeMillis();
         }
 
-        synchronized void sendPing(long currentTime) {
+        void sendPing(long currentTime) {
             try {
                 long timeSinceLastActivity = currentTime - lastActivityTime;
                 if (timeSinceLastActivity >= pingTimeout) {
@@ -262,15 +262,15 @@ public class TbWebSocketHandler extends TextWebSocketHandler implements WebSocke
             }
         }
 
-        synchronized void processPongMessage(long currentTime) {
+        void processPongMessage(long currentTime) {
             lastActivityTime = currentTime;
         }
 
-        synchronized void sendMsg(String msg) {
+        void sendMsg(String msg) {
             sendMsg(new TbWebSocketTextMsg(msg));
         }
 
-        synchronized void sendMsg(TbWebSocketMsg<?> msg) {
+        void sendMsg(TbWebSocketMsg<?> msg) {
             if (isSending.compareAndSet(false, true)) {
                 sendMsgInternal(msg);
             } else {

--- a/application/src/test/java/org/thingsboard/server/controller/plugin/TbWebSocketHandlerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/plugin/TbWebSocketHandlerTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.controller.plugin;
+
+import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.adapter.NativeWebSocketSession;
+import org.thingsboard.common.util.ThingsBoardThreadFactory;
+import org.thingsboard.server.service.ws.WebSocketSessionRef;
+
+import javax.websocket.RemoteEndpoint;
+import javax.websocket.SendHandler;
+import javax.websocket.SendResult;
+import javax.websocket.Session;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@Slf4j
+class TbWebSocketHandlerTest {
+
+    TbWebSocketHandler wsHandler;
+    NativeWebSocketSession session;
+    Session nativeSession;
+    RemoteEndpoint.Async asyncRemote;
+    WebSocketSessionRef sessionRef;
+    int maxMsgQueuePerSession;
+    TbWebSocketHandler.SessionMetaData sendHandler;
+    ExecutorService executor;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        maxMsgQueuePerSession = 100;
+        executor = Executors.newCachedThreadPool(ThingsBoardThreadFactory.forName(getClass().getSimpleName()));
+        wsHandler = spy(new TbWebSocketHandler());
+        willDoNothing().given(wsHandler).close(any(), any());
+        session = mock(NativeWebSocketSession.class);
+        nativeSession = mock(Session.class);
+        willReturn(nativeSession).given(session).getNativeSession(Session.class);
+        asyncRemote = mock(RemoteEndpoint.Async.class);
+        willReturn(asyncRemote).given(nativeSession).getAsyncRemote();
+        sessionRef = mock(WebSocketSessionRef.class, Mockito.RETURNS_DEEP_STUBS); //prevent NPE on logs
+        sendHandler = spy(wsHandler.new SessionMetaData(session, sessionRef, maxMsgQueuePerSession));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void sendHandler_sendMsg_parallel_no_race() throws InterruptedException {
+        CountDownLatch finishLatch = new CountDownLatch(maxMsgQueuePerSession * 2);
+        AtomicInteger sendersCount = new AtomicInteger();
+        willAnswer(invocation -> {
+            assertThat(sendersCount.incrementAndGet()).as("no race").isEqualTo(1);
+            String text = invocation.getArgument(0);
+            SendHandler onResultHandler = invocation.getArgument(1);
+            SendResult sendResult = new SendResult();
+            executor.submit(() -> {
+                sendersCount.decrementAndGet();
+                onResultHandler.onResult(sendResult);
+                finishLatch.countDown();
+            });
+            return null;
+        }).given(asyncRemote).sendText(anyString(), any());
+
+        assertThat(sendHandler.isSending.get()).as("sendHandler not is in sending state").isFalse();
+        //first batch
+        IntStream.range(0, maxMsgQueuePerSession).parallel().forEach(i -> sendHandler.sendMsg("hello " + i));
+        Awaitility.await("first batch processed").atMost(30, TimeUnit.SECONDS).until(() -> finishLatch.getCount() == maxMsgQueuePerSession);
+        assertThat(sendHandler.isSending.get()).as("sendHandler not is in sending state").isFalse();
+        //second batch - to test pause between big msg batches
+        IntStream.range(100, 100 + maxMsgQueuePerSession).parallel().forEach(i -> sendHandler.sendMsg("hello " + i));
+        assertThat(finishLatch.await(30, TimeUnit.SECONDS)).as("all callbacks fired").isTrue();
+
+        verify(sendHandler, never()).closeSession(any());
+        verify(sendHandler, times(maxMsgQueuePerSession * 2)).onResult(any());
+        assertThat(sendHandler.isSending.get()).as("sendHandler not is in sending state").isFalse();
+    }
+
+    @Test
+    void sendHandler_sendMsg_message_order() throws InterruptedException {
+        CountDownLatch finishLatch = new CountDownLatch(maxMsgQueuePerSession);
+        Collection<String> outputs = new ConcurrentLinkedQueue<>();
+        willAnswer(invocation -> {
+            String text = invocation.getArgument(0);
+            outputs.add(text);
+            SendHandler onResultHandler = invocation.getArgument(1);
+            SendResult sendResult = new SendResult();
+            executor.submit(() -> {
+                onResultHandler.onResult(sendResult);
+                finishLatch.countDown();
+            });
+            return null;
+        }).given(asyncRemote).sendText(anyString(), any());
+
+        List<String> inputs = IntStream.range(0, maxMsgQueuePerSession).mapToObj(i -> "msg " + i).collect(Collectors.toList());
+        inputs.forEach(s -> sendHandler.sendMsg(s));
+
+        assertThat(finishLatch.await(30, TimeUnit.SECONDS)).as("all callbacks fired").isTrue();
+        assertThat(outputs).as("inputs exactly the same as outputs").containsExactlyElementsOf(inputs);
+
+        verify(sendHandler, never()).closeSession(any());
+        verify(sendHandler, times(maxMsgQueuePerSession)).onResult(any());
+    }
+
+    @Test
+    void sendHandler_sendMsg_queue_size_exceed() {
+        willDoNothing().given(asyncRemote).sendText(anyString(), any()); // send text will never call back, so queue will grow each sendMsg
+        sendHandler.sendMsg("first message to stay in-flight all the time during this test");
+        IntStream.range(0, maxMsgQueuePerSession).parallel().forEach(i -> sendHandler.sendMsg("hello " + i));
+        verify(sendHandler, never()).closeSession(any());
+        sendHandler.sendMsg("excessive message");
+        verify(sendHandler, times(1)).closeSession(eq(new CloseStatus(1008, "Max pending updates limit reached!")));
+        verify(asyncRemote, times(1)).sendText(anyString(), any());
+    }
+
+}


### PR DESCRIPTION
## Web socket synchronized fix

We face a deadlock situation in version `3.5.1`. It looks like the dashboards open, but the content is never loaded.

Thread dump analyses prove the problem.

The web socket `handlePongMessage` is from the client, and at the same time, another thread is trying to close the connection by timeout.

Code analysis with @volodymyr-babak shows that the current implementation of `TbWebSocketHandler` is thread-safe, and `synchronized` is obsolete.

What is the fix:
 * TbWebSocketHandler.SessionMetaData removed synchronization to avoid deadlock with WsSession that already have its own lock.
* TbWebSocketHandler.checkLimits refactored to extract IO session.close() call from the synchronized scope 
* ws msg queue fixed the last msg pickup, and as a result - the msg order (see pictures and comments at the bottom)
* web socket handler tests added

Tested on stage and production.

PE: https://github.com/thingsboard/thingsboard-pe/pull/1855

Screenshot and thread dump during the issue:

![image](https://github.com/thingsboard/thingsboard/assets/79898499/3d4f219f-76c5-4614-9c9d-8ad3471b0a65)

```
"http-nio-0.0.0.0-8080-exec-8" - Thread t@163
   java.lang.Thread.State: BLOCKED
        at org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData.processPongMessage(TbWebSocketHandler.java:281)
        - waiting to lock <40f4000e> (a org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData) owned by "DefaultWebSocketService-1-9" t@4293
        at org.thingsboard.server.controller.plugin.TbWebSocketHandler.handlePongMessage(TbWebSocketHandler.java:135)
        at org.springframework.web.socket.handler.AbstractWebSocketHandler.handleMessage(AbstractWebSocketHandler.java:49)
        at org.springframework.web.socket.handler.WebSocketHandlerDecorator.handleMessage(WebSocketHandlerDecorator.java:75)
        at org.springframework.web.socket.handler.LoggingWebSocketHandlerDecorator.handleMessage(LoggingWebSocketHandlerDecorator.java:56)
        at org.springframework.web.socket.handler.ExceptionWebSocketHandlerDecorator.handleMessage(ExceptionWebSocketHandlerDecorator.java:58)
        at org.springframework.web.socket.adapter.standard.StandardWebSocketHandlerAdapter.handlePongMessage(StandardWebSocketHandlerAdapter.java:134)
        at org.springframework.web.socket.adapter.standard.StandardWebSocketHandlerAdapter.access$200(StandardWebSocketHandlerAdapter.java:43)
        at org.springframework.web.socket.adapter.standard.StandardWebSocketHandlerAdapter$5.onMessage(StandardWebSocketHandlerAdapter.java:99)
        at org.springframework.web.socket.adapter.standard.StandardWebSocketHandlerAdapter$5.onMessage(StandardWebSocketHandlerAdapter.java:96)
        at org.apache.tomcat.websocket.WsFrameBase.processDataControl(WsFrameBase.java:356)
        at org.apache.tomcat.websocket.WsFrameBase.processData(WsFrameBase.java:279)
        at org.apache.tomcat.websocket.WsFrameBase.processInputBuffer(WsFrameBase.java:130)
        at org.apache.tomcat.websocket.server.WsFrameServer.onDataAvailable(WsFrameServer.java:84)
        at org.apache.tomcat.websocket.server.WsFrameServer.doOnDataAvailable(WsFrameServer.java:183)
        at org.apache.tomcat.websocket.server.WsFrameServer.notifyDataAvailable(WsFrameServer.java:163)
        at org.apache.tomcat.websocket.server.WsHttpUpgradeHandler.upgradeDispatch(WsHttpUpgradeHandler.java:152)
        at org.apache.coyote.http11.upgrade.UpgradeProcessorInternal.dispatch(UpgradeProcessorInternal.java:60)
        at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:57)
        at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:926)
        at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1791)
        at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
        at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191)
        at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
        at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
        at java.base@11.0.18/java.lang.Thread.run(Thread.java:829)

   Locked ownable synchronizers:
        - locked <132bc3fb> (a org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker)

        - locked <3dbba0f6> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)


"DefaultWebSocketService-1-9" - Thread t@4293
   java.lang.Thread.State: WAITING
        at java.base@11.0.18/jdk.internal.misc.Unsafe.park(Native Method)
        - waiting to lock <3dbba0f6> (a java.util.concurrent.locks.ReentrantLock$NonfairSync) owned by "http-nio-0.0.0.0-8080-exec-8" t@163
        at java.base@11.0.18/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)
        at java.base@11.0.18/java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:885)
        at java.base@11.0.18/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:917)
        at java.base@11.0.18/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1240)
        at java.base@11.0.18/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:267)
        at org.apache.tomcat.websocket.WsSession.doClose(WsSession.java:654)
        at org.apache.tomcat.websocket.WsSession.doClose(WsSession.java:636)
        at org.apache.tomcat.websocket.WsSession.close(WsSession.java:624)
        at org.springframework.web.socket.adapter.standard.StandardWebSocketSession.closeInternal(StandardWebSocketSession.java:235)
        at org.springframework.web.socket.adapter.AbstractWebSocketSession.close(AbstractWebSocketSession.java:144)
        at org.thingsboard.server.controller.plugin.TbWebSocketHandler.close(TbWebSocketHandler.java:401)
        at org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData.closeSession(TbWebSocketHandler.java:274)
        at org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData.sendPing(TbWebSocketHandler.java:262)
        - locked <40f4000e> (a org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData)
        at org.thingsboard.server.controller.plugin.TbWebSocketHandler.sendPing(TbWebSocketHandler.java:384)
        at org.thingsboard.server.service.ws.DefaultWebSocketService.lambda$sendPing$19(DefaultWebSocketService.java:977)
        at org.thingsboard.server.service.ws.DefaultWebSocketService$$Lambda$3737/0x0000000841c42040.run(Unknown Source)
        at java.base@11.0.18/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
        at java.base@11.0.18/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base@11.0.18/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base@11.0.18/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base@11.0.18/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base@11.0.18/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)

   Locked ownable synchronizers:
        - None
```

and about 50 threads are blocked as well as shown below:

```
"DefaultWebSocketService-58-10" - Thread t@4443
   java.lang.Thread.State: BLOCKED
        at org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData.sendPing(TbWebSocketHandler.java:259)
        - waiting to lock <40f4000e> (a org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData) owned by "DefaultWebSocketService-1-9" t@4293
        at org.thingsboard.server.controller.plugin.TbWebSocketHandler.sendPing(TbWebSocketHandler.java:384)
        at org.thingsboard.server.service.ws.DefaultWebSocketService.lambda$sendPing$19(DefaultWebSocketService.java:977)
        at org.thingsboard.server.service.ws.DefaultWebSocketService$$Lambda$3737/0x0000000841c42040.run(Unknown Source)
        at java.base@11.0.18/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
        at java.base@11.0.18/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base@11.0.18/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base@11.0.18/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base@11.0.18/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base@11.0.18/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)

   Locked ownable synchronizers:
        - None

"DefaultWebSocketService-51-11" - Thread t@4444
   java.lang.Thread.State: BLOCKED
        at org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData.sendMsg(TbWebSocketHandler.java:285)
        - waiting to lock <40f4000e> (a org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData) owned by "DefaultWebSocketService-1-9" t@4293
        at org.thingsboard.server.controller.plugin.TbWebSocketHandler.send(TbWebSocketHandler.java:368)
        at org.thingsboard.server.service.ws.DefaultWebSocketService.lambda$sendWsMsg$18(DefaultWebSocketService.java:962)
        at org.thingsboard.server.service.ws.DefaultWebSocketService$$Lambda$3735/0x0000000841c43840.run(Unknown Source)
        at java.base@11.0.18/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
        at java.base@11.0.18/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base@11.0.18/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base@11.0.18/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base@11.0.18/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base@11.0.18/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)

   Locked ownable synchronizers:
        - None

```

Tests that prove msg order issue before this PR:

![image](https://github.com/thingsboard/thingsboard/assets/79898499/2696cf4d-34be-4136-a640-6e127fa6181c)

The cause was the `isSending` check and msgQueue.poll, not atomic. And the first message did not go through the queue.
The current implementation is always putting msg in the queue and then atomically trying to take control of `isSending` flag. Each callback resets `isSending` and then tries to take control atomically in the same fair condition as other threads.

Fixed code is ok:

![image](https://github.com/thingsboard/thingsboard/assets/79898499/1ae9f0c0-b92e-4190-bae5-0fe1696ba4a0)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



