### PR TITLE
Fix for custom translation in inbox notifications table

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/notification/inbox/inbox-table-config.resolver.ts
+++ b/ui-ngx/src/app/modules/home/pages/notification/inbox/inbox-table-config.resolver.ts
@@ -39,6 +39,7 @@ import {
 } from '@home/pages/notification/inbox/inbox-notification-dialog.component';
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
+import { UtilsService } from '@core/services/utils.service';
 
 @Injectable()
 export class InboxTableConfigResolver implements Resolve<EntityTableConfig<Notification>> {
@@ -48,7 +49,8 @@ export class InboxTableConfigResolver implements Resolve<EntityTableConfig<Notif
   constructor(private notificationService: NotificationService,
               private translate: TranslateService,
               private dialog: MatDialog,
-              private datePipe: DatePipe) {
+              private datePipe: DatePipe,
+              private utilsService: UtilsService) {
 
     this.config.entityType = EntityType.NOTIFICATION;
     this.config.detailsPanelEnabled = false;
@@ -92,8 +94,10 @@ export class InboxTableConfigResolver implements Resolve<EntityTableConfig<Notif
       new DateEntityTableColumn<Notification>('createdTime', 'common.created-time', this.datePipe, '170px'),
       new EntityTableColumn<Notification>('type', 'notification.type', '10%', (notification) =>
         this.translate.instant(NotificationTemplateTypeTranslateMap.get(notification.type).name)),
-      new EntityTableColumn<Notification>('subject', 'notification.subject', '30%'),
-      new EntityTableColumn<Notification>('text', 'notification.message', '60%')
+      new EntityTableColumn<Notification>('subject', 'notification.subject', '30%',
+        (entity) => this.utilsService.customTranslation(entity.subject, entity.subject)),
+      new EntityTableColumn<Notification>('text', 'notification.message', '60%',
+        (entity) => this.utilsService.customTranslation(entity.text, entity.text))
     );
 
   }


### PR DESCRIPTION
## Pull Request description

Added support of custom translations in Subject and Message columns of inbox notifications talbe.

Before:
![Screenshot from 2023-07-18 18-25-22](https://github.com/thingsboard/thingsboard-pe/assets/87172504/23d777af-319a-4751-be3b-4f24bb8ee7e4)

After:
![Screenshot from 2023-07-18 18-25-41](https://github.com/thingsboard/thingsboard-pe/assets/87172504/9c751d66-83a0-4399-ad7a-4db99f5a4b54)

## General checklist

- [x] This PR has the corresponding CE PR or contains unique code changes related to PE only (does not require same changes in CE).
- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-pe-ui-help)
