### PR TITLE
fix(sec): upgrade org.javadelight:delight-nashorn-sandbox to 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
             org/thingsboard/server/extensions/core/plugin/telemetry/gen/**/*
         </sonar.exclusions>
         <elasticsearch.version>5.0.2</elasticsearch.version>
-        <delight-nashorn-sandbox.version>0.2.1</delight-nashorn-sandbox.version>
+        <delight-nashorn-sandbox.version>0.2.3</delight-nashorn-sandbox.version>
         <!-- IMPORTANT: If you change the version of the kafka client, make sure to synchronize our overwritten implementation of the
         org.apache.kafka.common.network.NetworkReceive class in the application module. It addresses the issue https://issues.apache.org/jira/browse/KAFKA-4090.
         Here is the source to track https://github.com/apache/kafka/tree/trunk/clients/src/main/java/org/apache/kafka/common/network -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.javadelight:delight-nashorn-sandbox 0.2.1
- [CVE-2021-40660](https://www.oscs1024.com/hd/CVE-2021-40660)


### What did I do？
Upgrade org.javadelight:delight-nashorn-sandbox from 0.2.1 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS