### PR TITLE
Fixed hide edit button if entity is not selected Asset/Device Profile

### DIFF
--- a/ui-ngx/src/app/modules/home/components/profile/asset-profile-autocomplete.component.html
+++ b/ui-ngx/src/app/modules/home/components/profile/asset-profile-autocomplete.component.html
@@ -35,7 +35,7 @@
           (click)="clear()">
     <mat-icon class="material-icons">close</mat-icon>
   </button>
-  <button *ngIf="selectAssetProfileFormGroup.get('assetProfile').value && !disabled && editProfileEnabled"
+  <button *ngIf="selectAssetProfileFormGroup.get('assetProfile').value?.id && !disabled && editProfileEnabled"
           type="button"
           matSuffix mat-icon-button aria-label="Edit"
           matTooltip="{{ 'asset-profile.edit' | translate }}"

--- a/ui-ngx/src/app/modules/home/components/profile/device-profile-autocomplete.component.html
+++ b/ui-ngx/src/app/modules/home/components/profile/device-profile-autocomplete.component.html
@@ -35,7 +35,7 @@
           (click)="clear()">
     <mat-icon class="material-icons">close</mat-icon>
   </button>
-  <button *ngIf="selectDeviceProfileFormGroup.get('deviceProfile').value && !disabled && editProfileEnabled"
+  <button *ngIf="selectDeviceProfileFormGroup.get('deviceProfile').value?.id && !disabled && editProfileEnabled"
           type="button"
           matSuffix mat-icon-button aria-label="Edit"
           matTooltip="{{ 'device-profile.edit' | translate }}"


### PR DESCRIPTION
## Pull Request description

Fixed: [#8978](https://github.com/thingsboard/thingsboard/issues/8978)

Fix: Hide edit button if profile is not selected Asset/Device profile autocomplete.

Before fix:
![image](https://github.com/thingsboard/thingsboard/assets/83352633/8e767e0f-c932-415e-9d10-3eb2120601e9)
![image](https://github.com/thingsboard/thingsboard/assets/83352633/ba855e29-3ca9-49c1-a3b2-3de3970fcd5e)

After fix:
![image](https://github.com/thingsboard/thingsboard/assets/83352633/60c151a7-2725-4e17-823b-cd16041ef49c)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



