### PR TITLE
fix(sec): upgrade org.eclipse.californium:californium-core to 3.6.0

### DIFF
--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -42,7 +42,7 @@
         <pkg.implementationTitle>ThingsBoard Monitoring Service</pkg.implementationTitle>
         <pkg.mainClass>org.thingsboard.monitoring.ThingsboardMonitoringApplication</pkg.mainClass>
 
-        <californium.version>2.6.1</californium.version>
+        <californium.version>3.6.0</californium.version>
         <leshan.version>2.0.0-M4</leshan.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.californium:californium-core 2.6.1
- [CVE-2022-2576](https://www.oscs1024.com/hd/CVE-2022-2576)


### What did I do？
Upgrade org.eclipse.californium:californium-core from 2.6.1 to 3.6.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS