### PR TITLE
[3.5.2] Notification unread counter query speedup

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/install/SqlDatabaseUpgradeService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/SqlDatabaseUpgradeService.java
@@ -756,6 +756,10 @@ public class SqlDatabaseUpgradeService implements DatabaseEntitiesUpgradeService
                             conn.createStatement().execute("CREATE INDEX IF NOT EXISTS idx_rule_node_type_configuration_version ON rule_node(type, configuration_version);");
                         } catch (Exception e) {
                         }
+                        try {
+                            conn.createStatement().execute("CREATE INDEX IF NOT EXISTS idx_notification_recipient_id_unread ON notification(recipient_id) WHERE status <> 'READ';");
+                        } catch (Exception e) {
+                        }
 
                         conn.createStatement().execute("UPDATE tb_schema_settings SET schema_version = 3005002;");
                     }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/notification/JpaNotificationDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/notification/JpaNotificationDao.java
@@ -81,6 +81,9 @@ public class JpaNotificationDao extends JpaAbstractDao<NotificationEntity, Notif
         return notificationRepository.updateStatusByIdAndRecipientId(notificationId.getId(), recipientId.getId(), status) != 0;
     }
 
+    /**
+     * For this hot method, the partial index `idx_notification_recipient_id_unread` was introduced since 3.5.2
+     * */
     @Override
     public int countUnreadByRecipientId(TenantId tenantId, UserId recipientId) {
         return notificationRepository.countByRecipientIdAndStatusNot(recipientId.getId(), NotificationStatus.READ);

--- a/dao/src/main/resources/sql/schema-entities-idx.sql
+++ b/dao/src/main/resources/sql/schema-entities-idx.sql
@@ -113,3 +113,5 @@ CREATE INDEX IF NOT EXISTS idx_notification_request_status ON notification_reque
 CREATE INDEX IF NOT EXISTS idx_notification_id ON notification(id);
 
 CREATE INDEX IF NOT EXISTS idx_notification_recipient_id_created_time ON notification(recipient_id, created_time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_notification_recipient_id_unread ON notification(recipient_id) WHERE status <> 'READ';


### PR DESCRIPTION
## Notification unread counter query speedup

SQL partial index idx_notification_recipient_id_unread added for cheap and fast unread notification count on UI

According to the PostgreSQL stats from real production, the notification bell on UI consumes many resources for tenants with 100k+ notifications in history.

The new partial index solves the problem, and the UI notification bell appears immediately after the page refresh without noticeable delay.

![image](https://github.com/thingsboard/thingsboard/assets/79898499/eb3906e0-2208-4c33-82f4-f321a8f00362)

![image](https://github.com/thingsboard/thingsboard/assets/79898499/b491f7ad-7f29-4513-b8e8-ca1e3c2e6ecb)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



