### PR TITLE
[3.5.2] 'Update on value change' for save attributes rule node feature

### DIFF
--- a/application/src/main/data/json/edge/rule_chains/edge_root_rule_chain.json
+++ b/application/src/main/data/json/edge/rule_chains/edge_root_rule_chain.json
@@ -50,7 +50,9 @@
         "debugMode": false,
         "configuration": {
           "scope": "CLIENT_SCOPE",
-          "notifyDevice": "false"
+          "notifyDevice": "false",
+          "sendAttributesUpdatedNotification": "false",
+          "updateAttributesOnValueChange": "true"
         },
         "externalId": null
       },

--- a/application/src/main/data/json/edge/rule_chains/edge_root_rule_chain.json
+++ b/application/src/main/data/json/edge/rule_chains/edge_root_rule_chain.json
@@ -49,6 +49,7 @@
         "name": "Save Client Attributes",
         "debugMode": false,
         "configuration": {
+          "version": 1,
           "scope": "CLIENT_SCOPE",
           "notifyDevice": "false",
           "sendAttributesUpdatedNotification": "false",

--- a/application/src/main/data/json/edge/rule_chains/edge_root_rule_chain.json
+++ b/application/src/main/data/json/edge/rule_chains/edge_root_rule_chain.json
@@ -53,7 +53,7 @@
           "scope": "CLIENT_SCOPE",
           "notifyDevice": "false",
           "sendAttributesUpdatedNotification": "false",
-          "updateAttributesOnValueChange": "true"
+          "updateAttributesOnlyOnValueChange": "true"
         },
         "externalId": null
       },

--- a/application/src/main/data/json/tenant/device_profile/rule_chain_template.json
+++ b/application/src/main/data/json/tenant/device_profile/rule_chain_template.json
@@ -33,6 +33,7 @@
         "name": "Save Client Attributes",
         "debugMode": false,
         "configuration": {
+          "version": 1,
           "scope": "CLIENT_SCOPE",
           "notifyDevice": "false",
           "sendAttributesUpdatedNotification": "false",

--- a/application/src/main/data/json/tenant/device_profile/rule_chain_template.json
+++ b/application/src/main/data/json/tenant/device_profile/rule_chain_template.json
@@ -33,7 +33,10 @@
         "name": "Save Client Attributes",
         "debugMode": false,
         "configuration": {
-          "scope": "CLIENT_SCOPE"
+          "scope": "CLIENT_SCOPE",
+          "notifyDevice": "false",
+          "sendAttributesUpdatedNotification": "false",
+          "updateAttributesOnValueChange": "true"
         }
       },
       {

--- a/application/src/main/data/json/tenant/device_profile/rule_chain_template.json
+++ b/application/src/main/data/json/tenant/device_profile/rule_chain_template.json
@@ -37,7 +37,7 @@
           "scope": "CLIENT_SCOPE",
           "notifyDevice": "false",
           "sendAttributesUpdatedNotification": "false",
-          "updateAttributesOnValueChange": "true"
+          "updateAttributesOnlyOnValueChange": "true"
         }
       },
       {

--- a/application/src/main/data/json/tenant/rule_chains/root_rule_chain.json
+++ b/application/src/main/data/json/tenant/rule_chains/root_rule_chain.json
@@ -33,7 +33,9 @@
         "debugMode": false,
         "configuration": {
           "scope": "CLIENT_SCOPE",
-          "notifyDevice": "false"
+          "notifyDevice": "false",
+          "sendAttributesUpdatedNotification": "false",
+          "updateAttributesOnValueChange": "true"
         }
       },
       {

--- a/application/src/main/data/json/tenant/rule_chains/root_rule_chain.json
+++ b/application/src/main/data/json/tenant/rule_chains/root_rule_chain.json
@@ -36,7 +36,7 @@
           "scope": "CLIENT_SCOPE",
           "notifyDevice": "false",
           "sendAttributesUpdatedNotification": "false",
-          "updateAttributesOnValueChange": "true"
+          "updateAttributesOnlyOnValueChange": "true"
         }
       },
       {

--- a/application/src/main/data/json/tenant/rule_chains/root_rule_chain.json
+++ b/application/src/main/data/json/tenant/rule_chains/root_rule_chain.json
@@ -32,6 +32,7 @@
         "name": "Save Client Attributes",
         "debugMode": false,
         "configuration": {
+          "version": 1,
           "scope": "CLIENT_SCOPE",
           "notifyDevice": "false",
           "sendAttributesUpdatedNotification": "false",

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNode.java
@@ -61,14 +61,14 @@ import static org.thingsboard.server.common.data.msg.TbMsgType.POST_ATTRIBUTES_R
                       "If upsert(update/insert) operation is completed successfully rule node will send the incoming message via <b>Success</b> chain, otherwise, <b>Failure</b> chain is used. " +
                       "Additionally if checkbox <b>Send attributes updated notification</b> is set to true, rule node will put the \"Attributes Updated\" " +
                       "event for <b>SHARED_SCOPE</b> and <b>SERVER_SCOPE</b> attributes updates to the corresponding rule engine queue." +
-                      "Performance checkbox 'Update Attributes On Value Change' will skip attributes overwrites for values with no changes (avoid concurrent writes because this check is not transactional; will not update 'Last updated time' for skipped attributes).",
+                      "Performance checkbox 'Save attributes only if the value changes' will skip attributes overwrites for values with no changes (avoid concurrent writes because this check is not transactional; will not update 'Last updated time' for skipped attributes).",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
         configDirective = "tbActionNodeAttributesConfig",
         icon = "file_upload"
 )
 public class TbMsgAttributesNode implements TbNode, TbVersionedNode {
 
-    static final String UPDATE_ATTRIBUTES_ON_VALUE_CHANGE_KEY = "updateAttributesOnValueChange";
+    static final String UPDATE_ATTRIBUTES_ONLY_ON_VALUE_CHANGE_KEY = "updateAttributesOnlyOnValueChange";
     private TbMsgAttributesNodeConfiguration config;
 
     @Override
@@ -94,7 +94,7 @@ public class TbMsgAttributesNode implements TbNode, TbVersionedNode {
         String scope = getScope(msg.getMetaData().getValue(SCOPE));
         boolean sendAttributesUpdateNotification = checkSendNotification(scope);
 
-        if (!config.isUpdateAttributesOnValueChange()) {
+        if (!config.isUpdateAttributesOnlyOnValueChange()) {
             saveAttr(newAttributes, ctx, msg, scope, sendAttributesUpdateNotification);
             return;
         }
@@ -171,9 +171,9 @@ public class TbMsgAttributesNode implements TbNode, TbVersionedNode {
         boolean hasChanges = false;
         switch (fromVersion) {
             case 0:
-                if (!oldConfiguration.has(UPDATE_ATTRIBUTES_ON_VALUE_CHANGE_KEY)) {
+                if (!oldConfiguration.has(UPDATE_ATTRIBUTES_ONLY_ON_VALUE_CHANGE_KEY)) {
                     hasChanges = true;
-                    ((ObjectNode) oldConfiguration).put(UPDATE_ATTRIBUTES_ON_VALUE_CHANGE_KEY, false);
+                    ((ObjectNode) oldConfiguration).put(UPDATE_ATTRIBUTES_ONLY_ON_VALUE_CHANGE_KEY, false);
                 }
                 break;
             default:

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNode.java
@@ -25,7 +25,6 @@ import com.google.gson.JsonParser;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.rule.engine.api.RuleNode;
 import org.thingsboard.rule.engine.api.TbContext;
-import org.thingsboard.rule.engine.api.TbNode;
 import org.thingsboard.rule.engine.api.TbNodeConfiguration;
 import org.thingsboard.rule.engine.api.TbNodeException;
 import org.thingsboard.rule.engine.api.TbVersionedNode;
@@ -66,7 +65,7 @@ import static org.thingsboard.server.common.data.msg.TbMsgType.POST_ATTRIBUTES_R
         configDirective = "tbActionNodeAttributesConfig",
         icon = "file_upload"
 )
-public class TbMsgAttributesNode implements TbNode, TbVersionedNode {
+public class TbMsgAttributesNode implements TbVersionedNode {
 
     static final String UPDATE_ATTRIBUTES_ONLY_ON_VALUE_CHANGE_KEY = "updateAttributesOnlyOnValueChange";
     private TbMsgAttributesNodeConfiguration config;

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfiguration.java
@@ -26,7 +26,7 @@ public class TbMsgAttributesNodeConfiguration implements NodeConfiguration<TbMsg
 
     private Boolean notifyDevice;
     private boolean sendAttributesUpdatedNotification;
-    private boolean updateAttributesOnValueChange;
+    private boolean updateAttributesOnlyOnValueChange;
 
     @Override
     public TbMsgAttributesNodeConfiguration defaultConfiguration() {
@@ -35,7 +35,7 @@ public class TbMsgAttributesNodeConfiguration implements NodeConfiguration<TbMsg
         configuration.setNotifyDevice(false);
         configuration.setSendAttributesUpdatedNotification(false);
         //Since version 1. For an existing rule nodes for version 0. See the TbVersionedNode implementation
-        configuration.setUpdateAttributesOnValueChange(true);
+        configuration.setUpdateAttributesOnlyOnValueChange(true);
         return configuration;
     }
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfiguration.java
@@ -34,8 +34,8 @@ public class TbMsgAttributesNodeConfiguration implements NodeConfiguration<TbMsg
         configuration.setScope(DataConstants.SERVER_SCOPE);
         configuration.setNotifyDevice(false);
         configuration.setSendAttributesUpdatedNotification(false);
-        // backward compatibility for existing tenants, but rule chain templates will have the true value for new tenants
-        configuration.setUpdateAttributesOnValueChange(false);
+        //Since version 1. For an existing rule nodes for version 0. See the TbVersionedNode implementation
+        configuration.setUpdateAttributesOnValueChange(true);
         return configuration;
     }
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfiguration.java
@@ -34,6 +34,7 @@ public class TbMsgAttributesNodeConfiguration implements NodeConfiguration<TbMsg
         configuration.setScope(DataConstants.SERVER_SCOPE);
         configuration.setNotifyDevice(false);
         configuration.setSendAttributesUpdatedNotification(false);
+        // backward compatibility for existing tenants, but rule chain templates will have the true value for new tenants
         configuration.setUpdateAttributesOnValueChange(false);
         return configuration;
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfiguration.java
@@ -26,6 +26,7 @@ public class TbMsgAttributesNodeConfiguration implements NodeConfiguration<TbMsg
 
     private Boolean notifyDevice;
     private boolean sendAttributesUpdatedNotification;
+    private boolean updateAttributesOnValueChange;
 
     @Override
     public TbMsgAttributesNodeConfiguration defaultConfiguration() {
@@ -33,6 +34,7 @@ public class TbMsgAttributesNodeConfiguration implements NodeConfiguration<TbMsg
         configuration.setScope(DataConstants.SERVER_SCOPE);
         configuration.setNotifyDevice(false);
         configuration.setSendAttributesUpdatedNotification(false);
+        configuration.setUpdateAttributesOnValueChange(false);
         return configuration;
     }
 }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfigurationTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfigurationTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.telemetry;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TbMsgAttributesNodeConfigurationTest {
+
+    @Test
+    void testDefaultConfig_givenUpdateAttributesOnValueChange_thenTrue_sinceVersion1() {
+        assertThat(new TbMsgAttributesNodeConfiguration().defaultConfiguration().isUpdateAttributesOnValueChange()).isTrue();
+    }
+
+}

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfigurationTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeConfigurationTest.java
@@ -22,8 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TbMsgAttributesNodeConfigurationTest {
 
     @Test
-    void testDefaultConfig_givenUpdateAttributesOnValueChange_thenTrue_sinceVersion1() {
-        assertThat(new TbMsgAttributesNodeConfiguration().defaultConfiguration().isUpdateAttributesOnValueChange()).isTrue();
+    void testDefaultConfig_givenupdateAttributesOnlyOnValueChange_thenTrue_sinceVersion1() {
+        assertThat(new TbMsgAttributesNodeConfiguration().defaultConfiguration().isUpdateAttributesOnlyOnValueChange()).isTrue();
     }
 
 }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeTest.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.telemetry;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.rule.engine.api.TbNodeException;
+import org.thingsboard.server.common.data.util.TbPair;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.willCallRealMethod;
+import static org.mockito.Mockito.mock;
+
+@Slf4j
+class TbMsgAttributesNodeTest {
+
+    @Test
+    void testUpgrade_fromVersion0() throws TbNodeException {
+        final String updateAttributesOnValueChangeKey = "updateAttributesOnValueChange";
+        TbMsgAttributesNode node = mock(TbMsgAttributesNode.class);
+        willCallRealMethod().given(node).upgrade(anyInt(), any());
+
+        ObjectNode jsonNode = (ObjectNode) JacksonUtil.valueToTree(new TbMsgAttributesNodeConfiguration().defaultConfiguration());
+        jsonNode.remove(updateAttributesOnValueChangeKey);
+        assertThat(jsonNode.has(updateAttributesOnValueChangeKey)).as("pre condition has no " + updateAttributesOnValueChangeKey).isFalse();
+
+        TbPair<Boolean, JsonNode> upgradeResult = node.upgrade(0, jsonNode);
+
+        ObjectNode resultNode = (ObjectNode) upgradeResult.getSecond();
+        assertThat(upgradeResult.getFirst()).as("upgrade result has changes").isTrue();
+        assertThat(resultNode.has(updateAttributesOnValueChangeKey)).as("upgrade result has key " + updateAttributesOnValueChangeKey).isTrue();
+        assertThat(resultNode.get(updateAttributesOnValueChangeKey).asBoolean()).as("upgrade result value [false] for key " + updateAttributesOnValueChangeKey).isFalse();
+    }
+
+    @Test
+    void testUpgrade_fromVersion0_alreadyHasUpdateAttributesOnValueChange() throws TbNodeException {
+        final String updateAttributesOnValueChangeKey = "updateAttributesOnValueChange";
+        TbMsgAttributesNode node = mock(TbMsgAttributesNode.class);
+        willCallRealMethod().given(node).upgrade(anyInt(), any());
+
+        ObjectNode jsonNode = (ObjectNode) JacksonUtil.valueToTree(new TbMsgAttributesNodeConfiguration().defaultConfiguration());
+        jsonNode.remove(updateAttributesOnValueChangeKey);
+        jsonNode.put(updateAttributesOnValueChangeKey, true);
+        assertThat(jsonNode.has(updateAttributesOnValueChangeKey)).as("pre condition has no " + updateAttributesOnValueChangeKey).isTrue();
+        assertThat(jsonNode.get(updateAttributesOnValueChangeKey).asBoolean()).as("pre condition has [true] for key " + updateAttributesOnValueChangeKey).isTrue();
+
+        TbPair<Boolean, JsonNode> upgradeResult = node.upgrade(0, jsonNode);
+
+        ObjectNode resultNode = (ObjectNode) upgradeResult.getSecond();
+        assertThat(upgradeResult.getFirst()).as("upgrade result has changes").isFalse();
+        assertThat(resultNode.has(updateAttributesOnValueChangeKey)).as("upgrade result has key " + updateAttributesOnValueChangeKey).isTrue();
+        assertThat(resultNode.get(updateAttributesOnValueChangeKey).asBoolean()).as("upgrade result value [true] for key " + updateAttributesOnValueChangeKey).isTrue();
+    }
+
+}

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNodeTest.java
@@ -32,42 +32,43 @@ import static org.mockito.Mockito.mock;
 @Slf4j
 class TbMsgAttributesNodeTest {
 
+    final String updateAttributesOnlyOnValueChangeKey = "updateAttributesOnlyOnValueChange";
+
     @Test
     void testUpgrade_fromVersion0() throws TbNodeException {
-        final String updateAttributesOnValueChangeKey = "updateAttributesOnValueChange";
+
         TbMsgAttributesNode node = mock(TbMsgAttributesNode.class);
         willCallRealMethod().given(node).upgrade(anyInt(), any());
 
         ObjectNode jsonNode = (ObjectNode) JacksonUtil.valueToTree(new TbMsgAttributesNodeConfiguration().defaultConfiguration());
-        jsonNode.remove(updateAttributesOnValueChangeKey);
-        assertThat(jsonNode.has(updateAttributesOnValueChangeKey)).as("pre condition has no " + updateAttributesOnValueChangeKey).isFalse();
+        jsonNode.remove(updateAttributesOnlyOnValueChangeKey);
+        assertThat(jsonNode.has(updateAttributesOnlyOnValueChangeKey)).as("pre condition has no " + updateAttributesOnlyOnValueChangeKey).isFalse();
 
         TbPair<Boolean, JsonNode> upgradeResult = node.upgrade(0, jsonNode);
 
         ObjectNode resultNode = (ObjectNode) upgradeResult.getSecond();
         assertThat(upgradeResult.getFirst()).as("upgrade result has changes").isTrue();
-        assertThat(resultNode.has(updateAttributesOnValueChangeKey)).as("upgrade result has key " + updateAttributesOnValueChangeKey).isTrue();
-        assertThat(resultNode.get(updateAttributesOnValueChangeKey).asBoolean()).as("upgrade result value [false] for key " + updateAttributesOnValueChangeKey).isFalse();
+        assertThat(resultNode.has(updateAttributesOnlyOnValueChangeKey)).as("upgrade result has key " + updateAttributesOnlyOnValueChangeKey).isTrue();
+        assertThat(resultNode.get(updateAttributesOnlyOnValueChangeKey).asBoolean()).as("upgrade result value [false] for key " + updateAttributesOnlyOnValueChangeKey).isFalse();
     }
 
     @Test
-    void testUpgrade_fromVersion0_alreadyHasUpdateAttributesOnValueChange() throws TbNodeException {
-        final String updateAttributesOnValueChangeKey = "updateAttributesOnValueChange";
+    void testUpgrade_fromVersion0_alreadyHasupdateAttributesOnlyOnValueChange() throws TbNodeException {
         TbMsgAttributesNode node = mock(TbMsgAttributesNode.class);
         willCallRealMethod().given(node).upgrade(anyInt(), any());
 
         ObjectNode jsonNode = (ObjectNode) JacksonUtil.valueToTree(new TbMsgAttributesNodeConfiguration().defaultConfiguration());
-        jsonNode.remove(updateAttributesOnValueChangeKey);
-        jsonNode.put(updateAttributesOnValueChangeKey, true);
-        assertThat(jsonNode.has(updateAttributesOnValueChangeKey)).as("pre condition has no " + updateAttributesOnValueChangeKey).isTrue();
-        assertThat(jsonNode.get(updateAttributesOnValueChangeKey).asBoolean()).as("pre condition has [true] for key " + updateAttributesOnValueChangeKey).isTrue();
+        jsonNode.remove(updateAttributesOnlyOnValueChangeKey);
+        jsonNode.put(updateAttributesOnlyOnValueChangeKey, true);
+        assertThat(jsonNode.has(updateAttributesOnlyOnValueChangeKey)).as("pre condition has no " + updateAttributesOnlyOnValueChangeKey).isTrue();
+        assertThat(jsonNode.get(updateAttributesOnlyOnValueChangeKey).asBoolean()).as("pre condition has [true] for key " + updateAttributesOnlyOnValueChangeKey).isTrue();
 
         TbPair<Boolean, JsonNode> upgradeResult = node.upgrade(0, jsonNode);
 
         ObjectNode resultNode = (ObjectNode) upgradeResult.getSecond();
         assertThat(upgradeResult.getFirst()).as("upgrade result has changes").isFalse();
-        assertThat(resultNode.has(updateAttributesOnValueChangeKey)).as("upgrade result has key " + updateAttributesOnValueChangeKey).isTrue();
-        assertThat(resultNode.get(updateAttributesOnValueChangeKey).asBoolean()).as("upgrade result value [true] for key " + updateAttributesOnValueChangeKey).isTrue();
+        assertThat(resultNode.has(updateAttributesOnlyOnValueChangeKey)).as("upgrade result has key " + updateAttributesOnlyOnValueChangeKey).isTrue();
+        assertThat(resultNode.get(updateAttributesOnlyOnValueChangeKey).asBoolean()).as("upgrade result value [true] for key " + updateAttributesOnlyOnValueChangeKey).isTrue();
     }
 
 }


### PR DESCRIPTION
## 'Update on value change' for save attributes rule node feature

### ⚡ HighLoad ⚡ Performace feature

Will check the cache before node attribute save.

There is **no thread-safe** or transactivity (same as before). If you need **sequential** (happen-before) guarantees  - the SequentialByOriginator is the right choice.

The only difference user will experience: are **no update of the timestamp** of the attribute (extremely rare usage by users) and **no attr changes notification** as well if no update happens.

**Backward compatibility** for existing tenants, but **rule chain templates** will have the true value for **new tenants**

**UI** by @volodymyr-babak : https://github.com/thingsboard/thingsboard-rule-config-ui-ngx/pull/128

My concern is that UI have default value "false" when I create a new node. And I can not make default config true

![image](https://github.com/thingsboard/thingsboard/assets/79898499/94a1bdcd-b53a-41a0-8e55-8876cb0bae49)

![image](https://github.com/thingsboard/thingsboard/assets/79898499/1eda8d8e-c199-497e-8ca5-42d7107d40da)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



