### PR TITLE
Fixed showing exit dialog twice on dashboard page

### DIFF
--- a/ui-ngx/src/app/modules/home/components/dashboard-page/dashboard-page.component.ts
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/dashboard-page.component.ts
@@ -161,12 +161,14 @@ import { HasDirtyFlag } from '@core/guards/confirm-on-exit.guard';
 })
 export class DashboardPageComponent extends PageComponent implements IDashboardController, HasDirtyFlag, OnInit, AfterViewInit, OnDestroy {
 
+  private forcePristine = true;
+
   get isDirty(): boolean {
-    return this.isEdit;
+    return this.isEdit && this.forcePristine;
   }
 
   set isDirty(value: boolean) {
-
+    this.forcePristine = value;
   }
 
   authState: AuthState = getCurrentAuthState(this.store);

--- a/ui-ngx/src/app/modules/home/components/dashboard-page/dashboard-page.component.ts
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/dashboard-page.component.ts
@@ -161,14 +161,14 @@ import { HasDirtyFlag } from '@core/guards/confirm-on-exit.guard';
 })
 export class DashboardPageComponent extends PageComponent implements IDashboardController, HasDirtyFlag, OnInit, AfterViewInit, OnDestroy {
 
-  private forcePristine = true;
+  private forcePristine = false;
 
   get isDirty(): boolean {
-    return this.isEdit && this.forcePristine;
+    return this.isEdit && !this.forcePristine;
   }
 
   set isDirty(value: boolean) {
-    this.forcePristine = value;
+    this.forcePristine = !value;
   }
 
   authState: AuthState = getCurrentAuthState(this.store);


### PR DESCRIPTION
## Pull Request description

Steps to reproduce:
1. Login as a tenant user
2. Open any dashboard 
3. Enable edit mode
4. Click Add widget
5. Choose any widget but do not confirm adding
6. Click close (“X“) of pop-up window (of widget)
7. Try to follow to another menu item 
Occur twice  'Unsaved changes' window

After fix: 'Unsaved changes' window shows one time.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


