### PR TITLE
Fix for 'remove other entities' popover in version control

### DIFF
--- a/ui-ngx/src/app/modules/home/components/vc/entity-types-version-load.component.ts
+++ b/ui-ngx/src/app/modules/home/components/vc/entity-types-version-load.component.ts
@@ -218,7 +218,7 @@ export class EntityTypesVersionLoadComponent extends PageComponent implements On
   onRemoveOtherEntities(removeOtherEntitiesCheckbox: MatCheckbox, entityTypeControl: AbstractControl) {
     const removeOtherEntities: boolean = entityTypeControl.get('config.removeOtherEntities').value;
     if (removeOtherEntities) {
-      entityTypeControl.get('config').get('removeOtherEntities').patchValue(false, {emitEvent: false});
+      entityTypeControl.get('config').get('removeOtherEntities').patchValue(false, {emitEvent: true});
       const trigger = $('.mdc-checkbox__background', removeOtherEntitiesCheckbox._elementRef.nativeElement)[0];
       if (this.popoverService.hasPopover(trigger)) {
         this.popoverService.hidePopover(trigger);


### PR DESCRIPTION
Bug: on restoring of entities version if choose 'remove other entities' checkbox and cancel displayed popover, other entities are removed anyway.

**BEFORE**:
![Screenshot from 2023-08-23 18-38-33](https://github.com/thingsboard/thingsboard/assets/87172504/abb0cb68-d118-41d5-b4bc-ece5928d3466)
![Screenshot from 2023-08-23 18-39-18](https://github.com/thingsboard/thingsboard/assets/87172504/af51c57f-b62e-4148-adb6-92712b8f4eff)
![Screenshot from 2023-08-23 18-39-36](https://github.com/thingsboard/thingsboard/assets/87172504/3c74f7c2-53a5-420a-b000-53f074b790bb)


**AFTER**
![Screenshot from 2023-08-23 18-39-18](https://github.com/thingsboard/thingsboard/assets/87172504/8776c91f-20f9-48f9-bd14-ce647a399d24)
![Screenshot from 2023-08-23 18-41-16](https://github.com/thingsboard/thingsboard/assets/87172504/703a3eff-b8d7-4a9c-bea6-be5eec7d679d)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



