### PR TITLE
MathNode: tellFailure and process the next message in the queue in case we are the last consumer

### DIFF
--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/math/TbMathNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/math/TbMathNodeTest.java
@@ -17,6 +17,8 @@ package org.thingsboard.rule.engine.math;
 
 import com.google.common.util.concurrent.Futures;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Triple;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,10 +65,13 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -122,7 +127,15 @@ public class TbMathNodeTest {
         return initNode(TbRuleNodeMathFunctionType.CUSTOM, expression, result, arguments);
     }
 
+    private TbMathNode initNodeWithCustomFunction(TbContext ctx, String expression, TbMathResult result, TbMathArgument... arguments) {
+        return initNode(ctx, TbRuleNodeMathFunctionType.CUSTOM, expression, result, arguments);
+    }
+
     private TbMathNode initNode(TbRuleNodeMathFunctionType operation, String expression, TbMathResult result, TbMathArgument... arguments) {
+        return initNode(this.ctx, operation, expression, result, arguments);
+    }
+
+    private TbMathNode initNode(TbContext ctx, TbRuleNodeMathFunctionType operation, String expression, TbMathResult result, TbMathArgument... arguments) {
         try {
             TbMathNodeConfiguration configuration = new TbMathNodeConfiguration();
             configuration.setOperation(operation);
@@ -630,6 +643,65 @@ public class TbMathNodeTest {
         verify(ctx, new Timeout(TimeUnit.SECONDS.toMillis(5), times(slowMsgList.size()))).tellFailure(any(), any());
         verify(ctx, never()).tellSuccess(any());
 
+    }
+
+    @Test
+    public void testExp4j_concurrentBySingleOriginator_SingleMsg_manyNodesWithDifferentOutput() {
+        assertThat(RULE_DISPATCHER_POOL_SIZE).as("dispatcher pool size have to be > 1").isGreaterThan(1);
+        CountDownLatch processingLatch = new CountDownLatch(1);
+        List<Triple<TbContext, String, TbMathNode>> ctxNodes = IntStream.range(0, RULE_DISPATCHER_POOL_SIZE * 2)
+                .mapToObj(x -> {
+                    final TbContext ctx = mock(TbContext.class); // many rule nodes - many contexts
+                    willReturn(tenantId).given(ctx).getTenantId();
+                    willReturn(dbCallbackExecutor).given(ctx).getDbCallbackExecutor();
+                    final String resultKey = "result" + x;
+                    final TbMathNode node = spy(initNodeWithCustomFunction(ctx, "2a+3b",
+                            new TbMathResult(TbMathArgumentType.MESSAGE_METADATA, resultKey, 1, false, true, null),
+                            new TbMathArgument(TbMathArgumentType.MESSAGE_BODY, "a"),
+                            new TbMathArgument(TbMathArgumentType.MESSAGE_BODY, "b")));
+                    willAnswer(invocation -> {
+                        if (processingLatch.getCount() > 0) {
+                            log.debug("Await on processingLatch before processMsgAsync");
+                            try {
+                                assertThat(processingLatch.await(30, TimeUnit.SECONDS)).as("await on processingLatch").isTrue();
+                            } catch (InterruptedException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                        log.debug("\uD83D\uDC0C processMsgAsync on node with expected resultKey [{}]", resultKey);
+                        return invocation.callRealMethod();
+                    }).given(node).processMsgAsync(any(), any());
+                    willAnswer(invocation -> {
+                        TbMsg msg = invocation.getArgument(1);
+                        log.debug("submit originator onMsg [{}][{}]", msg.getOriginator(), msg);
+                        return invocation.callRealMethod();
+                    }).given(node).onMsg(any(), any());
+                    return Triple.of(ctx, resultKey, node);
+                })
+                .collect(Collectors.toList());
+
+        final TbMsg msg = TbMsg.newMsg("POST_TELEMETRY_REQUEST", originator, new TbMsgMetaData(), JacksonUtil.newObjectNode().put("a", 2).put("b", 2).toString());
+
+        ctxNodes.forEach(ctxNode -> ruleEngineDispatcherExecutor.executeAsync(() -> ctxNode.getRight().onMsg(ctxNode.getLeft(), msg)));
+        ctxNodes.forEach(ctxNode -> verify(ctxNode.getRight(), timeout(5000)).onMsg(eq(ctxNode.getLeft()), any()));
+        processingLatch.countDown();
+
+        SoftAssertions softly = new SoftAssertions();
+        ctxNodes.forEach(ctxNode -> {
+            final TbContext ctx = ctxNode.getLeft();
+            final String resultKey = ctxNode.getMiddle();
+            ArgumentCaptor<TbMsg> msgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+            verify(ctx, timeout(5000)).tellSuccess(msgCaptor.capture());
+
+            TbMsg resultMsg = msgCaptor.getValue();
+            assertThat(resultMsg).as("result msg non null for result key " + resultKey).isNotNull();
+            log.debug("asserting result key [{}] in metadata [{}]", resultKey, resultMsg.getMetaData().getData());
+            softly.assertThat(resultMsg.getMetaData().getValue(resultKey)).as("asserting result key " + resultKey)
+                    .isEqualTo("10.0");
+        });
+
+        softly.assertAll();
+        verify(ctx, never()).tellFailure(any(), any());
     }
 
     static class RuleDispatcherExecutor extends AbstractListeningExecutor {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/math/TbMathNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/math/TbMathNodeTest.java
@@ -57,7 +57,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -490,10 +489,11 @@ public class TbMathNodeTest {
                 new TbMathArgument(TbMathArgumentType.MESSAGE_BODY, "TestKey")
         );
         TbMsg msg = TbMsg.newMsg("TEST", originator, new TbMsgMetaData(), JacksonUtil.newObjectNode().put("a", 10).toString());
-        Throwable thrown = assertThrows(RuntimeException.class, () -> {
-            node.onMsg(ctx, msg);
-        });
-        Assert.assertNotNull(thrown.getMessage());
+        node.onMsg(ctx, msg);
+
+        ArgumentCaptor<Throwable> tCaptor = ArgumentCaptor.forClass(Throwable.class);
+        Mockito.verify(ctx, Mockito.timeout(5000)).tellFailure(eq(msg), tCaptor.capture());
+        Assert.assertNotNull(tCaptor.getValue().getMessage());
     }
 
     @Test
@@ -504,10 +504,11 @@ public class TbMathNodeTest {
         );
 
         TbMsg msg = TbMsg.newMsg("TEST", originator, new TbMsgMetaData(), "[]");
-        Throwable thrown = assertThrows(RuntimeException.class, () -> {
-            node.onMsg(ctx, msg);
-        });
-        Assert.assertNotNull(thrown.getMessage());
+        node.onMsg(ctx, msg);
+
+        ArgumentCaptor<Throwable> tCaptor = ArgumentCaptor.forClass(Throwable.class);
+        Mockito.verify(ctx, Mockito.timeout(5000)).tellFailure(eq(msg), tCaptor.capture());
+        Assert.assertNotNull(tCaptor.getValue().getMessage());
     }
 
     @Test

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/math/TbMathNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/math/TbMathNodeTest.java
@@ -678,10 +678,8 @@ public class TbMathNodeTest {
                     return Triple.of(ctx, resultKey, node);
                 })
                 .collect(Collectors.toList());
-
-        final TbMsg msg = TbMsg.newMsg("POST_TELEMETRY_REQUEST", originator, new TbMsgMetaData(), JacksonUtil.newObjectNode().put("a", 2).put("b", 2).toString());
-
-        ctxNodes.forEach(ctxNode -> ruleEngineDispatcherExecutor.executeAsync(() -> ctxNode.getRight().onMsg(ctxNode.getLeft(), msg)));
+        ctxNodes.forEach(ctxNode -> ruleEngineDispatcherExecutor.executeAsync(() -> ctxNode.getRight()
+                .onMsg(ctxNode.getLeft(), TbMsg.newMsg("POST_TELEMETRY_REQUEST", originator, new TbMsgMetaData(), "{\"a\":2,\"b\":2}"))));
         ctxNodes.forEach(ctxNode -> verify(ctxNode.getRight(), timeout(5000)).onMsg(eq(ctxNode.getLeft()), any()));
         processingLatch.countDown();
 

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/math/TbMathNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/math/TbMathNodeTest.java
@@ -652,7 +652,6 @@ public class TbMathNodeTest {
         List<Triple<TbContext, String, TbMathNode>> ctxNodes = IntStream.range(0, RULE_DISPATCHER_POOL_SIZE * 2)
                 .mapToObj(x -> {
                     final TbContext ctx = mock(TbContext.class); // many rule nodes - many contexts
-                    willReturn(tenantId).given(ctx).getTenantId();
                     willReturn(dbCallbackExecutor).given(ctx).getDbCallbackExecutor();
                     final String resultKey = "result" + x;
                     final TbMathNode node = spy(initNodeWithCustomFunction(ctx, "2a+3b",


### PR DESCRIPTION
## MathNode: tellFailure and process the next message in the queue in case we are the last consumer

Before this PR, the math node throws an exception instead of tellFailure.

In the case of two parallel math nodes with different parameters, but with the same input, the exception might leave message unprocessed in the msg queue

On the user level it will look like timeout to process with last rule node 'math node'

Test added to reproduce the issue
![image](https://github.com/thingsboard/thingsboard/assets/79898499/c52cc41b-3c52-45bd-b7d0-07f866c3a028)

The fixed version looks fine. All failed messages got the tellFailure response with no timeout
![image](https://github.com/thingsboard/thingsboard/assets/79898499/051bafcb-d873-4e88-80e4-e0a344e3f7f3)

Two tests that expected exceptions are also refactored
![image](https://github.com/thingsboard/thingsboard/assets/79898499/b47b1757-2745-4bec-93bf-0d4f90a0e36f)
after the fix
![image](https://github.com/thingsboard/thingsboard/assets/79898499/779c7e4d-1a2a-468c-a5bf-2c5cf5f3c6ad)


## Second fix concurrentBySingleOriginator_SingleMsg_manyNodesWithDifferentOutput

The new test failed because processing had to run in the right rule node instance. 
Adding the Supplier function in the queue object will resolve the issue.

![image](https://github.com/thingsboard/thingsboard/assets/79898499/d9f18ff5-169d-4e5e-bcc8-5799e4024b6c)

![image](https://github.com/thingsboard/thingsboard/assets/79898499/5c130584-1e0e-4d96-a346-f04c08fe9628)

The node fixed: call processMsgAsync via BiFunction this::processMsgAsync

![image](https://github.com/thingsboard/thingsboard/assets/79898499/5ec74a53-38e8-469e-8e3b-09b33e6c8d79)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



