### PR TITLE
Restore option to hide clear button for image input

### DIFF
--- a/ui-ngx/src/app/shared/components/image-input.component.html
+++ b/ui-ngx/src/app/shared/components/image-input.component.html
@@ -25,7 +25,7 @@
           <div class="tb-image-preview-text" *ngIf="!safeImageUrl && disabled; else elseBlock">{{ 'dashboard.empty-image' | translate }}</div>
           <ng-template #elseBlock><img class="tb-image-preview" [src]="safeImageUrl" /></ng-template>
         </div>
-        <button *ngIf="safeImageUrl && !disabled"
+        <button *ngIf="safeImageUrl && showClearButton && !disabled"
                 mat-icon-button color="primary"
                 class="tb-mat-24"
                 type="button"
@@ -52,7 +52,7 @@
           </div>
         </div>
       </div>
-      <button *ngIf="!showPreview && safeImageUrl && !disabled"
+      <button *ngIf="!showPreview && safeImageUrl && showClearButton && !disabled"
               mat-icon-button color="primary"
               class="tb-mat-24"
               type="button"

--- a/ui-ngx/src/app/shared/components/image-input.component.ts
+++ b/ui-ngx/src/app/shared/components/image-input.component.ts
@@ -66,6 +66,9 @@ export class ImageInputComponent extends PageComponent implements AfterViewInit,
   disabled: boolean;
 
   @Input()
+  showClearButton = true;
+
+  @Input()
   showPreview = true;
 
   @Input()


### PR DESCRIPTION
## Pull Request description

Restoring an option to hide the clear button for image input

Before:
![image](https://github.com/thingsboard/thingsboard/assets/17936317/de3b7884-0963-4098-a84b-a70f0ab88abc)


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



