### PR TITLE
fixed get customer alarms after entity change owner

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/AlarmController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/AlarmController.java
@@ -284,7 +284,11 @@ public class AlarmController extends BaseController {
         }
         TimePageLink pageLink = createTimePageLink(pageSize, page, textSearch, sortProperty, sortOrder, startTime, endTime);
 
-        return checkNotNull(alarmService.findAlarms(getCurrentUser().getTenantId(), new AlarmQuery(entityId, pageLink, alarmSearchStatus, alarmStatus, assigneeUserId, fetchOriginator)).get());
+        if (getCurrentUser().isCustomerUser()) {
+            return checkNotNull(alarmService.findCustomerAlarms(getCurrentUser().getTenantId(), getCurrentUser().getCustomerId(), new AlarmQuery(entityId, pageLink, alarmSearchStatus, alarmStatus, assigneeUserId, fetchOriginator)).get());
+        } else {
+            return checkNotNull(alarmService.findAlarms(getCurrentUser().getTenantId(), new AlarmQuery(entityId, pageLink, alarmSearchStatus, alarmStatus, assigneeUserId, fetchOriginator)).get());
+        }
     }
 
     @ApiOperation(value = "Get All Alarms (getAllAlarms)",
@@ -400,7 +404,11 @@ public class AlarmController extends BaseController {
         }
         TimePageLink pageLink = createTimePageLink(pageSize, page, textSearch, sortProperty, sortOrder, startTime, endTime);
 
-        return checkNotNull(alarmService.findAlarmsV2(getCurrentUser().getTenantId(), new AlarmQueryV2(entityId, pageLink, alarmTypeList, alarmStatusList, alarmSeverityList, assigneeUserId)).get());
+        if (getCurrentUser().isCustomerUser()) {
+            return checkNotNull(alarmService.findCustomerAlarmsV2(getCurrentUser().getTenantId(), getCurrentUser().getCustomerId(), new AlarmQueryV2(entityId, pageLink, alarmTypeList, alarmStatusList, alarmSeverityList, assigneeUserId)).get());
+        } else {
+            return checkNotNull(alarmService.findAlarmsV2(getCurrentUser().getTenantId(), new AlarmQueryV2(entityId, pageLink, alarmTypeList, alarmStatusList, alarmSeverityList, assigneeUserId)).get());
+        }
     }
 
     @ApiOperation(value = "Get All Alarms (getAllAlarmsV2)",

--- a/application/src/main/java/org/thingsboard/server/service/query/DefaultEntityQueryService.java
+++ b/application/src/main/java/org/thingsboard/server/service/query/DefaultEntityQueryService.java
@@ -190,7 +190,7 @@ public class DefaultEntityQueryService implements EntityQueryService {
             for (EntityData entityData : entities.getData()) {
                 entitiesMap.put(entityData.getEntityId(), entityData);
             }
-            PageData<AlarmData> alarms = alarmService.findAlarmDataByQueryForEntities(securityUser.getTenantId(), query, entitiesMap.keySet());
+            PageData<AlarmData> alarms = alarmService.findAlarmDataByQueryForEntities(securityUser.getTenantId(), securityUser.getCustomerId(), query, entitiesMap.keySet());
             for (AlarmData alarmData : alarms.getData()) {
                 EntityId entityId = alarmData.getEntityId();
                 if (entityId != null) {

--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbAlarmDataSubCtx.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbAlarmDataSubCtx.java
@@ -107,7 +107,7 @@ public class TbAlarmDataSubCtx extends TbAbstractDataSubCtx<AlarmDataQuery> {
         AlarmDataUpdate update;
         if (!entitiesMap.isEmpty()) {
             long start = System.currentTimeMillis();
-            PageData<AlarmData> alarms = alarmService.findAlarmDataByQueryForEntities(getTenantId(), query, getOrderedEntityIds());
+            PageData<AlarmData> alarms = alarmService.findAlarmDataByQueryForEntities(getTenantId(), getCustomerId(), query, getOrderedEntityIds());
             long end = System.currentTimeMillis();
             stats.getAlarmQueryInvocationCnt().incrementAndGet();
             stats.getAlarmQueryTimeSpent().addAndGet(end - start);

--- a/application/src/main/java/org/thingsboard/server/service/telemetry/DefaultAlarmSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/telemetry/DefaultAlarmSubscriptionService.java
@@ -206,8 +206,8 @@ public class DefaultAlarmSubscriptionService extends AbstractSubscriptionService
     }
 
     @Override
-    public PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, AlarmDataQuery query, Collection<EntityId> orderedEntityIds) {
-        return alarmService.findAlarmDataByQueryForEntities(tenantId, query, orderedEntityIds);
+    public PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, CustomerId customerId, AlarmDataQuery query, Collection<EntityId> orderedEntityIds) {
+        return alarmService.findAlarmDataByQueryForEntities(tenantId, customerId, query, orderedEntityIds);
     }
 
     @Override

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/alarm/AlarmService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/alarm/AlarmService.java
@@ -115,7 +115,7 @@ public interface AlarmService extends EntityDaoService {
 
     Alarm findLatestActiveByOriginatorAndType(TenantId tenantId, EntityId originator, String type);
 
-    PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId,
+    PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, CustomerId customerId,
                                                         AlarmDataQuery query, Collection<EntityId> orderedEntityIds);
 
     void deleteEntityAlarmRelations(TenantId tenantId, EntityId entityId);

--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/AlarmDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/AlarmDao.java
@@ -71,7 +71,7 @@ public interface AlarmDao extends Dao<Alarm> {
 
     PageData<AlarmInfo> findCustomerAlarmsV2(TenantId tenantId, CustomerId customerId, AlarmQueryV2 query);
 
-    PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, AlarmDataQuery query, Collection<EntityId> orderedEntityIds);
+    PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, CustomerId customerId, AlarmDataQuery query, Collection<EntityId> orderedEntityIds);
 
     Set<AlarmSeverity> findAlarmSeverities(TenantId tenantId, EntityId entityId, AlarmStatusFilter asf, String assigneeId);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
@@ -194,11 +194,11 @@ public class BaseAlarmService extends AbstractEntityService implements AlarmServ
     }
 
     @Override
-    public PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId,
+    public PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, CustomerId customerId,
                                                                AlarmDataQuery query, Collection<EntityId> orderedEntityIds) {
         validateId(tenantId, INCORRECT_TENANT_ID + tenantId);
         validateEntityDataPageLink(query.getPageLink());
-        return alarmDao.findAlarmDataByQueryForEntities(tenantId, query, orderedEntityIds);
+        return alarmDao.findAlarmDataByQueryForEntities(tenantId, customerId, query, orderedEntityIds);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/AlarmRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/AlarmRepository.java
@@ -215,6 +215,52 @@ public interface AlarmRepository extends JpaRepository<AlarmEntity, UUID> {
 
     @Query(value = "SELECT a " +
             "FROM AlarmInfoEntity a " +
+            "LEFT JOIN EntityAlarmEntity ea ON a.id = ea.alarmId " +
+            "WHERE a.tenantId = :tenantId AND a.customerId = :customerId " +
+            "AND ea.tenantId = :tenantId " +
+            "AND ea.entityId = :affectedEntityId " +
+            "AND ea.entityType = :affectedEntityType " +
+            "AND (:startTime IS NULL OR (a.createdTime >= :startTime AND ea.createdTime >= :startTime)) " +
+            "AND (:endTime IS NULL OR (a.createdTime <= :endTime AND ea.createdTime <= :endTime)) " +
+            "AND ((:clearFilterEnabled) IS FALSE OR a.cleared = :clearFilter) " +
+            "AND ((:ackFilterEnabled) IS FALSE OR a.acknowledged = :ackFilter) " +
+            "AND (:assigneeId IS NULL OR a.assigneeId = uuid(:assigneeId)) " +
+            "AND (LOWER(a.type) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
+            "  OR LOWER(a.severity) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
+            "  OR LOWER(a.status) LIKE LOWER(CONCAT('%', :searchText, '%'))) "
+            ,
+            countQuery = "" +
+                    "SELECT count(a) " + //alarms with relations only
+                    "FROM AlarmInfoEntity a " +
+                    "LEFT JOIN EntityAlarmEntity ea ON a.id = ea.alarmId " +
+                    "WHERE a.tenantId = :tenantId AND a.customerId = :customerId " +
+                    "AND ea.tenantId = :tenantId " +
+                    "AND ea.entityId = :affectedEntityId " +
+                    "AND ea.entityType = :affectedEntityType " +
+                    "AND (:startTime IS NULL OR (a.createdTime >= :startTime AND ea.createdTime >= :startTime)) " +
+                    "AND (:endTime IS NULL OR (a.createdTime <= :endTime AND ea.createdTime <= :endTime)) " +
+                    "AND ((:clearFilterEnabled) IS FALSE OR a.cleared = :clearFilter) " +
+                    "AND ((:ackFilterEnabled) IS FALSE OR a.acknowledged = :ackFilter) " +
+                    "AND (:assigneeId IS NULL OR a.assigneeId = uuid(:assigneeId)) " +
+                    "AND (LOWER(a.type) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
+                    "  OR LOWER(a.severity) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
+                    "  OR LOWER(a.status) LIKE LOWER(CONCAT('%', :searchText, '%'))) ")
+    Page<AlarmInfoEntity> findCustomerAlarms(@Param("tenantId") UUID tenantId,
+                                             @Param("customerId") UUID customerId,
+                                             @Param("affectedEntityId") UUID affectedEntityId,
+                                             @Param("affectedEntityType") String affectedEntityType,
+                                             @Param("startTime") Long startTime,
+                                             @Param("endTime") Long endTime,
+                                             @Param("clearFilterEnabled") boolean clearFilterEnabled,
+                                             @Param("clearFilter") boolean clearFilter,
+                                             @Param("ackFilterEnabled") boolean ackFilterEnabled,
+                                             @Param("ackFilter") boolean ackFilter,
+                                             @Param("assigneeId") String assigneeId,
+                                             @Param("searchText") String searchText,
+                                             Pageable pageable);
+
+    @Query(value = "SELECT a " +
+            "FROM AlarmInfoEntity a " +
             "WHERE a.tenantId = :tenantId AND a.customerId = :customerId " +
             "AND (:startTime IS NULL OR a.createdTime >= :startTime) " +
             "AND (:endTime IS NULL OR a.createdTime <= :endTime) " +
@@ -237,17 +283,69 @@ public interface AlarmRepository extends JpaRepository<AlarmEntity, UUID> {
                     "AND (LOWER(a.type) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
                     "  OR LOWER(a.severity) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
                     "  OR LOWER(a.status) LIKE LOWER(CONCAT('%', :searchText, '%'))) ")
-    Page<AlarmInfoEntity> findCustomerAlarms(@Param("tenantId") UUID tenantId,
-                                             @Param("customerId") UUID customerId,
-                                             @Param("startTime") Long startTime,
-                                             @Param("endTime") Long endTime,
-                                             @Param("clearFilterEnabled") boolean clearFilterEnabled,
-                                             @Param("clearFilter") boolean clearFilter,
-                                             @Param("ackFilterEnabled") boolean ackFilterEnabled,
-                                             @Param("ackFilter") boolean ackFilter,
-                                             @Param("assigneeId") String assigneeId,
-                                             @Param("searchText") String searchText,
-                                             Pageable pageable);
+    Page<AlarmInfoEntity> findAllCustomerAlarms(@Param("tenantId") UUID tenantId,
+                                                @Param("customerId") UUID customerId,
+                                                @Param("startTime") Long startTime,
+                                                @Param("endTime") Long endTime,
+                                                @Param("clearFilterEnabled") boolean clearFilterEnabled,
+                                                @Param("clearFilter") boolean clearFilter,
+                                                @Param("ackFilterEnabled") boolean ackFilterEnabled,
+                                                @Param("ackFilter") boolean ackFilter,
+                                                @Param("assigneeId") String assigneeId,
+                                                @Param("searchText") String searchText,
+                                                Pageable pageable);
+
+    @Query(value = "SELECT a " +
+            "FROM AlarmInfoEntity a " +
+            "LEFT JOIN EntityAlarmEntity ea ON a.id = ea.alarmId " +
+            "WHERE a.tenantId = :tenantId AND a.customerId = :customerId " +
+            "AND ea.tenantId = :tenantId " +
+            "AND ea.entityId = :affectedEntityId " +
+            "AND ea.entityType = :affectedEntityType " +
+            "AND (:startTime IS NULL OR (a.createdTime >= :startTime AND ea.createdTime >= :startTime)) " +
+            "AND (:endTime IS NULL OR (a.createdTime <= :endTime AND ea.createdTime <= :endTime)) " +
+            "AND ((:alarmTypes) IS NULL OR a.type IN (:alarmTypes)) " +
+            "AND ((:alarmSeverities) IS NULL OR a.severity IN (:alarmSeverities)) " +
+            "AND ((:clearFilterEnabled) IS FALSE OR a.cleared = :clearFilter) " +
+            "AND ((:ackFilterEnabled) IS FALSE OR a.acknowledged = :ackFilter) " +
+            "AND (:assigneeId IS NULL OR a.assigneeId = uuid(:assigneeId)) " +
+            "AND (LOWER(a.type) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
+            "  OR LOWER(a.severity) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
+            "  OR LOWER(a.status) LIKE LOWER(CONCAT('%', :searchText, '%'))) "
+            ,
+            countQuery = "" +
+                    "SELECT count(a) " + //alarms with relations only
+                    "FROM AlarmInfoEntity a " +
+                    "LEFT JOIN EntityAlarmEntity ea ON a.id = ea.alarmId " +
+                    "WHERE a.tenantId = :tenantId AND a.customerId = :customerId " +
+                    "AND ea.tenantId = :tenantId " +
+                    "AND ea.entityId = :affectedEntityId " +
+                    "AND ea.entityType = :affectedEntityType " +
+                    "AND (:startTime IS NULL OR (a.createdTime >= :startTime AND ea.createdTime >= :startTime)) " +
+                    "AND (:endTime IS NULL OR (a.createdTime <= :endTime AND ea.createdTime <= :endTime)) " +
+                    "AND ((:alarmTypes) IS NULL OR a.type IN (:alarmTypes)) " +
+                    "AND ((:alarmSeverities) IS NULL OR a.severity IN (:alarmSeverities)) " +
+                    "AND ((:clearFilterEnabled) IS FALSE OR a.cleared = :clearFilter) " +
+                    "AND ((:ackFilterEnabled) IS FALSE OR a.acknowledged = :ackFilter) " +
+                    "AND (:assigneeId IS NULL OR a.assigneeId = uuid(:assigneeId)) " +
+                    "AND (LOWER(a.type) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
+                    "  OR LOWER(a.severity) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
+                    "  OR LOWER(a.status) LIKE LOWER(CONCAT('%', :searchText, '%'))) ")
+    Page<AlarmInfoEntity> findCustomerAlarmsV2(@Param("tenantId") UUID tenantId,
+                                               @Param("customerId") UUID customerId,
+                                               @Param("affectedEntityId") UUID affectedEntityId,
+                                               @Param("affectedEntityType") String affectedEntityType,
+                                               @Param("startTime") Long startTime,
+                                               @Param("endTime") Long endTime,
+                                               @Param("alarmTypes") List<String> alarmTypes,
+                                               @Param("alarmSeverities") List<AlarmSeverity> alarmSeverities,
+                                               @Param("clearFilterEnabled") boolean clearFilterEnabled,
+                                               @Param("clearFilter") boolean clearFilter,
+                                               @Param("ackFilterEnabled") boolean ackFilterEnabled,
+                                               @Param("ackFilter") boolean ackFilter,
+                                               @Param("assigneeId") String assigneeId,
+                                               @Param("searchText") String searchText,
+                                               Pageable pageable);
 
     @Query(value = "SELECT a " +
             "FROM AlarmInfoEntity a " +
@@ -277,19 +375,19 @@ public interface AlarmRepository extends JpaRepository<AlarmEntity, UUID> {
                     "AND (LOWER(a.type) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
                     "  OR LOWER(a.severity) LIKE LOWER(CONCAT('%', :searchText, '%')) " +
                     "  OR LOWER(a.status) LIKE LOWER(CONCAT('%', :searchText, '%'))) ")
-    Page<AlarmInfoEntity> findCustomerAlarmsV2(@Param("tenantId") UUID tenantId,
-                                               @Param("customerId") UUID customerId,
-                                               @Param("startTime") Long startTime,
-                                               @Param("endTime") Long endTime,
-                                               @Param("alarmTypes") List<String> alarmTypes,
-                                               @Param("alarmSeverities") List<AlarmSeverity> alarmSeverities,
-                                               @Param("clearFilterEnabled") boolean clearFilterEnabled,
-                                               @Param("clearFilter") boolean clearFilter,
-                                               @Param("ackFilterEnabled") boolean ackFilterEnabled,
-                                               @Param("ackFilter") boolean ackFilter,
-                                               @Param("assigneeId") String assigneeId,
-                                               @Param("searchText") String searchText,
-                                               Pageable pageable);
+    Page<AlarmInfoEntity> findAllCustomerAlarmsV2(@Param("tenantId") UUID tenantId,
+                                                  @Param("customerId") UUID customerId,
+                                                  @Param("startTime") Long startTime,
+                                                  @Param("endTime") Long endTime,
+                                                  @Param("alarmTypes") List<String> alarmTypes,
+                                                  @Param("alarmSeverities") List<AlarmSeverity> alarmSeverities,
+                                                  @Param("clearFilterEnabled") boolean clearFilterEnabled,
+                                                  @Param("clearFilter") boolean clearFilter,
+                                                  @Param("ackFilterEnabled") boolean ackFilterEnabled,
+                                                  @Param("ackFilter") boolean ackFilter,
+                                                  @Param("assigneeId") String assigneeId,
+                                                  @Param("searchText") String searchText,
+                                                  Pageable pageable);
 
     @Query(value = "SELECT a.severity FROM AlarmEntity a " +
             "LEFT JOIN EntityAlarmEntity ea ON a.id = ea.alarmId " +

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/JpaAlarmDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/JpaAlarmDao.java
@@ -175,22 +175,43 @@ public class JpaAlarmDao extends JpaAbstractDao<AlarmEntity, Alarm> implements A
     @Override
     public PageData<AlarmInfo> findCustomerAlarms(TenantId tenantId, CustomerId customerId, AlarmQuery query) {
         log.trace("Try to find customer alarms by status [{}] and pageLink [{}]", query.getStatus(), query.getPageLink());
+        EntityId affectedEntity = query.getAffectedEntityId();
         AlarmStatusFilter asf = AlarmStatusFilter.from(query);
-        return DaoUtil.toPageData(
-                alarmRepository.findCustomerAlarms(
-                        tenantId.getId(),
-                        customerId.getId(),
-                        query.getPageLink().getStartTime(),
-                        query.getPageLink().getEndTime(),
-                        asf.hasClearFilter(),
-                        asf.hasClearFilter() && asf.getClearFilter(),
-                        asf.hasAckFilter(),
-                        asf.hasAckFilter() && asf.getAckFilter(),
-                        DaoUtil.getStringId(query.getAssigneeId()),
-                        Objects.toString(query.getPageLink().getTextSearch(), ""),
-                        DaoUtil.toPageable(query.getPageLink())
-                )
-        );
+        if (affectedEntity != null) {
+            return DaoUtil.toPageData(
+                    alarmRepository.findCustomerAlarms(
+                            tenantId.getId(),
+                            customerId.getId(),
+                            affectedEntity.getId(),
+                            affectedEntity.getEntityType().name(),
+                            query.getPageLink().getStartTime(),
+                            query.getPageLink().getEndTime(),
+                            asf.hasClearFilter(),
+                            asf.hasClearFilter() && asf.getClearFilter(),
+                            asf.hasAckFilter(),
+                            asf.hasAckFilter() && asf.getAckFilter(),
+                            DaoUtil.getStringId(query.getAssigneeId()),
+                            Objects.toString(query.getPageLink().getTextSearch(), ""),
+                            DaoUtil.toPageable(query.getPageLink())
+                    )
+            );
+        } else {
+            return DaoUtil.toPageData(
+                    alarmRepository.findAllCustomerAlarms(
+                            tenantId.getId(),
+                            customerId.getId(),
+                            query.getPageLink().getStartTime(),
+                            query.getPageLink().getEndTime(),
+                            asf.hasClearFilter(),
+                            asf.hasClearFilter() && asf.getClearFilter(),
+                            asf.hasAckFilter(),
+                            asf.hasAckFilter() && asf.getAckFilter(),
+                            DaoUtil.getStringId(query.getAssigneeId()),
+                            Objects.toString(query.getPageLink().getTextSearch(), ""),
+                            DaoUtil.toPageable(query.getPageLink())
+                    )
+            );
+        }
     }
 
     @Override
@@ -242,31 +263,55 @@ public class JpaAlarmDao extends JpaAbstractDao<AlarmEntity, Alarm> implements A
     @Override
     public PageData<AlarmInfo> findCustomerAlarmsV2(TenantId tenantId, CustomerId customerId, AlarmQueryV2 query) {
         log.trace("Try to find customer alarms by query [{}] and pageLink [{}]", query, query.getPageLink());
+        EntityId affectedEntity = query.getAffectedEntityId();
         List<String> typeList = query.getTypeList() != null && !query.getTypeList().isEmpty() ? query.getTypeList() : null;
         List<AlarmSeverity> severityList = query.getSeverityList() != null && !query.getSeverityList().isEmpty() ? query.getSeverityList() : null;
         AlarmStatusFilter asf = AlarmStatusFilter.from(query.getStatusList());
-        return DaoUtil.toPageData(
-                alarmRepository.findCustomerAlarmsV2(
-                        tenantId.getId(),
-                        customerId.getId(),
-                        query.getPageLink().getStartTime(),
-                        query.getPageLink().getEndTime(),
-                        typeList,
-                        severityList,
-                        asf.hasClearFilter(),
-                        asf.hasClearFilter() && asf.getClearFilter(),
-                        asf.hasAckFilter(),
-                        asf.hasAckFilter() && asf.getAckFilter(),
-                        DaoUtil.getStringId(query.getAssigneeId()),
-                        Objects.toString(query.getPageLink().getTextSearch(), ""),
-                        DaoUtil.toPageable(query.getPageLink())
-                )
-        );
+
+        if (affectedEntity != null) {
+            return DaoUtil.toPageData(
+                    alarmRepository.findCustomerAlarmsV2(
+                            tenantId.getId(),
+                            customerId.getId(),
+                            affectedEntity.getId(),
+                            affectedEntity.getEntityType().name(),
+                            query.getPageLink().getStartTime(),
+                            query.getPageLink().getEndTime(),
+                            typeList,
+                            severityList,
+                            asf.hasClearFilter(),
+                            asf.hasClearFilter() && asf.getClearFilter(),
+                            asf.hasAckFilter(),
+                            asf.hasAckFilter() && asf.getAckFilter(),
+                            DaoUtil.getStringId(query.getAssigneeId()),
+                            Objects.toString(query.getPageLink().getTextSearch(), ""),
+                            DaoUtil.toPageable(query.getPageLink())
+                    )
+            );
+        } else {
+            return DaoUtil.toPageData(
+                    alarmRepository.findAllCustomerAlarmsV2(
+                            tenantId.getId(),
+                            customerId.getId(),
+                            query.getPageLink().getStartTime(),
+                            query.getPageLink().getEndTime(),
+                            typeList,
+                            severityList,
+                            asf.hasClearFilter(),
+                            asf.hasClearFilter() && asf.getClearFilter(),
+                            asf.hasAckFilter(),
+                            asf.hasAckFilter() && asf.getAckFilter(),
+                            DaoUtil.getStringId(query.getAssigneeId()),
+                            Objects.toString(query.getPageLink().getTextSearch(), ""),
+                            DaoUtil.toPageable(query.getPageLink())
+                    )
+            );
+        }
     }
 
     @Override
-    public PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, AlarmDataQuery query, Collection<EntityId> orderedEntityIds) {
-        return alarmQueryRepository.findAlarmDataByQueryForEntities(tenantId, query, orderedEntityIds);
+    public PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, CustomerId customerId, AlarmDataQuery query, Collection<EntityId> orderedEntityIds) {
+        return alarmQueryRepository.findAlarmDataByQueryForEntities(tenantId, customerId, query, orderedEntityIds);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/AlarmQueryRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/AlarmQueryRepository.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 
 public interface AlarmQueryRepository {
 
-    PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId,
+    PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, CustomerId customerId,
                                                         AlarmDataQuery query, Collection<EntityId> orderedEntityIds);
 
     long countAlarmsByQuery(TenantId tenantId, CustomerId customerId, AlarmCountQuery query);

--- a/dao/src/test/java/org/thingsboard/server/dao/service/AlarmServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/AlarmServiceTest.java
@@ -382,7 +382,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setAssigneeId(tenantUser.getId());
         pageLink.setSortOrder(new EntityDataSortOrder(new EntityKey(EntityKeyType.ALARM_FIELD, "assignee")));
 
-        PageData<AlarmData> assignedAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(created.getOriginator()));
+        PageData<AlarmData> assignedAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, null, toQuery(pageLink), Collections.singletonList(created.getOriginator()));
         Assert.assertNotNull(assignedAlarms.getData());
         Assert.assertEquals(1, assignedAlarms.getData().size());
         Assert.assertEquals(created, new AlarmInfo(assignedAlarms.getData().get(0)));
@@ -398,7 +398,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
         Assert.assertNotNull(tenantUser2);
         pageLink.setAssigneeId(tenantUser2.getId());
 
-        PageData<AlarmData> assignedToNonExistingUserAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(created.getOriginator()));
+        PageData<AlarmData> assignedToNonExistingUserAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, null, toQuery(pageLink), Collections.singletonList(created.getOriginator()));
         Assert.assertNotNull(assignedToNonExistingUserAlarms.getData());
         Assert.assertTrue(assignedToNonExistingUserAlarms.getData().isEmpty());
 
@@ -454,10 +454,10 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
         pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
 
-        PageData<AlarmData> tenantAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Arrays.asList(tenantDevice.getId(), customerDevice.getId()));
+        PageData<AlarmData> tenantAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, null, toQuery(pageLink), Arrays.asList(tenantDevice.getId(), customerDevice.getId()));
         Assert.assertEquals(2, tenantAlarms.getData().size());
 
-        PageData<AlarmData> customerAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(customerDevice.getId()));
+        PageData<AlarmData> customerAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, customer.getId(), toQuery(pageLink), Collections.singletonList(customerDevice.getId()));
         Assert.assertEquals(1, customerAlarms.getData().size());
         Assert.assertEquals(deviceAlarm, new AlarmInfo(customerAlarms.getData().get(0)));
 
@@ -529,7 +529,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
 
         //TEST that propagated alarms are visible on the asset level.
-        PageData<AlarmData> customerAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(customerAsset.getId()));
+        PageData<AlarmData> customerAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, customer.getId(), toQuery(pageLink), Collections.singletonList(customerAsset.getId()));
         Assert.assertEquals(1, customerAlarms.getData().size());
         Assert.assertEquals(customerAlarm, new AlarmInfo(customerAlarms.getData().get(0)));
     }
@@ -580,12 +580,12 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStatusList(Collections.singletonList(AlarmSearchStatus.ACTIVE));
 
         //TEST that propagated alarms are visible on the asset level.
-        PageData<AlarmData> tenantAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(tenantId));
+        PageData<AlarmData> tenantAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, customer.getId(), toQuery(pageLink), Collections.singletonList(tenantId));
         Assert.assertEquals(1, tenantAlarms.getData().size());
         Assert.assertEquals(tenantAlarm, new AlarmInfo(tenantAlarms.getData().get(0)));
 
         //TEST that propagated alarms are visible on the asset level.
-        PageData<AlarmData> customerAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(customer.getId()));
+        PageData<AlarmData> customerAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, customer.getId(), toQuery(pageLink), Collections.singletonList(customer.getId()));
         Assert.assertEquals(1, customerAlarms.getData().size());
         Assert.assertEquals(customerAlarm, new AlarmInfo(customerAlarms.getData().get(0)));
     }
@@ -682,7 +682,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
         pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
 
-        PageData<AlarmData> alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(childId));
+        PageData<AlarmData> alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, null, toQuery(pageLink), Collections.singletonList(childId));
 
         Assert.assertNotNull(alarms.getData());
         Assert.assertEquals(1, alarms.getData().size());
@@ -698,13 +698,13 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
         pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
 
-        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(childId));
+        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, null, toQuery(pageLink), Collections.singletonList(childId));
         Assert.assertNotNull(alarms.getData());
         Assert.assertEquals(1, alarms.getData().size());
         Assert.assertEquals(created, new AlarmInfo(alarms.getData().get(0)));
 
         pageLink.setSearchPropagatedAlarms(true);
-        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(childId));
+        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, null, toQuery(pageLink), Collections.singletonList(childId));
         Assert.assertNotNull(alarms.getData());
         Assert.assertEquals(1, alarms.getData().size());
         Assert.assertEquals(created, new AlarmInfo(alarms.getData().get(0)));
@@ -725,7 +725,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
         pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
 
-        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(childId));
+        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, null, toQuery(pageLink), Collections.singletonList(childId));
         Assert.assertNotNull(alarms.getData());
         Assert.assertEquals(1, alarms.getData().size());
         Assert.assertEquals(created, new AlarmInfo(alarms.getData().get(0)));
@@ -741,7 +741,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
         pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
 
-        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(parentId));
+        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, null, toQuery(pageLink), Collections.singletonList(parentId));
         Assert.assertNotNull(alarms.getData());
         Assert.assertEquals(1, alarms.getData().size());
         Assert.assertEquals(created, new AlarmInfo(alarms.getData().get(0)));
@@ -789,7 +789,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
         pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
 
-        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(parentId));
+        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, null, toQuery(pageLink), Collections.singletonList(parentId));
         Assert.assertNotNull(alarms.getData());
         Assert.assertEquals(1, alarms.getData().size());
         Assert.assertEquals(created, new AlarmInfo(alarms.getData().get(0)));
@@ -806,7 +806,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
         pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
 
-        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(childId));
+        alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, null, toQuery(pageLink), Collections.singletonList(childId));
         Assert.assertNotNull(alarms.getData());
         Assert.assertEquals(1, alarms.getData().size());
         Assert.assertEquals(created, new AlarmInfo(alarms.getData().get(0)));

--- a/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/RuleEngineAlarmService.java
+++ b/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/RuleEngineAlarmService.java
@@ -109,5 +109,5 @@ public interface RuleEngineAlarmService {
 
     AlarmSeverity findHighestAlarmSeverity(TenantId tenantId, EntityId entityId, AlarmSearchStatus alarmSearchStatus, AlarmStatus alarmStatus, String assigneeId);
 
-    PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, AlarmDataQuery query, Collection<EntityId> orderedEntityIds);
+    PageData<AlarmData> findAlarmDataByQueryForEntities(TenantId tenantId, CustomerId customerId, AlarmDataQuery query, Collection<EntityId> orderedEntityIds);
 }


### PR DESCRIPTION
## Pull Request description

Put your PR description here instead of this sentence.   

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



