### PR TITLE
Fixed doubled error message for missing translate

### DIFF
--- a/ui-ngx/src/app/core/translate/missing-translate-handler.ts
+++ b/ui-ngx/src/app/core/translate/missing-translate-handler.ts
@@ -21,7 +21,7 @@ export class TbMissingTranslationHandler implements MissingTranslationHandler {
   handle(params: MissingTranslationHandlerParams) {
     if (params.key && !params.key.startsWith(customTranslationsPrefix)) {
       console.warn('Translation for \'' + params.key + '\' doesn\'t exist');
+      params.translateService.set(params.key, params.key);
     }
-    params.translateService.set(params.key, params.key);
   }
 }

--- a/ui-ngx/src/app/core/translate/missing-translate-handler.ts
+++ b/ui-ngx/src/app/core/translate/missing-translate-handler.ts
@@ -20,7 +20,8 @@ import { customTranslationsPrefix } from '@app/shared/models/constants';
 export class TbMissingTranslationHandler implements MissingTranslationHandler {
   handle(params: MissingTranslationHandlerParams) {
     if (params.key && !params.key.startsWith(customTranslationsPrefix)) {
-      console.warn('Translation for ' + params.key + ' doesn\'t exist');
+      console.warn('Translation for \'' + params.key + '\' doesn\'t exist');
     }
+    params.translateService.set(params.key, params.key);
   }
 }


### PR DESCRIPTION
## Pull Request description

Fixed: [#9183](https://github.com/thingsboard/thingsboard/issues/9183)

Before fix: we see double or even more console warn of missing translate.
After fix: missign translate show warn in console one time and setting missing key to translate store.
![image](https://github.com/thingsboard/thingsboard/assets/83352633/703468af-a365-43de-88ec-e6224aef57d6)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


