### PR TITLE
Removed default ports from device connectivity commands

### DIFF
--- a/application/src/test/java/org/thingsboard/server/controller/DeviceConnectivityControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/DeviceConnectivityControllerTest.java
@@ -66,7 +66,6 @@ import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.PEM_CERT_FI
 
 @TestPropertySource(properties = {
         "device.connectivity.https.enabled=true",
-        "device.connectivity.https.port=444",
         "device.connectivity.mqtts.enabled=true",
         "device.connectivity.mqtts.port=8888",
         "device.connectivity.mqtts.pem_cert_file=/tmp/" + PEM_CERT_FILE_NAME,
@@ -194,7 +193,7 @@ public class DeviceConnectivityControllerTest extends AbstractControllerTest {
         assertThat(httpCommands.get(HTTP).asText()).isEqualTo(String.format("curl -v -X POST http://localhost:8080/api/v1/%s/telemetry " +
                         "--header Content-Type:application/json --data \"{temperature:25}\"",
                 credentials.getCredentialsId()));
-        assertThat(httpCommands.get(HTTPS).asText()).isEqualTo(String.format("curl -v -X POST https://localhost:444/api/v1/%s/telemetry " +
+        assertThat(httpCommands.get(HTTPS).asText()).isEqualTo(String.format("curl -v -X POST https://localhost/api/v1/%s/telemetry " +
                         "--header Content-Type:application/json --data \"{temperature:25}\"",
                 credentials.getCredentialsId()));
 

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceConnectivityServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceConnectivityServiceImpl.java
@@ -67,6 +67,13 @@ public class DeviceConnectivityServiceImpl implements DeviceConnectivityService 
     public static final String INCORRECT_TENANT_ID = "Incorrect tenantId ";
     public static final String INCORRECT_DEVICE_ID = "Incorrect deviceId ";
     public static final String DEFAULT_DEVICE_TELEMETRY_TOPIC = "v1/devices/me/telemetry";
+    public static final String HTTP_DEFAULT_PORT = "80";
+    public static final String HTTPS_DEFAULT_PORT = "443";
+    public static final String MQTT_DEFAULT_PORT = "1883";
+    public static final String MQTTS_DEFAULT_PORT = "8883";
+    public static final String COAP_DEFAULT_PORT = "5683";
+    public static final String COAPS_DEFAULT_PORT = "5684";
+
 
     private final Map<String, Resource> certs = new ConcurrentHashMap<>();
 
@@ -203,7 +210,8 @@ public class DeviceConnectivityServiceImpl implements DeviceConnectivityService 
             return null;
         }
         String hostName = getHost(baseUrl, properties);
-        String port = properties.getPort().isEmpty() ? "" : ":" + properties.getPort();
+        String propertyPort = properties.getPort();
+        String port = (propertyPort.isEmpty() || HTTP_DEFAULT_PORT.equals(propertyPort) || HTTPS_DEFAULT_PORT.equals(propertyPort)) ? "" : ":" + propertyPort;
 
         return DeviceConnectivityUtil.getHttpPublishCommand(protocol, hostName, port, deviceCredentials);
     }
@@ -250,14 +258,16 @@ public class DeviceConnectivityServiceImpl implements DeviceConnectivityService 
     private String getMqttPublishCommand(String baseUrl, String deviceTelemetryTopic, DeviceCredentials deviceCredentials) throws URISyntaxException {
         DeviceConnectivityInfo properties = deviceConnectivityConfiguration.getConnectivity(MQTT);
         String mqttHost = getHost(baseUrl, properties);
-        String mqttPort = properties.getPort().isEmpty() ? null : properties.getPort();
+        String propertyPort = properties.getPort();
+        String mqttPort = (propertyPort.isEmpty() || MQTT_DEFAULT_PORT.equals(propertyPort)) ? null : properties.getPort();
         return DeviceConnectivityUtil.getMqttPublishCommand(MQTT, mqttHost, mqttPort, deviceTelemetryTopic, deviceCredentials);
     }
 
     private List<String> getMqttsPublishCommand(String baseUrl, String deviceTelemetryTopic, DeviceCredentials deviceCredentials) throws URISyntaxException {
         DeviceConnectivityInfo properties = deviceConnectivityConfiguration.getConnectivity(MQTTS);
         String mqttHost = getHost(baseUrl, properties);
-        String mqttPort = properties.getPort().isEmpty() ? null : properties.getPort();
+        String propertyPort = properties.getPort();
+        String mqttPort = (propertyPort.isEmpty() || MQTTS_DEFAULT_PORT.equals(propertyPort)) ? null : properties.getPort();
         String pubCommand = DeviceConnectivityUtil.getMqttPublishCommand(MQTTS, mqttHost, mqttPort, deviceTelemetryTopic, deviceCredentials);
 
         ArrayList<String> commands = new ArrayList<>();
@@ -272,7 +282,8 @@ public class DeviceConnectivityServiceImpl implements DeviceConnectivityService 
     private String getDockerMqttPublishCommand(String protocol, String baseUrl, String deviceTelemetryTopic, DeviceCredentials deviceCredentials) throws URISyntaxException {
         DeviceConnectivityInfo properties = deviceConnectivityConfiguration.getConnectivity(protocol);
         String mqttHost = getHost(baseUrl, properties);
-        String mqttPort = properties.getPort().isEmpty() ? null : properties.getPort();
+        String propertyPort = properties.getPort();
+        String mqttPort = (propertyPort.isEmpty() || MQTT_DEFAULT_PORT.equals(propertyPort) || MQTTS_DEFAULT_PORT.equals(propertyPort)) ? null : properties.getPort();
         return DeviceConnectivityUtil.getDockerMqttPublishCommand(protocol, baseUrl, mqttHost, mqttPort, deviceTelemetryTopic, deviceCredentials);
     }
 
@@ -312,14 +323,16 @@ public class DeviceConnectivityServiceImpl implements DeviceConnectivityService 
     private String getCoapPublishCommand(String protocol, String baseUrl, DeviceCredentials deviceCredentials) throws URISyntaxException {
         DeviceConnectivityInfo properties = deviceConnectivityConfiguration.getConnectivity(protocol);
         String hostName = getHost(baseUrl, properties);
-        String port = properties.getPort().isEmpty() ? "" : ":" + properties.getPort();
+        String propertyPort = properties.getPort();
+        String port = (propertyPort.isEmpty() || COAP_DEFAULT_PORT.equals(propertyPort) || COAPS_DEFAULT_PORT.equals(propertyPort)) ? "" : ":" + properties.getPort();
         return DeviceConnectivityUtil.getCoapPublishCommand(protocol, hostName, port, deviceCredentials);
     }
 
     private String getDockerCoapPublishCommand(String protocol, String baseUrl, DeviceCredentials deviceCredentials) throws URISyntaxException {
         DeviceConnectivityInfo properties = deviceConnectivityConfiguration.getConnectivity(protocol);
         String host = getHost(baseUrl, properties);
-        String port = properties.getPort().isEmpty() ? "" : ":" + properties.getPort();
+        String propertyPort = properties.getPort();
+        String port = (propertyPort.isEmpty() || COAP_DEFAULT_PORT.equals(propertyPort) || COAPS_DEFAULT_PORT.equals(propertyPort)) ? "" : ":" + properties.getPort();
         return DeviceConnectivityUtil.getDockerCoapPublishCommand(protocol, host, port, deviceCredentials);
     }
 


### PR DESCRIPTION
## Pull Request description

Removed default ports from device connectivity commands  

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



