### PR TITLE
Fix Widget Display Issues in Older Edge Versions Connected to 3.6 Servers

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/WidgetTypeMsgConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/WidgetTypeMsgConstructor.java
@@ -35,6 +35,13 @@ public class WidgetTypeMsgConstructor {
                 .setIdLSB(widgetTypeDetails.getId().getId().getLeastSignificantBits());
         if (widgetTypeDetails.getFqn() != null) {
             builder.setFqn(widgetTypeDetails.getFqn());
+            if (widgetTypeDetails.getFqn().contains(".")) {
+                String[] aliases = widgetTypeDetails.getFqn().split("\\.", 2);
+                if (aliases.length == 2) {
+                    builder.setBundleAlias(aliases[0]);
+                    builder.setAlias(aliases[1]);
+                }
+            }
         }
         if (widgetTypeDetails.getName() != null) {
             builder.setName(widgetTypeDetails.getName());

--- a/application/src/test/java/org/thingsboard/server/edge/WidgetEdgeTest.java
+++ b/application/src/test/java/org/thingsboard/server/edge/WidgetEdgeTest.java
@@ -58,6 +58,7 @@ public class WidgetEdgeTest extends AbstractEdgeTest {
         descriptor.put("key", "value");
         widgetType.setDescriptor(descriptor);
         widgetType.setDeprecated(true);
+        widgetType.setFqn("bundle_alias.type_alias");
         WidgetType savedWidgetType = doPost("/api/widgetType", widgetType, WidgetType.class);
         Assert.assertTrue(edgeImitator.waitForMessages());
         latestMessage = edgeImitator.getLatestMessage();
@@ -69,6 +70,8 @@ public class WidgetEdgeTest extends AbstractEdgeTest {
         Assert.assertEquals(savedWidgetType.getFqn(), widgetTypeUpdateMsg.getFqn());
         Assert.assertEquals(savedWidgetType.getName(), widgetTypeUpdateMsg.getName());
         Assert.assertTrue(widgetTypeUpdateMsg.getDeprecated());
+        Assert.assertEquals("bundle_alias", widgetTypeUpdateMsg.getBundleAlias());
+        Assert.assertEquals("type_alias", widgetTypeUpdateMsg.getAlias());
         Assert.assertEquals(JacksonUtil.toJsonNode(widgetTypeUpdateMsg.getDescriptorJson()), savedWidgetType.getDescriptor());
 
         // update widget bundle

--- a/common/edge-api/src/main/proto/edge.proto
+++ b/common/edge-api/src/main/proto/edge.proto
@@ -85,7 +85,7 @@ message ConnectResponseMsg {
 }
 
 message SyncRequestMsg {
-  bool syncRequired = 1; // deprecated
+  bool syncRequired = 1 [deprecated = true];
   optional bool fullSync = 2;
 }
 
@@ -113,7 +113,7 @@ enum UpdateMsgType {
   ENTITY_DELETED_RPC_MESSAGE = 2;
   ALARM_ACK_RPC_MESSAGE = 3;
   ALARM_CLEAR_RPC_MESSAGE = 4;
-  ENTITY_MERGE_RPC_MESSAGE = 5; // deprecated
+  ENTITY_MERGE_RPC_MESSAGE = 5 [deprecated = true];
 }
 
 message EntityDataProto {
@@ -204,7 +204,7 @@ message DeviceUpdateMsg {
   string type = 9;
   optional string label = 10;
   optional string additionalInfo = 11;
-  optional string conflictName = 12; // deprecated
+  optional string conflictName = 12 [deprecated = true];
   optional int64 firmwareIdMSB = 13;
   optional int64 firmwareIdLSB = 14;
   optional bytes deviceDataBytes = 15;
@@ -365,8 +365,8 @@ message WidgetTypeUpdateMsg {
   UpdateMsgType msgType = 1;
   int64 idMSB = 2;
   int64 idLSB = 3;
-  optional string bundleAlias = 4; // deprecated
-  optional string alias = 5; // deprecated
+  optional string bundleAlias = 4 [deprecated = true];
+  optional string alias = 5 [deprecated = true];
   optional string name = 6;
   optional string descriptorJson = 7;
   bool isSystem = 8;
@@ -447,8 +447,8 @@ message DeviceCredentialsRequestMsg {
   int64 deviceIdLSB = 2;
 }
 
-// deprecated
 message DeviceProfileDevicesRequestMsg {
+  option deprecated = true;
   int64 deviceProfileIdMSB = 1;
   int64 deviceProfileIdLSB = 2;
 }
@@ -562,7 +562,7 @@ message UplinkMsg {
   repeated UserCredentialsRequestMsg userCredentialsRequestMsg = 10;
   repeated DeviceCredentialsRequestMsg deviceCredentialsRequestMsg = 11;
   repeated DeviceRpcCallMsg deviceRpcCallMsg = 12;
-  repeated DeviceProfileDevicesRequestMsg deviceProfileDevicesRequestMsg = 13; // deprecated
+  repeated DeviceProfileDevicesRequestMsg deviceProfileDevicesRequestMsg = 13 [deprecated = true];
   repeated WidgetBundleTypesRequestMsg widgetBundleTypesRequestMsg = 14;
   repeated EntityViewsRequestMsg entityViewsRequestMsg = 15;
   repeated AssetUpdateMsg assetUpdateMsg = 16;

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -2003,6 +2003,7 @@
         "type-rule-chain-metadata": "Rule Chain Metadata",
         "type-edge": "Edge",
         "type-user": "User",
+        "type-tenant": "Tenant",
         "type-customer": "Customer",
         "type-relation": "Relation",
         "type-widgets-bundle": "Widgets Bundle",


### PR DESCRIPTION
## Pull Request description

Older versions of Edge experience issues with widget display when connected to version 3.6 servers. This is due to the removal of alias and bundle alias fields in the latest release. This fix populates the deprecated fields, allowing older Edge versions to connect successfully to new servers.

![image](https://github.com/thingsboard/thingsboard/assets/3466101/5227bb10-f4d5-456d-9a87-9769c7bde758)


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



