### PR TITLE
fixed alarm severity change

### DIFF
--- a/common/data/src/main/java/org/thingsboard/server/common/data/alarm/AlarmModificationRequest.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/alarm/AlarmModificationRequest.java
@@ -22,6 +22,8 @@ public interface AlarmModificationRequest {
 
     TenantId getTenantId();
 
+    AlarmSeverity getSeverity();
+
     long getStartTs();
 
     long getEndTs();

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbAlarmResult.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbAlarmResult.java
@@ -37,6 +37,11 @@ public class TbAlarmResult {
     }
 
     public static TbAlarmResult fromAlarmResult(AlarmApiCallResult result) {
-        return new TbAlarmResult(result.isCreated(), result.isModified(), result.isSeverityChanged(), result.isCleared(), result.getAlarm());
+        return new TbAlarmResult(
+                result.isCreated(),
+                result.isModified() && !result.isSeverityChanged(),
+                result.isSeverityChanged(),
+                result.isCleared(),
+                result.getAlarm());
     }
 }


### PR DESCRIPTION
## Pull Request description

https://thingsboard-portal.atlassian.net/browse/PROD-2411

When Device Profile increases the severity (i.e. Warning to Minor), the rule chain does NOT generate ‘Alarm Severity Updated’ type. It only does ‘Alarm Updated’, which can be the case for any changes, not severity. 
  
![Screenshot from 2023-09-12 17-09-18](https://github.com/thingsboard/thingsboard/assets/56396344/a3ae7549-1f39-40ca-9533-5b12744a2f2d)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



