### PR TITLE
Fixed padding for image input

### DIFF
--- a/ui-ngx/src/app/shared/components/image-input.component.scss
+++ b/ui-ngx/src/app/shared/components/image-input.component.scss
@@ -22,7 +22,7 @@ $previewSize: 78px !default;
 
   .tb-container {
     margin-top: 0;
-    padding: 0;
+    padding: 0 0 16px;
     label.tb-title {
       display: block;
       padding-bottom: 8px;
@@ -121,6 +121,7 @@ $previewSize: 78px !default;
 
   .tb-hint{
     margin-top: 8px;
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
## Pull Request description

Added padding bottom for image input component.

Before fix:
![image](https://github.com/thingsboard/thingsboard/assets/83352633/cbc8d055-6a49-463a-8b76-79e68c9d18d7)

After fix:
![image](https://github.com/thingsboard/thingsboard/assets/83352633/c7f69fb9-9f49-4a16-bebc-8f62e1887ec2)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



