### PR TITLE
Use translation placeholder for closing button in embed dialog.

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/dialog/embed-dashboard-dialog.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/dialog/embed-dashboard-dialog.component.html
@@ -35,7 +35,7 @@
             type="button"
             [disabled]="(isLoading$ | async)"
             (click)="close()" cdkFocusInitial>
-      Close
+      {{ 'action.close' | translate }}
     </button>
   </div>
 </div>


### PR DESCRIPTION
Please, take a look at [closeDialog API](https://github.com/thingsboard/thingsboard/blob/master/ui-ngx/src/app/modules/home/models/widget-component.models.ts#L440). It stopped working after 3.5.0. Many thanks!