### PR TITLE
Time unit selection support and tests for delay node

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
@@ -121,7 +121,7 @@ public class TbMsgDelayNode implements TbNode {
     }
 
     @Override
-    public TbPair<Boolean, JsonNode> upgrade(int fromVersion, JsonNode oldConfiguration) throws TbNodeException {
+    public TbPair<Boolean, JsonNode> upgrade(int fromVersion, JsonNode oldConfiguration) {
         boolean hasChanges = false;
         switch (fromVersion) {
             case 0: {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
@@ -58,9 +58,7 @@ public class TbMsgDelayNode implements TbNode {
 
     private TbMsgDelayNodeConfiguration config;
     private Map<UUID, TbMsg> pendingMsgs;
-    private final Set<TimeUnit> supportedTimeUnits = EnumSet.of(
-            TimeUnit.MILLISECONDS, TimeUnit.SECONDS, TimeUnit.MINUTES, TimeUnit.HOURS, TimeUnit.DAYS
-    );
+    private final Set<TimeUnit> supportedTimeUnits = EnumSet.of(TimeUnit.SECONDS, TimeUnit.MINUTES, TimeUnit.HOURS);
 
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
@@ -31,7 +31,6 @@ import org.thingsboard.server.common.data.util.TbPair;
 import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
 
-import java.time.Duration;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -89,7 +88,7 @@ public class TbMsgDelayNode implements TbNode {
                 TbMsg tickMsg = ctx.newMsg(null, TbMsgType.DELAY_TIMEOUT_SELF_MSG, ctx.getSelfId(), msg.getCustomerId(), TbMsgMetaData.EMPTY, msg.getId().toString());
                 long periodValue = getDelayPeriodValue(msg);
                 TimeUnit periodTimeUnit = getDelayPeriodTimeUnit(msg);
-                ctx.tellSelf(tickMsg, Duration.of(periodValue, periodTimeUnit.toChronoUnit()).toMillis());
+                ctx.tellSelf(tickMsg, periodTimeUnit.toMillis(periodValue));
                 ctx.ack(msg);
             } else {
                 ctx.tellFailure(msg, new RuntimeException("Max limit of pending messages reached!"));

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
@@ -98,32 +98,28 @@ public class TbMsgDelayNode implements TbNode {
     }
 
     private long getDelayPeriodValue(TbMsg msg) {
-        int periodValue;
-        if (config.isUsePeriodValuePattern()) {
-            try {
-                periodValue = Integer.parseInt(TbNodeUtils.processPattern(config.getPeriodValuePattern(), msg));
-            } catch (NumberFormatException e) {
-                throw new RuntimeException("Can't parse period value using pattern: " + config.getPeriodValuePattern());
-            }
-        } else {
-            periodValue = config.getPeriodValue();
+        if (!config.isUsePeriodValuePattern()) {
+            return config.getPeriodValue();
         }
-        return periodValue;
+        try {
+            return Integer.parseInt(TbNodeUtils.processPattern(config.getPeriodValuePattern(), msg));
+        } catch (NumberFormatException e) {
+            throw new RuntimeException("Can't parse period value using pattern: " + config.getPeriodValuePattern());
+        }
     }
 
     private TimeUnit getDelayPeriodTimeUnit(TbMsg msg) {
+        if (!config.isUsePeriodTimeUnitPattern()) {
+            return config.getPeriodTimeUnit();
+        }
         TimeUnit periodTimeUnit;
-        if (config.isUsePeriodTimeUnitPattern()) {
-            try {
-                periodTimeUnit = TimeUnit.valueOf(TbNodeUtils.processPattern(config.getPeriodTimeUnitPattern(), msg));
-            } catch (IllegalArgumentException | NullPointerException e) {
-                throw new RuntimeException("Can't parse period time unit using pattern: " + config.getPeriodTimeUnitPattern());
-            }
-            if (!supportedTimeUnits.contains(periodTimeUnit)) {
-                throw new RuntimeException("Unsupported time unit: " + periodTimeUnit);
-            }
-        } else {
-            periodTimeUnit = config.getPeriodTimeUnit();
+        try {
+            periodTimeUnit = TimeUnit.valueOf(TbNodeUtils.processPattern(config.getPeriodTimeUnitPattern(), msg));
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new RuntimeException("Can't parse period time unit using pattern: " + config.getPeriodTimeUnitPattern());
+        }
+        if (!supportedTimeUnits.contains(periodTimeUnit)) {
+            throw new RuntimeException("Unsupported time unit: " + periodTimeUnit);
         }
         return periodTimeUnit;
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
@@ -77,14 +77,7 @@ public class TbMsgDelayNode implements TbNode {
             TbMsg pendingMsg = pendingMsgs.remove(UUID.fromString(msg.getData()));
             if (pendingMsg != null) {
                 ctx.enqueueForTellNext(
-                        TbMsg.newMsg(
-                                pendingMsg.getQueueName(),
-                                pendingMsg.getType(),
-                                pendingMsg.getOriginator(),
-                                pendingMsg.getCustomerId(),
-                                pendingMsg.getMetaData(),
-                                pendingMsg.getData()
-                        ),
+                        TbMsg.newMsg(pendingMsg, pendingMsg.getQueueName(), null, null),
                         TbNodeConnectionType.SUCCESS
                 );
             }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
@@ -66,6 +66,10 @@ public class TbMsgDelayNode implements TbNode {
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
         this.config = TbNodeUtils.convert(configuration, TbMsgDelayNodeConfiguration.class);
         this.pendingMsgs = new HashMap<>();
+        if (config.getMaxPendingMsgs() < 1 || config.getMaxPendingMsgs() > 100000) {
+            throw new TbNodeException("Invalid maximum pending messages limit [" + config.getMaxPendingMsgs() + "], " +
+                    "should be in range from 1 to 100000 (inclusive)!", true);
+        }
         if (!supportedTimeUnits.contains(config.getPeriodTimeUnit())) {
             throw new TbNodeException("Unsupported time unit: " + config.getPeriodTimeUnit(), true);
         }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
@@ -106,7 +106,17 @@ public class TbMsgDelayNode implements TbNode {
         } else {
             periodValue = config.getPeriodValue();
         }
-        return config.getPeriodTimeUnit().toMillis(periodValue);
+        TimeUnit periodTimeUnit;
+        if (config.isUsePeriodTimeUnitPattern()) {
+            try {
+                periodTimeUnit = TimeUnit.valueOf(TbNodeUtils.processPattern(config.getPeriodTimeUnitPattern(), msg));
+            } catch (IllegalArgumentException | NullPointerException e) {
+                throw new RuntimeException("Can't parse period time unit using pattern: " + config.getPeriodTimeUnitPattern());
+            }
+        } else {
+            periodTimeUnit = config.getPeriodTimeUnit();
+        }
+        return periodTimeUnit.toMillis(periodValue);
     }
 
     private boolean isParsable(TbMsg msg, String pattern) {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
@@ -103,7 +103,7 @@ public class TbMsgDelayNode implements TbNode {
         try {
             return Integer.parseInt(TbNodeUtils.processPattern(config.getPeriodValuePattern(), msg));
         } catch (NumberFormatException e) {
-            throw new RuntimeException("Can't parse period value using pattern: " + config.getPeriodValuePattern());
+            throw new RuntimeException("Can't parse period value using pattern: " + config.getPeriodValuePattern(), e);
         }
     }
 
@@ -115,7 +115,7 @@ public class TbMsgDelayNode implements TbNode {
         try {
             periodTimeUnit = TimeUnit.valueOf(TbNodeUtils.processPattern(config.getPeriodTimeUnitPattern(), msg));
         } catch (IllegalArgumentException | NullPointerException e) {
-            throw new RuntimeException("Can't parse period time unit using pattern: " + config.getPeriodTimeUnitPattern());
+            throw new RuntimeException("Can't parse period time unit using pattern: " + config.getPeriodTimeUnitPattern(), e);
         }
         if (!supportedTimeUnits.contains(periodTimeUnit)) {
             throw new RuntimeException("Unsupported time unit: " + periodTimeUnit);

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNode.java
@@ -187,6 +187,9 @@ public class TbMsgDelayNode implements TbNode {
                     oldConfigurationNode.remove(useMetadataPeriodInSecondsPatternsPropertyName);
                     hasChanges = true;
                 }
+
+                oldConfigurationNode.set("periodTimeUnitPattern", null);
+                oldConfigurationNode.put("usePeriodTimeUnitPattern", false);
             }
             default:
                 break;

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeConfiguration.java
@@ -38,6 +38,8 @@ public class TbMsgDelayNodeConfiguration implements NodeConfiguration<TbMsgDelay
         configuration.setPeriodTimeUnit(TimeUnit.SECONDS);
         configuration.setMaxPendingMsgs(1000);
         configuration.setUsePeriodValuePattern(false);
+        configuration.setPeriodTimeUnitPattern(null);
+        configuration.setUsePeriodTimeUnitPattern(false);
         return configuration;
     }
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeConfiguration.java
@@ -28,6 +28,8 @@ public class TbMsgDelayNodeConfiguration implements NodeConfiguration<TbMsgDelay
     private int maxPendingMsgs;
     private String periodValuePattern;
     private boolean usePeriodValuePattern;
+    private String periodTimeUnitPattern;
+    private boolean usePeriodTimeUnitPattern;
 
     @Override
     public TbMsgDelayNodeConfiguration defaultConfiguration() {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeConfiguration.java
@@ -18,20 +18,25 @@ package org.thingsboard.rule.engine.delay;
 import lombok.Data;
 import org.thingsboard.rule.engine.api.NodeConfiguration;
 
+import java.util.concurrent.TimeUnit;
+
 @Data
 public class TbMsgDelayNodeConfiguration implements NodeConfiguration<TbMsgDelayNodeConfiguration> {
 
-    private int periodInSeconds;
+    private int periodValue;
+    private TimeUnit periodTimeUnit;
     private int maxPendingMsgs;
-    private String periodInSecondsPattern;
-    private boolean useMetadataPeriodInSecondsPatterns;
+    private String periodValuePattern;
+    private boolean usePeriodValuePattern;
 
     @Override
     public TbMsgDelayNodeConfiguration defaultConfiguration() {
-        TbMsgDelayNodeConfiguration configuration = new TbMsgDelayNodeConfiguration();
-        configuration.setPeriodInSeconds(60);
+        var configuration = new TbMsgDelayNodeConfiguration();
+        configuration.setPeriodValue(60);
+        configuration.setPeriodTimeUnit(TimeUnit.SECONDS);
         configuration.setMaxPendingMsgs(1000);
-        configuration.setUseMetadataPeriodInSecondsPatterns(false);
+        configuration.setUsePeriodValuePattern(false);
         return configuration;
     }
+
 }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeTest.java
@@ -1,0 +1,332 @@
+/**
+ * Copyright © 2016-2023 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.delay;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.rule.engine.api.TbNodeConfiguration;
+import org.thingsboard.rule.engine.api.TbNodeException;
+import org.thingsboard.server.common.data.id.CustomerId;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.RuleNodeId;
+import org.thingsboard.server.common.data.msg.TbMsgType;
+import org.thingsboard.server.common.data.msg.TbNodeConnectionType;
+import org.thingsboard.server.common.data.util.TbPair;
+import org.thingsboard.server.common.msg.TbMsg;
+import org.thingsboard.server.common.msg.TbMsgMetaData;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class TbMsgDelayNodeTest {
+
+    @Mock
+    private TbContext ctxMock;
+
+    private TbMsgDelayNode node;
+    private TbMsgDelayNodeConfiguration config;
+
+    private final CustomerId customerId = new CustomerId(UUID.randomUUID());
+    private final DeviceId deviceId = new DeviceId(UUID.randomUUID());
+    private TbMsg msg;
+
+    @BeforeEach
+    public void setUp() {
+        node = new TbMsgDelayNode();
+        config = new TbMsgDelayNodeConfiguration();
+        msg = newMsg();
+    }
+
+    @Test
+    public void givenDefaultConfiguration_whenInit_thenStartsAndCorrectValuesAreSet() {
+        // GIVEN-WHEN
+        config = config.defaultConfiguration();
+
+        // THEN
+        assertThat(config.getPeriodValue()).isEqualTo(60);
+        assertThat(config.getPeriodTimeUnit()).isEqualTo(TimeUnit.SECONDS);
+        assertThat(config.getMaxPendingMsgs()).isEqualTo(1000);
+        assertThat(config.getPeriodValuePattern()).isNull();
+        assertThat(config.isUsePeriodValuePattern()).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 1000, 100000})
+    public void givenValidMaxPendingMsgsLimits_whenInit_thenNodeStartsSuccessfully(int maxPendingMsgs) {
+        // GIVEN
+        config = config.defaultConfiguration();
+        config.setMaxPendingMsgs(maxPendingMsgs);
+
+        // WHEN-THEN
+        try {
+            node.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+        } catch (TbNodeException e) {
+            fail("Node failed to start!", e);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {Integer.MIN_VALUE, 0, 1000001, Integer.MAX_VALUE})
+    public void givenInvalidMaxPendingMsgsLimits_whenInit_thenNodeFailsToStartWithCorrectException(int maxPendingMsgs) {
+        // GIVEN
+        config = config.defaultConfiguration();
+        config.setMaxPendingMsgs(maxPendingMsgs);
+
+        // WHEN-THEN
+        assertThatThrownBy(() -> node.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config))))
+                .isInstanceOf(TbNodeException.class)
+                .hasMessage("Invalid maximum pending messages limit [" + maxPendingMsgs + "], " +
+                        "should be in range from 1 to 100000 (inclusive)!")
+                .matches(e -> ((TbNodeException) e).isUnrecoverable());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TimeUnit.class, names = {"MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS"})
+    public void givenValidPeriodTimeUnits_whenInit_thenNodeStartsSuccessfully(TimeUnit periodTimeUnit) {
+        // GIVEN
+        config = config.defaultConfiguration();
+        config.setPeriodTimeUnit(periodTimeUnit);
+
+        // WHEN-THEN
+        try {
+            node.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+        } catch (TbNodeException e) {
+            fail("Node failed to start!", e);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = TimeUnit.class, mode = EnumSource.Mode.EXCLUDE, names = {"MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS"})
+    public void givenInvalidPeriodTimeUnits_whenInit_thenNodeFailsToStartWithCorrectException(TimeUnit periodTimeUnit) {
+        // GIVEN
+        config = config.defaultConfiguration();
+        config.setPeriodTimeUnit(periodTimeUnit);
+
+        // WHEN-THEN
+        assertThatThrownBy(() -> node.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config))))
+                .isInstanceOf(TbNodeException.class)
+                .hasMessage("Unsupported time unit: " + periodTimeUnit)
+                .matches(e -> ((TbNodeException) e).isUnrecoverable());
+    }
+
+    @Test
+    public void givenTwoMsgsAndLimitOfOne_whenOnMsg_thenShouldDelayFirstAndFailSecond() {
+        // GIVEN
+        config = config.defaultConfiguration();
+        config.setMaxPendingMsgs(1);
+
+        var selfId = new RuleNodeId(UUID.randomUUID());
+
+        try {
+            node.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+        } catch (TbNodeException e) {
+            fail("Node failed to start!", e);
+        }
+
+        given(ctxMock.getSelfId()).willReturn(selfId);
+
+        var expectedTickMsg = TbMsg.newMsg(
+                null, TbMsgType.DELAY_TIMEOUT_SELF_MSG, selfId,
+                msg.getCustomerId(), TbMsgMetaData.EMPTY, msg.getId().toString()
+        );
+        given(ctxMock.newMsg(
+                isNull(), eq(TbMsgType.DELAY_TIMEOUT_SELF_MSG), eq(selfId),
+                eq(msg.getCustomerId()), eq(TbMsgMetaData.EMPTY), eq(msg.getId().toString())
+        )).willReturn(expectedTickMsg);
+
+        // WHEN 1: first message is received
+        var firstMsg = msg;
+
+        node.onMsg(ctxMock, firstMsg);
+
+        // THEN 1: first message is correctly delayed
+        ArgumentCaptor<TbMsg> tickMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        then(ctxMock).should(times(1)).tellSelf(tickMsgCaptor.capture(), anyLong());
+        assertThat(tickMsgCaptor.getValue()).isEqualTo(expectedTickMsg);
+        then(ctxMock).should(times(1)).ack(firstMsg);
+
+        // WHEN 2: second message is received
+        var secondMsg = newMsg();
+
+        node.onMsg(ctxMock, secondMsg);
+
+        // THEN 2: seconds message fails because of the limit
+        var failedMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        var exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        then(ctxMock).should(times(1)).tellFailure(failedMsgCaptor.capture(), exceptionCaptor.capture());
+        assertThat(failedMsgCaptor.getValue()).isEqualTo(secondMsg);
+        assertThat(exceptionCaptor.getValue()).isInstanceOf(RuntimeException.class);
+        assertThat(exceptionCaptor.getValue()).hasMessage("Max limit of pending messages reached!");
+
+        // WHEN 3: tick message from delayed first message is received
+        node.onMsg(ctxMock, expectedTickMsg);
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        // THEN 3: correct outbound message is sent
+        var outboundMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        then(ctxMock).should(times(1)).enqueueForTellNext(
+                outboundMsgCaptor.capture(), eq(TbNodeConnectionType.SUCCESS)
+        );
+        var actualOutboundMsg = outboundMsgCaptor.getValue();
+        assertThat(actualOutboundMsg.getType()).isEqualTo(firstMsg.getType());
+        assertThat(actualOutboundMsg.getOriginator()).isEqualTo(firstMsg.getOriginator());
+        assertThat(actualOutboundMsg.getCustomerId()).isEqualTo(firstMsg.getCustomerId());
+        assertThat(actualOutboundMsg.getData()).isEqualTo(firstMsg.getData());
+        assertThat(actualOutboundMsg.getMetaData()).isEqualTo(firstMsg.getMetaData());
+        assertThat(actualOutboundMsg.getQueueName()).isEqualTo(firstMsg.getQueueName());
+        assertThat(actualOutboundMsg.getTs()).isEqualTo(firstMsg.getTs());
+        assertThat(actualOutboundMsg.getInternalType()).isEqualTo(firstMsg.getInternalType());
+        assertThat(actualOutboundMsg.getDataType()).isEqualTo(firstMsg.getDataType());
+        assertThat(actualOutboundMsg.getRuleChainId()).isEqualTo(firstMsg.getRuleChainId());
+        assertThat(actualOutboundMsg.getRuleNodeId()).isEqualTo(firstMsg.getRuleNodeId());
+        assertThat(actualOutboundMsg.isValid()).isEqualTo(firstMsg.isValid());
+        assertThat(actualOutboundMsg.getMetaDataTs()).isEqualTo(firstMsg.getMetaDataTs());
+        assertThat(actualOutboundMsg.getAndIncrementRuleNodeCounter()).isEqualTo(firstMsg.getAndIncrementRuleNodeCounter());
+    }
+
+    private TbMsg newMsg() {
+        var data = JacksonUtil.newObjectNode();
+        data.put("humidity", 58.3);
+        return TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, deviceId, customerId, new TbMsgMetaData(), JacksonUtil.toString(data));
+    }
+
+    @Test
+    public void givenThirtySecondsDelayWithNoPattern_whenOnMsg_thenShouldUseCorrectDelay() {
+        // GIVEN
+        config = config.defaultConfiguration();
+        config.setPeriodValue(30);
+
+        try {
+            node.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+        } catch (TbNodeException e) {
+            fail("Node failed to start!", e);
+        }
+
+        // WHEN
+        node.onMsg(ctxMock, msg);
+
+        // THEN
+        then(ctxMock).should(times(1)).tellSelf(any(), eq(30000L));
+    }
+
+    @Test
+    public void givenOneHourDelayWithPattern_whenOnMsg_thenShouldUseCorrectDelay() {
+        // GIVEN
+        config = config.defaultConfiguration();
+        config.setPeriodTimeUnit(TimeUnit.HOURS);
+        config.setUsePeriodValuePattern(true);
+        config.setPeriodValuePattern("$[processingDelayInHours]");
+
+        var data = JacksonUtil.newObjectNode();
+        data.put("processingDelayInHours", 1);
+        msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, deviceId, customerId, new TbMsgMetaData(), JacksonUtil.toString(data));
+
+        try {
+            node.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+        } catch (TbNodeException e) {
+            fail("Node failed to start!", e);
+        }
+
+        // WHEN
+        node.onMsg(ctxMock, msg);
+
+        // THEN
+        then(ctxMock).should(times(1)).tellSelf(any(), eq(Duration.ofHours(1).toMillis()));
+    }
+
+    @Test
+    public void givenNotParsableDelayWithPattern_whenOnMsg_thenShouldThrowException() {
+        // GIVEN
+        config = config.defaultConfiguration();
+        config.setPeriodTimeUnit(TimeUnit.HOURS);
+        config.setUsePeriodValuePattern(true);
+        config.setPeriodValuePattern("$[processingDelayInHours]");
+
+        var data = JacksonUtil.newObjectNode();
+        data.put("processingDelayInHours", "one hour");
+        msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, deviceId, customerId, new TbMsgMetaData(), JacksonUtil.toString(data));
+
+        try {
+            node.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+        } catch (TbNodeException e) {
+            fail("Node failed to start!", e);
+        }
+
+        // WHEN-THEN
+        assertThatThrownBy(() -> node.onMsg(ctxMock, msg))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Can't parse period value using pattern: $[processingDelayInHours]");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideOldConfigurations")
+    public void givenOldConfigurations_whenUpgrade_thenShouldCorrectlyUpgrade(
+            String oldConfigurationStr, int fromVersion, String expectedUpgradedConfigurationStr
+    ) {
+        // GIVEN
+        var oldConfigurationNode = JacksonUtil.toJsonNode(oldConfigurationStr);
+
+        // WHEN
+        TbPair<Boolean, JsonNode> upgradeResult = node.upgrade(fromVersion, oldConfigurationNode);
+
+        // THEN
+        boolean actualHasChanges = upgradeResult.getFirst();
+        assertThat(actualHasChanges).isTrue();
+
+        var actualUpgradedConfiguration = JacksonUtil.treeToValue(upgradeResult.getSecond(), TbMsgDelayNodeConfiguration.class);
+        var expectedUpgradedConfiguration = JacksonUtil.fromString(expectedUpgradedConfigurationStr, TbMsgDelayNodeConfiguration.class);
+        assertThat(actualUpgradedConfiguration).isEqualTo(expectedUpgradedConfiguration);
+    }
+
+    private static Stream<Arguments> provideOldConfigurations() {
+        return Stream.of(
+                Arguments.of("{\"periodInSeconds\":60,\"maxPendingMsgs\":1000,\"periodInSecondsPattern\":null,\"useMetadataPeriodInSecondsPatterns\":false}", 0, "{\"periodValue\":60,\"periodTimeUnit\":\"SECONDS\",\"maxPendingMsgs\":1000,\"periodValuePattern\":null,\"usePeriodValuePattern\":false}"),
+                Arguments.of("{\"periodInSeconds\":60,\"maxPendingMsgs\":1000,\"periodInSecondsPattern\":\"${metadataKey}\",\"useMetadataPeriodInSecondsPatterns\":true}", 0, "{\"periodValue\":60,\"periodTimeUnit\":\"SECONDS\",\"maxPendingMsgs\":1000,\"periodValuePattern\":\"${metadataKey}\",\"usePeriodValuePattern\":true}")
+        );
+    }
+
+}

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeTest.java
@@ -200,12 +200,6 @@ public class TbMsgDelayNodeTest {
         // WHEN 3: tick message from delayed first message is received
         node.onMsg(ctxMock, expectedTickMsg);
 
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-
         // THEN 3: correct outbound message is sent
         var outboundMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
         then(ctxMock).should(times(1)).enqueueForTellNext(

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeTest.java
@@ -183,6 +183,7 @@ public class TbMsgDelayNodeTest {
             fail("Node failed to start!", e);
         }
 
+        given(ctxMock.isLocalEntity(any())).willReturn(true);
         given(ctxMock.getSelfId()).willReturn(selfId);
 
         var expectedTickMsg = TbMsg.newMsg(
@@ -255,6 +256,8 @@ public class TbMsgDelayNodeTest {
         config = config.defaultConfiguration();
         config.setPeriodValue(30);
 
+        given(ctxMock.isLocalEntity(msg.getOriginator())).willReturn(true);
+
         try {
             node.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
         } catch (TbNodeException e) {
@@ -276,6 +279,8 @@ public class TbMsgDelayNodeTest {
         config.setPeriodValuePattern("$[processingDelayValue]");
         config.setUsePeriodTimeUnitPattern(true);
         config.setPeriodTimeUnitPattern("$[processingDelayTimeUnit]");
+
+        given(ctxMock.isLocalEntity(msg.getOriginator())).willReturn(true);
 
         var data = JacksonUtil.newObjectNode();
         data.put("processingDelayValue", 1);
@@ -302,6 +307,8 @@ public class TbMsgDelayNodeTest {
         config.setUsePeriodValuePattern(true);
         config.setPeriodValuePattern("$[processingDelayValue]");
 
+        given(ctxMock.isLocalEntity(msg.getOriginator())).willReturn(true);
+
         var data = JacksonUtil.newObjectNode();
         data.put("processingDelayValue", "one hour");
         msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, deviceId, customerId, new TbMsgMetaData(), JacksonUtil.toString(data));
@@ -325,6 +332,8 @@ public class TbMsgDelayNodeTest {
         config.setUsePeriodTimeUnitPattern(true);
         config.setPeriodTimeUnitPattern("$[processingDelayTimeUnit]");
 
+        given(ctxMock.isLocalEntity(msg.getOriginator())).willReturn(true);
+
         var data = JacksonUtil.newObjectNode();
         data.put("processingDelayTimeUnit", "week");
         msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, deviceId, customerId, new TbMsgMetaData(), JacksonUtil.toString(data));
@@ -347,6 +356,8 @@ public class TbMsgDelayNodeTest {
         config = config.defaultConfiguration();
         config.setUsePeriodTimeUnitPattern(true);
         config.setPeriodTimeUnitPattern("$[processingDelayTimeUnit]");
+
+        given(ctxMock.isLocalEntity(msg.getOriginator())).willReturn(true);
 
         var data = JacksonUtil.newObjectNode();
         data.put("processingDelayTimeUnit", "MILLISECONDS");

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeTest.java
@@ -120,7 +120,7 @@ public class TbMsgDelayNodeTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = TimeUnit.class, names = {"MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS"})
+    @EnumSource(value = TimeUnit.class, names = {"SECONDS", "MINUTES", "HOURS"})
     public void givenValidPeriodTimeUnits_whenInit_thenNodeStartsSuccessfully(TimeUnit periodTimeUnit) {
         // GIVEN
         config = config.defaultConfiguration();
@@ -135,7 +135,7 @@ public class TbMsgDelayNodeTest {
     }
 
     @ParameterizedTest
-    @EnumSource(value = TimeUnit.class, mode = EnumSource.Mode.EXCLUDE, names = {"MILLISECONDS", "SECONDS", "MINUTES", "HOURS", "DAYS"})
+    @EnumSource(value = TimeUnit.class, mode = EnumSource.Mode.EXCLUDE, names = {"SECONDS", "MINUTES", "HOURS"})
     public void givenInvalidPeriodTimeUnits_whenInit_thenNodeFailsToStartWithCorrectException(TimeUnit periodTimeUnit) {
         // GIVEN
         config = config.defaultConfiguration();

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/delay/TbMsgDelayNodeTest.java
@@ -34,6 +34,7 @@ import org.thingsboard.rule.engine.api.TbNodeException;
 import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.RuleNodeId;
+import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.msg.TbMsgType;
 import org.thingsboard.server.common.data.msg.TbNodeConnectionType;
 import org.thingsboard.server.common.data.util.TbPair;
@@ -148,6 +149,24 @@ public class TbMsgDelayNodeTest {
                 .isInstanceOf(TbNodeException.class)
                 .hasMessage("Unsupported time unit: " + periodTimeUnit)
                 .matches(e -> ((TbNodeException) e).isUnrecoverable());
+    }
+
+    @Test
+    public void givenNonLocalOriginator_whenOnMsg_thenAcksMsgAndReturns() {
+        // GIVEN
+        given(ctxMock.isLocalEntity(msg.getOriginator())).willReturn(false);
+        given(ctxMock.getSelfId()).willReturn(new RuleNodeId(UUID.randomUUID()));
+        given(ctxMock.getTenantId()).willReturn(TenantId.fromUUID(UUID.randomUUID()));
+
+        // WHEN
+        node.onMsg(ctxMock, msg);
+
+        // THEN
+        then(ctxMock).should(times(1)).isLocalEntity(msg.getOriginator());
+        then(ctxMock).should(times(1)).getTenantId();
+        then(ctxMock).should(times(1)).getSelfId();
+        then(ctxMock).should(times(1)).ack(msg);
+        then(ctxMock).shouldHaveNoMoreInteractions();
     }
 
     @Test


### PR DESCRIPTION
## Pull Request description

Scope of changes:
- Add delay period time unit support: previously you could specify delay period only in seconds; now it is possible to specify period value and period time unit separately; possible values for time unit are: seconds, minutes and hours. Time unit input also supports templatization.
- Add maximum pending messages limit validation on backend
- Add tests for rule node

Documentation changes: merged [PR](https://github.com/thingsboard/thingsboard.github.io/pull/1189/files)
UI changes: TODO by a frontend team

Design:
![image](https://github.com/thingsboard/thingsboard/assets/99619831/80e64ca8-6aa5-4ba2-8ead-a53690cf3303)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.



