### PR TITLE
Command whitespaces hotfix

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/gateway/gateway-configuration.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/gateway/gateway-configuration.component.html
@@ -586,6 +586,9 @@
                 <mat-error *ngIf="commandControl.get('command').hasError('required')">
                   {{ 'gateway.statistics.command-required' | translate }}
                 </mat-error>
+                <mat-error *ngIf="commandControl.get('command').hasError('pattern')">
+                  {{ 'gateway.statistics.command-pattern' | translate }}
+                </mat-error>
                 <mat-icon matIconSuffix style="cursor:pointer;"
                           matTooltip="{{ 'gateway.hints.command' | translate }}">info_outlined
                 </mat-icon>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/gateway/gateway-configuration.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/gateway/gateway-configuration.component.ts
@@ -409,14 +409,9 @@ export class GatewayConfigurationComponent implements OnInit {
     const commandsFormArray = this.commandFormArray();
     const commandFormGroup = this.fb.group({
       attributeOnGateway: [command.attributeOnGateway || null, [Validators.required, Validators.pattern(/^[^.\s]+$/)]],
-      command: [command.command || null, [Validators.required]],
+      command: [command.command || null, [Validators.required, Validators.pattern(/^(?=\S).*\S$/)]],
       timeout: [command.timeout || null, [Validators.required, Validators.min(1), Validators.pattern(/^-?[0-9]+$/), Validators.pattern(/^[^.\s]+$/)]],
     });
-    commandFormGroup.get('command').valueChanges.subscribe(value=>{
-      if (value && !(value as String).trim().length) {
-        commandFormGroup.get('command').setValue("", {emitEvent: false});
-      }
-    })
     commandsFormArray.push(commandFormGroup);
   }
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/gateway/gateway-configuration.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/gateway/gateway-configuration.component.ts
@@ -409,9 +409,14 @@ export class GatewayConfigurationComponent implements OnInit {
     const commandsFormArray = this.commandFormArray();
     const commandFormGroup = this.fb.group({
       attributeOnGateway: [command.attributeOnGateway || null, [Validators.required, Validators.pattern(/^[^.\s]+$/)]],
-      command: [command.command || null, [Validators.required, Validators.pattern(/^[^.\s]+$/)]],
+      command: [command.command || null, [Validators.required]],
       timeout: [command.timeout || null, [Validators.required, Validators.min(1), Validators.pattern(/^-?[0-9]+$/), Validators.pattern(/^[^.\s]+$/)]],
     });
+    commandFormGroup.get('command').valueChanges.subscribe(value=>{
+      if (value && !(value as String).trim().length) {
+        commandFormGroup.get('command').setValue("", {emitEvent: false});
+      }
+    })
     commandsFormArray.push(commandFormGroup);
   }
 

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -2783,6 +2783,7 @@
             "attribute-name-required": "Attribute name is required",
             "command": "Command",
             "command-required": "Command is required",
+            "command-pattern": "Command is not valid",
             "remove": "Remove command"
         },
         "storage": "Storage",


### PR DESCRIPTION
## Pull Request description

Fixed issue when spaces inside command was defined as error
<img width="876" alt="image" src="https://github.com/thingsboard/thingsboard/assets/12072486/5c5e009c-fe02-4990-929d-f7ef810bff13">

And removed posibility to send string containing only spaces as command


## General checklist

- [X] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [X] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [X] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [X] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [X] Description contains human-readable scope of changes.
- [X] Description contains brief notes about what needs to be added to the documentation.
- [X] No merge conflicts, commented blocks of code, code formatting issues.
- [X] Changes are backward compatible or upgrade script is provided.
- [X] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [X] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [X] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [X] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)





