### PR TITLE
Create alarm node: add ability to use propagation settings when parsing alarm from message

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNodeConfiguration.java
@@ -33,6 +33,7 @@ public class TbCreateAlarmNodeConfiguration extends TbAbstractAlarmNodeConfigura
     private boolean propagateToOwner;
     private boolean propagateToTenant;
     private boolean useMessageAlarmData;
+    private boolean usePropagationConfigWhenParsingAlarmFromMsg;
     private boolean overwriteAlarmDetails = true;
     private boolean dynamicSeverity;
 
@@ -50,6 +51,7 @@ public class TbCreateAlarmNodeConfiguration extends TbAbstractAlarmNodeConfigura
         configuration.setPropagateToOwner(false);
         configuration.setPropagateToTenant(false);
         configuration.setUseMessageAlarmData(false);
+        configuration.setUsePropagationConfigWhenParsingAlarmFromMsg(false);
         configuration.setOverwriteAlarmDetails(false);
         configuration.setRelationTypes(Collections.emptyList());
         configuration.setDynamicSeverity(false);


### PR DESCRIPTION
## Pull Request description

Currently, when parsing alarm from incoming message it is not possible to configure propagation separately using UI. Everything needs to be specified in the message itself. This PR adds backend support for overwriting propagation configuration using UI, when alarm is parsed from message.

Before:
![image](https://github.com/thingsboard/thingsboard/assets/99619831/461309e9-1749-441f-aaaa-7d680cb5b0ac)

After:
![image](https://github.com/thingsboard/thingsboard/assets/99619831/112e8c97-7786-4b86-a319-070bc193eaf5)

Documentation for this node will be completely revamped in the separate PR

[PE PR](https://github.com/thingsboard/thingsboard-pe/pull/2073)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



