### PR TITLE
Fix delete queries

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/EntityAlarmRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/EntityAlarmRepository.java
@@ -36,6 +36,8 @@ public interface EntityAlarmRepository extends JpaRepository<EntityAlarmEntity, 
     void deleteByEntityId(@Param("entityId") UUID entityId);
 
     @Transactional
-    void deleteByTenantId(UUID tenantId);
+    @Modifying
+    @Query("DELETE FROM EntityAlarmEntity a WHERE a.tenantId = :tenantId")
+    void deleteByTenantId(@Param("tenantId") UUID tenantId);
 
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/notification/NotificationRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/notification/NotificationRepository.java
@@ -59,13 +59,19 @@ public interface NotificationRepository extends JpaRepository<NotificationEntity
     Page<NotificationEntity> findByRequestId(UUID requestId, Pageable pageable);
 
     @Transactional
-    int deleteByIdAndRecipientId(UUID id, UUID recipientId);
+    @Modifying
+    @Query("DELETE FROM NotificationEntity n WHERE n.id = :id AND n.recipientId = :recipientId")
+    int deleteByIdAndRecipientId(@Param("id") UUID id, @Param("recipientId") UUID recipientId);
 
     @Transactional
-    void deleteByRequestId(UUID requestId);
+    @Modifying
+    @Query("DELETE FROM NotificationEntity n WHERE n.requestId = :requestId")
+    void deleteByRequestId(@Param("requestId") UUID requestId);
 
     @Transactional
-    void deleteByRecipientId(UUID recipientId);
+    @Modifying
+    @Query("DELETE FROM NotificationEntity n WHERE n.recipientId = :recipientId")
+    void deleteByRecipientId(@Param("recipientId") UUID recipientId);
 
     @Modifying
     @Transactional

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/notification/NotificationRequestRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/notification/NotificationRequestRepository.java
@@ -70,9 +70,13 @@ public interface NotificationRequestRepository extends JpaRepository<Notificatio
     boolean existsByTenantIdAndStatusAndTemplateId(UUID tenantId, NotificationRequestStatus status, UUID templateId);
 
     @Transactional
-    int deleteAllByCreatedTimeBefore(long ts);
+    @Modifying
+    @Query("DELETE FROM NotificationRequestEntity r WHERE r.createdTime < :ts")
+    int deleteAllByCreatedTimeBefore(@Param("ts") long ts);
 
     @Transactional
-    void deleteByTenantId(UUID tenantId);
+    @Modifying
+    @Query("DELETE FROM NotificationRequestEntity r WHERE r.tenantId = :tenantId")
+    void deleteByTenantId(@Param("tenantId") UUID tenantId);
 
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/notification/NotificationRuleRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/notification/NotificationRuleRepository.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.dao.sql.notification;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -58,7 +59,9 @@ public interface NotificationRuleRepository extends JpaRepository<NotificationRu
                                                                       Pageable pageable);
 
     @Transactional
-    void deleteByTenantId(UUID tenantId);
+    @Modifying
+    @Query("DELETE FROM NotificationRuleEntity r WHERE r.tenantId = :tenantId")
+    void deleteByTenantId(@Param("tenantId") UUID tenantId);
 
     NotificationRuleEntity findByTenantIdAndName(UUID tenantId, String name);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/notification/NotificationTargetRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/notification/NotificationTargetRepository.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.dao.sql.notification;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -49,7 +50,9 @@ public interface NotificationTargetRepository extends JpaRepository<Notification
     List<NotificationTargetEntity> findByTenantIdAndIdIn(UUID tenantId, List<UUID> ids);
 
     @Transactional
-    void deleteByTenantId(UUID tenantId);
+    @Modifying
+    @Query("DELETE FROM NotificationTargetEntity t WHERE t.tenantId = :tenantId")
+    void deleteByTenantId(@Param("tenantId") UUID tenantId);
 
     long countByTenantId(UUID tenantId);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/notification/NotificationTemplateRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/notification/NotificationTemplateRepository.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.dao.sql.notification;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -42,7 +43,9 @@ public interface NotificationTemplateRepository extends JpaRepository<Notificati
                                                                                      Pageable pageable);
 
     @Transactional
-    void deleteByTenantId(UUID tenantId);
+    @Modifying
+    @Query("DELETE FROM NotificationTemplateEntity t WHERE t.tenantId = :tenantId")
+    void deleteByTenantId(@Param("tenantId") UUID tenantId);
 
     NotificationTemplateEntity findByTenantIdAndName(UUID tenantId, String name);
 


### PR DESCRIPTION
## Pull Request description

When using derived delete queries, Hibernate executes a select query for deleted entities first.

With this, one of our customers experienced OOM error on notifications cleanup, due to all the outdated notification requests being loaded into memory:

![image](https://github.com/thingsboard/thingsboard/assets/56742475/fe79bd3b-f82d-4b47-bcc3-652eb42d56d1)

```
Hibernate:
    select
        notificati0_.id as id1_23_,
        notificati0_.created_time as created_2_23_,
        notificati0_.additional_config as addition3_23_,
        notificati0_.info as info4_23_,
        notificati0_.originator_entity_id as originat5_23_,
        notificati0_.originator_entity_type as originat6_23_,
        notificati0_.rule_id as rule_id7_23_,
        notificati0_.stats as stats8_23_,
        notificati0_.status as status9_23_,
        notificati0_.targets as targets10_23_,
        notificati0_.template as templat11_23_,
        notificati0_.template_id as templat12_23_,
        notificati0_.tenant_id as tenant_13_23_
    from
        notification_request notificati0_
    where
        notificati0_.created_time<?
```

After this fix, the executed query looks like:
```
Hibernate:
    delete
    from
        notification_request
    where
        created_time<?
```


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



