### PR TITLE
Fixed message 'No data to display on widget' not displayed

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/cards/aggregated-value-card-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/cards/aggregated-value-card-widget.component.ts
@@ -116,7 +116,7 @@ export class AggregatedValueCardWidgetComponent implements OnInit, AfterViewInit
   ngOnInit(): void {
     this.ctx.$scope.aggregatedValueCardWidget = this;
     this.settings = {...aggregatedValueCardDefaultSettings, ...this.ctx.settings};
-    this.showSubtitle = this.settings.showSubtitle;
+    this.showSubtitle = this.settings.showSubtitle && this.ctx.datasources?.length > 0;
     const subtitle = this.settings.subtitle;
     this.subtitle$ = this.ctx.registerLabelPattern(subtitle, this.subtitle$);
     this.subtitleStyle = textStyle(this.settings.subtitleFont, '0.25px');
@@ -156,7 +156,7 @@ export class AggregatedValueCardWidgetComponent implements OnInit, AfterViewInit
   }
 
   ngAfterViewInit(): void {
-    if (this.showChart) {
+    if (this.showChart && this.ctx.datasources?.length) {
       const settings = {
         shadowSize: 0,
         enableSelection: false,

--- a/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/flot-widget.component.ts
@@ -60,7 +60,9 @@ export class FlotWidgetComponent implements OnInit {
     this.settings = this.ctx.settings;
     this.chartType = this.chartType || 'line';
     this.configureLegend();
-    this.flot = new TbFlot(this.ctx, this.chartType, $(this.flotElement.nativeElement));
+    if (this.ctx.datasources?.length) {
+      this.flot = new TbFlot(this.ctx, this.chartType, $(this.flotElement.nativeElement));
+    }
   }
 
   private configureLegend(): void {


### PR DESCRIPTION
 Timeseries Line Chart, Timeseries Bar Chart, State Chart, Value and chart card widgets do not display "No data to display on widget" when all data is filtered out.

**BEFORE**

[Screencast from 18.10.23 12:52:49.webm](https://github.com/thingsboard/thingsboard/assets/87172504/875e61a2-06e6-4231-b53d-6249bed80328)

**AFTER**

[Screencast from 18.10.23 12:54:52.webm](https://github.com/thingsboard/thingsboard/assets/87172504/52b4eb5a-13f9-4f7b-9be7-ffb2e6695b5d)


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


