### PR TITLE
Improved show confirm on exit dialog in widget editor

### DIFF
--- a/ui-ngx/src/app/core/guards/confirm-on-exit.guard.ts
+++ b/ui-ngx/src/app/core/guards/confirm-on-exit.guard.ts
@@ -28,10 +28,12 @@ import { isDefined } from '../utils';
 
 export interface HasConfirmForm {
   confirmForm(): UntypedFormGroup;
+  confirmOnExitMessage?: string;
 }
 
 export interface HasDirtyFlag {
   isDirty: boolean;
+  confirmOnExitMessage?: string;
 }
 
 @Injectable({
@@ -66,9 +68,10 @@ export class ConfirmOnExitGuard implements CanDeactivate<HasConfirmForm & HasDir
         isDirty = component.isDirty;
       }
       if (isDirty) {
+        const message = this.getMessage(component);
         return this.dialogService.confirm(
           this.translate.instant('confirm-on-exit.title'),
-          this.translate.instant('confirm-on-exit.html-message')
+          message
         ).pipe(
           map((dialogResult) => {
             if (dialogResult) {
@@ -84,5 +87,11 @@ export class ConfirmOnExitGuard implements CanDeactivate<HasConfirmForm & HasDir
       }
     }
     return true;
+  }
+
+  private getMessage(component: HasConfirmForm & HasDirtyFlag): string {
+    return component.confirmOnExitMessage
+      ? component.confirmOnExitMessage
+      : this.translate.instant('confirm-on-exit.html-message');
   }
 }

--- a/ui-ngx/src/app/modules/home/components/dashboard-page/dashboard-page.component.ts
+++ b/ui-ngx/src/app/modules/home/components/dashboard-page/dashboard-page.component.ts
@@ -956,6 +956,7 @@ export class DashboardPageComponent extends PageComponent implements IDashboardC
 
   public toggleDashboardEditMode() {
     this.setEditMode(!this.isEdit, true);
+    this.notifyDashboardToggleEditMode();
   }
 
   public saveDashboard() {
@@ -1061,6 +1062,16 @@ export class DashboardPageComponent extends PageComponent implements IDashboardC
 
   private filtersUpdated() {
     this.dashboardCtx.aliasController.updateFilters(this.dashboard.configuration.filters);
+  }
+
+  private notifyDashboardToggleEditMode() {
+    if (this.widgetEditMode) {
+      const message: WindowMessage = {
+        type: 'widgetEditModeToggle',
+        data: this.isEdit
+      };
+      this.window.parent.postMessage(JSON.stringify(message), '*');
+    }
   }
 
   private notifyDashboardUpdated() {

--- a/ui-ngx/src/app/modules/home/pages/widget/widget-editor.component.ts
+++ b/ui-ngx/src/app/modules/home/pages/widget/widget-editor.component.ts
@@ -122,7 +122,19 @@ export class WidgetEditorComponent extends PageComponent implements OnInit, OnDe
   widget: WidgetInfo;
   origWidget: WidgetInfo;
 
-  isDirty = false;
+  private isEditModeWidget = false;
+  private _isDirty = false;
+
+  get isDirty(): boolean {
+    return this._isDirty || this.isEditModeWidget;
+  }
+
+  set isDirty(value: boolean) {
+    if (!value) {
+      this.isEditModeWidget = false;
+    }
+    this._isDirty = value;
+  }
 
   fullscreen = false;
   htmlFullscreen = false;
@@ -450,6 +462,10 @@ export class WidgetEditorComponent extends PageComponent implements OnInit, OnDe
           break;
         case 'widgetEditUpdated':
           this.onWidgetEditUpdated(message.data);
+          this.onWidgetEditModeToggled(false);
+          break;
+        case 'widgetEditModeToggle':
+          this.onWidgetEditModeToggled(message.data);
           break;
       }
     }
@@ -484,6 +500,10 @@ export class WidgetEditorComponent extends PageComponent implements OnInit, OnDe
     this.widget.defaultConfig = JSON.stringify(widget.config);
     this.iframe.attr('data-widget', JSON.stringify(this.widget));
     this.isDirty = true;
+  }
+
+  private onWidgetEditModeToggled(mode: boolean) {
+    this.isEditModeWidget = mode;
   }
 
   private onWidgetException(details: ExceptionData) {
@@ -639,7 +659,7 @@ export class WidgetEditorComponent extends PageComponent implements OnInit, OnDe
   }
 
   undoDisabled(): boolean {
-    return !this.isDirty
+    return !this._isDirty
     || !this.iframeWidgetEditModeInited
     || this.saveWidgetPending
     || this.saveWidgetAsPending;
@@ -647,7 +667,7 @@ export class WidgetEditorComponent extends PageComponent implements OnInit, OnDe
 
   saveDisabled(): boolean {
     return this.isReadOnly
-      || !this.isDirty
+      || !this._isDirty
       || !this.iframeWidgetEditModeInited
       || this.saveWidgetPending
       || this.saveWidgetAsPending;
@@ -798,5 +818,12 @@ export class WidgetEditorComponent extends PageComponent implements OnInit, OnDe
     }
     this.widget.defaultConfig = JSON.stringify(config);
     this.isDirty = true;
+  }
+
+  get confirmOnExitMessage(): string {
+    if (this.isEditModeWidget && !this._isDirty) {
+      return this.translate.instant('widget.confirm-to-exit-editor-html');
+    }
+    return '';
   }
 }

--- a/ui-ngx/src/app/shared/models/window-message.model.ts
+++ b/ui-ngx/src/app/shared/models/window-message.model.ts
@@ -14,7 +14,8 @@
 /// limitations under the License.
 ///
 
-export type WindowMessageType = 'widgetException' | 'widgetEditModeInited' | 'widgetEditUpdated' | 'openDashboardMessage' | 'reloadUserMessage' | 'toggleDashboardLayout';
+export type WindowMessageType = 'widgetException' | 'widgetEditModeInited' | 'widgetEditUpdated' | 'openDashboardMessage'
+  | 'reloadUserMessage' | 'toggleDashboardLayout' | 'widgetEditModeToggle';
 
 export interface WindowMessage {
   type: WindowMessageType;

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -4759,6 +4759,7 @@
         "no-widgets-text": "No widgets found",
         "management": "Widget management",
         "editor": "Widget Editor",
+        "confirm-to-exit-editor-html": "You have unsaved default widget settings.<br>Are you sure you want to leave this page?",
         "widget-type-not-found": "Problem loading widget configuration.<br>Probably associated\n    widget type was removed.",
         "widget-type-load-error": "Widget wasn't loaded due to the following errors:",
         "remove": "Remove widget",


### PR DESCRIPTION
## Pull Request description

Added display of a confirm dialog about not saving changes in the widget editor. It also considers whether the widget editing mode is activated to show the dialog.

After:
![image](https://github.com/thingsboard/thingsboard/assets/18036670/c908b50f-7d52-4436-a984-1d2a0c74e581)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



