### PR TITLE
GatewaySessionHandlerTest createWeakMap() test simplified

### DIFF
--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandlerTest.java
@@ -15,47 +15,21 @@
  */
 package org.thingsboard.server.transport.mqtt.session;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.ConcurrentReferenceHashMap;
 
-import java.util.WeakHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
-import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.willCallRealMethod;
 import static org.mockito.Mockito.mock;
 
 public class GatewaySessionHandlerTest {
 
     @Test
-    public void givenWeakHashMap_WhenGC_thenMapIsEmpty() {
-        WeakHashMap<String, Lock> map = new WeakHashMap<>();
-
-        String deviceName = new String("device"); //constants are static and doesn't affected by GC, so use new instead
-        map.put(deviceName, new ReentrantLock());
-        assertTrue(map.containsKey(deviceName));
-
-        deviceName = null;
-        System.gc();
-
-        await().atMost(10, TimeUnit.SECONDS).until(() -> !map.containsKey("device"));
-    }
-
-    @Test
-    public void givenConcurrentReferenceHashMap_WhenGC_thenMapIsEmpty() {
+    public void givenGatewaySessionHandler_WhenCreateWeakMap_thenConcurrentReferenceHashMapClass() {
         GatewaySessionHandler gsh = mock(GatewaySessionHandler.class);
         willCallRealMethod().given(gsh).createWeakMap();
 
-        ConcurrentMap<String, Lock> map = gsh.createWeakMap();
-        map.put("device", new ReentrantLock());
-        assertTrue(map.containsKey("device"));
-
-        System.gc();
-
-        await().atMost(10, TimeUnit.SECONDS).until(() -> !map.containsKey("device"));
+        assertThat(gsh.createWeakMap()).isInstanceOf(ConcurrentReferenceHashMap.class);
     }
 
 }


### PR DESCRIPTION
## GatewaySessionHandlerTest createWeakMap() test simplified

This test was fluky because it relies on a single GC run. GC implementation is not guaranteed that memory become crystal clear after GC call. It is rather to do the best effort to clean as much as possible with less CPU time.

For the business logic it matter that that map is kind of Weak map that is absolutely fine. It is not a point to verify the Spring ConcurrentReferenceMap implementation

![image](https://github.com/thingsboard/thingsboard/assets/79898499/c008f046-e271-4740-a56b-2cc58ce02e06)
 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



