### PR TITLE
Hotfix/3.6 transport api performance

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -1205,6 +1205,7 @@ queue:
     max_pending_requests: "${TB_QUEUE_TRANSPORT_MAX_PENDING_REQUESTS:10000}"
     max_requests_timeout: "${TB_QUEUE_TRANSPORT_MAX_REQUEST_TIMEOUT:10000}"
     max_callback_threads: "${TB_QUEUE_TRANSPORT_MAX_CALLBACK_THREADS:100}"
+    max_core_handler_threads: "${TB_QUEUE_TRANSPORT_MAX_CORE_HANDLER_THREADS:16}"
     request_poll_interval: "${TB_QUEUE_TRANSPORT_REQUEST_POLL_INTERVAL_MS:25}"
     response_poll_interval: "${TB_QUEUE_TRANSPORT_RESPONSE_POLL_INTERVAL_MS:25}"
   core:

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceCredentialsServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceCredentialsServiceImpl.java
@@ -82,7 +82,7 @@ public class DeviceCredentialsServiceImpl extends AbstractCachedEntityService<St
         validateString(credentialsId, "Incorrect credentialsId " + credentialsId);
         return cache.getAndPutInTransaction(credentialsId,
                 () -> deviceCredentialsDao.findByCredentialsId(TenantId.SYS_TENANT_ID, credentialsId),
-                false);
+                true); // caching null values is essential for permanently invalid requests
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/device/JpaDeviceCredentialsDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/device/JpaDeviceCredentialsDao.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.dao.sql.device;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
@@ -33,6 +34,7 @@ import java.util.UUID;
 /**
  * Created by Valerii Sosliuk on 5/6/2017.
  */
+@Slf4j
 @Component
 @SqlDao
 public class JpaDeviceCredentialsDao extends JpaAbstractDao<DeviceCredentialsEntity, DeviceCredentials> implements DeviceCredentialsDao {
@@ -65,6 +67,7 @@ public class JpaDeviceCredentialsDao extends JpaAbstractDao<DeviceCredentialsEnt
 
     @Override
     public DeviceCredentials findByCredentialsId(TenantId tenantId, String credentialsId) {
+        log.trace("[{}] findByCredentialsId [{}]", tenantId, credentialsId);
         return DaoUtil.getData(deviceCredentialsRepository.findByCredentialsId(credentialsId));
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/DeviceCredentialsCacheTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/DeviceCredentialsCacheTest.java
@@ -127,10 +127,10 @@ public class DeviceCredentialsCacheTest extends AbstractServiceTest {
 
         when(deviceCredentialsDao.findByCredentialsId(SYSTEM_TENANT_ID, CREDENTIALS_ID_1)).thenReturn(null);
 
-        deviceCredentialsService.findDeviceCredentialsByCredentialsId(CREDENTIALS_ID_1);
-        deviceCredentialsService.findDeviceCredentialsByCredentialsId(CREDENTIALS_ID_1);
+        deviceCredentialsService.findDeviceCredentialsByCredentialsId(CREDENTIALS_ID_1); // cache miss, DB read (not found), Cache put null value
+        deviceCredentialsService.findDeviceCredentialsByCredentialsId(CREDENTIALS_ID_1); // cache hit (null value, credentials not found)
 
-        verify(deviceCredentialsDao, times(3)).findByCredentialsId(SYSTEM_TENANT_ID, CREDENTIALS_ID_1);
+        verify(deviceCredentialsDao, times(2)).findByCredentialsId(SYSTEM_TENANT_ID, CREDENTIALS_ID_1);
     }
 
     private DeviceCredentialsService unwrapDeviceCredentialsService() throws Exception {


### PR DESCRIPTION
## Hotfix/3.6 transport api performance

* DefaultTransportApiService: **handlerExecutor** implemented with * TB_QUEUE_TRANSPORT_MAX_CORE_HANDLER_THREADS=16; submit validateCredentials to the handlerExecutor;
* deviceCreationLocks - weak map
* **cache nulls** (not found) results for deviceCredentialsDao.**findByCredentialsId** to reduce the load on permanent failure requests 
* log (minor) JpaDeviceCredentialsDao: trace log added for findByCredentialsId Sergey Matvienko Today 13:13 
* log major tenantId, gatewayId **AbstractGatewaySessionHandler**(mqtt transport): log tenantId, gatewayId at the beginning of each message

cache / db calls
![image](https://github.com/thingsboard/thingsboard/assets/79898499/2a7040b0-38df-4526-90bd-3c7a2ff972fa)

MQTT gateway logs
![image](https://github.com/thingsboard/thingsboard/assets/79898499/17330124-125e-4e74-9d44-0d3b22683841)


Before this, the validation runs initially in a blocking way in transport API consumer:

![2023-10-31_08-17](https://github.com/thingsboard/thingsboard/assets/79898499/2e12119c-225d-4bce-b28a-079f58fd9b45)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



