### PR TITLE
Workaround failed Thingsboard installation and update when running sh scripts from an arbitrary path

### DIFF
--- a/packaging/java/scripts/install/install.sh
+++ b/packaging/java/scripts/install/install.sh
@@ -46,7 +46,7 @@ source "${CONF_FOLDER}/${configfile}"
 
 run_user=${pkg.user}
 
-su -s /bin/sh -c "java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardInstallApplication \
+su --login -s /bin/sh -c "java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardInstallApplication \
                     -Dinstall.data_dir=${installDir} \
                     -Dinstall.load_demo=${loadDemo} \
                     -Dspring.jpa.hibernate.ddl-auto=none \

--- a/packaging/java/scripts/install/upgrade.sh
+++ b/packaging/java/scripts/install/upgrade.sh
@@ -45,7 +45,7 @@ source "${CONF_FOLDER}/${configfile}"
 
 run_user=${pkg.user}
 
-su -s /bin/sh -c "java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardInstallApplication \
+su --login -s /bin/sh -c "java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardInstallApplication \
                     -Dinstall.data_dir=${installDir} \
                     -Dspring.jpa.hibernate.ddl-auto=none \
                     -Dinstall.upgrade=true \


### PR DESCRIPTION
su --login option makes the shell use the home directory of the "thingsboard" OS user.
It workarounds Java complains for "Invalid source directory" during installation or upgrade.

```
sudo /usr/share/thingsboard/bin/install/install.sh --loadDemo
Exception in thread "main" java.lang.IllegalStateException: java.lang.IllegalArgumentException: Invalid source directory /home/user/Desktop
	at org.springframework.boot.loader.PropertiesLauncher.<init>(PropertiesLauncher.java:158)
	at org.springframework.boot.loader.PropertiesLauncher.main(PropertiesLauncher.java:465)
Caused by: java.lang.IllegalArgumentException: Invalid source directory /home/user/Desktop
	at org.springframework.boot.loader.archive.ExplodedArchive.<init>(ExplodedArchive.java:73)
	at org.springframework.boot.loader.PropertiesLauncher.getProperty(PropertiesLauncher.java:426)
	at org.springframework.boot.loader.PropertiesLauncher.getProperty(PropertiesLauncher.java:395)
	at org.springframework.boot.loader.PropertiesLauncher.initializeProperties(PropertiesLauncher.java:173)
	at org.springframework.boot.loader.PropertiesLauncher.<init>(PropertiesLauncher.java:153)
	... 1 more
ThingsBoard installation failed!
```

