### PR TITLE
Added support basic settings form of custom widgets

### DIFF
--- a/ui-ngx/src/app/modules/home/components/public-api.ts
+++ b/ui-ngx/src/app/modules/home/components/public-api.ts
@@ -15,3 +15,5 @@
 ///
 
 export * from './home-components.module';
+
+export * from './widget/config/widget-config.component.models';

--- a/ui-ngx/src/app/modules/home/components/widget/widget-component.service.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-component.service.ts
@@ -29,7 +29,13 @@ import {
 import cssjs from '@core/css/css';
 import { UtilsService } from '@core/services/utils.service';
 import { ModulesWithFactories, ResourcesService } from '@core/services/resources.service';
-import { Widget, widgetActionSources, WidgetControllerDescriptor, WidgetType } from '@shared/models/widget.models';
+import {
+  IWidgetSettingsComponent,
+  Widget,
+  widgetActionSources,
+  WidgetControllerDescriptor,
+  WidgetType
+} from '@shared/models/widget.models';
 import { catchError, map, mergeMap, switchMap, tap } from 'rxjs/operators';
 import { isFunction, isUndefined } from '@core/utils';
 import { TranslateService } from '@ngx-translate/core';
@@ -47,6 +53,8 @@ import moment from 'moment';
 import { IModulesMap } from '@modules/common/modules-map.models';
 import { HOME_COMPONENTS_MODULE_TOKEN } from '@home/components/tokens';
 import { widgetSettingsComponentsMap } from '@home/components/widget/lib/settings/widget-settings.module';
+import { basicWidgetConfigComponentsMap } from '@home/components/widget/config/basic/basic-widget-config.module';
+import { IBasicWidgetConfigComponent } from '@home/components/widget/config/widget-config.component.models';
 
 @Injectable()
 export class WidgetComponentService {
@@ -397,6 +405,7 @@ export class WidgetComponentService {
 
   private registerWidgetSettingsForms(widgetInfo: WidgetInfo, factories: ComponentFactory<any>[]) {
     const directives: string[] = [];
+    const basicDirectives: string[] = [];
     if (widgetInfo.settingsDirective && widgetInfo.settingsDirective.length) {
       directives.push(widgetInfo.settingsDirective);
     }
@@ -407,12 +416,19 @@ export class WidgetComponentService {
       directives.push(widgetInfo.latestDataKeySettingsDirective);
     }
     if (widgetInfo.basicModeDirective && widgetInfo.basicModeDirective.length) {
-      directives.push(widgetInfo.basicModeDirective);
+      basicDirectives.push(widgetInfo.basicModeDirective);
     }
+
+    this.expandSettingComponentMap(widgetSettingsComponentsMap, directives, factories);
+    this.expandSettingComponentMap(basicWidgetConfigComponentsMap, basicDirectives, factories);
+  }
+
+  private expandSettingComponentMap(settingsComponentsMap: {[key: string]: Type<IWidgetSettingsComponent | IBasicWidgetConfigComponent>},
+                                    directives: string[], factories: ComponentFactory<any>[]): void {
     if (directives.length) {
       factories.filter((factory) => directives.includes(factory.selector))
         .forEach((foundFactory) => {
-          widgetSettingsComponentsMap[foundFactory.selector] = foundFactory.componentType;
+          settingsComponentsMap[foundFactory.selector] = foundFactory.componentType;
         });
     }
   }


### PR DESCRIPTION
## Pull Request description

In the current version of Thingsboard users can't create custom basic settings components, as `BasicWidgetConfigComponent` isn't shared and registration of basic settings forms doesn't work properly (**basic** components put into **advanced components map** as a result system doesn't see **basic** forms).

This PR share `BasicWidgetConfigComponent` and update `registerWidgetSettingsForms` to allow the creation  of custom basic settings forms.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



