### PR TITLE
[fix][bug]String asObjectToBytes

### DIFF
--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbUtils.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbUtils.java
@@ -61,9 +61,9 @@ public class TbUtils {
         parserConfig.addImport("decodeToJson", new MethodStub(TbUtils.class.getMethod("decodeToJson",
                 ExecutionContext.class, String.class)));
         parserConfig.addImport("stringToBytes", new MethodStub(TbUtils.class.getMethod("stringToBytes",
-                ExecutionContext.class, String.class)));
+                ExecutionContext.class, Object.class)));
         parserConfig.addImport("stringToBytes", new MethodStub(TbUtils.class.getMethod("stringToBytes",
-                ExecutionContext.class, String.class, String.class)));
+                ExecutionContext.class, Object.class, String.class)));
         parserConfig.registerNonConvertableMethods(TbUtils.class, Collections.singleton("stringToBytes"));
         parserConfig.addImport("parseInt", new MethodStub(TbUtils.class.getMethod("parseInt",
                 String.class)));
@@ -192,14 +192,22 @@ public class TbUtils {
         return new String(bytes, charsetName);
     }
 
-    public static List<Byte> stringToBytes(ExecutionContext ctx, String str) {
-        byte[] bytes = str.getBytes();
-        return bytesToList(ctx, bytes);
+    public static List<Byte> stringToBytes(ExecutionContext ctx, Object str) throws IllegalAccessException {
+        if (str instanceof String) {
+            byte[] bytes = str.toString().getBytes();
+            return bytesToList(ctx, bytes);
+        } else {
+            throw new IllegalAccessException("Invalid type parameter [" + str.getClass().getSimpleName() + "]. Expected 'String'");
+        }
     }
 
-    public static List<Byte> stringToBytes(ExecutionContext ctx, String str, String charsetName) throws UnsupportedEncodingException {
-        byte[] bytes = str.getBytes(charsetName);
-        return bytesToList(ctx, bytes);
+    public static List<Byte> stringToBytes(ExecutionContext ctx, Object str, String charsetName) throws UnsupportedEncodingException, IllegalAccessException {
+        if (str instanceof String) {
+            byte[] bytes = str.toString().getBytes(charsetName);
+            return bytesToList(ctx, bytes);
+        } else {
+            throw new IllegalAccessException("Invalid type parameter [" + str.getClass().getSimpleName() + "]. Expected 'String'");
+        }
     }
 
     private static byte[] bytesFromList(List<Byte> bytesList) {

--- a/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
+++ b/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
@@ -350,7 +350,7 @@ public class TbUtilsTest {
     }
 
     @Test
-    public void parseBytesDecodeToJson() throws IOException {
+    public void parseBytesDecodeToJson() throws IOException, IllegalAccessException {
         String expectedStr = "{\"hello\": \"world\"}";
         ExecutionHashMap<String, Object> expectedJson = new ExecutionHashMap<>(1, ctx);
         expectedJson.put("hello", "world");
@@ -365,6 +365,24 @@ public class TbUtilsTest {
         expectedJson.put("hello", "world");
         Object actualJson =  TbUtils.decodeToJson(ctx, expectedStr);
         Assert.assertEquals(expectedJson,actualJson);
+    }
+
+    @Test
+    public void stringToBytesInputObjectTest() throws IOException, IllegalAccessException {
+        String expectedStr = "{\"hello\": \"world\"}";
+        Object inputJson = TbUtils.decodeToJson(ctx, expectedStr);
+        byte[] arrayBytes = {119, 111, 114, 108, 100};
+        List<Byte> expectedBytes = Bytes.asList(arrayBytes);
+        List<Byte> actualBytes = TbUtils.stringToBytes(ctx, ((ExecutionHashMap) inputJson).get("hello"));
+        Assert.assertEquals(expectedBytes, actualBytes);
+        actualBytes = TbUtils.stringToBytes(ctx, ((ExecutionHashMap) inputJson).get("hello"), "UTF-8");
+        Assert.assertEquals(expectedBytes, actualBytes);
+
+        expectedStr = "{\"hello\": 1234}";
+        inputJson = TbUtils.decodeToJson(ctx, expectedStr);
+        Object finalInputJson = inputJson;
+        Assert.assertThrows(IllegalAccessException.class, () -> TbUtils.stringToBytes(ctx, ((ExecutionHashMap) finalInputJson).get("hello")));
+        Assert.assertThrows(IllegalAccessException.class, () -> TbUtils.stringToBytes(ctx, ((ExecutionHashMap) finalInputJson).get("hello"), "UTF-8"));
     }
 
     private static List<Byte> toList(byte[] data) {


### PR DESCRIPTION
## Pull Request description
https://thingsboard-portal.atlassian.net/browse/PROD-2554
If parameter is Object as int:
![зображення](https://github.com/thingsboard/thingsboard/assets/44275303/da1e7a27-4ffc-4238-906f-d47106135d60) 
If parameter is Object as String:
![зображення](https://github.com/thingsboard/thingsboard/assets/44275303/904e6654-6f51-4f65-b0b2-202d25cc5017)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



