### PR TITLE
Fixed value and chart card crash on empty colorProcessor type

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/color-settings-panel.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/color-settings-panel.component.ts
@@ -65,7 +65,7 @@ export class ColorSettingsPanelComponent extends PageComponent implements OnInit
   ngOnInit(): void {
     this.colorSettingsFormGroup = this.fb.group(
       {
-        type: [this.colorSettings?.type, []],
+        type: [this.colorSettings?.type || ColorType.constant, []],
         color: [this.colorSettings?.color, []],
         rangeList: [this.colorSettings?.rangeList, []],
         colorFunction: [this.colorSettings?.colorFunction, []]

--- a/ui-ngx/src/app/shared/models/widget-settings.models.ts
+++ b/ui-ngx/src/app/shared/models/widget-settings.models.ts
@@ -161,6 +161,8 @@ export abstract class ColorProcessor {
         return new RangeColorProcessor(settings);
       case ColorType.function:
         return new FunctionColorProcessor(settings);
+      default:
+        return new ConstantColorProcessor(settings);
     }
   }
 


### PR DESCRIPTION

## Pull Request description

This pull request is created to fix the crash on empty colorProcessor type , as a fix solution added default value to colorSettings type and default case for colorProcessor  to ensure the layered approach that application is resilient against errors.

**BEFORE** 

https://github.com/thingsboard/thingsboard/assets/54553744/5a23300a-8d03-4658-9797-4bcee61b5c0f

**AFTER**

https://github.com/thingsboard/thingsboard/assets/54553744/c4784a93-215d-44f2-b4e2-2ea15cfc53a9




## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



