### PR TITLE
packaging: remove dupplicated "adduser --quiet" option in deb preinst

### DIFF
--- a/packaging/java/scripts/control/deb/preinst
+++ b/packaging/java/scripts/control/deb/preinst
@@ -10,7 +10,6 @@ if ! getent passwd ${pkg.user} >/dev/null; then
     adduser --quiet \
             --system \
             --ingroup ${pkg.user} \
-            --quiet \
             --disabled-login \
             --disabled-password \
             --home ${pkg.installFolder} \

--- a/packaging/js/scripts/control/deb/preinst
+++ b/packaging/js/scripts/control/deb/preinst
@@ -8,7 +8,6 @@ if ! getent passwd ${pkg.user} >/dev/null; then
     adduser --quiet \
             --system \
             --ingroup ${pkg.user} \
-            --quiet \
             --disabled-login \
             --disabled-password \
             --home ${pkg.installFolder} \


### PR DESCRIPTION
## Pull Request description

adduser command (from Debian "preinst" file) contains the duplicated option "--quiet"
