### PR TITLE
Fixed uncontrolled focus alarm type list

### DIFF
--- a/ui-ngx/src/app/shared/components/entity/entity-subtype-list.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-subtype-list.component.ts
@@ -294,6 +294,9 @@ export class EntitySubTypeListComponent implements ControlValueAccessor, OnInit,
     this.searchText = searchText;
     return this.getEntitySubtypes(searchText).pipe(
       map(subTypes => {
+        if (!subTypes.length) {
+          return subTypes;
+        }
         let result;
         if (this.hasPageDataEntitySubTypes.has(this.entityType)) {
           result = subTypes;
@@ -368,10 +371,6 @@ export class EntitySubTypeListComponent implements ControlValueAccessor, OnInit,
   clear(value: string = '') {
     this.entitySubtypeInput.nativeElement.value = value;
     this.entitySubtypeListFormGroup.get('entitySubtype').patchValue(value, {emitEvent: true});
-    setTimeout(() => {
-      this.entitySubtypeInput.nativeElement.blur();
-      this.entitySubtypeInput.nativeElement.focus();
-    }, 0);
   }
 
   customTranslate(entity: string) {

--- a/ui-ngx/src/app/shared/components/entity/entity-subtype-list.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-subtype-list.component.ts
@@ -265,8 +265,8 @@ export class EntitySubTypeListComponent implements ControlValueAccessor, OnInit,
     const value = (event.value || '').trim();
     if (value) {
       this.add(value);
+      this.clear('');
     }
-    this.clear('');
   }
   remove(entitySubtype: string) {
     const index = this.entitySubtypeList.indexOf(entitySubtype);
@@ -294,9 +294,6 @@ export class EntitySubTypeListComponent implements ControlValueAccessor, OnInit,
     this.searchText = searchText;
     return this.getEntitySubtypes(searchText).pipe(
       map(subTypes => {
-        if (!subTypes.length) {
-          return subTypes;
-        }
         let result;
         if (this.hasPageDataEntitySubTypes.has(this.entityType)) {
           result = subTypes;
@@ -371,6 +368,10 @@ export class EntitySubTypeListComponent implements ControlValueAccessor, OnInit,
   clear(value: string = '') {
     this.entitySubtypeInput.nativeElement.value = value;
     this.entitySubtypeListFormGroup.get('entitySubtype').patchValue(value, {emitEvent: true});
+    setTimeout(() => {
+      this.entitySubtypeInput.nativeElement.blur();
+      this.entitySubtypeInput.nativeElement.focus();
+    }, 0);
   }
 
   customTranslate(entity: string) {


### PR DESCRIPTION
## Pull Request description

Hotfix alarm type list uncontrolled focus.

Steps to reproduce:
1. Login as a tenant user;
2. Open the alarm menu or any dashboard with an alarm widget;
3. Open (click) the Alarm filter;
4. Set existing alarm types ;
5. Add a manual alarm type - and try to add a second;

As a result, You can’t add new alarm types and focus on this field stay active event if click out of the field.

After fix all works correctly.
![image](https://github.com/thingsboard/thingsboard/assets/83352633/e4de2531-3ef1-4043-9bc5-769f56ccfcc5)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



