### PR TITLE
Fixed alias controller in entity list type added disable entity list for empty entity type

### DIFF
--- a/ui-ngx/src/app/modules/home/components/entity/entity-filter.component.ts
+++ b/ui-ngx/src/app/modules/home/components/entity/entity-filter.component.ts
@@ -14,13 +14,14 @@
 /// limitations under the License.
 ///
 
-import { Component, EventEmitter, forwardRef, Input, OnInit, Output } from '@angular/core';
-import { ControlValueAccessor, UntypedFormBuilder, UntypedFormGroup, NG_VALUE_ACCESSOR, Validators } from '@angular/forms';
+import { Component, EventEmitter, forwardRef, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { ControlValueAccessor, FormBuilder, FormGroup, NG_VALUE_ACCESSOR, Validators } from '@angular/forms';
 import { AliasFilterType, aliasFilterTypeTranslationMap, EntityAliasFilter } from '@shared/models/alias.models';
 import { AliasEntityType, EntityType } from '@shared/models/entity-type.models';
-import { TranslateService } from '@ngx-translate/core';
 import { EntityService } from '@core/http/entity.service';
 import { EntitySearchDirection, entitySearchDirectionTranslations } from '@shared/models/relation.models';
+import { Subject, Subscription } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'tb-entity-filter',
@@ -34,7 +35,7 @@ import { EntitySearchDirection, entitySearchDirectionTranslations } from '@share
     }
   ]
 })
-export class EntityFilterComponent implements ControlValueAccessor, OnInit {
+export class EntityFilterComponent implements ControlValueAccessor, OnInit, OnDestroy {
 
   @Input() disabled: boolean;
 
@@ -44,8 +45,8 @@ export class EntityFilterComponent implements ControlValueAccessor, OnInit {
 
   @Output() resolveMultipleChanged: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-  entityFilterFormGroup: UntypedFormGroup;
-  filterFormGroup: UntypedFormGroup;
+  entityFilterFormGroup: FormGroup;
+  filterFormGroup: FormGroup;
 
   aliasFilterTypes: Array<AliasFilterType>;
 
@@ -59,9 +60,11 @@ export class EntityFilterComponent implements ControlValueAccessor, OnInit {
 
   private propagateChange = null;
 
-  constructor(private translate: TranslateService,
-              private entityService: EntityService,
-              private fb: UntypedFormBuilder) {
+  private destroy$ = new Subject<void>();
+  private subscriptions = new Subscription();
+
+  constructor(private entityService: EntityService,
+              private fb: FormBuilder) {
   }
 
   ngOnInit(): void {
@@ -71,13 +74,23 @@ export class EntityFilterComponent implements ControlValueAccessor, OnInit {
     this.entityFilterFormGroup = this.fb.group({
       type: [null, [Validators.required]]
     });
-    this.entityFilterFormGroup.get('type').valueChanges.subscribe((type: AliasFilterType) => {
+    this.entityFilterFormGroup.get('type').valueChanges.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe((type: AliasFilterType) => {
       this.filterTypeChanged(type);
     });
-    this.entityFilterFormGroup.valueChanges.subscribe(() => {
+    this.entityFilterFormGroup.valueChanges.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(() => {
       this.updateModel();
     });
     this.filterFormGroup = this.fb.group({});
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.subscriptions.unsubscribe();
   }
 
   registerOnChange(fn: any): void {
@@ -105,6 +118,8 @@ export class EntityFilterComponent implements ControlValueAccessor, OnInit {
   }
 
   private updateFilterFormGroup(type: AliasFilterType, filter?: EntityAliasFilter) {
+    this.subscriptions.unsubscribe();
+    this.subscriptions = new Subscription();
     switch (type) {
       case AliasFilterType.singleEntity:
         this.filterFormGroup = this.fb.group({
@@ -114,8 +129,17 @@ export class EntityFilterComponent implements ControlValueAccessor, OnInit {
       case AliasFilterType.entityList:
         this.filterFormGroup = this.fb.group({
           entityType: [filter ? filter.entityType : null, [Validators.required]],
-          entityList: [filter ? filter.entityList : [], [Validators.required]],
+          entityList: [{
+            value: filter ? filter.entityList : [],
+            disabled: !filter?.entityType
+          }, [Validators.required]],
         });
+        const entityTypeSubscription = this.filterFormGroup.get('entityType').valueChanges.subscribe((entityType) => {
+          if (entityType && this.filterFormGroup.get('entityList').disabled) {
+            this.filterFormGroup.get('entityList').enable({emitEvent: false});
+          }
+        });
+        this.subscriptions.add(entityTypeSubscription);
         break;
       case AliasFilterType.entityName:
         this.filterFormGroup = this.fb.group({
@@ -175,10 +199,11 @@ export class EntityFilterComponent implements ControlValueAccessor, OnInit {
           maxLevel: [filter ? filter.maxLevel : 1, []],
           fetchLastLevelOnly: [filter ? filter.fetchLastLevelOnly : false, []]
         });
-        this.filterFormGroup.get('rootStateEntity').valueChanges.subscribe((rootStateEntity: boolean) => {
+        const rootStateSubscription = this.filterFormGroup.get('rootStateEntity').valueChanges.subscribe((rootStateEntity: boolean) => {
           this.filterFormGroup.get('rootEntity').setValidators(rootStateEntity ? [] : [Validators.required]);
           this.filterFormGroup.get('rootEntity').updateValueAndValidity();
         });
+        this.subscriptions.add(rootStateSubscription);
         if (type === AliasFilterType.relationsQuery) {
           this.filterFormGroup.addControl('filters',
             this.fb.control(filter ? filter.filters : [], []));
@@ -201,9 +226,10 @@ export class EntityFilterComponent implements ControlValueAccessor, OnInit {
         }
         break;
     }
-    this.filterFormGroup.valueChanges.subscribe(() => {
+    const filterFormSubscription = this.filterFormGroup.valueChanges.subscribe(() => {
       this.updateModel();
     });
+    this.subscriptions.add(filterFormSubscription);
   }
 
   private filterTypeChanged(type: AliasFilterType) {


### PR DESCRIPTION
## Pull Request description

Added:
1. Fixed memory leak
2. Disable entity list for empty entity type in entity list type alias

Before:
![image](https://github.com/thingsboard/thingsboard/assets/18036670/c67cc23b-b179-415d-81a5-6212ae0941b3)

After:
![image](https://github.com/thingsboard/thingsboard/assets/18036670/3a6c0926-de6c-4bd2-9857-9cf35f27d2f7)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



