### PR TITLE
Added fix for docker command for gateway launch command and support for ipv6 adresses in device connectivity

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/DeviceConnectivityController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/DeviceConnectivityController.java
@@ -106,7 +106,7 @@ public class DeviceConnectivityController extends BaseController {
     @RequestMapping(value = "/device-connectivity/gateway-launch/{deviceId}", method = RequestMethod.GET)
     @ResponseBody
     public JsonNode getGatewayLaunchCommands(@ApiParam(value = DEVICE_ID_PARAM_DESCRIPTION)
-                                                      @PathVariable(DEVICE_ID) String strDeviceId, HttpServletRequest request) throws ThingsboardException, URISyntaxException {
+                                             @PathVariable(DEVICE_ID) String strDeviceId, HttpServletRequest request) throws ThingsboardException, URISyntaxException {
         checkParameter(DEVICE_ID, strDeviceId);
         DeviceId deviceId = new DeviceId(toUUID(strDeviceId));
         Device device = checkDeviceId(deviceId, Operation.READ_CREDENTIALS);

--- a/application/src/test/java/org/thingsboard/server/controller/DeviceConnectivityControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/DeviceConnectivityControllerTest.java
@@ -336,39 +336,39 @@ public class DeviceConnectivityControllerTest extends AbstractControllerTest {
 
         assertThat(commands).hasSize(3);
         JsonNode httpCommands = commands.get(HTTP);
-        assertThat(httpCommands.get(HTTP).asText()).isEqualTo(String.format("curl -v -X POST http://localhost:8080/api/v1/%s/telemetry " +
+        assertThat(httpCommands.get(HTTP).asText()).isEqualTo(String.format("curl -v -X POST http://[::1]:8080/api/v1/%s/telemetry " +
                         "--header Content-Type:application/json --data \"{temperature:25}\"",
                 credentials.getCredentialsId()));
-        assertThat(httpCommands.get(HTTPS).asText()).isEqualTo(String.format("curl -v -X POST https://localhost/api/v1/%s/telemetry " +
+        assertThat(httpCommands.get(HTTPS).asText()).isEqualTo(String.format("curl -v -X POST https://[::1]/api/v1/%s/telemetry " +
                         "--header Content-Type:application/json --data \"{temperature:25}\"",
                 credentials.getCredentialsId()));
 
         JsonNode mqttCommands = commands.get(MQTT);
-        assertThat(mqttCommands.get(MQTT).asText()).isEqualTo(String.format("mosquitto_pub -d -q 1 -h localhost -p 1883 -t v1/devices/me/telemetry " +
+        assertThat(mqttCommands.get(MQTT).asText()).isEqualTo(String.format("mosquitto_pub -d -q 1 -h ::1 -p 1883 -t v1/devices/me/telemetry " +
                 "-u \"%s\" -m \"{temperature:25}\"", credentials.getCredentialsId()));
         assertThat(mqttCommands.get(MQTTS).get(0).asText()).isEqualTo("curl -f -S -o ca-root.pem http://localhost:80/api/device-connectivity/mqtts/certificate/download");
-        assertThat(mqttCommands.get(MQTTS).get(1).asText()).isEqualTo(String.format("mosquitto_pub -d -q 1 --cafile ca-root.pem -h localhost -p 8883 " +
+        assertThat(mqttCommands.get(MQTTS).get(1).asText()).isEqualTo(String.format("mosquitto_pub -d -q 1 --cafile ca-root.pem -h ::1 -p 8883 " +
                 "-t v1/devices/me/telemetry -u \"%s\" -m \"{temperature:25}\"", credentials.getCredentialsId()));
 
         JsonNode dockerMqttCommands = commands.get(MQTT).get(DOCKER);
-        assertThat(dockerMqttCommands.get(MQTT).asText()).isEqualTo(String.format("docker run --rm -it --network=host thingsboard/mosquitto-clients mosquitto_pub -d -q 1 -h localhost" +
+        assertThat(dockerMqttCommands.get(MQTT).asText()).isEqualTo(String.format("docker run --rm -it --network=host thingsboard/mosquitto-clients mosquitto_pub -d -q 1 -h ::1" +
                 " -p 1883 -t v1/devices/me/telemetry -u \"%s\" -m \"{temperature:25}\"", credentials.getCredentialsId()));
         assertThat(dockerMqttCommands.get(MQTTS).asText()).isEqualTo(String.format("docker run --rm -it --network=host thingsboard/mosquitto-clients " +
                         "/bin/sh -c \"curl -f -S -o ca-root.pem http://localhost:80/api/device-connectivity/mqtts/certificate/download && " +
-                        "mosquitto_pub -d -q 1 --cafile ca-root.pem -h localhost -p 8883 -t v1/devices/me/telemetry -u \"%s\" -m \"{temperature:25}\"\"",
+                        "mosquitto_pub -d -q 1 --cafile ca-root.pem -h ::1 -p 8883 -t v1/devices/me/telemetry -u \"%s\" -m \"{temperature:25}\"\"",
                 credentials.getCredentialsId()));
 
         JsonNode linuxCoapCommands = commands.get(COAP);
-        assertThat(linuxCoapCommands.get(COAP).asText()).isEqualTo(String.format("coap-client -v 6 -m POST coap://localhost:5683/api/v1/%s/telemetry " +
+        assertThat(linuxCoapCommands.get(COAP).asText()).isEqualTo(String.format("coap-client -v 6 -m POST coap://[::1]:5683/api/v1/%s/telemetry " +
                 "-t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
-        assertThat(linuxCoapCommands.get(COAPS).asText()).isEqualTo(String.format("coap-client-openssl -v 6 -m POST coaps://localhost:5684/api/v1/%s/telemetry" +
+        assertThat(linuxCoapCommands.get(COAPS).asText()).isEqualTo(String.format("coap-client-openssl -v 6 -m POST coaps://[::1]:5684/api/v1/%s/telemetry" +
                 " -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
 
         JsonNode dockerCoapCommands = commands.get(COAP).get(DOCKER);
         assertThat(dockerCoapCommands.get(COAP).asText()).isEqualTo(String.format("docker run --rm -it --network=host" +
-                " thingsboard/coap-clients coap-client -v 6 -m POST coap://localhost:5683/api/v1/%s/telemetry -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+                " thingsboard/coap-clients coap-client -v 6 -m POST coap://[::1]:5683/api/v1/%s/telemetry -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
         assertThat(dockerCoapCommands.get(COAPS).asText()).isEqualTo(String.format("docker run --rm -it --network=host" +
-                " thingsboard/coap-clients coap-client-openssl -v 6 -m POST coaps://localhost:5684/api/v1/%s/telemetry -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+                " thingsboard/coap-clients coap-client-openssl -v 6 -m POST coaps://[::1]:5684/api/v1/%s/telemetry -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/server/controller/DeviceConnectivityControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/DeviceConnectivityControllerTest.java
@@ -18,8 +18,6 @@ package org.thingsboard.server.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -32,7 +30,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.common.util.ThingsBoardExecutors;
 import org.thingsboard.server.common.data.AdminSettings;
 import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.DeviceProfile;
@@ -46,7 +43,6 @@ import org.thingsboard.server.common.data.device.profile.DefaultDeviceProfileCon
 import org.thingsboard.server.common.data.device.profile.DeviceProfileData;
 import org.thingsboard.server.common.data.device.profile.MqttDeviceProfileTransportConfiguration;
 import org.thingsboard.server.common.data.id.DeviceProfileId;
-import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.security.Authority;
 import org.thingsboard.server.common.data.security.DeviceCredentials;
 import org.thingsboard.server.common.data.security.DeviceCredentialsType;
@@ -58,14 +54,16 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.CA_ROOT_CERT_PEM;
 import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.COAP;
 import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.COAPS;
 import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.DOCKER;
 import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.HTTP;
 import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.HTTPS;
+import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.LINUX;
 import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.MQTT;
 import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.MQTTS;
-import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.CA_ROOT_CERT_PEM;
+import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.WINDOWS;
 
 @TestPropertySource(properties = {
         "device.connectivity.mqtts.pem_cert_file=/tmp/" + CA_ROOT_CERT_PEM
@@ -295,6 +293,140 @@ public class DeviceConnectivityControllerTest extends AbstractControllerTest {
     }
 
     @Test
+    public void testFetchGatewayLaunchCommands() throws Exception {
+        Device device = new Device();
+        device.setName("My device");
+        device.setType("default");
+        ObjectNode additionalInfo = JacksonUtil.newObjectNode();
+        additionalInfo.put("gateway", true);
+        device.setAdditionalInfo(additionalInfo);
+        Device savedDevice = doPost("/api/device", device, Device.class);
+        DeviceCredentials credentials =
+                doGet("/api/device/" + savedDevice.getId().getId() + "/credentials", DeviceCredentials.class);
+
+        JsonNode commands =
+                doGetTyped("/api/device-connectivity/gateway-launch/" + savedDevice.getId().getId(), new TypeReference<>() {
+                });
+
+        JsonNode dockerMqttCommands = commands.get(MQTT);
+        assertThat(dockerMqttCommands.get(LINUX).asText()).isEqualTo(String.format("docker run -it -v ~/.tb-gateway/logs:/thingsboard_gateway/logs -v ~/.tb-gateway/extensions:/thingsboard_gateway/extensions -v ~/.tb-gateway/config:/thingsboard_gateway/config --network=host -p 5000:5000 --name tbGatewayLocalhost -e host=localhost -e port=1883 -e accessToken=%s --restart always thingsboard/tb-gateway", credentials.getCredentialsId()));
+        assertThat(dockerMqttCommands.get(WINDOWS).asText()).isEqualTo("docker run -it -v %HOMEPATH%/tb-gateway/logs:/thingsboard_gateway/logs -v %HOMEPATH%/tb-gateway/extensions:/thingsboard_gateway/extensions -v %HOMEPATH%/tb-gateway/config:/thingsboard_gateway/config --network=host -p 5000:5000 --name tbGatewayLocalhost -e host=localhost -e port=1883 -e accessToken=" + credentials.getCredentialsId() + " --restart always thingsboard/tb-gateway");
+
+        JsonNode dockerMqttsCommands = commands.get(MQTTS);
+        assertThat(dockerMqttsCommands.get(LINUX).asText()).isEqualTo(String.format("docker run -it -v ~/.tb-gateway/logs:/thingsboard_gateway/logs -v ~/.tb-gateway/extensions:/thingsboard_gateway/extensions -v ~/.tb-gateway/config:/thingsboard_gateway/config --network=host -p 5000:5000 --name tbGatewayLocalhost -e host=localhost -e port=8883 -e accessToken=%s --restart always thingsboard/tb-gateway", credentials.getCredentialsId()));
+        assertThat(dockerMqttsCommands.get(WINDOWS).asText()).isEqualTo("docker run -it -v %HOMEPATH%/tb-gateway/logs:/thingsboard_gateway/logs -v %HOMEPATH%/tb-gateway/extensions:/thingsboard_gateway/extensions -v %HOMEPATH%/tb-gateway/config:/thingsboard_gateway/config --network=host -p 5000:5000 --name tbGatewayLocalhost -e host=localhost -e port=8883 -e accessToken=" + credentials.getCredentialsId() + " --restart always thingsboard/tb-gateway");
+    }
+
+    @Test
+    public void testFetchPublishTelemetryCommandsForDeviceWithIpV6LocalhostAddress() throws Exception {
+        loginSysAdmin();
+        setConnectivityHost("::1");
+        loginTenantAdmin();
+
+        Device device = new Device();
+        device.setName("My device");
+        device.setType("default");
+        Device savedDevice = doPost("/api/device", device, Device.class);
+        DeviceCredentials credentials =
+                doGet("/api/device/" + savedDevice.getId().getId() + "/credentials", DeviceCredentials.class);
+
+        JsonNode commands =
+                doGetTyped("/api/device-connectivity/" + savedDevice.getId().getId(), new TypeReference<>() {
+                });
+
+        assertThat(commands).hasSize(3);
+        JsonNode httpCommands = commands.get(HTTP);
+        assertThat(httpCommands.get(HTTP).asText()).isEqualTo(String.format("curl -v -X POST http://localhost:8080/api/v1/%s/telemetry " +
+                        "--header Content-Type:application/json --data \"{temperature:25}\"",
+                credentials.getCredentialsId()));
+        assertThat(httpCommands.get(HTTPS).asText()).isEqualTo(String.format("curl -v -X POST https://localhost/api/v1/%s/telemetry " +
+                        "--header Content-Type:application/json --data \"{temperature:25}\"",
+                credentials.getCredentialsId()));
+
+        JsonNode mqttCommands = commands.get(MQTT);
+        assertThat(mqttCommands.get(MQTT).asText()).isEqualTo(String.format("mosquitto_pub -d -q 1 -h localhost -p 1883 -t v1/devices/me/telemetry " +
+                "-u \"%s\" -m \"{temperature:25}\"", credentials.getCredentialsId()));
+        assertThat(mqttCommands.get(MQTTS).get(0).asText()).isEqualTo("curl -f -S -o ca-root.pem http://localhost:80/api/device-connectivity/mqtts/certificate/download");
+        assertThat(mqttCommands.get(MQTTS).get(1).asText()).isEqualTo(String.format("mosquitto_pub -d -q 1 --cafile ca-root.pem -h localhost -p 8883 " +
+                "-t v1/devices/me/telemetry -u \"%s\" -m \"{temperature:25}\"", credentials.getCredentialsId()));
+
+        JsonNode dockerMqttCommands = commands.get(MQTT).get(DOCKER);
+        assertThat(dockerMqttCommands.get(MQTT).asText()).isEqualTo(String.format("docker run --rm -it --network=host thingsboard/mosquitto-clients mosquitto_pub -d -q 1 -h localhost" +
+                " -p 1883 -t v1/devices/me/telemetry -u \"%s\" -m \"{temperature:25}\"", credentials.getCredentialsId()));
+        assertThat(dockerMqttCommands.get(MQTTS).asText()).isEqualTo(String.format("docker run --rm -it --network=host thingsboard/mosquitto-clients " +
+                        "/bin/sh -c \"curl -f -S -o ca-root.pem http://localhost:80/api/device-connectivity/mqtts/certificate/download && " +
+                        "mosquitto_pub -d -q 1 --cafile ca-root.pem -h localhost -p 8883 -t v1/devices/me/telemetry -u \"%s\" -m \"{temperature:25}\"\"",
+                credentials.getCredentialsId()));
+
+        JsonNode linuxCoapCommands = commands.get(COAP);
+        assertThat(linuxCoapCommands.get(COAP).asText()).isEqualTo(String.format("coap-client -v 6 -m POST coap://localhost:5683/api/v1/%s/telemetry " +
+                "-t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+        assertThat(linuxCoapCommands.get(COAPS).asText()).isEqualTo(String.format("coap-client-openssl -v 6 -m POST coaps://localhost:5684/api/v1/%s/telemetry" +
+                " -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+
+        JsonNode dockerCoapCommands = commands.get(COAP).get(DOCKER);
+        assertThat(dockerCoapCommands.get(COAP).asText()).isEqualTo(String.format("docker run --rm -it --network=host" +
+                " thingsboard/coap-clients coap-client -v 6 -m POST coap://localhost:5683/api/v1/%s/telemetry -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+        assertThat(dockerCoapCommands.get(COAPS).asText()).isEqualTo(String.format("docker run --rm -it --network=host" +
+                " thingsboard/coap-clients coap-client-openssl -v 6 -m POST coaps://localhost:5684/api/v1/%s/telemetry -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+    }
+
+    @Test
+    public void testFetchPublishTelemetryCommandsForDeviceWithIpV6Address() throws Exception {
+
+        loginSysAdmin();
+        setConnectivityHost("1:1:1:1:1:1:1:1");
+        loginTenantAdmin();
+
+        Device device = new Device();
+        device.setName("My device");
+        device.setType("default");
+        Device savedDevice = doPost("/api/device", device, Device.class);
+        DeviceCredentials credentials =
+                doGet("/api/device/" + savedDevice.getId().getId() + "/credentials", DeviceCredentials.class);
+
+        JsonNode commands =
+                doGetTyped("/api/device-connectivity/" + savedDevice.getId().getId(), new TypeReference<>() {
+                });
+        assertThat(commands).hasSize(3);
+        JsonNode httpCommands = commands.get(HTTP);
+        assertThat(httpCommands.get(HTTP).asText()).isEqualTo(String.format("curl -v -X POST http://[1:1:1:1:1:1:1:1]:8080/api/v1/%s/telemetry " +
+                        "--header Content-Type:application/json --data \"{temperature:25}\"",
+                credentials.getCredentialsId()));
+        assertThat(httpCommands.get(HTTPS).asText()).isEqualTo(String.format("curl -v -X POST https://[1:1:1:1:1:1:1:1]/api/v1/%s/telemetry " +
+                        "--header Content-Type:application/json --data \"{temperature:25}\"",
+                credentials.getCredentialsId()));
+
+        JsonNode mqttCommands = commands.get(MQTT);
+        assertThat(mqttCommands.get(MQTT).asText()).isEqualTo(String.format("mosquitto_pub -d -q 1 -h 1:1:1:1:1:1:1:1 -p 1883 -t v1/devices/me/telemetry " +
+                "-u \"%s\" -m \"{temperature:25}\"", credentials.getCredentialsId()));
+        assertThat(mqttCommands.get(MQTTS).get(0).asText()).isEqualTo("curl -f -S -o ca-root.pem http://localhost:80/api/device-connectivity/mqtts/certificate/download");
+        assertThat(mqttCommands.get(MQTTS).get(1).asText()).isEqualTo(String.format("mosquitto_pub -d -q 1 --cafile ca-root.pem -h 1:1:1:1:1:1:1:1 -p 8883 " +
+                "-t v1/devices/me/telemetry -u \"%s\" -m \"{temperature:25}\"", credentials.getCredentialsId()));
+
+        JsonNode dockerMqttCommands = commands.get(MQTT).get(DOCKER);
+        assertThat(dockerMqttCommands.get(MQTT).asText()).isEqualTo(String.format("docker run --rm -it thingsboard/mosquitto-clients mosquitto_pub -d -q 1 -h 1:1:1:1:1:1:1:1" +
+                " -p 1883 -t v1/devices/me/telemetry -u \"%s\" -m \"{temperature:25}\"", credentials.getCredentialsId()));
+        assertThat(dockerMqttCommands.get(MQTTS).asText()).isEqualTo(String.format("docker run --rm -it thingsboard/mosquitto-clients " +
+                        "/bin/sh -c \"curl -f -S -o ca-root.pem http://localhost:80/api/device-connectivity/mqtts/certificate/download && " +
+                        "mosquitto_pub -d -q 1 --cafile ca-root.pem -h 1:1:1:1:1:1:1:1 -p 8883 -t v1/devices/me/telemetry -u \"%s\" -m \"{temperature:25}\"\"",
+                credentials.getCredentialsId()));
+
+        JsonNode linuxCoapCommands = commands.get(COAP);
+        assertThat(linuxCoapCommands.get(COAP).asText()).isEqualTo(String.format("coap-client -v 6 -m POST coap://[1:1:1:1:1:1:1:1]:5683/api/v1/%s/telemetry " +
+                "-t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+        assertThat(linuxCoapCommands.get(COAPS).asText()).isEqualTo(String.format("coap-client-openssl -v 6 -m POST coaps://[1:1:1:1:1:1:1:1]:5684/api/v1/%s/telemetry" +
+                " -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+
+        JsonNode dockerCoapCommands = commands.get(COAP).get(DOCKER);
+        assertThat(dockerCoapCommands.get(COAP).asText()).isEqualTo(String.format("docker run --rm -it" +
+                " thingsboard/coap-clients coap-client -v 6 -m POST coap://[1:1:1:1:1:1:1:1]:5683/api/v1/%s/telemetry -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+        assertThat(dockerCoapCommands.get(COAPS).asText()).isEqualTo(String.format("docker run --rm -it" +
+                " thingsboard/coap-clients coap-client-openssl -v 6 -m POST coaps://[1:1:1:1:1:1:1:1]:5684/api/v1/%s/telemetry -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+
+    }
+
+    @Test
     public void testFetchPublishTelemetryCommandsForDeviceWithMqttBasicCreds() throws Exception {
         Device device = new Device();
         device.setName("My device");
@@ -449,47 +581,7 @@ public class DeviceConnectivityControllerTest extends AbstractControllerTest {
     public void testFetchPublishTelemetryCommandsForDefaultDeviceIfPortsSetToDefault() throws Exception {
         loginSysAdmin();
 
-        ObjectNode config = JacksonUtil.newObjectNode();
-
-        ObjectNode http = JacksonUtil.newObjectNode();
-        http.put("enabled", true);
-        http.put("host", "");
-        http.put("port", 80);
-        config.set("http", http);
-
-        ObjectNode https = JacksonUtil.newObjectNode();
-        https.put("enabled", true);
-        https.put("host", "");
-        https.put("port", 443);
-        config.set("https", https);
-
-        ObjectNode mqtt = JacksonUtil.newObjectNode();
-        mqtt.put("enabled", false);
-        mqtt.put("host", "");
-        mqtt.put("port", 1883);
-        config.set("mqtt", mqtt);
-
-        ObjectNode mqtts = JacksonUtil.newObjectNode();
-        mqtts.put("enabled", false);
-        mqtts.put("host", "");
-        mqtts.put("port", 8883);
-        config.set("mqtts", mqtts);
-
-        ObjectNode coap = JacksonUtil.newObjectNode();
-        coap.put("enabled", false);
-        coap.put("host", "");
-        coap.put("port", 5683);
-        config.set("coap", coap);
-
-        ObjectNode coaps = JacksonUtil.newObjectNode();
-        coaps.put("enabled", false);
-        coaps.put("host", "");
-        coaps.put("port", 5684);
-        config.set("coaps", coaps);
-
-        AdminSettings adminSettings = doGet("/api/admin/settings/connectivity", AdminSettings.class);
-        adminSettings.setJsonValue(config);
-        doPost("/api/admin/settings", adminSettings).andExpect(status().isOk());
+        setConnectivityHost("");
 
         login("tenant2@thingsboard.org", "testPassword1");
 
@@ -518,47 +610,7 @@ public class DeviceConnectivityControllerTest extends AbstractControllerTest {
     public void testFetchPublishTelemetryCommandsForDefaultDeviceIfHostIsNotLocalhost() throws Exception {
         loginSysAdmin();
 
-        ObjectNode config = JacksonUtil.newObjectNode();
-
-        ObjectNode http = JacksonUtil.newObjectNode();
-        http.put("enabled", true);
-        http.put("host", "test.domain");
-        http.put("port", 8080);
-        config.set("http", http);
-
-        ObjectNode https = JacksonUtil.newObjectNode();
-        https.put("enabled", true);
-        https.put("host", "test.domain");
-        https.put("port", 443);
-        config.set("https", https);
-
-        ObjectNode mqtt = JacksonUtil.newObjectNode();
-        mqtt.put("enabled", true);
-        mqtt.put("host", "test.domain");
-        mqtt.put("port", 1883);
-        config.set("mqtt", mqtt);
-
-        ObjectNode mqtts = JacksonUtil.newObjectNode();
-        mqtts.put("enabled", true);
-        mqtts.put("host", "test.domain");
-        mqtts.put("port", 8883);
-        config.set("mqtts", mqtts);
-
-        ObjectNode coap = JacksonUtil.newObjectNode();
-        coap.put("enabled", true);
-        coap.put("host", "test.domain");
-        coap.put("port", 5683);
-        config.set("coap", coap);
-
-        ObjectNode coaps = JacksonUtil.newObjectNode();
-        coaps.put("enabled", true);
-        coaps.put("host", "test.domain");
-        coaps.put("port", 5684);
-        config.set("coaps", coaps);
-
-        AdminSettings adminSettings = doGet("/api/admin/settings/connectivity", AdminSettings.class);
-        adminSettings.setJsonValue(config);
-        doPost("/api/admin/settings", adminSettings).andExpect(status().isOk());
+        setConnectivityHost("test.domain");
 
         login("tenant2@thingsboard.org", "testPassword1");
 
@@ -611,5 +663,50 @@ public class DeviceConnectivityControllerTest extends AbstractControllerTest {
                 "thingsboard/coap-clients coap-client -v 6 -m POST coap://test.domain:5683/api/v1/%s/telemetry -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
         assertThat(dockerCoapCommands.get(COAPS).asText()).isEqualTo(String.format("docker run --rm -it " +
                 "thingsboard/coap-clients coap-client-openssl -v 6 -m POST coaps://test.domain:5684/api/v1/%s/telemetry -t json -e \"{temperature:25}\"", credentials.getCredentialsId()));
+    }
+
+
+    private void setConnectivityHost(String host) throws Exception {
+        ObjectNode config = JacksonUtil.newObjectNode();
+
+        ObjectNode http = JacksonUtil.newObjectNode();
+        http.put("enabled", true);
+        http.put("host", host);
+        http.put("port", 8080);
+        config.set("http", http);
+
+        ObjectNode https = JacksonUtil.newObjectNode();
+        https.put("enabled", true);
+        https.put("host", host);
+        https.put("port", 443);
+        config.set("https", https);
+
+        ObjectNode mqtt = JacksonUtil.newObjectNode();
+        mqtt.put("enabled", true);
+        mqtt.put("host", host);
+        mqtt.put("port", 1883);
+        config.set("mqtt", mqtt);
+
+        ObjectNode mqtts = JacksonUtil.newObjectNode();
+        mqtts.put("enabled", true);
+        mqtts.put("host", host);
+        mqtts.put("port", 8883);
+        config.set("mqtts", mqtts);
+
+        ObjectNode coap = JacksonUtil.newObjectNode();
+        coap.put("enabled", true);
+        coap.put("host", host);
+        coap.put("port", 5683);
+        config.set("coap", coap);
+
+        ObjectNode coaps = JacksonUtil.newObjectNode();
+        coaps.put("enabled", true);
+        coaps.put("host", host);
+        coaps.put("port", 5684);
+        config.set("coaps", coaps);
+
+        AdminSettings adminSettings = doGet("/api/admin/settings/connectivity", AdminSettings.class);
+        adminSettings.setJsonValue(config);
+        doPost("/api/admin/settings", adminSettings).andExpect(status().isOk());
     }
 }

--- a/application/src/test/java/org/thingsboard/server/controller/DeviceConnectivityControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/DeviceConnectivityControllerTest.java
@@ -581,7 +581,47 @@ public class DeviceConnectivityControllerTest extends AbstractControllerTest {
     public void testFetchPublishTelemetryCommandsForDefaultDeviceIfPortsSetToDefault() throws Exception {
         loginSysAdmin();
 
-        setConnectivityHost("");
+        ObjectNode config = JacksonUtil.newObjectNode();
+
+        ObjectNode http = JacksonUtil.newObjectNode();
+        http.put("enabled", true);
+        http.put("host", "");
+        http.put("port", 80);
+        config.set("http", http);
+
+        ObjectNode https = JacksonUtil.newObjectNode();
+        https.put("enabled", true);
+        https.put("host", "");
+        https.put("port", 443);
+        config.set("https", https);
+
+        ObjectNode mqtt = JacksonUtil.newObjectNode();
+        mqtt.put("enabled", false);
+        mqtt.put("host", "");
+        mqtt.put("port", 1883);
+        config.set("mqtt", mqtt);
+
+        ObjectNode mqtts = JacksonUtil.newObjectNode();
+        mqtts.put("enabled", false);
+        mqtts.put("host", "");
+        mqtts.put("port", 8883);
+        config.set("mqtts", mqtts);
+
+        ObjectNode coap = JacksonUtil.newObjectNode();
+        coap.put("enabled", false);
+        coap.put("host", "");
+        coap.put("port", 5683);
+        config.set("coap", coap);
+
+        ObjectNode coaps = JacksonUtil.newObjectNode();
+        coaps.put("enabled", false);
+        coaps.put("host", "");
+        coaps.put("port", 5684);
+        config.set("coaps", coaps);
+
+        AdminSettings adminSettings = doGet("/api/admin/settings/connectivity", AdminSettings.class);
+        adminSettings.setJsonValue(config);
+        doPost("/api/admin/settings", adminSettings).andExpect(status().isOk());
 
         login("tenant2@thingsboard.org", "testPassword1");
 

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceConnectivityServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceConnectivityServiceImpl.java
@@ -43,7 +43,6 @@ import org.thingsboard.server.dao.util.DeviceConnectivityUtil;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -64,6 +63,7 @@ import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.LINUX;
 import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.MQTT;
 import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.MQTTS;
 import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.WINDOWS;
+import static org.thingsboard.server.dao.util.DeviceConnectivityUtil.getHost;
 
 @Service("DeviceConnectivityDaoService")
 @Slf4j
@@ -230,7 +230,7 @@ public class DeviceConnectivityServiceImpl implements DeviceConnectivityService 
                 deviceCredentials.getCredentialsType() != DeviceCredentialsType.ACCESS_TOKEN) {
             return null;
         }
-        String hostName = getHost(baseUrl, properties);
+        String hostName = getHost(baseUrl, properties, protocol);
         String propertiesPort = properties.getPort();
         String port = (propertiesPort.isEmpty() || HTTP_DEFAULT_PORT.equals(propertiesPort) || HTTPS_DEFAULT_PORT.equals(propertiesPort))
                 ? "" : ":" + propertiesPort;
@@ -278,14 +278,14 @@ public class DeviceConnectivityServiceImpl implements DeviceConnectivityService 
 
     private String getMqttPublishCommand(String baseUrl, String deviceTelemetryTopic, DeviceCredentials deviceCredentials) throws URISyntaxException {
         DeviceConnectivityInfo properties = getConnectivity(MQTT);
-        String mqttHost = getHost(baseUrl, properties);
+        String mqttHost = getHost(baseUrl, properties, MQTT);
         String mqttPort = properties.getPort().isEmpty() ? null : properties.getPort();
         return DeviceConnectivityUtil.getMqttPublishCommand(MQTT, mqttHost, mqttPort, deviceTelemetryTopic, deviceCredentials);
     }
 
     private List<String> getMqttsPublishCommand(String baseUrl, String deviceTelemetryTopic, DeviceCredentials deviceCredentials) throws URISyntaxException {
         DeviceConnectivityInfo properties = getConnectivity(MQTTS);
-        String mqttHost = getHost(baseUrl, properties);
+        String mqttHost = getHost(baseUrl, properties, MQTTS);
         String mqttPort = properties.getPort().isEmpty() ? null : properties.getPort();
         String pubCommand = DeviceConnectivityUtil.getMqttPublishCommand(MQTTS, mqttHost, mqttPort, deviceTelemetryTopic, deviceCredentials);
 
@@ -301,7 +301,7 @@ public class DeviceConnectivityServiceImpl implements DeviceConnectivityService 
     private JsonNode getGatewayDockerCommands(String baseUrl, DeviceCredentials deviceCredentials, String mqttType) throws URISyntaxException {
         ObjectNode dockerLaunchCommands = JacksonUtil.newObjectNode();
         DeviceConnectivityInfo properties = getConnectivity(mqttType);
-        String mqttHost = getHost(baseUrl, properties);
+        String mqttHost = getHost(baseUrl, properties, mqttType);
         String mqttPort = properties.getPort().isEmpty() ? null : properties.getPort();
         Optional.ofNullable(DeviceConnectivityUtil.getGatewayLaunchCommand(LINUX, mqttHost, mqttPort, deviceCredentials))
                 .ifPresent(v -> dockerLaunchCommands.put(LINUX, v));
@@ -312,7 +312,7 @@ public class DeviceConnectivityServiceImpl implements DeviceConnectivityService 
 
     private String getDockerMqttPublishCommand(String protocol, String baseUrl, String deviceTelemetryTopic, DeviceCredentials deviceCredentials) throws URISyntaxException {
         DeviceConnectivityInfo properties = getConnectivity(protocol);
-        String mqttHost = getHost(baseUrl, properties);
+        String mqttHost = getHost(baseUrl, properties, protocol);
         String mqttPort = properties.getPort().isEmpty() ? null : properties.getPort();
         return DeviceConnectivityUtil.getDockerMqttPublishCommand(protocol, baseUrl, mqttHost, mqttPort, deviceTelemetryTopic, deviceCredentials);
     }
@@ -352,20 +352,16 @@ public class DeviceConnectivityServiceImpl implements DeviceConnectivityService 
 
     private String getCoapPublishCommand(String protocol, String baseUrl, DeviceCredentials deviceCredentials) throws URISyntaxException {
         DeviceConnectivityInfo properties = getConnectivity(protocol);
-        String hostName = getHost(baseUrl, properties);
+        String hostName = getHost(baseUrl, properties, protocol);
         String port = properties.getPort().isEmpty() ? "" : ":" + properties.getPort();
         return DeviceConnectivityUtil.getCoapPublishCommand(protocol, hostName, port, deviceCredentials);
     }
 
     private String getDockerCoapPublishCommand(String protocol, String baseUrl, DeviceCredentials deviceCredentials) throws URISyntaxException {
         DeviceConnectivityInfo properties = getConnectivity(protocol);
-        String host = getHost(baseUrl, properties);
+        String host = getHost(baseUrl, properties, protocol);
         String port = properties.getPort().isEmpty() ? "" : ":" + properties.getPort();
         return DeviceConnectivityUtil.getDockerCoapPublishCommand(protocol, host, port, deviceCredentials);
-    }
-
-    private String getHost(String baseUrl, DeviceConnectivityInfo properties) throws URISyntaxException {
-        return properties.getHost().isEmpty() ? new URI(baseUrl).getHost() : properties.getHost();
     }
 
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
@@ -46,7 +46,7 @@ public class DeviceConnectivityUtil {
     public static final String GATEWAY_DOCKER_RUN = "docker run -it ";
     public static final String MQTT_IMAGE = "thingsboard/mosquitto-clients ";
     public static final String COAP_IMAGE = "thingsboard/coap-clients ";
-    private final static Pattern VALID_URL_PATTERN = Pattern.compile("^(http|https|ftp)://.*$");
+    private final static Pattern VALID_URL_PATTERN = Pattern.compile("^(https?)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]");
 
     public static String getHttpPublishCommand(String protocol, String host, String port, DeviceCredentials deviceCredentials) {
         return String.format("curl -v -X POST %s://%s%s/api/v1/%s/telemetry --header Content-Type:application/json --data " + JSON_EXAMPLE_PAYLOAD,

--- a/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
@@ -183,17 +183,20 @@ public class DeviceConnectivityUtil {
 
     public static String getHost(String baseUrl, DeviceConnectivityInfo properties, String protocol) throws URISyntaxException {
         String host = properties.getHost().isEmpty() ? baseUrl : properties.getHost();
+        InetAddress inetAddress;
         if (VALID_URL_PATTERN.matcher(host).matches()) {
             host = new URI(host).getHost();
-        } else {
-            try {
-                InetAddress inetAddress = InetAddress.getByName(host);
-                host = inetAddress.getCanonicalHostName().replaceAll("[\\[\\]]", "");
-                if (inetAddress instanceof Inet6Address && !inetAddress.isLoopbackAddress() && !protocol.startsWith(MQTT)) {
-                    host = "[" + host + "]";
-                }
-            } catch (UnknownHostException e) {
-                return host;
+        }
+        try {
+            inetAddress = InetAddress.getByName(host);
+            host = inetAddress.getHostName();
+        } catch (UnknownHostException e) {
+            return host;
+        }
+        if (inetAddress instanceof Inet6Address) {
+            host = host.replaceAll("[\\[\\]]", "");
+            if (!inetAddress.isLoopbackAddress() && !protocol.startsWith(MQTT)) {
+                host = "[" + host + "]";
             }
         }
         return host;

--- a/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
@@ -182,12 +182,17 @@ public class DeviceConnectivityUtil {
     }
 
     public static String getHost(String baseUrl, DeviceConnectivityInfo properties, String protocol) throws URISyntaxException {
-        String host = properties.getHost().isEmpty() ? baseUrl : properties.getHost();
+        String initialHost = properties.getHost().isEmpty() ? baseUrl : properties.getHost();
         InetAddress inetAddress;
-        if (VALID_URL_PATTERN.matcher(host).matches()) {
-            host = new URI(host).getHost();
+        String host = null;
+        if (VALID_URL_PATTERN.matcher(initialHost).matches()) {
+            host = new URI(initialHost).getHost();
+        }
+        if (host == null) {
+            host = initialHost;
         }
         try {
+            host = host.replaceAll("^https?://", "");
             inetAddress = InetAddress.getByName(host);
             host = inetAddress.getHostName();
         } catch (UnknownHostException e) {

--- a/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
@@ -194,13 +194,12 @@ public class DeviceConnectivityUtil {
         try {
             host = host.replaceAll("^https?://", "");
             inetAddress = InetAddress.getByName(host);
-            host = inetAddress.getHostName();
         } catch (UnknownHostException e) {
             return host;
         }
         if (inetAddress instanceof Inet6Address) {
             host = host.replaceAll("[\\[\\]]", "");
-            if (!inetAddress.isLoopbackAddress() && !protocol.startsWith(MQTT)) {
+            if (!protocol.startsWith(MQTT)) {
                 host = "[" + host + "]";
             }
         }

--- a/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
@@ -19,9 +19,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.device.credentials.BasicMqttCredentials;
 import org.thingsboard.server.common.data.security.DeviceCredentials;
+import org.thingsboard.server.dao.device.DeviceConnectivityInfo;
 
-import java.util.Arrays;
-import java.util.List;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.regex.Pattern;
 
 public class DeviceConnectivityUtil {
 
@@ -41,7 +46,7 @@ public class DeviceConnectivityUtil {
     public static final String GATEWAY_DOCKER_RUN = "docker run -it ";
     public static final String MQTT_IMAGE = "thingsboard/mosquitto-clients ";
     public static final String COAP_IMAGE = "thingsboard/coap-clients ";
-    public static final List<String> LOCAL_HOSTS = Arrays.asList("localhost", "127.0.0.1");
+    private final static Pattern VALID_URL_PATTERN = Pattern.compile("^(http|https|ftp)://.*$");
 
     public static String getHttpPublishCommand(String protocol, String host, String port, DeviceCredentials deviceCredentials) {
         return String.format("curl -v -X POST %s://%s%s/api/v1/%s/telemetry --header Content-Type:application/json --data " + JSON_EXAMPLE_PAYLOAD,
@@ -71,7 +76,7 @@ public class DeviceConnectivityUtil {
                         command.append(" -u \"").append(credentials.getUserName()).append("\"");
                     }
                     if (credentials.getPassword() != null) {
-                        command.append(" -P \"").append(credentials.getPassword()).append("\"");;
+                        command.append(" -P \"").append(credentials.getPassword()).append("\"");
                     }
                 } else {
                     return null;
@@ -90,17 +95,19 @@ public class DeviceConnectivityUtil {
             gatewayVolumePathPrefix = "%HOMEPATH%/tb-gateway";
         }
 
-        String gatewayContainerName = "tbGateway" + StringUtils.capitalize(host.replace(".", ""));
+        String gatewayContainerName = "tbGateway" + StringUtils.capitalize(host.replaceAll("[^A-Za-z0-9]", ""));
 
         StringBuilder command = new StringBuilder(GATEWAY_DOCKER_RUN);
         command.append("-v {gatewayVolumePathPrefix}/logs:/thingsboard_gateway/logs".replace("{gatewayVolumePathPrefix}", gatewayVolumePathPrefix));
         command.append(" -v {gatewayVolumePathPrefix}/extensions:/thingsboard_gateway/extensions".replace("{gatewayVolumePathPrefix}", gatewayVolumePathPrefix));
         command.append(" -v {gatewayVolumePathPrefix}/config:/thingsboard_gateway/config".replace("{gatewayVolumePathPrefix}", gatewayVolumePathPrefix));
+        command.append(isLocalhost(host) ? " --network=host" : "");
+        command.append(" -p 5000:5000");
         command.append(" --name ").append(gatewayContainerName);
         command.append(" -e host=").append(host);
         command.append(" -e port=").append(port);
 
-        switch(deviceCredentials.getCredentialsType()) {
+        switch (deviceCredentials.getCredentialsType()) {
             case ACCESS_TOKEN:
                 command.append(" -e accessToken=").append(deviceCredentials.getCredentialsId());
                 break;
@@ -139,7 +146,7 @@ public class DeviceConnectivityUtil {
         }
 
         StringBuilder mqttDockerCommand = new StringBuilder();
-        mqttDockerCommand.append(DOCKER_RUN).append(LOCAL_HOSTS.contains(host) ? "--network=host ":"").append(MQTT_IMAGE);
+        mqttDockerCommand.append(DOCKER_RUN).append(isLocalhost(host) ? "--network=host " : "").append(MQTT_IMAGE);
 
         if (MQTTS.equals(protocol)) {
             mqttDockerCommand.append("/bin/sh -c \"")
@@ -171,6 +178,33 @@ public class DeviceConnectivityUtil {
 
     public static String getDockerCoapPublishCommand(String protocol, String host, String port, DeviceCredentials deviceCredentials) {
         String coapCommand = getCoapPublishCommand(protocol, host, port, deviceCredentials);
-        return coapCommand != null ? String.format("%s%s%s", DOCKER_RUN + (LOCAL_HOSTS.contains(host) ? "--network=host ":""), COAP_IMAGE, coapCommand) : null;
+        return coapCommand != null ? String.format("%s%s%s", DOCKER_RUN + (isLocalhost(host) ? "--network=host " : ""), COAP_IMAGE, coapCommand) : null;
+    }
+
+    public static String getHost(String baseUrl, DeviceConnectivityInfo properties, String protocol) throws URISyntaxException {
+        String host = properties.getHost().isEmpty() ? baseUrl : properties.getHost();
+        if (VALID_URL_PATTERN.matcher(host).matches()) {
+            host = new URI(host).getHost();
+        } else {
+            try {
+                InetAddress inetAddress = InetAddress.getByName(host);
+                host = inetAddress.getCanonicalHostName().replaceAll("[\\[\\]]", "");
+                if (inetAddress instanceof Inet6Address && !inetAddress.isLoopbackAddress() && !protocol.startsWith(MQTT)) {
+                    host = "[" + host + "]";
+                }
+            } catch (UnknownHostException e) {
+                return host;
+            }
+        }
+        return host;
+    }
+
+    private static boolean isLocalhost(String host) {
+        try {
+            InetAddress inetAddress = InetAddress.getByName(host);
+            return inetAddress.isLoopbackAddress();
+        } catch (UnknownHostException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Pull Request description

This PR contains the following things:
1. Added --network=host for docker command in gateway launch command in ThingsBoard IoT gateways dashboard.
2. Added support for IPv6 baseUrl and device connectivity host. Earlier, any IPv6 address was processed incorrectly, because it should be differently represented for different protocols ( e.g. ::1 for MQTT, but [::1] for others)
3. Added default REST connector port forwarding to docker launch command.

PE PR - https://github.com/thingsboard/thingsboard-pe/pull/2159

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.

