### PR TITLE
[fix_bug][3.6.2]stringToBytes_Input_parameter_Objects

### DIFF
--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbUtils.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbUtils.java
@@ -182,7 +182,7 @@ public class TbUtils {
         return TbJson.parse(ctx, jsonStr);
     }
 
-    public static String bytesToString(List<Byte> bytesList) {
+    public static String bytesToString(List<?> bytesList) {
         byte[] bytes = bytesFromList(bytesList);
         return new String(bytes);
     }
@@ -210,10 +210,22 @@ public class TbUtils {
         }
     }
 
-    private static byte[] bytesFromList(List<Byte> bytesList) {
+    private static byte[] bytesFromList(List<?> bytesList) {
         byte[] bytes = new byte[bytesList.size()];
         for (int i = 0; i < bytesList.size(); i++) {
-            bytes[i] = bytesList.get(i);
+            if (bytesList.get(i) instanceof Integer) {
+                byte val = ((Integer) bytesList.get(i)).byteValue();
+                if (((Integer) bytesList.get(i)).intValue() > 255 || ((Integer) bytesList.get(i)).intValue() < -128){
+                    throw new NumberFormatException("The value " + bytesList.get(i) + " could not be converted to a byte. Integer to byte needs only 8-bits (min/max = -128/127 or 0/255) !");
+                } else {
+                    bytes[i] = val;                }
+            } else if (bytesList.get(i) instanceof String) {
+                bytes[i] = parseInt((String) bytesList.get(i)).byteValue();
+            } else if (bytesList.get(i) instanceof Byte) {
+                bytes[i] = (byte) bytesList.get(i);
+            } else {
+                throw new NumberFormatException("Value \"" + bytesList.get(i) + " could not be converted to a byte. Must be format HexDecimal/String/Integer !");
+            }
         }
         return bytes;
     }


### PR DESCRIPTION
 ## Pull Request description

refactoring, Input parameter Object as HexString, DigString, Integer, Byte
```
var bytes = [(byte)0x00, (byte)0x08, (byte)0x10, (byte)0x1C, (byte)0xFF, (byte)0xFC, (byte)0xAD, (byte)0x88, (byte)0x75, (byte)0x74, (byte)0x8A, (byte)0x82];
var str = bytesToString(bytes);
msg.str_00 = str;
var arrayMix = ["0x00", 8,  "16", "0x1C", 255, 252, 173, 136,  117, 116, -118, "-126"];
var str_Mx = bytesToString(arrayMix);
msg.str_Mx = str_Mx;
msg.byte = bytes;
msg.arrayRadic_Mx = arrayMix;
return {msg: msg, metadata: metadata, msgType: msgType};
```
before:

after:
![зображення](https://github.com/thingsboard/thingsboard/assets/44275303/99f23031-3036-48ef-ba10-3f3d70238baf)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



