### PR TITLE
[3.6.2]Fix bug tbDate object mapper

### DIFF
--- a/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbDateTest.java
+++ b/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbDateTest.java
@@ -15,6 +15,8 @@
  */
 package org.thingsboard.script.api.tbel;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -781,5 +783,20 @@ class TbDateTest {
         Assert.assertEquals(d.getMinutes(), d.getUTCMinutes());
         Assert.assertEquals(d.getSeconds(), d.getUTCSeconds());
         Assert.assertEquals(d.getMilliseconds(), d.getUTCMilliseconds());
+    }
+
+    @Test
+    public void tbDateSerializedPMapperTest() {
+        String stringDateUTC = "2023-09-06T01:04:05.345Z";
+        TbDate expectedDate = new TbDate(stringDateUTC);
+        String serializedTbDate = JacksonUtil.toString(expectedDate);
+        JsonNode tbDateNode = JacksonUtil.toJsonNode(serializedTbDate);
+        Assert.assertNotNull(tbDateNode);
+        ((ObjectNode) tbDateNode).put("test", (String) null);
+        serializedTbDate = JacksonUtil.toString(tbDateNode);
+        TbDate actualDate = JacksonUtil.fromStringIgnoreUnknownProperties(serializedTbDate, TbDate.class);
+        Assert.assertNotNull(actualDate);
+        Assert.assertEquals(expectedDate.toString(), actualDate.toString());
+        Assert.assertEquals(expectedDate.getInstant(), actualDate.getInstant());
     }
 }

--- a/common/util/src/main/java/org/thingsboard/common/util/JacksonUtil.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/JacksonUtil.java
@@ -52,7 +52,9 @@ import java.util.regex.Pattern;
  */
 public class JacksonUtil {
 
-    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
     public static final ObjectMapper PRETTY_SORTED_JSON_MAPPER = JsonMapper.builder()
             .enable(SerializationFeature.INDENT_OUTPUT)
             .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
@@ -64,7 +66,8 @@ public class JacksonUtil {
             .build();
     public static final ObjectMapper IGNORE_UNKNOWN_PROPERTIES_JSON_MAPPER = JsonMapper.builder()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            .build();
+            .build()
+            .registerModule(new JavaTimeModule());
 
     public static ObjectMapper getObjectMapperWithJavaTimeModule() {
         return new ObjectMapper().registerModule(new JavaTimeModule());


### PR DESCRIPTION
## Pull Request description

### Before:
![зображення](https://github.com/thingsboard/thingsboard/assets/44275303/50c648d5-6f79-4ae1-b6b9-9e56f23e4066)
```
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.Instant` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling (through reference chain: java.util.LinkedHashMap["msg"]->java.util.LinkedHashMap["date1"]->org.thingsboard.script.api.tbel.TbDate["instant"])

```
### After:
![зображення](https://github.com/thingsboard/thingsboard/assets/44275303/b78e0e72-2249-4c91-9a6e-7ae0a5549f39)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



