### PR TITLE
Edge - alarm comment support

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/DefaultEdgeNotificationService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/DefaultEdgeNotificationService.java
@@ -216,6 +216,9 @@ public class DefaultEdgeNotificationService implements EdgeNotificationService {
                         case ALARM:
                             alarmProcessor.processAlarmNotification(tenantId, edgeNotificationMsg);
                             break;
+                        case ALARM_COMMENT:
+                            alarmProcessor.processAlarmCommentNotification(tenantId, edgeNotificationMsg);
+                            break;
                         case RELATION:
                             relationProcessor.processRelationNotification(tenantId, edgeNotificationMsg);
                             break;

--- a/application/src/main/java/org/thingsboard/server/service/edge/EdgeEventSourcingListener.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/EdgeEventSourcingListener.java
@@ -23,10 +23,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.cluster.TbClusterService;
+import org.thingsboard.server.common.data.EdgeUtils;
 import org.thingsboard.server.common.data.OtaPackageInfo;
 import org.thingsboard.server.common.data.User;
 import org.thingsboard.server.common.data.alarm.Alarm;
 import org.thingsboard.server.common.data.alarm.AlarmApiCallResult;
+import org.thingsboard.server.common.data.alarm.AlarmComment;
 import org.thingsboard.server.common.data.edge.EdgeEventActionType;
 import org.thingsboard.server.common.data.edge.EdgeEventType;
 import org.thingsboard.server.common.data.relation.EntityRelation;
@@ -42,8 +44,6 @@ import org.thingsboard.server.dao.eventsourcing.SaveEntityEvent;
 import org.thingsboard.server.dao.user.UserServiceImpl;
 
 import javax.annotation.PostConstruct;
-
-import static org.thingsboard.server.service.entitiy.DefaultTbNotificationEntityService.edgeTypeByActionType;
 
 /**
  * This event listener does not support async event processing because relay on ThreadLocal
@@ -91,8 +91,12 @@ public class EdgeEventSourcingListener {
     public void handleEvent(DeleteEntityEvent<?> event) {
         try {
             log.trace("[{}] DeleteEntityEvent called: {}", event.getTenantId(), event);
+            EdgeEventType type = null;
+            if (event.getEntity() instanceof AlarmComment) {
+                type = EdgeEventType.ALARM_COMMENT;
+            }
             tbClusterService.sendNotificationMsgToEdge(event.getTenantId(), null, event.getEntityId(),
-                    JacksonUtil.toString(event.getEntity()), null, EdgeEventActionType.DELETED,
+                    JacksonUtil.toString(event.getEntity()), type, EdgeEventActionType.DELETED,
                     edgeSynchronizationManager.getEdgeId().get());
         } catch (Exception e) {
             log.error("[{}] failed to process DeleteEntityEvent: {}", event.getTenantId(), event, e);
@@ -104,7 +108,7 @@ public class EdgeEventSourcingListener {
         try {
             log.trace("[{}] ActionEntityEvent called: {}", event.getTenantId(), event);
             tbClusterService.sendNotificationMsgToEdge(event.getTenantId(), event.getEdgeId(), event.getEntityId(),
-                    event.getBody(), null, edgeTypeByActionType(event.getActionType()),
+                    event.getBody(), null, EdgeUtils.getEdgeEventActionTypeByActionType(event.getActionType()),
                     edgeSynchronizationManager.getEdgeId().get());
         } catch (Exception e) {
             log.error("[{}] failed to process ActionEntityEvent: {}", event.getTenantId(), event, e);
@@ -125,7 +129,7 @@ public class EdgeEventSourcingListener {
             }
             log.trace("[{}] RelationActionEvent called: {}", event.getTenantId(), event);
             tbClusterService.sendNotificationMsgToEdge(event.getTenantId(), null, null,
-                    JacksonUtil.toString(relation), EdgeEventType.RELATION, edgeTypeByActionType(event.getActionType()),
+                    JacksonUtil.toString(relation), EdgeEventType.RELATION, EdgeUtils.getEdgeEventActionTypeByActionType(event.getActionType()),
                     edgeSynchronizationManager.getEdgeId().get());
         } catch (Exception e) {
             log.error("[{}] failed to process RelationActionEvent: {}", event.getTenantId(), event, e);
@@ -150,7 +154,7 @@ public class EdgeEventSourcingListener {
                 cleanUpUserAdditionalInfo(user);
                 return !user.equals(oldUser);
             }
-        } else if (entity instanceof AlarmApiCallResult || entity instanceof Alarm) {
+        } else if (entity instanceof AlarmApiCallResult || entity instanceof Alarm || entity instanceof AlarmComment) {
             return false;
         }
         // Default: If the entity doesn't match any of the conditions, consider it as valid.

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcSession.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcSession.java
@@ -39,6 +39,7 @@ import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
 import org.thingsboard.server.common.data.page.SortOrder;
 import org.thingsboard.server.common.data.page.TimePageLink;
+import org.thingsboard.server.gen.edge.v1.AlarmCommentUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.AlarmUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.AssetProfileUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.AssetUpdateMsg;
@@ -644,6 +645,8 @@ public final class EdgeGrpcSession implements Closeable {
                 return ctx.getRuleChainProcessor().convertRuleChainMetadataEventToDownlink(edgeEvent, this.edgeVersion);
             case ALARM:
                 return ctx.getAlarmProcessor().convertAlarmEventToDownlink(edgeEvent, this.edgeVersion);
+            case ALARM_COMMENT:
+                return ctx.getAlarmProcessor().convertAlarmCommentEventToDownlink(edgeEvent, this.edgeVersion);
             case USER:
                 return ctx.getUserProcessor().convertUserEventToDownlink(edgeEvent, this.edgeVersion);
             case RELATION:
@@ -712,6 +715,12 @@ public final class EdgeGrpcSession implements Closeable {
                 for (AlarmUpdateMsg alarmUpdateMsg : uplinkMsg.getAlarmUpdateMsgList()) {
                     result.add(((AlarmProcessor) ctx.getAlarmEdgeProcessorFactory().getProcessorByEdgeVersion(this.edgeVersion))
                             .processAlarmMsgFromEdge(edge.getTenantId(), edge.getId(), alarmUpdateMsg));
+                }
+            }
+            if (uplinkMsg.getAlarmCommentUpdateMsgCount() > 0) {
+                for (AlarmCommentUpdateMsg alarmCommentUpdateMsg : uplinkMsg.getAlarmCommentUpdateMsgList()) {
+                    result.add(((AlarmProcessor) ctx.getAlarmEdgeProcessorFactory().getProcessorByEdgeVersion(this.edgeVersion))
+                            .processAlarmCommentMsgFromEdge(edge.getTenantId(), edge.getId(), alarmCommentUpdateMsg));
                 }
             }
             if (uplinkMsg.getEntityViewUpdateMsgCount() > 0) {

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/alarm/AlarmMsgConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/alarm/AlarmMsgConstructor.java
@@ -16,6 +16,8 @@
 package org.thingsboard.server.service.edge.rpc.constructor.alarm;
 
 import org.thingsboard.server.common.data.alarm.Alarm;
+import org.thingsboard.server.common.data.alarm.AlarmComment;
+import org.thingsboard.server.gen.edge.v1.AlarmCommentUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.AlarmUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.UpdateMsgType;
 import org.thingsboard.server.service.edge.rpc.constructor.MsgConstructor;
@@ -23,4 +25,6 @@ import org.thingsboard.server.service.edge.rpc.constructor.MsgConstructor;
 public interface AlarmMsgConstructor extends MsgConstructor {
 
     AlarmUpdateMsg constructAlarmUpdatedMsg(UpdateMsgType msgType, Alarm alarm, String entityName);
+
+    AlarmCommentUpdateMsg constructAlarmCommentUpdatedMsg(UpdateMsgType msgType, AlarmComment alarmComment);
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/alarm/AlarmMsgConstructorV1.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/alarm/AlarmMsgConstructorV1.java
@@ -24,7 +24,7 @@ import org.thingsboard.server.queue.util.TbCoreComponent;
 
 @Component
 @TbCoreComponent
-public class AlarmMsgConstructorV1 implements AlarmMsgConstructor {
+public class AlarmMsgConstructorV1 extends BaseAlarmMsgConstructor {
 
     @Override
     public AlarmUpdateMsg constructAlarmUpdatedMsg(UpdateMsgType msgType, Alarm alarm, String entityName) {

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/alarm/BaseAlarmMsgConstructor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/alarm/BaseAlarmMsgConstructor.java
@@ -15,22 +15,15 @@
  */
 package org.thingsboard.server.service.edge.rpc.constructor.alarm;
 
-import org.springframework.stereotype.Component;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.server.common.data.alarm.Alarm;
-import org.thingsboard.server.gen.edge.v1.AlarmUpdateMsg;
+import org.thingsboard.server.common.data.alarm.AlarmComment;
+import org.thingsboard.server.gen.edge.v1.AlarmCommentUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.UpdateMsgType;
-import org.thingsboard.server.queue.util.TbCoreComponent;
 
-@Component
-@TbCoreComponent
-public class AlarmMsgConstructorV2 extends BaseAlarmMsgConstructor {
+public abstract class BaseAlarmMsgConstructor implements AlarmMsgConstructor {
 
     @Override
-    public AlarmUpdateMsg constructAlarmUpdatedMsg(UpdateMsgType msgType, Alarm alarm, String entityName) {
-        return AlarmUpdateMsg.newBuilder().setMsgType(msgType)
-                .setEntity(JacksonUtil.toString(alarm))
-                .setIdMSB(alarm.getId().getId().getMostSignificantBits())
-                .setIdLSB(alarm.getId().getId().getLeastSignificantBits()).build();
+    public AlarmCommentUpdateMsg constructAlarmCommentUpdatedMsg(UpdateMsgType msgType, AlarmComment alarmComment) {
+        return AlarmCommentUpdateMsg.newBuilder().setMsgType(msgType).setEntity(JacksonUtil.toString(alarmComment)).build();
     }
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessor.java
@@ -51,6 +51,7 @@ import org.thingsboard.server.common.data.id.UserId;
 import org.thingsboard.server.common.data.kv.AttributeKvEntry;
 import org.thingsboard.server.common.data.msg.TbMsgType;
 import org.thingsboard.server.common.data.page.PageData;
+import org.thingsboard.server.common.data.page.PageDataIterableByTenantIdEntityId;
 import org.thingsboard.server.common.data.page.PageLink;
 import org.thingsboard.server.common.data.relation.EntityRelation;
 import org.thingsboard.server.common.data.relation.RelationTypeGroup;
@@ -59,6 +60,7 @@ import org.thingsboard.server.common.data.rule.RuleChainConnectionInfo;
 import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.TbMsgDataType;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
+import org.thingsboard.server.dao.alarm.AlarmCommentService;
 import org.thingsboard.server.dao.alarm.AlarmService;
 import org.thingsboard.server.dao.asset.AssetProfileService;
 import org.thingsboard.server.dao.asset.AssetService;
@@ -144,6 +146,9 @@ public abstract class BaseEdgeProcessor {
 
     @Autowired
     protected AlarmService alarmService;
+
+    @Autowired
+    protected AlarmCommentService alarmCommentService;
 
     @Autowired
     protected DeviceService deviceService;
@@ -350,10 +355,13 @@ public abstract class BaseEdgeProcessor {
             case ALARM_ASSIGNED:
             case ALARM_UNASSIGNED:
             case CREDENTIALS_REQUEST:
+            case ADDED_COMMENT:
+            case UPDATED_COMMENT:
                 return true;
         }
         switch (type) {
             case ALARM:
+            case ALARM_COMMENT:
             case RULE_CHAIN:
             case RULE_CHAIN_METADATA:
             case USER:
@@ -441,14 +449,17 @@ public abstract class BaseEdgeProcessor {
             case CREDENTIALS_UPDATED:
             case ASSIGNED_TO_CUSTOMER:
             case UNASSIGNED_FROM_CUSTOMER:
+            case UPDATED_COMMENT:
                 return UpdateMsgType.ENTITY_UPDATED_RPC_MESSAGE;
             case ADDED:
             case ASSIGNED_TO_EDGE:
             case RELATION_ADD_OR_UPDATE:
+            case ADDED_COMMENT:
                 return UpdateMsgType.ENTITY_CREATED_RPC_MESSAGE;
             case DELETED:
             case UNASSIGNED_FROM_EDGE:
             case RELATION_DELETED:
+            case DELETED_COMMENT:
                 return UpdateMsgType.ENTITY_DELETED_RPC_MESSAGE;
             case ALARM_ACK:
                 return UpdateMsgType.ALARM_ACK_RPC_MESSAGE;
@@ -517,22 +528,14 @@ public abstract class BaseEdgeProcessor {
 
     private ListenableFuture<Void> processNotificationToRelatedEdges(TenantId tenantId, EntityId entityId, EdgeEventType type,
                                                                      EdgeEventActionType actionType, EdgeId sourceEdgeId) {
-        PageLink pageLink = new PageLink(DEFAULT_PAGE_SIZE);
-        PageData<EdgeId> pageData;
         List<ListenableFuture<Void>> futures = new ArrayList<>();
-        do {
-            pageData = edgeService.findRelatedEdgeIdsByEntityId(tenantId, entityId, pageLink);
-            if (pageData != null && pageData.getData() != null && !pageData.getData().isEmpty()) {
-                for (EdgeId relatedEdgeId : pageData.getData()) {
-                    if (!relatedEdgeId.equals(sourceEdgeId)) {
-                        futures.add(saveEdgeEvent(tenantId, relatedEdgeId, type, actionType, entityId, null));
-                    }
-                }
-                if (pageData.hasNext()) {
-                    pageLink = pageLink.nextPageLink();
-                }
+        PageDataIterableByTenantIdEntityId<EdgeId> edgeIds =
+                new PageDataIterableByTenantIdEntityId<>(edgeService::findRelatedEdgeIdsByEntityId, tenantId, entityId, DEFAULT_PAGE_SIZE);
+        for (EdgeId relatedEdgeId : edgeIds) {
+            if (!relatedEdgeId.equals(sourceEdgeId)) {
+                futures.add(saveEdgeEvent(tenantId, relatedEdgeId, type, actionType, entityId, null));
             }
-        } while (pageData != null && pageData.hasNext());
+        }
         return Futures.transform(Futures.allAsList(futures), voids -> null, dbCallbackExecutorService);
     }
 
@@ -715,19 +718,13 @@ public abstract class BaseEdgeProcessor {
     }
 
     private boolean isEntityNotAssignedToEdge(TenantId tenantId, EntityId entityId, EdgeId edgeId) {
-        PageLink pageLink = new PageLink(DEFAULT_PAGE_SIZE);
-        PageData<EdgeId> pageData;
-        do {
-            pageData = edgeService.findRelatedEdgeIdsByEntityId(tenantId, entityId, pageLink);
-            if (pageData != null && pageData.getData() != null && !pageData.getData().isEmpty()) {
-                if (pageData.getData().contains(edgeId)) {
-                    return false;
-                }
-                if (pageData.hasNext()) {
-                    pageLink = pageLink.nextPageLink();
-                }
+        PageDataIterableByTenantIdEntityId<EdgeId> edgeIds =
+                new PageDataIterableByTenantIdEntityId<>(edgeService::findRelatedEdgeIdsByEntityId, tenantId, entityId, DEFAULT_PAGE_SIZE);
+        for (EdgeId edgeId1 : edgeIds) {
+            if (edgeId1.equals(edgeId)) {
+                return false;
             }
-        } while (pageData != null && pageData.hasNext());
+        }
         return true;
     }
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/alarm/AlarmEdgeProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/alarm/AlarmEdgeProcessor.java
@@ -22,22 +22,30 @@ import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.EdgeUtils;
 import org.thingsboard.server.common.data.alarm.Alarm;
+import org.thingsboard.server.common.data.alarm.AlarmComment;
 import org.thingsboard.server.common.data.edge.EdgeEvent;
 import org.thingsboard.server.common.data.edge.EdgeEventActionType;
 import org.thingsboard.server.common.data.edge.EdgeEventType;
+import org.thingsboard.server.common.data.id.AlarmCommentId;
 import org.thingsboard.server.common.data.id.AlarmId;
 import org.thingsboard.server.common.data.id.EdgeId;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.page.PageData;
+import org.thingsboard.server.common.data.page.PageDataIterable;
+import org.thingsboard.server.common.data.page.PageDataIterableByTenantIdEntityId;
 import org.thingsboard.server.common.data.page.PageLink;
+import org.thingsboard.server.gen.edge.v1.AlarmCommentUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.AlarmUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.DownlinkMsg;
 import org.thingsboard.server.gen.edge.v1.EdgeVersion;
+import org.thingsboard.server.gen.edge.v1.UpdateMsgType;
 import org.thingsboard.server.gen.transport.TransportProtos;
+import org.thingsboard.server.service.edge.rpc.constructor.alarm.AlarmMsgConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -67,58 +75,100 @@ public abstract class AlarmEdgeProcessor extends BaseAlarmProcessor implements A
         return null;
     }
 
+    @Override
+    public ListenableFuture<Void> processAlarmCommentMsgFromEdge(TenantId tenantId, EdgeId edgeId, AlarmCommentUpdateMsg alarmCommentUpdateMsg) {
+        log.trace("[{}] processAlarmCommentMsgFromEdge [{}]", tenantId, alarmCommentUpdateMsg);
+        try {
+            edgeSynchronizationManager.getEdgeId().set(edgeId);
+            return processAlarmCommentMsg(tenantId, alarmCommentUpdateMsg);
+        } finally {
+            edgeSynchronizationManager.getEdgeId().remove();
+        }
+    }
+
+    @Override
+    public DownlinkMsg convertAlarmCommentEventToDownlink(EdgeEvent edgeEvent, EdgeVersion edgeVersion) {
+        AlarmCommentId alarmCommentId = new AlarmCommentId(edgeEvent.getEntityId());
+        UpdateMsgType msgType = getUpdateMsgType(edgeEvent.getAction());
+        AlarmComment alarmComment;
+        switch (edgeEvent.getAction()) {
+            case ADDED_COMMENT:
+            case UPDATED_COMMENT:
+                alarmComment = alarmCommentService.findAlarmCommentById(edgeEvent.getTenantId(), alarmCommentId);
+                break;
+            case DELETED_COMMENT:
+                alarmComment = JacksonUtil.convertValue(edgeEvent.getBody(), AlarmComment.class);
+                break;
+            default:
+                return null;
+        }
+        return Optional.ofNullable(alarmComment).map(comment -> buildAlarmCommentDownlinkMsg(msgType, comment, edgeVersion)).orElse(null);
+    }
+
+    private DownlinkMsg buildAlarmCommentDownlinkMsg(UpdateMsgType msgType, AlarmComment alarmComment, EdgeVersion edgeVersion) {
+        return DownlinkMsg.newBuilder()
+                .setDownlinkMsgId(EdgeUtils.nextPositiveInt())
+                .addAlarmCommentUpdateMsg(((AlarmMsgConstructor) alarmMsgConstructorFactory
+                        .getMsgConstructorByEdgeVersion(edgeVersion)).constructAlarmCommentUpdatedMsg(msgType, alarmComment))
+                .build();
+    }
+
     public ListenableFuture<Void> processAlarmNotification(TenantId tenantId, TransportProtos.EdgeNotificationMsgProto edgeNotificationMsg) {
         EdgeEventActionType actionType = EdgeEventActionType.valueOf(edgeNotificationMsg.getAction());
         AlarmId alarmId = new AlarmId(new UUID(edgeNotificationMsg.getEntityIdMSB(), edgeNotificationMsg.getEntityIdLSB()));
         EdgeId originatorEdgeId = safeGetEdgeId(edgeNotificationMsg.getOriginatorEdgeIdMSB(), edgeNotificationMsg.getOriginatorEdgeIdLSB());
-        switch (actionType) {
-            case DELETED:
-                Alarm deletedAlarm = JacksonUtil.fromString(edgeNotificationMsg.getBody(), Alarm.class);
-                if (deletedAlarm == null) {
-                    return Futures.immediateFuture(null);
-                }
-                List<ListenableFuture<Void>> delFutures = pushEventToAllRelatedEdges(tenantId, deletedAlarm.getOriginator(),
-                        alarmId, actionType, JacksonUtil.valueToTree(deletedAlarm), originatorEdgeId);
-                return Futures.transform(Futures.allAsList(delFutures), voids -> null, dbCallbackExecutorService);
-            default:
-                ListenableFuture<Alarm> alarmFuture = alarmService.findAlarmByIdAsync(tenantId, alarmId);
-                return Futures.transformAsync(alarmFuture, alarm -> {
-                    if (alarm == null) {
-                        return Futures.immediateFuture(null);
-                    }
-                    EdgeEventType type = EdgeUtils.getEdgeEventTypeByEntityType(alarm.getOriginator().getEntityType());
-                    if (type == null) {
-                        return Futures.immediateFuture(null);
-                    }
-                    List<ListenableFuture<Void>> futures = pushEventToAllRelatedEdges(tenantId, alarm.getOriginator(),
-                            alarmId, actionType, null, originatorEdgeId);
-                    return Futures.transform(Futures.allAsList(futures), voids -> null, dbCallbackExecutorService);
-                }, dbCallbackExecutorService);
+        if (EdgeEventActionType.DELETED.equals(actionType)) {
+            Alarm deletedAlarm = JacksonUtil.fromString(edgeNotificationMsg.getBody(), Alarm.class);
+            if (deletedAlarm == null) {
+                return Futures.immediateFuture(null);
+            }
+            List<ListenableFuture<Void>> delFutures = pushEventToAllRelatedEdges(tenantId, deletedAlarm.getOriginator(),
+                    alarmId, actionType, JacksonUtil.valueToTree(deletedAlarm), originatorEdgeId, EdgeEventType.ALARM);
+            return Futures.transform(Futures.allAsList(delFutures), voids -> null, dbCallbackExecutorService);
         }
+        ListenableFuture<Alarm> alarmFuture = alarmService.findAlarmByIdAsync(tenantId, alarmId);
+        return Futures.transformAsync(alarmFuture, alarm -> {
+            if (alarm == null) {
+                return Futures.immediateFuture(null);
+            }
+            EdgeEventType type = EdgeUtils.getEdgeEventTypeByEntityType(alarm.getOriginator().getEntityType());
+            if (type == null) {
+                return Futures.immediateFuture(null);
+            }
+            List<ListenableFuture<Void>> futures = pushEventToAllRelatedEdges(tenantId, alarm.getOriginator(),
+                    alarmId, actionType, null, originatorEdgeId, EdgeEventType.ALARM);
+            return Futures.transform(Futures.allAsList(futures), voids -> null, dbCallbackExecutorService);
+        }, dbCallbackExecutorService);
     }
 
-    private List<ListenableFuture<Void>> pushEventToAllRelatedEdges(TenantId tenantId, EntityId originatorId, AlarmId alarmId, EdgeEventActionType actionType, JsonNode body, EdgeId sourceEdgeId) {
-        PageLink pageLink = new PageLink(DEFAULT_PAGE_SIZE);
-        PageData<EdgeId> pageData;
-        List<ListenableFuture<Void>> futures = new ArrayList<>();
-        do {
-            pageData = edgeService.findRelatedEdgeIdsByEntityId(tenantId, originatorId, pageLink);
-            if (pageData != null && pageData.getData() != null && !pageData.getData().isEmpty()) {
-                for (EdgeId relatedEdgeId : pageData.getData()) {
-                    if (!relatedEdgeId.equals(sourceEdgeId)) {
-                        futures.add(saveEdgeEvent(tenantId,
-                                relatedEdgeId,
-                                EdgeEventType.ALARM,
-                                actionType,
-                                alarmId,
-                                body));
-                    }
-                }
-                if (pageData.hasNext()) {
-                    pageLink = pageLink.nextPageLink();
-                }
+    public ListenableFuture<Void> processAlarmCommentNotification(TenantId tenantId, TransportProtos.EdgeNotificationMsgProto edgeNotificationMsg) {
+        EdgeEventActionType actionType = EdgeEventActionType.valueOf(edgeNotificationMsg.getAction());
+        AlarmId alarmId = new AlarmId(new UUID(edgeNotificationMsg.getEntityIdMSB(), edgeNotificationMsg.getEntityIdLSB()));
+        EdgeId originatorEdgeId = safeGetEdgeId(edgeNotificationMsg.getOriginatorEdgeIdMSB(), edgeNotificationMsg.getOriginatorEdgeIdLSB());
+        if (EdgeEventActionType.DELETED.equals(actionType)) {
+            AlarmComment deletedAlarmComment = JacksonUtil.fromString(edgeNotificationMsg.getBody(), AlarmComment.class);
+            if (deletedAlarmComment == null) {
+                return Futures.immediateFuture(null);
             }
-        } while (pageData != null && pageData.hasNext());
+            Alarm alarmById = alarmService.findAlarmById(tenantId, new AlarmId(deletedAlarmComment.getAlarmId().getId()));
+            List<ListenableFuture<Void>> delFutures = pushEventToAllRelatedEdges(tenantId, alarmById.getOriginator(),
+                    alarmId, actionType, JacksonUtil.valueToTree(deletedAlarmComment), originatorEdgeId, EdgeEventType.ALARM_COMMENT);
+            return Futures.transform(Futures.allAsList(delFutures), voids -> null, dbCallbackExecutorService);
+        }
+        return Futures.immediateFuture(null);
+    }
+
+    private List<ListenableFuture<Void>> pushEventToAllRelatedEdges(TenantId tenantId, EntityId originatorId, AlarmId alarmId,
+                                                                    EdgeEventActionType actionType, JsonNode body, EdgeId sourceEdgeId,
+                                                                    EdgeEventType edgeEventType) {
+        List<ListenableFuture<Void>> futures = new ArrayList<>();
+        PageDataIterableByTenantIdEntityId<EdgeId> edgeIds =
+                new PageDataIterableByTenantIdEntityId<>(edgeService::findRelatedEdgeIdsByEntityId, tenantId, originatorId, DEFAULT_PAGE_SIZE);
+        for (EdgeId relatedEdgeId : edgeIds) {
+            if (!relatedEdgeId.equals(sourceEdgeId)) {
+                futures.add(saveEdgeEvent(tenantId, relatedEdgeId, edgeEventType, actionType, alarmId, body));
+            }
+        }
         return futures;
     }
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/alarm/AlarmProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/alarm/AlarmProcessor.java
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.thingsboard.server.common.data.edge.EdgeEvent;
 import org.thingsboard.server.common.data.id.EdgeId;
 import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.gen.edge.v1.AlarmCommentUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.AlarmUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.DownlinkMsg;
 import org.thingsboard.server.gen.edge.v1.EdgeVersion;
@@ -29,4 +30,8 @@ public interface AlarmProcessor extends EdgeProcessor {
     ListenableFuture<Void> processAlarmMsgFromEdge(TenantId tenantId, EdgeId edgeId, AlarmUpdateMsg alarmUpdateMsg);
 
     DownlinkMsg convertAlarmEventToDownlink(EdgeEvent edgeEvent, EdgeVersion edgeVersion);
+
+    ListenableFuture<Void> processAlarmCommentMsgFromEdge(TenantId tenantId, EdgeId edgeId, AlarmCommentUpdateMsg alarmCommentUpdateMsg);
+
+    DownlinkMsg convertAlarmCommentEventToDownlink(EdgeEvent edgeEvent, EdgeVersion edgeVersion);
 }

--- a/application/src/main/java/org/thingsboard/server/service/entitiy/DefaultTbNotificationEntityService.java
+++ b/application/src/main/java/org/thingsboard/server/service/entitiy/DefaultTbNotificationEntityService.java
@@ -19,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.server.common.msg.rule.engine.DeviceCredentialsUpdateNotificationMsg;
 import org.thingsboard.server.cluster.TbClusterService;
 import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.HasName;
@@ -27,7 +26,6 @@ import org.thingsboard.server.common.data.Tenant;
 import org.thingsboard.server.common.data.User;
 import org.thingsboard.server.common.data.audit.ActionType;
 import org.thingsboard.server.common.data.edge.Edge;
-import org.thingsboard.server.common.data.edge.EdgeEventActionType;
 import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.EdgeId;
@@ -40,6 +38,7 @@ import org.thingsboard.server.common.data.security.DeviceCredentials;
 import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.TbMsgDataType;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
+import org.thingsboard.server.common.msg.rule.engine.DeviceCredentialsUpdateNotificationMsg;
 import org.thingsboard.server.service.action.EntityActionService;
 import org.thingsboard.server.service.gateway_device.GatewayNotificationsService;
 
@@ -173,40 +172,5 @@ public class DefaultTbNotificationEntityService implements TbNotificationEntityS
         metaData.putValue("assignedFromTenantId", tenant.getId().getId().toString());
         metaData.putValue("assignedFromTenantName", tenant.getName());
         return metaData;
-    }
-
-    public static EdgeEventActionType edgeTypeByActionType(ActionType actionType) {
-        switch (actionType) {
-            case ADDED:
-                return EdgeEventActionType.ADDED;
-            case UPDATED:
-                return EdgeEventActionType.UPDATED;
-            case ALARM_ACK:
-                return EdgeEventActionType.ALARM_ACK;
-            case ALARM_CLEAR:
-                return EdgeEventActionType.ALARM_CLEAR;
-            case ALARM_ASSIGNED:
-                return EdgeEventActionType.ALARM_ASSIGNED;
-            case ALARM_UNASSIGNED:
-                return EdgeEventActionType.ALARM_UNASSIGNED;
-            case DELETED:
-                return EdgeEventActionType.DELETED;
-            case RELATION_ADD_OR_UPDATE:
-                return EdgeEventActionType.RELATION_ADD_OR_UPDATE;
-            case RELATION_DELETED:
-                return EdgeEventActionType.RELATION_DELETED;
-            case ASSIGNED_TO_CUSTOMER:
-                return EdgeEventActionType.ASSIGNED_TO_CUSTOMER;
-            case UNASSIGNED_FROM_CUSTOMER:
-                return EdgeEventActionType.UNASSIGNED_FROM_CUSTOMER;
-            case ASSIGNED_TO_EDGE:
-                return EdgeEventActionType.ASSIGNED_TO_EDGE;
-            case UNASSIGNED_FROM_EDGE:
-                return EdgeEventActionType.UNASSIGNED_FROM_EDGE;
-            case CREDENTIALS_UPDATED:
-                return EdgeEventActionType.CREDENTIALS_UPDATED;
-            default:
-                return null;
-        }
     }
 }

--- a/application/src/test/java/org/thingsboard/server/controller/AbstractNotifyEntityTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/AbstractNotifyEntityTest.java
@@ -20,6 +20,7 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.thingsboard.server.cluster.TbClusterService;
+import org.thingsboard.server.common.data.EdgeUtils;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.HasName;
 import org.thingsboard.server.common.data.HasTenantId;
@@ -47,7 +48,6 @@ import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.thingsboard.server.service.entitiy.DefaultTbNotificationEntityService.edgeTypeByActionType;
 
 @Slf4j
 public abstract class AbstractNotifyEntityTest extends AbstractWebTest {
@@ -91,7 +91,7 @@ public abstract class AbstractNotifyEntityTest extends AbstractWebTest {
         int cntTime = 1;
         Mockito.verify(tbClusterService, times(cntTime)).sendNotificationMsgToEdge(Mockito.eq(tenantId),
                 Mockito.isNull(), Mockito.isNull(), Mockito.any(), Mockito.eq(EdgeEventType.RELATION),
-                Mockito.eq(edgeTypeByActionType(actionType)), Mockito.any());
+                Mockito.eq(EdgeUtils.getEdgeEventActionTypeByActionType(actionType)), Mockito.any());
         ArgumentMatcher<EntityId> matcherOriginatorId = argument -> argument.equals(relation.getTo());
         ArgumentMatcher<HasName> matcherEntityClassEquals = Objects::isNull;
         ArgumentMatcher<CustomerId> matcherCustomerId = customerId == null ?
@@ -111,7 +111,7 @@ public abstract class AbstractNotifyEntityTest extends AbstractWebTest {
                                                    ActionType actionType, int cntTime) {
         Mockito.verify(tbClusterService, times(cntTime)).sendNotificationMsgToEdge(Mockito.eq(tenantId),
                 Mockito.isNull(), Mockito.isNull(), Mockito.any(), Mockito.eq(EdgeEventType.RELATION),
-                Mockito.eq(edgeTypeByActionType(actionType)), Mockito.any());
+                Mockito.eq(EdgeUtils.getEdgeEventActionTypeByActionType(actionType)), Mockito.any());
         ArgumentMatcher<EntityId> matcherOriginatorId = argument -> argument.getClass().equals(relation.getFrom().getClass());
         ArgumentMatcher<HasName> matcherEntityClassEquals = Objects::isNull;
         ArgumentMatcher<CustomerId> matcherCustomerId = customerId == null ?
@@ -317,7 +317,7 @@ public abstract class AbstractNotifyEntityTest extends AbstractWebTest {
 
     private void testNotificationMsgToEdgeServiceNeverWithActionType(EntityId entityId, ActionType actionType) {
         EdgeEventActionType edgeEventActionType = ActionType.CREDENTIALS_UPDATED.equals(actionType) ?
-                EdgeEventActionType.CREDENTIALS_UPDATED : edgeTypeByActionType(actionType);
+                EdgeEventActionType.CREDENTIALS_UPDATED : EdgeUtils.getEdgeEventActionTypeByActionType(actionType);
         Mockito.verify(tbClusterService, never()).sendNotificationMsgToEdge(Mockito.any(), Mockito.any(),
                 Mockito.any(entityId.getClass()), Mockito.any(), Mockito.any(), Mockito.eq(edgeEventActionType), Mockito.any());
     }
@@ -353,7 +353,7 @@ public abstract class AbstractNotifyEntityTest extends AbstractWebTest {
 
     private void testNotificationMsgToEdgeServiceTime(EntityId entityId, TenantId tenantId, ActionType actionType, int cntTime) {
         EdgeEventActionType edgeEventActionType = ActionType.CREDENTIALS_UPDATED.equals(actionType) ?
-                EdgeEventActionType.CREDENTIALS_UPDATED : edgeTypeByActionType(actionType);
+                EdgeEventActionType.CREDENTIALS_UPDATED : EdgeUtils.getEdgeEventActionTypeByActionType(actionType);
         ArgumentMatcher<EntityId> matcherEntityId = cntTime == 1 ? argument -> argument.equals(entityId) :
                 argument -> argument.getClass().equals(entityId.getClass());
         Mockito.verify(tbClusterService, times(cntTime)).sendNotificationMsgToEdge(Mockito.eq(tenantId),
@@ -364,7 +364,7 @@ public abstract class AbstractNotifyEntityTest extends AbstractWebTest {
     private void testSendNotificationMsgToEdgeServiceTimeEntityEqAny(TenantId tenantId, ActionType actionType, int cntTime) {
         Mockito.verify(tbClusterService, times(cntTime)).sendNotificationMsgToEdge(Mockito.eq(tenantId),
                 Mockito.any(), Mockito.any(EntityId.class), Mockito.any(), Mockito.isNull(),
-                Mockito.eq(edgeTypeByActionType(actionType)), Mockito.any());
+                Mockito.eq(EdgeUtils.getEdgeEventActionTypeByActionType(actionType)), Mockito.any());
     }
 
     protected void testBroadcastEntityStateChangeEventTime(EntityId entityId, TenantId tenantId, int cntTime) {

--- a/application/src/test/java/org/thingsboard/server/edge/imitator/EdgeImitator.java
+++ b/application/src/test/java/org/thingsboard/server/edge/imitator/EdgeImitator.java
@@ -27,6 +27,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.thingsboard.edge.rpc.EdgeGrpcClient;
 import org.thingsboard.edge.rpc.EdgeRpcClient;
 import org.thingsboard.server.gen.edge.v1.AdminSettingsUpdateMsg;
+import org.thingsboard.server.gen.edge.v1.AlarmCommentUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.AlarmUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.AssetProfileUpdateMsg;
 import org.thingsboard.server.gen.edge.v1.AssetUpdateMsg;
@@ -229,6 +230,11 @@ public class EdgeImitator {
         if (downlinkMsg.getAlarmUpdateMsgCount() > 0) {
             for (AlarmUpdateMsg alarmUpdateMsg : downlinkMsg.getAlarmUpdateMsgList()) {
                 result.add(saveDownlinkMsg(alarmUpdateMsg));
+            }
+        }
+        if (downlinkMsg.getAlarmCommentUpdateMsgCount() > 0) {
+            for (AlarmCommentUpdateMsg alarmCommentUpdateMsg : downlinkMsg.getAlarmCommentUpdateMsgList()) {
+                result.add(saveDownlinkMsg(alarmCommentUpdateMsg));
             }
         }
         if (downlinkMsg.getEntityDataCount() > 0) {

--- a/application/src/test/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessorTest.java
@@ -32,6 +32,7 @@ import org.thingsboard.server.common.data.id.DashboardId;
 import org.thingsboard.server.common.data.id.EdgeId;
 import org.thingsboard.server.common.data.id.RuleChainId;
 import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.dao.alarm.AlarmCommentService;
 import org.thingsboard.server.dao.alarm.AlarmService;
 import org.thingsboard.server.dao.asset.AssetProfileService;
 import org.thingsboard.server.dao.asset.AssetService;
@@ -156,6 +157,9 @@ public abstract class BaseEdgeProcessorTest {
 
     @MockBean
     protected AlarmService alarmService;
+
+    @MockBean
+    protected AlarmCommentService alarmCommentService;
 
     @MockBean
     protected DeviceService deviceService;

--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/alarm/AlarmCommentService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/alarm/AlarmCommentService.java
@@ -25,6 +25,7 @@ import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
 
 public interface AlarmCommentService {
+
     AlarmComment createOrUpdateAlarmComment(TenantId tenantId, AlarmComment alarmComment);
 
     AlarmComment saveAlarmComment(TenantId tenantId, AlarmComment alarmComment);

--- a/common/data/src/main/java/org/thingsboard/server/common/data/EdgeUtils.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/EdgeUtils.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.common.data;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Throwables;
 import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.server.common.data.audit.ActionType;
 import org.thingsboard.server.common.data.edge.EdgeEvent;
 import org.thingsboard.server.common.data.edge.EdgeEventActionType;
 import org.thingsboard.server.common.data.edge.EdgeEventType;
@@ -32,12 +33,20 @@ import java.util.concurrent.ThreadLocalRandom;
 public final class EdgeUtils {
 
     private static final EnumMap<EntityType, EdgeEventType> entityTypeEdgeEventTypeEnumMap;
+    private static final EnumMap<ActionType, EdgeEventActionType> actionTypeEdgeEventActionTypeEnumMap;
 
     static {
         entityTypeEdgeEventTypeEnumMap = new EnumMap<>(EntityType.class);
         for (EdgeEventType edgeEventType : EdgeEventType.values()) {
             if (edgeEventType.getEntityType() != null) {
                 entityTypeEdgeEventTypeEnumMap.put(edgeEventType.getEntityType(), edgeEventType);
+            }
+        }
+
+        actionTypeEdgeEventActionTypeEnumMap = new EnumMap<>(ActionType.class);
+        for (EdgeEventActionType edgeEventActionType : EdgeEventActionType.values()) {
+            if (edgeEventActionType.getActionType() != null) {
+                actionTypeEdgeEventActionTypeEnumMap.put(edgeEventActionType.getActionType(), edgeEventActionType);
             }
         }
     }
@@ -52,6 +61,10 @@ public final class EdgeUtils {
 
     public static EdgeEventType getEdgeEventTypeByEntityType(EntityType entityType) {
         return entityTypeEdgeEventTypeEnumMap.get(entityType);
+    }
+
+    public static EdgeEventActionType getEdgeEventActionTypeByActionType(ActionType actionType) {
+        return actionTypeEdgeEventActionTypeEnumMap.get(actionType);
     }
 
     public static EdgeEvent constructEdgeEvent(TenantId tenantId,

--- a/common/data/src/main/java/org/thingsboard/server/common/data/edge/EdgeEventActionType.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/edge/EdgeEventActionType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright © 2016-2024 The Thingsboard Authors
+ * Copyright © 2016-2023 The Thingsboard Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,26 +15,39 @@
  */
 package org.thingsboard.server.common.data.edge;
 
+import lombok.Getter;
+import org.thingsboard.server.common.data.audit.ActionType;
+
+@Getter
 public enum EdgeEventActionType {
-    ADDED,
-    DELETED,
-    UPDATED,
-    POST_ATTRIBUTES,
-    ATTRIBUTES_UPDATED,
-    ATTRIBUTES_DELETED,
-    TIMESERIES_UPDATED,
-    CREDENTIALS_UPDATED,
-    ASSIGNED_TO_CUSTOMER,
-    UNASSIGNED_FROM_CUSTOMER,
-    RELATION_ADD_OR_UPDATE,
-    RELATION_DELETED,
-    RPC_CALL,
-    ALARM_ACK,
-    ALARM_CLEAR,
-    ALARM_ASSIGNED,
-    ALARM_UNASSIGNED,
-    ASSIGNED_TO_EDGE,
-    UNASSIGNED_FROM_EDGE,
-    CREDENTIALS_REQUEST,
-    ENTITY_MERGE_REQUEST // deprecated
+    ADDED(ActionType.ADDED),
+    UPDATED(ActionType.UPDATED),
+    DELETED(ActionType.DELETED),
+    POST_ATTRIBUTES(null),
+    ATTRIBUTES_UPDATED(ActionType.ATTRIBUTES_UPDATED),
+    ATTRIBUTES_DELETED(ActionType.ATTRIBUTES_DELETED),
+    TIMESERIES_UPDATED(ActionType.TIMESERIES_UPDATED),
+    CREDENTIALS_UPDATED(ActionType.CREDENTIALS_UPDATED),
+    ASSIGNED_TO_CUSTOMER(ActionType.ASSIGNED_TO_CUSTOMER),
+    UNASSIGNED_FROM_CUSTOMER(ActionType.UNASSIGNED_FROM_CUSTOMER),
+    RELATION_ADD_OR_UPDATE(ActionType.RELATION_ADD_OR_UPDATE),
+    RELATION_DELETED(ActionType.RELATION_DELETED),
+    RPC_CALL(ActionType.RPC_CALL),
+    ALARM_ACK(ActionType.ALARM_ACK),
+    ALARM_CLEAR(ActionType.ALARM_CLEAR),
+    ALARM_ASSIGNED(ActionType.ALARM_ASSIGNED),
+    ALARM_UNASSIGNED(ActionType.ALARM_UNASSIGNED),
+    ADDED_COMMENT(ActionType.ADDED_COMMENT),
+    UPDATED_COMMENT(ActionType.UPDATED_COMMENT),
+    DELETED_COMMENT(ActionType.DELETED_COMMENT),
+    ASSIGNED_TO_EDGE(ActionType.ASSIGNED_TO_EDGE),
+    UNASSIGNED_FROM_EDGE(ActionType.UNASSIGNED_FROM_EDGE),
+    CREDENTIALS_REQUEST(null),
+    ENTITY_MERGE_REQUEST(null); // deprecated
+
+    private final ActionType actionType;
+
+    EdgeEventActionType(ActionType actionType) {
+        this.actionType = actionType;
+    }
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/edge/EdgeEventType.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/edge/EdgeEventType.java
@@ -27,6 +27,7 @@ public enum EdgeEventType {
     ASSET_PROFILE(true, EntityType.ASSET_PROFILE),
     ENTITY_VIEW(false, EntityType.ENTITY_VIEW),
     ALARM(false, EntityType.ALARM),
+    ALARM_COMMENT(false, null),
     RULE_CHAIN(false, EntityType.RULE_CHAIN),
     RULE_CHAIN_METADATA(false, null),
     EDGE(false, EntityType.EDGE),

--- a/common/edge-api/src/main/proto/edge.proto
+++ b/common/edge-api/src/main/proto/edge.proto
@@ -325,6 +325,11 @@ message AlarmUpdateMsg {
   string entity = 18;
 }
 
+message AlarmCommentUpdateMsg {
+  UpdateMsgType msgType = 1;
+  string entity = 2;
+}
+
 message CustomerUpdateMsg {
   UpdateMsgType msgType = 1;
   int64 idMSB = 2;
@@ -618,6 +623,7 @@ message UplinkMsg {
   repeated AssetProfileUpdateMsg assetProfileUpdateMsg = 19;
   repeated DeviceProfileUpdateMsg deviceProfileUpdateMsg = 20;
   repeated ResourceUpdateMsg resourceUpdateMsg = 21;
+  repeated AlarmCommentUpdateMsg alarmCommentUpdateMsg = 22;
 }
 
 message UplinkResponseMsg {
@@ -661,5 +667,6 @@ message DownlinkMsg {
   repeated TenantUpdateMsg tenantUpdateMsg = 26;
   repeated TenantProfileUpdateMsg tenantProfileUpdateMsg = 27;
   repeated ResourceUpdateMsg resourceUpdateMsg = 28;
+  repeated AlarmCommentUpdateMsg alarmCommentUpdateMsg = 29;
 }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmCommentService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmCommentService.java
@@ -31,6 +31,7 @@ import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
 import org.thingsboard.server.dao.entity.AbstractEntityService;
+import org.thingsboard.server.dao.eventsourcing.DeleteEntityEvent;
 import org.thingsboard.server.dao.service.DataValidator;
 
 import java.util.UUID;
@@ -61,7 +62,10 @@ public class BaseAlarmCommentService extends AbstractEntityService implements Al
     public AlarmComment saveAlarmComment(TenantId tenantId, AlarmComment alarmComment) {
         log.debug("Deleting Alarm Comment: {}", alarmComment);
         alarmCommentDataValidator.validate(alarmComment, c -> tenantId);
-        return alarmCommentDao.save(tenantId, alarmComment);
+        AlarmComment result = alarmCommentDao.save(tenantId, alarmComment);
+        eventPublisher.publishEvent(DeleteEntityEvent.builder().tenantId(tenantId).entity(result)
+                .entityId(result.getAlarmId()).build());
+        return result;
     }
 
     @Override
@@ -112,5 +116,4 @@ public class BaseAlarmCommentService extends AbstractEntityService implements Al
         }
         return null;
     }
-
 }

--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
@@ -135,7 +135,7 @@ public class BaseAlarmService extends AbstractCachedEntityService<TenantId, Page
         }
         if (result.getAlarm() != null) {
             eventPublisher.publishEvent(SaveEntityEvent.builder().tenantId(result.getAlarm().getTenantId())
-                    .entityId(result.getAlarm().getId()).added(true).build());
+                    .entityId(result.getAlarm().getId()).entity(result).added(true).build());
             publishEvictEvent(new AlarmTypesCacheEvictEvent(request.getTenantId()));
         }
         return withPropagated(result);

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/edge/TbMsgPushToCloudNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/edge/TbMsgPushToCloudNode.java
@@ -79,6 +79,11 @@ public class TbMsgPushToCloudNode extends AbstractTbMsgPushNode<TbMsgPushToCloud
     }
 
     @Override
+    Object getAlarmCommentEventType() {
+        return null;
+    }
+
+    @Override
     String getIgnoredMessageSource() {
         return null;
     }


### PR DESCRIPTION
## Pull Request description

Add Alarm Comment support: to and from edge / to and from cloud using toEdge and toCloud rule nodes.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).