### PR TITLE
Fix new activity state not being created correctly

### DIFF
--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/activity/AbstractActivityManager.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/activity/AbstractActivityManager.java
@@ -78,12 +78,12 @@ public abstract class AbstractActivityManager<Key, Metadata> implements Activity
         states.compute(key, (__, stateWrapper) -> {
             if (stateWrapper == null) {
                 ActivityState<Metadata> newState = new ActivityState<>();
-                newState.setMetadata(metadata);
                 stateWrapper = new ActivityStateWrapper();
                 stateWrapper.setState(newState);
                 stateWrapper.setStrategy(getStrategy());
             }
             var state = stateWrapper.getState();
+            state.setMetadata(metadata);
             if (state.getLastRecordedTime() < newLastRecordedTime) {
                 state.setLastRecordedTime(newLastRecordedTime);
             }

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/activity/AbstractActivityManager.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/activity/AbstractActivityManager.java
@@ -28,10 +28,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
-public abstract class AbstractActivityManager<Key, Metadata> implements ActivityManager<Key> {
+public abstract class AbstractActivityManager<Key, Metadata> implements ActivityManager<Key, Metadata> {
 
     private final ConcurrentMap<Key, ActivityStateWrapper> states = new ConcurrentHashMap<>();
 
@@ -54,8 +53,6 @@ public abstract class AbstractActivityManager<Key, Metadata> implements Activity
 
     protected abstract long getReportingPeriodMillis();
 
-    protected abstract ActivityState<Metadata> createNewState(Key key);
-
     protected abstract ActivityStrategy getStrategy();
 
     protected abstract ActivityState<Metadata> updateState(Key key, ActivityState<Metadata> state);
@@ -67,7 +64,7 @@ public abstract class AbstractActivityManager<Key, Metadata> implements Activity
     protected abstract void reportActivity(Key key, Metadata metadata, long timeToReport, ActivityReportCallback<Key> callback);
 
     @Override
-    public void onActivity(Key key, long newLastRecordedTime) {
+    public void onActivity(Key key, Metadata metadata, long newLastRecordedTime) {
         if (key == null) {
             log.error("Failed to process activity event: provided activity key is null.");
             return;
@@ -77,14 +74,11 @@ public abstract class AbstractActivityManager<Key, Metadata> implements Activity
         var shouldReport = new AtomicBoolean(false);
         var lastRecordedTime = new AtomicLong();
         var lastReportedTime = new AtomicLong();
-        var metadata = new AtomicReference<Metadata>();
 
-        var activityStateWrapper = states.compute(key, (__, stateWrapper) -> {
+        states.compute(key, (__, stateWrapper) -> {
             if (stateWrapper == null) {
-                var newState = createNewState(key);
-                if (newState == null) {
-                    return null;
-                }
+                ActivityState<Metadata> newState = new ActivityState<>();
+                newState.setMetadata(metadata);
                 stateWrapper = new ActivityStateWrapper();
                 stateWrapper.setState(newState);
                 stateWrapper.setStrategy(getStrategy());
@@ -96,17 +90,12 @@ public abstract class AbstractActivityManager<Key, Metadata> implements Activity
             shouldReport.set(stateWrapper.getStrategy().onActivity());
             lastRecordedTime.set(state.getLastRecordedTime());
             lastReportedTime.set(stateWrapper.getLastReportedTime());
-            metadata.set(state.getMetadata());
             return stateWrapper;
         });
 
-        if (activityStateWrapper == null) {
-            return;
-        }
-
         if (shouldReport.get() && lastReportedTime.get() < lastRecordedTime.get()) {
             log.debug("Going to report first activity event for key: [{}].", key);
-            reportActivity(key, metadata.get(), lastRecordedTime.get(), new ActivityReportCallback<>() {
+            reportActivity(key, metadata, lastRecordedTime.get(), new ActivityReportCallback<>() {
                 @Override
                 public void onSuccess(Key key, long reportedTime) {
                     updateLastReportedTime(key, reportedTime);

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/activity/ActivityManager.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/activity/ActivityManager.java
@@ -15,9 +15,9 @@
  */
 package org.thingsboard.server.common.transport.activity;
 
-public interface ActivityManager<Key> {
+public interface ActivityManager<Key, Metadata> {
 
-    void onActivity(Key key, long activityTimeMillis);
+    void onActivity(Key key, Metadata metadata, long activityTimeMillis);
 
     void onReportingPeriodEnd();
 

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
@@ -96,8 +96,6 @@ import org.thingsboard.server.queue.TbQueueProducer;
 import org.thingsboard.server.queue.TbQueueRequestTemplate;
 import org.thingsboard.server.queue.common.AsyncCallbackTemplate;
 import org.thingsboard.server.queue.common.TbProtoQueueMsg;
-import org.thingsboard.server.queue.discovery.QueueKey;
-import org.thingsboard.server.queue.discovery.TopicService;
 import org.thingsboard.server.queue.discovery.PartitionService;
 import org.thingsboard.server.queue.discovery.TbServiceInfoProvider;
 import org.thingsboard.server.queue.discovery.TopicService;
@@ -774,7 +772,7 @@ public class DefaultTransportService extends TransportActivityManager implements
     }
 
     private void recordActivityInternal(TransportProtos.SessionInfoProto sessionInfo) {
-        onActivity(toSessionId(sessionInfo), getCurrentTimeMillis());
+        onActivity(toSessionId(sessionInfo), sessionInfo, getCurrentTimeMillis());
     }
 
     @Override

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/TransportActivityManager.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/TransportActivityManager.java
@@ -58,17 +58,6 @@ public abstract class TransportActivityManager extends AbstractActivityManager<U
     }
 
     @Override
-    protected ActivityState<TransportProtos.SessionInfoProto> createNewState(UUID sessionId) {
-        SessionMetaData session = sessions.get(sessionId);
-        if (session == null) {
-            return null;
-        }
-        ActivityState<TransportProtos.SessionInfoProto> state = new ActivityState<>();
-        state.setMetadata(session.getSessionInfo());
-        return state;
-    }
-
-    @Override
     protected ActivityStrategy getStrategy() {
         return reportingStrategyType.toStrategy();
     }

--- a/common/transport/transport-api/src/test/java/org/thingsboard/server/common/transport/service/TransportActivityManagerTest.java
+++ b/common/transport/transport-api/src/test/java/org/thingsboard/server/common/transport/service/TransportActivityManagerTest.java
@@ -40,6 +40,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -61,6 +63,34 @@ public class TransportActivityManagerTest {
     public void setup() {
         sessions = new ConcurrentHashMap<>();
         ReflectionTestUtils.setField(transportServiceMock, "sessions", sessions);
+    }
+
+    @Test
+    void givenFirstActivityForAlreadyRemovedSessionAndFirstEventReportingStrategy_whenOnActivity_thenShouldRecordActivityAndReport() {
+        // GIVEN
+        ConcurrentMap<UUID, Object> states = new ConcurrentHashMap<>();
+        ReflectionTestUtils.setField(transportServiceMock, "states", states);
+
+        var strategyMock = mock(ActivityStrategy.class);
+        when(transportServiceMock.getStrategy()).thenReturn(strategyMock);
+        when(strategyMock.onActivity()).thenReturn(true);
+
+        long activityTime = 123L;
+        var sessionInfo = TransportProtos.SessionInfoProto.newBuilder()
+                .setSessionIdMSB(SESSION_ID.getMostSignificantBits())
+                .setSessionIdLSB(SESSION_ID.getLeastSignificantBits())
+                .build();
+
+        doCallRealMethod().when(transportServiceMock).getLastRecordedTime(SESSION_ID);
+        doCallRealMethod().when(transportServiceMock).onActivity(SESSION_ID, sessionInfo, activityTime);
+
+        // WHEN
+        transportServiceMock.onActivity(SESSION_ID, sessionInfo, activityTime);
+
+        // THEN
+        assertThat(states).containsKey(SESSION_ID);
+        assertThat(transportServiceMock.getLastRecordedTime(SESSION_ID)).isEqualTo(activityTime);
+        verify(transportServiceMock).reportActivity(eq(SESSION_ID), eq(sessionInfo), eq(activityTime), any(ActivityReportCallback.class));
     }
 
     @Test

--- a/common/transport/transport-api/src/test/java/org/thingsboard/server/common/transport/service/TransportActivityManagerTest.java
+++ b/common/transport/transport-api/src/test/java/org/thingsboard/server/common/transport/service/TransportActivityManagerTest.java
@@ -175,28 +175,7 @@ public class TransportActivityManagerTest {
         transportServiceMock.recordActivity(sessionInfo);
 
         // THEN
-        verify(transportServiceMock).onActivity(SESSION_ID, expectedTime);
-    }
-
-    @Test
-    void givenKey_whenCreatingNewState_thenShouldCorrectlyCreateNewEmptyState() {
-        // GIVEN
-        TransportProtos.SessionInfoProto sessionInfo = TransportProtos.SessionInfoProto.newBuilder()
-                .setSessionIdMSB(SESSION_ID.getMostSignificantBits())
-                .setSessionIdLSB(SESSION_ID.getLeastSignificantBits())
-                .build();
-        sessions.put(SESSION_ID, new SessionMetaData(sessionInfo, TransportProtos.SessionType.ASYNC, null));
-
-        when(transportServiceMock.createNewState(SESSION_ID)).thenCallRealMethod();
-
-        ActivityState<TransportProtos.SessionInfoProto> expectedState = new ActivityState<>();
-        expectedState.setMetadata(sessionInfo);
-
-        // WHEN
-        ActivityState<TransportProtos.SessionInfoProto> actualState = transportServiceMock.createNewState(SESSION_ID);
-
-        // THEN
-        assertThat(actualState).isEqualTo(expectedState);
+        verify(transportServiceMock).onActivity(SESSION_ID, sessionInfo, expectedTime);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Pull Request description

Scenario for this bug:
- First activity for a session is reported
- Session is removed
- Activity manager tries to create new activity state for this session
- New state is not created due to a check if session is still present (state will be null in case session is not present)
- Bug: Activity manager sees that created state is null and does not record activity

Now transport activity manager does not check if session is still present when creating new state.

No documentation changes needed.

[PE PR](https://github.com/thingsboard/thingsboard-pe/pull/2309)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



