### PR TITLE
Fixed singletonMode info on copy of rule-node

### DIFF
--- a/ui-ngx/src/app/core/services/item-buffer.service.ts
+++ b/ui-ngx/src/app/core/services/item-buffer.service.ts
@@ -27,7 +27,7 @@ import {
   widgetType
 } from '@shared/models/widget.models';
 import { DashboardUtilsService } from '@core/services/dashboard-utils.service';
-import { deepClone, isEqual } from '@core/utils';
+import { deepClone, isDefinedAndNotNull, isEqual } from '@core/utils';
 import { UtilsService } from '@core/services/utils.service';
 import { Observable, of, throwError } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -308,6 +308,9 @@ export class ItemBufferService {
       }
       if (origNode.error) {
         node.error = origNode.error;
+      }
+      if (isDefinedAndNotNull(origNode.singletonMode)) {
+        node.singletonMode = origNode.singletonMode;
       }
       ruleNodes.nodes.push(node);
       if (i === 0) {

--- a/ui-ngx/src/app/core/services/item-buffer.service.ts
+++ b/ui-ngx/src/app/core/services/item-buffer.service.ts
@@ -312,6 +312,9 @@ export class ItemBufferService {
       if (isDefinedAndNotNull(origNode.singletonMode)) {
         node.singletonMode = origNode.singletonMode;
       }
+      if (isDefinedAndNotNull(origNode.queueName)) {
+        node.queueName = origNode.queueName;
+      }
       ruleNodes.nodes.push(node);
       if (i === 0) {
         top = node.y;


### PR DESCRIPTION
## Pull Request description

When copying rule-node there was a bug that didn't allowed to copy the info about singletonMode if it presents. As a solution  singletonMode field placed to a buffer rule-node info.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



