### PR TITLE
Fix debug log message in MqttTransportHandler:exceptionCaught()

### DIFF
--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -1017,6 +1017,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                 log.debug("[{}][{}][{}] IOException: {}", sessionId,
                         Optional.ofNullable(this.deviceSessionCtx.getDeviceInfo()).map(TransportDeviceInfo::getDeviceId).orElse(null),
                         Optional.ofNullable(this.deviceSessionCtx.getDeviceInfo()).map(TransportDeviceInfo::getDeviceName).orElse(""),
+                        cause.getMessage(),
                         cause);
             } else if (log.isInfoEnabled()) {
                 log.info("[{}][{}][{}] IOException: {}", sessionId,


### PR DESCRIPTION
## Pull Request description

Fix debug log message in `MqttTransportHandler:exceptionCaught()`

Currently logs the following:

```
2024-01-02 03:04:05,67890 [...] DEBUG o.t.s.t.mqtt.MqttTransportHandler - [<X>][<Y][<Z>] IOException: {}
java.io.IOException: Connection reset by peer
        at java.base/sun.nio.ch.FileDispatcherImpl.read0(Native Method)
[...]
```

Note the `{}` in the first line.

This patch makes it print the cause message instead of those brackets:

```
2024-01-02 03:04:05,67890 [...] DEBUG o.t.s.t.mqtt.MqttTransportHandler - [<X>][<Y][<Z>] IOException: Connection reset by peer
java.io.IOException: Connection reset by peer
        at java.base/sun.nio.ch.FileDispatcherImpl.read0(Native Method)
[...]
```