### PR TITLE
Add the possibility of setting the value range manually in the Signal Strength widget configuration

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/indicator/signal-strength-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/indicator/signal-strength-widget.component.ts
@@ -32,6 +32,7 @@ import { WidgetContext } from '@home/models/widget-component.models';
 import {
   backgroundStyle,
   ColorProcessor,
+  ColorRange,
   ComponentStyle,
   DateFormatProcessor,
   getDataKey,
@@ -129,6 +130,7 @@ export class SignalStrengthWidgetComponent implements OnInit, OnDestroy, AfterVi
   private rssi = -100;
   private noSignal = false;
   private noData = false;
+  private lowestSignalRangeValue: number;
 
   constructor(public widgetComponent: WidgetComponent,
               private imagePipe: ImagePipe,
@@ -141,7 +143,7 @@ export class SignalStrengthWidgetComponent implements OnInit, OnDestroy, AfterVi
   ngOnInit(): void {
     this.ctx.$scope.signalStrengthWidget = this;
     this.settings = {...signalStrengthDefaultSettings, ...this.ctx.settings};
-
+    this.lowestSignalRangeValue = this.getLowestSignalRange();
     this.layout = this.settings.layout;
 
     this.showDate = this.settings.showDate;
@@ -246,7 +248,7 @@ export class SignalStrengthWidgetComponent implements OnInit, OnDestroy, AfterVi
       }
     }
 
-    this.noSignal = this.rssi <= -100;
+    this.noSignal = this.rssi <= this.lowestSignalRangeValue;
 
     this.activeBarsColor.update(this.rssi);
 
@@ -389,4 +391,15 @@ export class SignalStrengthWidgetComponent implements OnInit, OnDestroy, AfterVi
     }
   }
 
+  getLowestSignalRange(): number {
+    return this.settings.activeBarsColor.rangeList.reduce((acc: number, colorRange: ColorRange)=>{
+      if (acc < colorRange.from && acc < colorRange.to) {
+        return acc;
+      }
+      if (colorRange.from < colorRange.to) {
+        return colorRange.from;
+      }
+      return colorRange.to;
+    }, -100);
+  }
 }


### PR DESCRIPTION
## Before
https://github.com/thingsboard/thingsboard/assets/31017535/a85db53e-ceaf-4878-ba55-52ebf7eb5e30

## After
https://github.com/thingsboard/thingsboard/assets/31017535/5e5a1439-0c93-4a94-8ebb-94676cda616a


## Pull Request description

The Signal Strength widget has some limitations. 
Currently, a value of -100 is the final acceptable value to display on the widget. A value of -100 is hardcoded and is not displayed on the chart. 

The customer has a scenario where the value displayed on the widget may be outside of this range (e.g., -130).

Therefore, the customer would like to be able to manually set the values for each range in the way that there is a possibility to configure the color of active/inactive signal bars under the 'Signal strength card style' section:

https://thingsboard-portal.atlassian.net/browse/PROD-2773 

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




