### PR TITLE
Updated CassandraBaseTimeseriesDao to do one db insert instead of 5 when setNullValuesEnabled=true

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDao.java
@@ -86,6 +86,18 @@ public class CassandraBaseTimeseriesDao extends AbstractCassandraBaseTimeseriesD
     public static final String ASC_ORDER = "ASC";
     public static final long SECONDS_IN_DAY = TimeUnit.DAYS.toSeconds(1);
     protected static final List<Long> FIXED_PARTITION = List.of(0L);
+    private static String INSERT_WITH_NULL = INSERT_INTO + ModelConstants.TS_KV_CF +
+            "(" + ModelConstants.ENTITY_TYPE_COLUMN +
+            "," + ModelConstants.ENTITY_ID_COLUMN +
+            "," + ModelConstants.KEY_COLUMN +
+            "," + ModelConstants.PARTITION_COLUMN +
+            "," + ModelConstants.TS_COLUMN +
+            "," + ModelConstants.BOOLEAN_VALUE_COLUMN +
+            "," + ModelConstants.STRING_VALUE_COLUMN +
+            "," + ModelConstants.LONG_VALUE_COLUMN +
+            "," + ModelConstants.DOUBLE_VALUE_COLUMN +
+            "," + ModelConstants.JSON_VALUE_COLUMN + ")" +
+            " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
     private CassandraTsPartitionsCache cassandraTsPartitionsCache;
 
@@ -566,18 +578,7 @@ public class CassandraBaseTimeseriesDao extends AbstractCassandraBaseTimeseriesD
             stmtCreationLock.lock();
             try {
                 if (saveWithNullStmt == null) {
-                    saveWithNullStmt = prepare(INSERT_INTO + ModelConstants.TS_KV_CF +
-                            "(" + ModelConstants.ENTITY_TYPE_COLUMN +
-                            "," + ModelConstants.ENTITY_ID_COLUMN +
-                            "," + ModelConstants.KEY_COLUMN +
-                            "," + ModelConstants.PARTITION_COLUMN +
-                            "," + ModelConstants.TS_COLUMN +
-                            "," + ModelConstants.BOOLEAN_VALUE_COLUMN +
-                            "," + ModelConstants.STRING_VALUE_COLUMN +
-                            "," + ModelConstants.LONG_VALUE_COLUMN +
-                            "," + ModelConstants.DOUBLE_VALUE_COLUMN +
-                            "," + ModelConstants.JSON_VALUE_COLUMN + ")" +
-                            " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                    saveWithNullStmt = prepare(INSERT_WITH_NULL);
                 }
             } finally {
                 stmtCreationLock.unlock();
@@ -591,18 +592,7 @@ public class CassandraBaseTimeseriesDao extends AbstractCassandraBaseTimeseriesD
             stmtCreationLock.lock();
             try {
                 if (saveWithNullWithTtlStmt == null) {
-                    saveWithNullWithTtlStmt = prepare(INSERT_INTO + ModelConstants.TS_KV_CF +
-                            "(" + ModelConstants.ENTITY_TYPE_COLUMN +
-                            "," + ModelConstants.ENTITY_ID_COLUMN +
-                            "," + ModelConstants.KEY_COLUMN +
-                            "," + ModelConstants.PARTITION_COLUMN +
-                            "," + ModelConstants.TS_COLUMN +
-                            "," + ModelConstants.BOOLEAN_VALUE_COLUMN +
-                            "," + ModelConstants.STRING_VALUE_COLUMN +
-                            "," + ModelConstants.LONG_VALUE_COLUMN +
-                            "," + ModelConstants.DOUBLE_VALUE_COLUMN +
-                            "," + ModelConstants.JSON_VALUE_COLUMN + ")" +
-                            " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TTL ?");
+                    saveWithNullWithTtlStmt = prepare(INSERT_WITH_NULL + " USING TTL ?");
                 }
             } finally {
                 stmtCreationLock.unlock();

--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDao.java
@@ -86,7 +86,7 @@ public class CassandraBaseTimeseriesDao extends AbstractCassandraBaseTimeseriesD
     public static final String ASC_ORDER = "ASC";
     public static final long SECONDS_IN_DAY = TimeUnit.DAYS.toSeconds(1);
     protected static final List<Long> FIXED_PARTITION = List.of(0L);
-    private static String INSERT_WITH_NULL = INSERT_INTO + ModelConstants.TS_KV_CF +
+    protected static final String INSERT_WITH_NULL = INSERT_INTO + ModelConstants.TS_KV_CF +
             "(" + ModelConstants.ENTITY_TYPE_COLUMN +
             "," + ModelConstants.ENTITY_ID_COLUMN +
             "," + ModelConstants.KEY_COLUMN +

--- a/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
@@ -678,12 +678,12 @@ public abstract class BaseTimeseriesServiceTest extends AbstractServiceTest {
 
     @Test
     public void shouldSaveEntryOfEachType() throws Exception {
-        List<TsKvEntry> timeseries = List.of(
-                new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(1), new BooleanDataEntry("test", true)),
-                new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(2), new StringDataEntry("test", "text")),
-                new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(3), new LongDataEntry("test", 15L)),
-                new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(4), new DoubleDataEntry("test", 10.5)),
-                new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(5), new JsonDataEntry("test", "{\"test\":\"testValue\"}")));
+        BasicTsKvEntry booleanEntry = new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(1), new BooleanDataEntry("test", true));
+        BasicTsKvEntry stringEntry = new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(2), new StringDataEntry("test", "text"));
+        BasicTsKvEntry longEntry = new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(3), new LongDataEntry("test", 15L));
+        BasicTsKvEntry doubleEntry = new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(4), new DoubleDataEntry("test", 10.5));
+        BasicTsKvEntry jsonEntry = new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(5), new JsonDataEntry("test", "{\"test\":\"testValue\"}"));
+        List<TsKvEntry> timeseries = List.of(booleanEntry, stringEntry, longEntry, doubleEntry, jsonEntry);
 
         DeviceId deviceId = new DeviceId(Uuids.timeBased());
         for (TsKvEntry tsKvEntry : timeseries) {
@@ -693,10 +693,13 @@ public abstract class BaseTimeseriesServiceTest extends AbstractServiceTest {
         List<TsKvEntry> listUntil3Minutes = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("test", 0L,
                 TimeUnit.MINUTES.toMillis(3), 1000, 10, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(2, listUntil3Minutes.size());
+        assertThat(listUntil3Minutes).containsOnlyOnceElementsOf(List.of(
+                booleanEntry, stringEntry));
 
         List<TsKvEntry> fullList = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("test", 0L,
                 TimeUnit.MINUTES.toMillis(6), 1000, 10, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(5, fullList.size());
+        assertThat(fullList).containsOnlyOnceElementsOf(timeseries);
     }
 
     private TsKvEntry save(DeviceId deviceId, long ts, long value) throws Exception {

--- a/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlSetNullEnabledTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlSetNullEnabledTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.service.timeseries.nosql;
+
+import com.datastax.oss.driver.api.core.uuid.Uuids;
+import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.kv.Aggregation;
+import org.thingsboard.server.common.data.kv.BaseReadTsKvQuery;
+import org.thingsboard.server.common.data.kv.BasicTsKvEntry;
+import org.thingsboard.server.common.data.kv.DoubleDataEntry;
+import org.thingsboard.server.common.data.kv.LongDataEntry;
+import org.thingsboard.server.common.data.kv.TsKvEntry;
+import org.thingsboard.server.dao.service.DaoNoSqlTest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@DaoNoSqlTest
+@TestPropertySource(properties = {
+        "cassandra.query.set_null_values_enabled=true",
+})
+public class TimeseriesServiceNoSqlSetNullEnabledTest extends TimeseriesServiceNoSqlTest {
+
+    @Override
+    @Test
+    public void testNullValuesOfNoneTargetColumn() throws ExecutionException, InterruptedException, TimeoutException {
+        long ts = TimeUnit.MINUTES.toMillis(1);
+        TsKvEntry longEntry = new BasicTsKvEntry(ts, new LongDataEntry("temp", 0L));
+        double doubleValue = 20.6;
+        TsKvEntry doubleEntry = new BasicTsKvEntry(ts, new DoubleDataEntry("temp", doubleValue));
+        DeviceId deviceId = new DeviceId(Uuids.timeBased());
+        tsService.save(tenantId, deviceId, longEntry).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        tsService.save(tenantId, deviceId, doubleEntry).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+
+        List<TsKvEntry> listWithoutAgg = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("temp", 0L,
+                ts + 1 , 1000, 3, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        assertEquals(1, listWithoutAgg.size());
+        assertFalse(listWithoutAgg.get(0).getLongValue().isPresent());
+        assertTrue(listWithoutAgg.get(0).getDoubleValue().isPresent());
+        assertThat(listWithoutAgg.get(0).getDoubleValue().get()).isEqualTo(doubleValue);
+
+        // long value should be set to null after second insert, so avg = doubleValue
+        List<TsKvEntry> listWithAgg = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("temp", 0L,
+                ts + 1 , 1000, 3, Aggregation.AVG))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        assertEquals(1, listWithAgg.size());
+        assertTrue(listWithAgg.get(0).getDoubleValue().isPresent());
+        assertThat(listWithAgg.get(0).getDoubleValue().get()).isEqualTo(doubleValue);
+    }
+}

--- a/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlTest.java
@@ -15,9 +15,105 @@
  */
 package org.thingsboard.server.dao.service.timeseries.nosql;
 
+import com.datastax.oss.driver.api.core.uuid.Uuids;
+import org.junit.Test;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.kv.Aggregation;
+import org.thingsboard.server.common.data.kv.BaseReadTsKvQuery;
+import org.thingsboard.server.common.data.kv.BasicTsKvEntry;
+import org.thingsboard.server.common.data.kv.BooleanDataEntry;
+import org.thingsboard.server.common.data.kv.DoubleDataEntry;
+import org.thingsboard.server.common.data.kv.JsonDataEntry;
+import org.thingsboard.server.common.data.kv.LongDataEntry;
+import org.thingsboard.server.common.data.kv.StringDataEntry;
+import org.thingsboard.server.common.data.kv.TsKvEntry;
 import org.thingsboard.server.dao.service.DaoNoSqlTest;
 import org.thingsboard.server.dao.service.timeseries.BaseTimeseriesServiceTest;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 @DaoNoSqlTest
 public class TimeseriesServiceNoSqlTest extends BaseTimeseriesServiceTest {
+
+    @Test
+    public void shouldSaveEntryOfEachTypeWithTtl() throws ExecutionException, InterruptedException, TimeoutException {
+        long ttlInSec = TimeUnit.SECONDS.toSeconds(3);
+        List<TsKvEntry> timeseries = List.of(
+                new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(1), new BooleanDataEntry("test", true)),
+                new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(2), new StringDataEntry("test", "text")),
+                new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(3), new LongDataEntry("test", 15L)),
+                new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(4), new DoubleDataEntry("test", 10.5)),
+                new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(5), new JsonDataEntry("test", "{\"test\":\"testValue\"}")));
+
+        DeviceId deviceId = new DeviceId(Uuids.timeBased());
+        tsService.save(tenantId, deviceId, timeseries, ttlInSec);
+
+        List<TsKvEntry> fullList = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("test", 0L,
+                TimeUnit.MINUTES.toMillis(6), 1000, 10, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        assertEquals(5, fullList.size());
+
+        // check entries after ttl
+        Thread.sleep(TimeUnit.SECONDS.toMillis(ttlInSec));
+        List<TsKvEntry> listAfterTtl = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("test", 0L,
+                TimeUnit.MINUTES.toMillis(6), 1000, 10, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        assertEquals(0, listAfterTtl.size());
+    }
+
+    @Test
+    public void shouldDeleteValueAfterTtl() throws ExecutionException, InterruptedException, TimeoutException {
+        long longEntryTs = TimeUnit.MINUTES.toMillis(2);
+        long doubleEntryTs = TimeUnit.MINUTES.toMillis(3);
+        long ttlInSec = TimeUnit.SECONDS.toSeconds(3);
+        long longValue = 0L;
+        TsKvEntry longEntry = new BasicTsKvEntry(longEntryTs, new LongDataEntry("temp", longValue));
+        double doubleValue = 20.6;
+        TsKvEntry doubleEntry = new BasicTsKvEntry(doubleEntryTs, new DoubleDataEntry("temp", doubleValue));
+        DeviceId deviceId = new DeviceId(Uuids.timeBased());
+        tsService.save(tenantId, deviceId, longEntry).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        tsService.save(tenantId, deviceId, Collections.singletonList(doubleEntry), ttlInSec).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(ttlInSec));
+        List<TsKvEntry> listAfterTtl = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("temp", 0L,
+                doubleEntryTs + 1 , 1000, 3, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        assertEquals(1, listAfterTtl.size());
+        assertTrue(listAfterTtl.get(0).getLongValue().isPresent());
+        assertThat(listAfterTtl.get(0).getLongValue().get()).isEqualTo(longValue);
+        assertFalse(listAfterTtl.get(0).getDoubleValue().isPresent());
+    }
+
+    @Test
+    public void testNullValuesOfNoneTargetColumn() throws ExecutionException, InterruptedException, TimeoutException {
+        long ts = TimeUnit.MINUTES.toMillis(1);
+        long longValue = 10L;
+        TsKvEntry longEntry = new BasicTsKvEntry(ts, new LongDataEntry("temp", longValue));
+        double doubleValue = 20.6;
+        TsKvEntry doubleEntry = new BasicTsKvEntry(ts, new DoubleDataEntry("temp", doubleValue));
+        DeviceId deviceId = new DeviceId(Uuids.timeBased());
+        tsService.save(tenantId, deviceId, longEntry).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        tsService.save(tenantId, deviceId, doubleEntry).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+
+        List<TsKvEntry> listWithoutAgg = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("temp", 0L,
+                ts + 1 , 1000, 3, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        assertEquals(1, listWithoutAgg.size());
+        assertTrue(listWithoutAgg.get(0).getLongValue().isPresent());
+        assertFalse(listWithoutAgg.get(0).getDoubleValue().isPresent());
+        assertThat(listWithoutAgg.get(0).getLongValue().get()).isEqualTo(longValue);
+
+        // long value should not be reset to null, so avg = (doubleValue + longValue)/ 2
+        List<TsKvEntry> listWithAgg = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("temp", 0L,
+                ts + 1, 200000, 3, Aggregation.AVG))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+        assertEquals(1, listWithAgg.size());
+        assertTrue(listWithAgg.get(0).getDoubleValue().isPresent());
+        double expectedValue = (doubleValue + longValue)/ 2;
+        assertThat(listWithAgg.get(0).getDoubleValue().get()).isEqualTo(expectedValue);
+    }
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlTest.java
@@ -62,32 +62,10 @@ public class TimeseriesServiceNoSqlTest extends BaseTimeseriesServiceTest {
         assertEquals(5, fullList.size());
 
         // check entries after ttl
-        Thread.sleep(TimeUnit.SECONDS.toMillis(ttlInSec));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(ttlInSec + 1));
         List<TsKvEntry> listAfterTtl = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("test", 0L,
                 TimeUnit.MINUTES.toMillis(6), 1000, 10, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(0, listAfterTtl.size());
-    }
-
-    @Test
-    public void shouldDeleteValueAfterTtl() throws ExecutionException, InterruptedException, TimeoutException {
-        long longEntryTs = TimeUnit.MINUTES.toMillis(2);
-        long doubleEntryTs = TimeUnit.MINUTES.toMillis(3);
-        long ttlInSec = TimeUnit.SECONDS.toSeconds(3);
-        long longValue = 0L;
-        TsKvEntry longEntry = new BasicTsKvEntry(longEntryTs, new LongDataEntry("temp", longValue));
-        double doubleValue = 20.6;
-        TsKvEntry doubleEntry = new BasicTsKvEntry(doubleEntryTs, new DoubleDataEntry("temp", doubleValue));
-        DeviceId deviceId = new DeviceId(Uuids.timeBased());
-        tsService.save(tenantId, deviceId, longEntry).get(MAX_TIMEOUT, TimeUnit.SECONDS);
-        tsService.save(tenantId, deviceId, Collections.singletonList(doubleEntry), ttlInSec).get(MAX_TIMEOUT, TimeUnit.SECONDS);
-
-        Thread.sleep(TimeUnit.SECONDS.toMillis(ttlInSec));
-        List<TsKvEntry> listAfterTtl = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("temp", 0L,
-                doubleEntryTs + 1 , 1000, 3, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
-        assertEquals(1, listAfterTtl.size());
-        assertTrue(listAfterTtl.get(0).getLongValue().isPresent());
-        assertThat(listAfterTtl.get(0).getLongValue().get()).isEqualTo(longValue);
-        assertFalse(listAfterTtl.get(0).getDoubleValue().isPresent());
     }
 
     @Test


### PR DESCRIPTION
## Pull Request description

Previously, Cassandra saved value only for 1 type. If we had to save null values for the other types, we used param setNullValuesEnabled and did 5 inserts to the DB. Now, we do one insert to DB when setNullValuesEnabled=true.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



