### PR TITLE
Error handling for PartitionChangeEvent listeners

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultSubscriptionManagerService.java
@@ -19,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
-import org.thingsboard.server.common.msg.rule.engine.DeviceAttributesEventNotificationMsg;
 import org.thingsboard.server.cluster.TbClusterService;
 import org.thingsboard.server.common.data.DataConstants;
 import org.thingsboard.server.common.data.EntityType;
@@ -37,15 +36,16 @@ import org.thingsboard.server.common.data.kv.TsKvEntry;
 import org.thingsboard.server.common.msg.queue.ServiceType;
 import org.thingsboard.server.common.msg.queue.TbCallback;
 import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
+import org.thingsboard.server.common.msg.rule.engine.DeviceAttributesEventNotificationMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.ToCoreNotificationMsg;
 import org.thingsboard.server.queue.TbQueueProducer;
 import org.thingsboard.server.queue.common.TbProtoQueueMsg;
-import org.thingsboard.server.queue.discovery.TopicService;
 import org.thingsboard.server.queue.discovery.PartitionService;
 import org.thingsboard.server.queue.discovery.TbApplicationEventListener;
 import org.thingsboard.server.queue.discovery.TbServiceInfoProvider;
-import org.thingsboard.server.queue.discovery.event.PartitionChangeEvent;
+import org.thingsboard.server.queue.discovery.TopicService;
 import org.thingsboard.server.queue.discovery.event.OtherServiceShutdownEvent;
+import org.thingsboard.server.queue.discovery.event.PartitionChangeEvent;
 import org.thingsboard.server.queue.provider.TbQueueProducerProvider;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 import org.thingsboard.server.service.state.DefaultDeviceStateService;
@@ -154,7 +154,7 @@ public class DefaultSubscriptionManagerService extends TbApplicationEventListene
     protected void onTbApplicationEvent(PartitionChangeEvent partitionChangeEvent) {
         if (ServiceType.TB_CORE.equals(partitionChangeEvent.getServiceType())) {
             entitySubscriptions.values().removeIf(sub ->
-                    !partitionService.resolve(ServiceType.TB_CORE, sub.getTenantId(), sub.getEntityId()).isMyPartition());
+                    !partitionService.isMyPartition(ServiceType.TB_CORE, sub.getTenantId(), sub.getEntityId()));
         }
     }
 

--- a/common/queue/src/main/java/org/thingsboard/server/queue/discovery/TbApplicationEventListener.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/discovery/TbApplicationEventListener.java
@@ -41,7 +41,11 @@ public abstract class TbApplicationEventListener<T extends TbApplicationEvent> i
             seqNumberLock.unlock();
         }
         if (validUpdate && filterTbApplicationEvent(event)) {
-            onTbApplicationEvent(event);
+            try {
+                onTbApplicationEvent(event);
+            } catch (Exception e) {
+                log.error("Failed to handle partition change event: {}", event, e);
+            }
         } else {
             log.info("Application event ignored due to invalid sequence number ({} > {}). Event: {}", lastProcessedSequenceNumber, event.getSequenceNumber(), event);
         }

--- a/common/version-control/src/main/java/org/thingsboard/server/service/sync/vc/DefaultClusterVersionControlService.java
+++ b/common/version-control/src/main/java/org/thingsboard/server/service/sync/vc/DefaultClusterVersionControlService.java
@@ -160,7 +160,7 @@ public class DefaultClusterVersionControlService extends TbApplicationEventListe
     @Override
     protected void onTbApplicationEvent(PartitionChangeEvent event) {
         for (TenantId tenantId : vcService.getActiveRepositoryTenants()) {
-            if (!partitionService.resolve(ServiceType.TB_VC_EXECUTOR, tenantId, tenantId).isMyPartition()) {
+            if (!partitionService.isMyPartition(ServiceType.TB_VC_EXECUTOR, tenantId, tenantId)) {
                 var lock = getRepoLock(tenantId);
                 lock.lock();
                 try {


### PR DESCRIPTION
## Pull Request description

TB Cores rebalancing failed due to an error in one of the partition change event handlers.
Event listeners are called synchronously, thus if one of them failed, the next one won't get to process the event.

In our case, `DefaultTbCoreConsumerService` did not subscribe to new partitions because of a failure in `DefaultSubscriptionManagerService`.

```
Failed to recalculate partitions
org.thingsboard.server.common.data.exception.TenantNotFoundException: Tenant with id xxx not found
	at org.thingsboard.server.service.queue.DefaultTenantRoutingInfoService.getRoutingInfo(DefaultTenantRoutingInfoService.java:60)
	at org.thingsboard.server.queue.discovery.HashPartitionService.lambda$isIsolated$22(HashPartitionService.java:501)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
	at org.thingsboard.server.queue.discovery.HashPartitionService.isIsolated(HashPartitionService.java:500)
	at org.thingsboard.server.queue.discovery.HashPartitionService.getIsolatedOrSystemTenantId(HashPartitionService.java:519)
	at org.thingsboard.server.queue.discovery.HashPartitionService.resolve(HashPartitionService.java:260)
	at org.thingsboard.server.queue.discovery.HashPartitionService.resolve(HashPartitionService.java:281)
	at org.thingsboard.server.service.subscription.DefaultSubscriptionManagerService.lambda$onTbApplicationEvent$2(DefaultSubscriptionManagerService.java:176)
	at java.base/java.util.concurrent.ConcurrentHashMap.removeValueIf(ConcurrentHashMap.java:1659)
	at java.base/java.util.concurrent.ConcurrentHashMap$ValuesView.removeIf(ConcurrentHashMap.java:4753)
	at org.thingsboard.server.service.subscription.DefaultSubscriptionManagerService.onTbApplicationEvent(DefaultSubscriptionManagerService.java:175)
	at org.thingsboard.server.service.subscription.DefaultSubscriptionManagerService.onTbApplicationEvent(DefaultSubscriptionManagerService.java:87)
	at org.thingsboard.server.queue.discovery.TbApplicationEventListener.onApplicationEvent(TbApplicationEventListener.java:59)
	at org.thingsboard.server.queue.discovery.TbApplicationEventListener.onApplicationEvent(TbApplicationEventListener.java:40)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:176)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:169)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:143)
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:421)
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:378)
	at org.thingsboard.server.queue.discovery.HashPartitionService.publishPartitionChangeEvent(HashPartitionService.java:411)
	at java.base/java.util.HashMap.forEach(HashMap.java:1337)
	at org.thingsboard.server.queue.discovery.HashPartitionService.recalculatePartitions(HashPartitionService.java:370)
	at org.thingsboard.server.queue.discovery.ZkDiscoveryService.recalculatePartitions(ZkDiscoveryService.java:367)
	at org.thingsboard.server.queue.discovery.ZkDiscoveryService.lambda$childEvent$4(ZkDiscoveryService.java:349)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

![image](https://github.com/thingsboard/thingsboard/assets/56742475/c8ea375f-676e-43f3-ad3d-9f458d352220)


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



