### PR TITLE
cid: add to dtls config

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -1006,6 +1006,8 @@ transport:
       bind_address: "${COAP_DTLS_BIND_ADDRESS:0.0.0.0}"
       # CoAP DTLS bind port
       bind_port: "${COAP_DTLS_BIND_PORT:5684}"
+      # CoAP DTLS connection id length. RFC 9146, Connection Identifier for DTLS 1.2
+      cid: "${COAP_DTLS_CID:}"
       # Server DTLS credentials
       credentials:
         # Server credentials type (PEM - pem certificate file; KEYSTORE - java keystore)
@@ -1044,6 +1046,8 @@ transport:
     dtls:
       # RFC7925_RETRANSMISSION_TIMEOUT_IN_MILLISECONDS = 9000
       retransmission_timeout: "${LWM2M_DTLS_RETRANSMISSION_TIMEOUT_MS:9000}"
+      # CoAP DTLS connection id length. RFC 9146, Connection Identifier for DTLS 1.2
+      cid: "${LWM2M_DTLS_CID:}"
     server:
       # LwM2M Server ID
       id: "${LWM2M_SERVER_ID:123}"

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
@@ -63,7 +63,6 @@ import org.thingsboard.server.common.data.query.SingleEntityFilter;
 import org.thingsboard.server.common.data.security.DeviceCredentials;
 import org.thingsboard.server.common.data.security.DeviceCredentialsType;
 import org.thingsboard.server.dao.service.DaoSqlTest;
-import org.thingsboard.server.service.ws.telemetry.cmd.TelemetryCmdsWrapper;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.EntityDataCmd;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.EntityDataUpdate;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.LatestValueCmd;
@@ -76,7 +75,6 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -102,6 +100,7 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfil
 
 @TestPropertySource(properties = {
         "transport.lwm2m.enabled=true",
+        "transport.lwm2m.dtls.cid=6"
 })
 @Slf4j
 @DaoSqlTest

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
@@ -235,7 +235,8 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
         getWsClient().waitForReply();
 
         getWsClient().registerWaitForUpdate();
-        createNewClient(security, coapConfig, false, endpoint, false, null);
+//        Integer cid = 6;
+        createNewClient(security, coapConfig, false, endpoint, false, null, null);
         awaitObserveReadAll(0, false, device.getId().getId().toString());
         String msg = getWsClient().waitForUpdate();
 
@@ -300,12 +301,13 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
         this.resources = resources;
     }
 
-    public void createNewClient(Security security, Configuration coapConfig, boolean isRpc, String endpoint, boolean isBootstrap, Security securityBs) throws Exception {
+    public void createNewClient(Security security, Configuration coapConfig, boolean isRpc, String endpoint,
+                                boolean isBootstrap, Security securityBs, Integer cid) throws Exception {
         this.clientDestroy();
         lwM2MTestClient = new LwM2MTestClient(this.executor, endpoint);
         int clientPort = SocketUtils.findAvailableUdpPort();
         lwM2MTestClient.init(security, coapConfig, clientPort, isRpc, isBootstrap, this.shortServerId, this.shortServerIdBs,
-                securityBs, this.defaultLwM2mUplinkMsgHandlerTest, this.clientContextTest);
+                securityBs, this.defaultLwM2mUplinkMsgHandlerTest, this.clientContextTest, cid);
     }
 
     private void clientDestroy() {

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
@@ -93,8 +93,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_BOOTSTRAP_STARTED;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_BOOTSTRAP_SUCCESS;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_INIT;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_READ_CONNECTION_ID;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_REGISTRATION_STARTED;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_REGISTRATION_SUCCESS;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_WRITE_CONNECTION_ID;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
 
@@ -174,6 +176,7 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
     protected final Set<Lwm2mTestHelper.LwM2MClientState> expectedStatusesBsSuccess = new HashSet<>(Arrays.asList(ON_INIT, ON_BOOTSTRAP_STARTED, ON_BOOTSTRAP_SUCCESS));
     protected final Set<Lwm2mTestHelper.LwM2MClientState> expectedStatusesRegistrationLwm2mSuccess = new HashSet<>(Arrays.asList(ON_INIT, ON_REGISTRATION_STARTED, ON_REGISTRATION_SUCCESS));
     protected final Set<Lwm2mTestHelper.LwM2MClientState> expectedStatusesRegistrationBsSuccess = new HashSet<>(Arrays.asList(ON_BOOTSTRAP_STARTED, ON_BOOTSTRAP_SUCCESS, ON_REGISTRATION_STARTED, ON_REGISTRATION_SUCCESS));
+    protected final Set<Lwm2mTestHelper.LwM2MClientState> expectedStatusesConnectionIdsSuccess = new HashSet<>(Arrays.asList(ON_WRITE_CONNECTION_ID, ON_READ_CONNECTION_ID));
     protected DeviceProfile deviceProfile;
     protected ScheduledExecutorService executor;
     protected LwM2MTestClient lwM2MTestClient;

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/Lwm2mTestHelper.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/Lwm2mTestHelper.java
@@ -67,7 +67,9 @@ public class Lwm2mTestHelper {
         ON_DEREGISTRATION_SUCCESS(13, "onDeregistrationSuccess"),
         ON_DEREGISTRATION_FAILURE(14, "onDeregistrationFailure"),
         ON_DEREGISTRATION_TIMEOUT(15, "onDeregistrationTimeout"),
-        ON_EXPECTED_ERROR(16, "onUnexpectedError");
+        ON_WRITE_CONNECTION_ID(16, "onWriteConnectionId"),
+        ON_READ_CONNECTION_ID(17, "onReadConnectionId"),
+        ON_EXPECTED_ERROR(18, "onUnexpectedError");
 
         public int code;
         public String type;

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
@@ -126,7 +126,7 @@ public class LwM2MTestClient {
     public void init(Security security, Configuration coapConfig, int port, boolean isRpc, boolean isBootstrap,
                      int shortServerId, int shortServerIdBs, Security securityBs,
                      LwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandler,
-                     LwM2mClientContext clientContext) throws InvalidDDFFileException, IOException {
+                     LwM2mClientContext clientContext, Integer cid) throws InvalidDDFFileException, IOException {
         Assert.assertNull("client already initialized", leshanClient);
         this.defaultLwM2mUplinkMsgHandlerTest = defaultLwM2mUplinkMsgHandler;
         this.clientContext = clientContext;
@@ -173,7 +173,6 @@ public class LwM2MTestClient {
 
         DtlsConnectorConfig.Builder dtlsConfig = new DtlsConnectorConfig.Builder(coapConfig);
         dtlsConfig.set(DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, true);
-        Integer cid = 6;
         dtlsConfig.set(DTLS_CONNECTION_ID_LENGTH, cid);
         if (cid != null && cid > 4) {
             dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, 0);

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
@@ -55,6 +55,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY;
 import static org.eclipse.leshan.core.LwM2mId.ACCESS_CONTROL;
 import static org.eclipse.leshan.core.LwM2mId.DEVICE;
@@ -162,6 +164,13 @@ public class LwM2MTestClient {
 
         DtlsConnectorConfig.Builder dtlsConfig = new DtlsConnectorConfig.Builder(coapConfig);
         dtlsConfig.set(DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, true);
+        Integer cid = 6;
+        dtlsConfig.set(DTLS_CONNECTION_ID_LENGTH, cid);
+        if (cid != null && cid > 4) {
+            dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, 0);
+        } else {
+            dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, null);
+        }
 
         DefaultRegistrationEngineFactory engineFactory = new DefaultRegistrationEngineFactory();
         engineFactory.setReconnectOnUpdate(false);

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/sql/OtaLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/sql/OtaLwM2MIntegrationTest.java
@@ -99,7 +99,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_WITHOUT_FW_INFO));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO);
-        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO, false, null);
+        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO, false, null, null);
         awaitObserveReadAll(0, false, device.getId().getId().toString());
 
         device.setFirmwareId(createFirmware().getId());
@@ -124,7 +124,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_OTA5));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_OTA5);
-        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA5, false, null);
+        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA5, false, null, null);
         awaitObserveReadAll(9, false, device.getId().getId().toString());
 
         device.setFirmwareId(createFirmware().getId());
@@ -154,7 +154,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_OTA9));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_OTA9);
-        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA9, false, null);
+        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA9, false, null, null);
         awaitObserveReadAll(9, false, device.getId().getId().toString());
 
         device.setSoftwareId(createSoftware().getId());

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcLwM2MIntegrationTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractRpcLwM2MIntegrationTest extends AbstractLwM2MInteg
 
     private void initRpc () throws Exception {
         String endpoint = DEVICE_ENDPOINT_RPC_PREF + endpointSequence.incrementAndGet();
-        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, true, endpoint, false, null);
+        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, true, endpoint, false, null, null);
         expectedObjects = ConcurrentHashMap.newKeySet();
         expectedObjectIdVers = ConcurrentHashMap.newKeySet();
         expectedInstances = ConcurrentHashMap.newKeySet();

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/AbstractSecurityLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/AbstractSecurityLwM2MIntegrationTest.java
@@ -196,7 +196,7 @@ public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2M
         createDeviceProfile(transportConfiguration);
         final Device device = createDevice(deviceCredentials, endpoint);
         device.getId().getId().toString();
-        createNewClient(security, coapConfig, true, endpoint, isBootstrap, null);
+        createNewClient(security, coapConfig, true, endpoint, isBootstrap, null, null);
         lwM2MTestClient.start(isStartLw);
         awaitObserveReadAll(0, isBootstrap, device.getId().getId().toString());
         await(awaitAlias)
@@ -245,7 +245,7 @@ public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2M
         createDeviceProfile(transportConfiguration);
         final Device device = createDevice(deviceCredentials, endpoint);
         String deviceIdStr = device.getId().getId().toString();
-        createNewClient(security, coapConfig, true, endpoint, isBootstrap, securityBs);
+        createNewClient(security, coapConfig, true, endpoint, isBootstrap, securityBs, null);
         lwM2MTestClient.start(true);
         awaitObserveReadAll(0, isBootstrap, deviceIdStr);
         await(awaitAlias)

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/PskLwm2mIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/PskLwm2mIntegrationTest.java
@@ -65,6 +65,32 @@ public class PskLwm2mIntegrationTest extends AbstractSecurityLwM2MIntegrationTes
                 ON_REGISTRATION_SUCCESS,
                 true);
     }
+    @Test
+    public void testWithPskConnectIdSuccess() throws Exception {
+        String clientEndpoint = CLIENT_ENDPOINT_PSK;
+        String identity = CLIENT_PSK_IDENTITY;
+        String keyPsk = CLIENT_PSK_KEY;
+        PSKClientCredential clientCredentials = new PSKClientCredential();
+        clientCredentials.setEndpoint(clientEndpoint);
+        clientCredentials.setIdentity(identity);
+        clientCredentials.setKey(keyPsk);
+        Security security = psk(SECURE_URI,
+                shortServerId,
+                identity.getBytes(StandardCharsets.UTF_8),
+                Hex.decodeHex(keyPsk.toCharArray()));
+        Lwm2mDeviceProfileTransportConfiguration transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITHOUT_PARAMS, getBootstrapServerCredentialsSecure(PSK, NONE));
+        LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsSecure(clientCredentials, null, null, PSK, false);
+        this.basicTestConnection(security,
+                deviceCredentials,
+                COAP_CONFIG,
+                clientEndpoint,
+                transportConfiguration,
+                "await on client state (Psk_Lwm2m)",
+                expectedStatusesConnectionIdsSuccess,
+                false,
+                ON_REGISTRATION_SUCCESS,
+                true);
+    }
 
     @Test
     public void testWithPskConnectLwm2mBadPskKeyByLength_BAD_REQUEST() throws Exception {

--- a/common/coap-server/src/main/java/org/thingsboard/server/coapserver/TbCoapDtlsSettings.java
+++ b/common/coap-server/src/main/java/org/thingsboard/server/coapserver/TbCoapDtlsSettings.java
@@ -41,11 +41,10 @@ import java.util.Collections;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.eclipse.californium.elements.config.CertificateAuthenticationMode.WANTED;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE;
-import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
-import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_ROLE;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole.SERVER_ONLY;
+import static org.thingsboard.common.util.SslUtil.setDtlsConnectorConfigCid;
 
 @Slf4j
 @ConditionalOnProperty(prefix = "transport.coap.dtls", value = "enabled", havingValue = "true", matchIfMissing = false)
@@ -98,12 +97,7 @@ public class TbCoapDtlsSettings {
         configBuilder.set(DTLS_CLIENT_AUTHENTICATION_MODE, WANTED);
         configBuilder.set(DTLS_RETRANSMISSION_TIMEOUT, dtlsRetransmissionTimeout, MILLISECONDS);
         configBuilder.set(DTLS_ROLE, SERVER_ONLY);
-        configBuilder.set(DTLS_CONNECTION_ID_LENGTH, cid);
-        if (cid != null && cid > 4) {
-            configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, 0);
-        } else {
-            configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, null);
-        }
+        setDtlsConnectorConfigCid(configBuilder, cid);
         configBuilder.setAdvancedCertificateVerifier(
                 new TbCoapDtlsCertificateVerifier(
                         transportService,

--- a/common/coap-server/src/main/java/org/thingsboard/server/coapserver/TbCoapDtlsSettings.java
+++ b/common/coap-server/src/main/java/org/thingsboard/server/coapserver/TbCoapDtlsSettings.java
@@ -41,6 +41,8 @@ import java.util.Collections;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.eclipse.californium.elements.config.CertificateAuthenticationMode.WANTED;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_ROLE;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole.SERVER_ONLY;
@@ -55,6 +57,9 @@ public class TbCoapDtlsSettings {
 
     @Value("${transport.coap.dtls.bind_port}")
     private Integer port;
+
+    @Value("${transport.coap.dtls.cid}")
+    private Integer cid;
 
     @Value("${transport.coap.dtls.retransmission_timeout:9000}")
     private int dtlsRetransmissionTimeout;
@@ -93,6 +98,12 @@ public class TbCoapDtlsSettings {
         configBuilder.set(DTLS_CLIENT_AUTHENTICATION_MODE, WANTED);
         configBuilder.set(DTLS_RETRANSMISSION_TIMEOUT, dtlsRetransmissionTimeout, MILLISECONDS);
         configBuilder.set(DTLS_ROLE, SERVER_ONLY);
+        configBuilder.set(DTLS_CONNECTION_ID_LENGTH, cid);
+        if (cid != null && cid > 4) {
+            configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, 0);
+        } else {
+            configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, null);
+        }
         configBuilder.setAdvancedCertificateVerifier(
                 new TbCoapDtlsCertificateVerifier(
                         transportService,

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapService.java
@@ -38,6 +38,8 @@ import javax.annotation.PreDestroy;
 import java.security.cert.X509Certificate;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CURVES_ONLY;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT;
@@ -96,6 +98,13 @@ public class LwM2MTransportBootstrapService {
         dtlsConfig.set(DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, serverConfig.isRecommendedCiphers());
         dtlsConfig.set(DTLS_RETRANSMISSION_TIMEOUT, serverConfig.getDtlsRetransmissionTimeout(), MILLISECONDS);
         dtlsConfig.set(DTLS_ROLE, SERVER_ONLY);
+        Integer cid = serverConfig.getCid();
+        dtlsConfig.set(DTLS_CONNECTION_ID_LENGTH, cid);
+        if (cid != null && cid > 4) {
+            dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, 0);
+        } else {
+            dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, null);
+        }
         setServerWithCredentials(builder, dtlsConfig);
 
         /* Set DTLS Config */

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapService.java
@@ -38,13 +38,12 @@ import javax.annotation.PreDestroy;
 import java.security.cert.X509Certificate;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
-import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CURVES_ONLY;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_ROLE;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole.SERVER_ONLY;
+import static org.thingsboard.common.util.SslUtil.setDtlsConnectorConfigCid;
 import static org.thingsboard.server.transport.lwm2m.server.DefaultLwM2mTransportService.PSK_CIPHER_SUITES;
 import static org.thingsboard.server.transport.lwm2m.server.DefaultLwM2mTransportService.RPK_OR_X509_CIPHER_SUITES;
 import static org.thingsboard.server.transport.lwm2m.server.LwM2MNetworkConfig.getCoapConfig;
@@ -98,14 +97,7 @@ public class LwM2MTransportBootstrapService {
         dtlsConfig.set(DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, serverConfig.isRecommendedCiphers());
         dtlsConfig.set(DTLS_RETRANSMISSION_TIMEOUT, serverConfig.getDtlsRetransmissionTimeout(), MILLISECONDS);
         dtlsConfig.set(DTLS_ROLE, SERVER_ONLY);
-        Integer cid = serverConfig.getCid();
-        dtlsConfig.set(DTLS_CONNECTION_ID_LENGTH, cid);
-        if (cid != null && cid > 4) {
-            dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, 0);
-        } else {
-            dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, null);
-        }
-        setServerWithCredentials(builder, dtlsConfig);
+        setDtlsConnectorConfigCid(dtlsConfig, serverConfig.getCid());
 
         /* Set DTLS Config */
         builder.setDtlsConfig(dtlsConfig);

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/config/LwM2MTransportServerConfig.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/config/LwM2MTransportServerConfig.java
@@ -42,6 +42,10 @@ public class LwM2MTransportServerConfig implements LwM2MSecureServerConfig {
     private int dtlsRetransmissionTimeout;
 
     @Getter
+    @Value("${transport.lwm2m.dtls.cid:}")
+    private Integer cid;
+
+    @Getter
     @Value("${transport.lwm2m.timeout:}")
     private Long timeout;
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
@@ -43,8 +43,6 @@ import javax.annotation.PreDestroy;
 import java.security.cert.X509Certificate;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
-import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CURVES_ONLY;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT;
@@ -54,6 +52,7 @@ import static org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_ECDHE
 import static org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8;
 import static org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256;
 import static org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
+import static org.thingsboard.common.util.SslUtil.setDtlsConnectorConfigCid;
 import static org.thingsboard.server.transport.lwm2m.server.LwM2MNetworkConfig.getCoapConfig;
 import static org.thingsboard.server.transport.lwm2m.server.ota.DefaultLwM2MOtaUpdateService.FIRMWARE_UPDATE_COAP_RESOURCE;
 
@@ -142,13 +141,8 @@ public class DefaultLwM2mTransportService implements LwM2MTransportService {
         dtlsConfig.set(DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, config.isRecommendedCiphers());
         dtlsConfig.set(DTLS_RETRANSMISSION_TIMEOUT, config.getDtlsRetransmissionTimeout(), MILLISECONDS);
         dtlsConfig.set(DTLS_ROLE, SERVER_ONLY);
-        Integer cid = config.getCid();
-        dtlsConfig.set(DTLS_CONNECTION_ID_LENGTH, cid);
-        if (cid != null && cid > 4) {
-            dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, 0);
-        } else {
-            dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, null);
-        }
+        setDtlsConnectorConfigCid(dtlsConfig, config.getCid());
+
         /*  Create credentials */
         this.setServerWithCredentials(builder, dtlsConfig);
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
@@ -43,6 +43,8 @@ import javax.annotation.PreDestroy;
 import java.security.cert.X509Certificate;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CURVES_ONLY;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT;
@@ -140,7 +142,13 @@ public class DefaultLwM2mTransportService implements LwM2MTransportService {
         dtlsConfig.set(DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, config.isRecommendedCiphers());
         dtlsConfig.set(DTLS_RETRANSMISSION_TIMEOUT, config.getDtlsRetransmissionTimeout(), MILLISECONDS);
         dtlsConfig.set(DTLS_ROLE, SERVER_ONLY);
-
+        Integer cid = config.getCid();
+        dtlsConfig.set(DTLS_CONNECTION_ID_LENGTH, cid);
+        if (cid != null && cid > 4) {
+            dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, 0);
+        } else {
+            dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, null);
+        }
         /*  Create credentials */
         this.setServerWithCredentials(builder, dtlsConfig);
 

--- a/common/util/pom.xml
+++ b/common/util/pom.xml
@@ -104,6 +104,10 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.californium</groupId>
+            <artifactId>scandium</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common/util/src/main/java/org/thingsboard/common/util/SslUtil.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/SslUtil.java
@@ -30,6 +30,7 @@ import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 import org.bouncycastle.operator.InputDecryptorProvider;
 import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
 import org.bouncycastle.pkcs.jcajce.JcePKCSPBEInputDecryptorProviderBuilder;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.thingsboard.server.common.data.StringUtils;
 
 import java.io.StringReader;
@@ -38,6 +39,9 @@ import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 
 @Slf4j
 public class SslUtil {
@@ -100,6 +104,15 @@ public class SslUtil {
             }
         }
         return privateKey;
+    }
+
+    public static void setDtlsConnectorConfigCid (DtlsConnectorConfig.Builder configBuilder, Integer cid) {
+        configBuilder.set(DTLS_CONNECTION_ID_LENGTH, cid);
+        if (cid != null && cid > 4) {
+            configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, 0);
+        } else {
+            configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, null);
+        }
     }
 
 }


### PR DESCRIPTION
## Pull Request description

### Problem:
[Put your PR description here instead of this sentence.   ](https://github.com/thingsboard/thingsboard/issues/10061)

`When a LwM2M client indicates (in the dtls "Client Hello" message) it wants to use the connection_id extension, its request is ignored by the server (the "Server Hello, Server Hello Done" message does not contain the connection_id extension). As a result, a client that has requested the extension and changes ip address or port (for instance due to a longer sleep period) cannot reuse the dtls session.`

**if  disabled support for connection id.**
<img width="289" alt="testDtlsBefore" src="https://github.com/thingsboard/thingsboard/assets/44275303/f023ab8b-5766-4a10-8ebd-1c35949b01bd">


### Solution
- add DTLS connection id length to DtlsConnectorConfig Servers
#### Coap Transport or LwM2M  Transport:



For the server to use the Connection_id extension:
in **thingsboard.yml:**

```
transport:
  coap:
   dtls:
     cid: "${COAP_DTLS_CID:}"
 ...
  lwm2m:
   dtls:
     cid: "${LWM2M_DTLS_CID:}"

```

**DTLS connection id length.** 
```
""/null | disabled support for connection id.
0       | enable support for connection id, but don't use it for incoming traffic to this peer.
n       | use connection id of n bytes. 
        |    Note: chose n large enough for the number of considered peers. 
        |    Recommended to have 100 time more values than peers.
        |    E.g. 65000 peers, chose not 2 bytes, chose at lease 3 bytes!
```

**if  enable support for connection id.**
For example : "transport.lwm2m.dtls.cid=6".
<img width="384" alt="testDtlsAfter" src="https://github.com/thingsboard/thingsboard/assets/44275303/0fa1afae-bd70-4366-b7a1-6b212c9d587b">



## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
 
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



