### PR TITLE
fix_bug_cid_length

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -1013,7 +1013,7 @@ transport:
       # - 'on' to activate Connection ID support (same as CID 0 or more 0).
       # - A positive value defines generated CID size in bytes.
       # - A value of 0 means we accept using CID but will not generate one for foreign peer (enables support but not for incoming traffic).
-      # - A value between 0 and <= 4: SingleNodeConnectionIdGenerator is used
+      # - A value between 1 and <= 4: SingleNodeConnectionIdGenerator is used
       # - A value that are > 4: MultiNodeConnectionIdGenerator is used
       connection_id_length: "${COAP_DTLS_CONNECTION_ID_LENGTH:}"
       # Server DTLS credentials
@@ -1061,7 +1061,7 @@ transport:
       # - 'on' to activate Connection ID support (same as CID 0 or more 0).
       # - A positive value defines generated CID size in bytes.
       # - A value of 0 means we accept using CID but will not generate one for foreign peer (enables support but not for incoming traffic).
-      # - A value between 0 and <= 4: SingleNodeConnectionIdGenerator is used
+      # - A value between 1 and <= 4: SingleNodeConnectionIdGenerator is used
       # - A value that are > 4: MultiNodeConnectionIdGenerator is used
       connection_id_length: "${LWM2M_DTLS_CONNECTION_ID_LENGTH:}"
     server:

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -482,7 +482,7 @@ actors:
 # Cache settings parameters
 cache:
   # caffeine or redis
-  type: "${CACHE_TYPE:caffeine}"
+  type: "${CACHE_TYPE:redis}"
   maximumPoolSize: "${CACHE_MAXIMUM_POOL_SIZE:16}" # max pool size to process futures that call the external cache
   attributes:
     # make sure that if cache.type is 'redis' and cache.attributes.enabled is 'true' if you change 'maxmemory-policy' Redis config property to 'allkeys-lru', 'allkeys-lfu' or 'allkeys-random'
@@ -1006,6 +1006,16 @@ transport:
       bind_address: "${COAP_DTLS_BIND_ADDRESS:0.0.0.0}"
       # CoAP DTLS bind port
       bind_port: "${COAP_DTLS_BIND_PORT:5684}"
+      # CoAP DTLS connection ID length. RFC 9146, Connection Identifier for DTLS 1.2
+      # Default: off
+      # Control usage of DTLS connection ID length (CID).
+      # - 'off' to deactivate it.
+      # - 'on' to activate Connection ID support (same as CID 0 or more 0).
+      # - A positive value defines generated CID size in bytes.
+      # - A value of 0 means we accept using CID but will not generate one for foreign peer (enables support but not for incoming traffic).
+      # - A value between 0 and <= 4: SingleNodeConnectionIdGenerator is used
+      # - A value that are > 4: MultiNodeConnectionIdGenerator is used
+      connection_id_length: "${COAP_DTLS_CONNECTION_ID_LENGTH:}"
       # Server DTLS credentials
       credentials:
         # Server credentials type (PEM - pem certificate file; KEYSTORE - java keystore)
@@ -1044,6 +1054,16 @@ transport:
     dtls:
       # RFC7925_RETRANSMISSION_TIMEOUT_IN_MILLISECONDS = 9000
       retransmission_timeout: "${LWM2M_DTLS_RETRANSMISSION_TIMEOUT_MS:9000}"
+      # CoAP DTLS connection ID length for LWM2M. RFC 9146, Connection Identifier for DTLS 1.2
+      # Default: off
+      # Control usage of DTLS connection ID length (CID).
+      # - 'off' to deactivate it.
+      # - 'on' to activate Connection ID support (same as CID 0 or more 0).
+      # - A positive value defines generated CID size in bytes.
+      # - A value of 0 means we accept using CID but will not generate one for foreign peer (enables support but not for incoming traffic).
+      # - A value between 0 and <= 4: SingleNodeConnectionIdGenerator is used
+      # - A value that are > 4: MultiNodeConnectionIdGenerator is used
+      connection_id_length: "${LWM2M_DTLS_CONNECTION_ID_LENGTH:}"
     server:
       # LwM2M Server ID
       id: "${LWM2M_SERVER_ID:123}"

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -482,7 +482,7 @@ actors:
 # Cache settings parameters
 cache:
   # caffeine or redis
-  type: "${CACHE_TYPE:redis}"
+  type: "${CACHE_TYPE:caffeine}"
   maximumPoolSize: "${CACHE_MAXIMUM_POOL_SIZE:16}" # max pool size to process futures that call the external cache
   attributes:
     # make sure that if cache.type is 'redis' and cache.attributes.enabled is 'true' if you change 'maxmemory-policy' Redis config property to 'allkeys-lru', 'allkeys-lfu' or 'allkeys-random'

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
@@ -63,7 +63,6 @@ import org.thingsboard.server.common.data.query.SingleEntityFilter;
 import org.thingsboard.server.common.data.security.DeviceCredentials;
 import org.thingsboard.server.common.data.security.DeviceCredentialsType;
 import org.thingsboard.server.dao.service.DaoSqlTest;
-import org.thingsboard.server.service.ws.telemetry.cmd.TelemetryCmdsWrapper;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.EntityDataCmd;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.EntityDataUpdate;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.LatestValueCmd;
@@ -76,7 +75,6 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -233,7 +231,7 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
         getWsClient().waitForReply();
 
         getWsClient().registerWaitForUpdate();
-        createNewClient(security, coapConfig, false, endpoint, false, null);
+        createNewClient(security, coapConfig, false, endpoint, false, null, null);
         awaitObserveReadAll(0, false, device.getId().getId().toString());
         String msg = getWsClient().waitForUpdate();
 
@@ -298,12 +296,12 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
         this.resources = resources;
     }
 
-    public void createNewClient(Security security, Configuration coapConfig, boolean isRpc, String endpoint, boolean isBootstrap, Security securityBs) throws Exception {
+    public void createNewClient(Security security, Configuration coapConfig, boolean isRpc, String endpoint, boolean isBootstrap, Security securityBs, Integer dtlsCidLength) throws Exception {
         this.clientDestroy();
         lwM2MTestClient = new LwM2MTestClient(this.executor, endpoint);
         int clientPort = SocketUtils.findAvailableUdpPort();
         lwM2MTestClient.init(security, coapConfig, clientPort, isRpc, isBootstrap, this.shortServerId, this.shortServerIdBs,
-                securityBs, this.defaultLwM2mUplinkMsgHandlerTest, this.clientContextTest);
+                securityBs, this.defaultLwM2mUplinkMsgHandlerTest, this.clientContextTest, dtlsCidLength);
     }
 
     private void clientDestroy() {

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/Lwm2mTestHelper.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/Lwm2mTestHelper.java
@@ -50,7 +50,7 @@ public class Lwm2mTestHelper {
 
     public enum LwM2MClientState {
 
-        ON_INIT(1, "onInit"),
+        ON_INIT(0, "onInit"),
         ON_BOOTSTRAP_STARTED(1, "onBootstrapStarted"),
         ON_BOOTSTRAP_SUCCESS(2, "onBootstrapSuccess"),
         ON_BOOTSTRAP_FAILURE(3, "onBootstrapFailure"),
@@ -58,16 +58,18 @@ public class Lwm2mTestHelper {
         ON_REGISTRATION_STARTED(5, "onRegistrationStarted"),
         ON_REGISTRATION_SUCCESS(6, "onRegistrationSuccess"),
         ON_REGISTRATION_FAILURE(7, "onRegistrationFailure"),
-        ON_REGISTRATION_TIMEOUT(7, "onRegistrationTimeout"),
-        ON_UPDATE_STARTED(8, "onUpdateStarted"),
-        ON_UPDATE_SUCCESS(9, "onUpdateSuccess"),
-        ON_UPDATE_FAILURE(10, "onUpdateFailure"),
-        ON_UPDATE_TIMEOUT(11, "onUpdateTimeout"),
-        ON_DEREGISTRATION_STARTED(12, "onDeregistrationStarted"),
-        ON_DEREGISTRATION_SUCCESS(13, "onDeregistrationSuccess"),
-        ON_DEREGISTRATION_FAILURE(14, "onDeregistrationFailure"),
-        ON_DEREGISTRATION_TIMEOUT(15, "onDeregistrationTimeout"),
-        ON_EXPECTED_ERROR(16, "onUnexpectedError");
+        ON_REGISTRATION_TIMEOUT(8, "onRegistrationTimeout"),
+        ON_UPDATE_STARTED(9, "onUpdateStarted"),
+        ON_UPDATE_SUCCESS(10, "onUpdateSuccess"),
+        ON_UPDATE_FAILURE(11, "onUpdateFailure"),
+        ON_UPDATE_TIMEOUT(12, "onUpdateTimeout"),
+        ON_DEREGISTRATION_STARTED(13, "onDeregistrationStarted"),
+        ON_DEREGISTRATION_SUCCESS(14, "onDeregistrationSuccess"),
+        ON_DEREGISTRATION_FAILURE(15, "onDeregistrationFailure"),
+        ON_DEREGISTRATION_TIMEOUT(16, "onDeregistrationTimeout"),
+        ON_EXPECTED_ERROR(17, "onUnexpectedError"),
+        ON_READ_CONNECTION_ID(18, "onReadConnectionId"),
+        ON_WRITE_CONNECTION_ID(19, "onWriteConnectionId");
 
         public int code;
         public String type;

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
@@ -17,8 +17,14 @@ package org.thingsboard.server.transport.lwm2m.client;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.californium.elements.Connector;
 import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.californium.scandium.DTLSConnector;
 import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.ClientHandshaker;
+import org.eclipse.californium.scandium.dtls.DTLSContext;
+import org.eclipse.californium.scandium.dtls.Handshaker;
+import org.eclipse.californium.scandium.dtls.SessionAdapter;
 import org.eclipse.leshan.client.californium.LeshanClient;
 import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
@@ -30,6 +36,7 @@ import org.eclipse.leshan.client.resource.LwM2mInstanceEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.client.servers.ServerIdentity;
 import org.eclipse.leshan.core.ResponseCode;
+import org.eclipse.leshan.core.californium.DefaultEndpointFactory;
 import org.eclipse.leshan.core.model.InvalidDDFFileException;
 import org.eclipse.leshan.core.model.LwM2mModel;
 import org.eclipse.leshan.core.model.ObjectLoader;
@@ -50,11 +57,15 @@ import org.thingsboard.server.transport.lwm2m.utils.LwM2mValueConverterImpl;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDED_CIPHER_SUITES_ONLY;
 import static org.eclipse.leshan.core.LwM2mId.ACCESS_CONTROL;
 import static org.eclipse.leshan.core.LwM2mId.DEVICE;
@@ -75,6 +86,7 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClient
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_DEREGISTRATION_TIMEOUT;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_EXPECTED_ERROR;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_INIT;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_READ_CONNECTION_ID;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_REGISTRATION_FAILURE;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_REGISTRATION_STARTED;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_REGISTRATION_SUCCESS;
@@ -83,6 +95,7 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClient
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_UPDATE_STARTED;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_UPDATE_SUCCESS;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_UPDATE_TIMEOUT;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_WRITE_CONNECTION_ID;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_0;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_1;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_12;
@@ -109,13 +122,15 @@ public class LwM2MTestClient {
     private LwM2MLocationParams locationParams;
     private LwM2mTemperatureSensor lwM2MTemperatureSensor;
     private Set<LwM2MClientState> clientStates;
+    private Map<LwM2MClientState, Integer> clientDtlsCid;
     private LwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandlerTest;
     private LwM2mClientContext clientContext;
 
     public void init(Security security, Configuration coapConfig, int port, boolean isRpc, boolean isBootstrap,
                      int shortServerId, int shortServerIdBs, Security securityBs,
                      LwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandler,
-                     LwM2mClientContext clientContext) throws InvalidDDFFileException, IOException {
+                     LwM2mClientContext clientContext,
+                     Integer dtlsCidLength) throws InvalidDDFFileException, IOException {
         Assert.assertNull("client already initialized", leshanClient);
         this.defaultLwM2mUplinkMsgHandlerTest = defaultLwM2mUplinkMsgHandler;
         this.clientContext = clientContext;
@@ -163,10 +178,46 @@ public class LwM2MTestClient {
         DtlsConnectorConfig.Builder dtlsConfig = new DtlsConnectorConfig.Builder(coapConfig);
         dtlsConfig.set(DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, true);
 
+        dtlsConfig.set(DTLS_CONNECTION_ID_LENGTH, dtlsCidLength);
+        if (dtlsCidLength != null) {
+            if (dtlsCidLength > 4) {
+                dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, 0);
+            } else {
+                dtlsConfig.set(DTLS_CONNECTION_ID_NODE_ID, null);
+            }
+        }
+
         DefaultRegistrationEngineFactory engineFactory = new DefaultRegistrationEngineFactory();
         engineFactory.setReconnectOnUpdate(false);
         engineFactory.setResumeOnConnect(true);
         engineFactory.setCommunicationPeriod(5000);
+
+        /** Configure EndpointFactory */
+        DefaultEndpointFactory endpointFactory = new DefaultEndpointFactory(endpoint) {
+            @Override
+            protected Connector createSecuredConnector(DtlsConnectorConfig dtlsConfig) {
+                return new DTLSConnector(dtlsConfig) {
+                    @Override
+                    protected void onInitializeHandshaker(Handshaker handshaker) {
+                        handshaker.addSessionListener(new SessionAdapter() {
+
+                            @Override
+                            public void contextEstablished(Handshaker handshaker, DTLSContext establishedContext) {
+                            if (handshaker instanceof ClientHandshaker) {
+                                log.warn("DTLS initiated by client: SUCCEED, WriteConnectionId: [{}], ReadConnectionId: [{}]", establishedContext.getWriteConnectionId(), establishedContext.getReadConnectionId());
+                                clientStates.add(ON_WRITE_CONNECTION_ID);
+                                clientStates.add(ON_READ_CONNECTION_ID);
+                                Integer lenWrite = establishedContext.getWriteConnectionId() == null ? null : establishedContext.getWriteConnectionId().getBytes().length;
+                                Integer lenRead = establishedContext.getReadConnectionId() == null ? null : establishedContext.getReadConnectionId().getBytes().length;
+                                clientDtlsCid.put(ON_WRITE_CONNECTION_ID, lenWrite);
+                                clientDtlsCid.put(ON_READ_CONNECTION_ID, lenRead);
+                            }
+                            }
+                        });
+                    }
+                };
+            }
+        };
 
         LeshanClientBuilder builder = new LeshanClientBuilder(endpoint);
         builder.setLocalAddress("0.0.0.0", port);
@@ -174,12 +225,14 @@ public class LwM2MTestClient {
         builder.setCoapConfig(coapConfig);
         builder.setDtlsConfig(dtlsConfig);
         builder.setRegistrationEngineFactory(engineFactory);
+        builder.setEndpointFactory(endpointFactory);
         builder.setSharedExecutor(executor);
         builder.setDecoder(new DefaultLwM2mDecoder(false));
 
         builder.setEncoder(new DefaultLwM2mEncoder(new LwM2mValueConverterImpl(), false));
         clientStates = new HashSet<>();
         clientStates.add(ON_INIT);
+        clientDtlsCid = new HashMap<>();
         leshanClient = builder.build();
 
         LwM2mClientObserver observer = new LwM2mClientObserver() {

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/sql/OtaLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/sql/OtaLwM2MIntegrationTest.java
@@ -99,7 +99,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_WITHOUT_FW_INFO));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO);
-        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO, false, null);
+        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO, false, null, null);
         awaitObserveReadAll(0, false, device.getId().getId().toString());
 
         device.setFirmwareId(createFirmware().getId());
@@ -124,7 +124,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_OTA5));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_OTA5);
-        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA5, false, null);
+        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA5, false, null, null);
         awaitObserveReadAll(9, false, device.getId().getId().toString());
 
         device.setFirmwareId(createFirmware().getId());
@@ -154,7 +154,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_OTA9));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_OTA9);
-        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA9, false, null);
+        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA9, false, null, null);
         awaitObserveReadAll(9, false, device.getId().getId().toString());
 
         device.setSoftwareId(createSoftware().getId());

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcLwM2MIntegrationTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractRpcLwM2MIntegrationTest extends AbstractLwM2MInteg
 
     private void initRpc () throws Exception {
         String endpoint = DEVICE_ENDPOINT_RPC_PREF + endpointSequence.incrementAndGet();
-        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, true, endpoint, false, null);
+        createNewClient(SECURITY_NO_SEC, COAP_CONFIG, true, endpoint, false, null, null);
         expectedObjects = ConcurrentHashMap.newKeySet();
         expectedObjectIdVers = ConcurrentHashMap.newKeySet();
         expectedInstances = ConcurrentHashMap.newKeySet();

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_3/AbstractSecurityLwM2MIntegrationDtlsCidLengthTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_3/AbstractSecurityLwM2MIntegrationDtlsCidLengthTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql.serverDtlsCidLength_3;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.leshan.client.object.Security;
+import org.springframework.test.context.TestPropertySource;
+import org.thingsboard.server.common.data.device.credentials.lwm2m.AbstractLwM2MClientSecurityCredential;
+import org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MDeviceCredentials;
+import org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MSecurityMode;
+import org.thingsboard.server.common.data.device.profile.Lwm2mDeviceProfileTransportConfiguration;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+import org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState;
+import org.thingsboard.server.transport.lwm2m.security.AbstractSecurityLwM2MIntegrationTest;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MSecurityMode.NO_SEC;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_INIT;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_READ_CONNECTION_ID;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_REGISTRATION_STARTED;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_REGISTRATION_SUCCESS;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_WRITE_CONNECTION_ID;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
+import static org.thingsboard.server.transport.lwm2m.security.AbstractSecurityLwM2MIntegrationTest.SERVER_DTLS_CID_LENGTH;
+
+
+@TestPropertySource(properties = {
+        "transport.lwm2m.dtls.connection_id_length=" + SERVER_DTLS_CID_LENGTH
+})
+
+@DaoSqlTest
+@Slf4j
+public abstract class AbstractSecurityLwM2MIntegrationDtlsCidLengthTest extends AbstractSecurityLwM2MIntegrationTest {
+
+    protected AbstractLwM2MClientSecurityCredential clientCredentials;
+    protected Security security;
+    protected Lwm2mDeviceProfileTransportConfiguration transportConfiguration;
+    protected LwM2MDeviceCredentials deviceCredentials;
+    protected String clientEndpoint;
+    protected LwM2MSecurityMode lwM2MSecurityMode;
+    protected String awaitAlias;
+    protected final Random randomSuffix = new Random();
+
+    protected final Set<LwM2MClientState> expectedStatusesRegistrationLwm2mDtlsCidSuccess = new HashSet<>(Arrays.asList(ON_INIT, ON_REGISTRATION_STARTED, ON_REGISTRATION_SUCCESS, ON_READ_CONNECTION_ID, ON_WRITE_CONNECTION_ID));
+
+
+    protected void testNoSecDtlsCidLength(Integer dtlsCidLength) throws Exception {
+        testDtlsCidLength(dtlsCidLength, expectedStatusesRegistrationLwm2mSuccess);
+    }
+    protected void testPskDtlsCidLength(Integer dtlsCidLength) throws Exception {
+        testDtlsCidLength(dtlsCidLength, expectedStatusesRegistrationLwm2mDtlsCidSuccess);
+    }
+
+    protected void testDtlsCidLength(Integer dtlsCidLength,  Set<LwM2MClientState> expectedStatuses) throws Exception {
+        this.basicTestConnectionDtlsCidLength(
+                security,
+                deviceCredentials,
+                COAP_CONFIG,
+                clientEndpoint,
+                transportConfiguration,
+                awaitAlias,
+                expectedStatuses,
+                dtlsCidLength);
+    }
+
+    protected void initNoSecClient(String clientEndpointNext){
+        lwM2MSecurityMode = NO_SEC;
+        security = SECURITY_NO_SEC;
+        clientEndpoint = clientEndpointNext;
+        transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITHOUT_PARAMS, getBootstrapServerCredentialsSecure(lwM2MSecurityMode, NONE));
+        deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(clientEndpoint));
+        awaitAlias = "await on client state (NoSec_Lwm2m)";
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_3/NoSecLwM2MIntegrationDtlsCidLengthTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_3/NoSecLwM2MIntegrationDtlsCidLengthTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql.serverDtlsCidLength_3;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MSecurityMode.NO_SEC;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
+
+public class NoSecLwM2MIntegrationDtlsCidLengthTest extends AbstractSecurityLwM2MIntegrationDtlsCidLengthTest {
+
+    @Before
+    public void setUpNoSecDtlsCidLength() {
+        lwM2MSecurityMode = NO_SEC;
+        security = SECURITY_NO_SEC;
+        clientEndpoint = CLIENT_ENDPOINT_NO_SEC + "_" + randomSuffix.nextInt(100);
+        transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITHOUT_PARAMS, getBootstrapServerCredentialsSecure(lwM2MSecurityMode, NONE));
+        deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(clientEndpoint));
+        awaitAlias = "await on client state (NoSec_Lwm2m)";
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_2() throws Exception {
+        testNoSecDtlsCidLength(2);
+
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_0() throws Exception {
+        testNoSecDtlsCidLength(0);
+
+    }
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_Null() throws Exception {
+        testNoSecDtlsCidLength(null);
+
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_3/PskLwm2mIntegrationDtlsCidLengthTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_3/PskLwm2mIntegrationDtlsCidLengthTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql.serverDtlsCidLength_3;
+
+import org.eclipse.leshan.core.util.Hex;
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.server.common.data.device.credentials.lwm2m.PSKClientCredential;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.eclipse.leshan.client.object.Security.psk;
+import static org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MSecurityMode.PSK;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
+
+public class PskLwm2mIntegrationDtlsCidLengthTest extends AbstractSecurityLwM2MIntegrationDtlsCidLengthTest {
+
+    @Before
+    public void setPskUpDtlsCidLength() {
+        lwM2MSecurityMode = PSK;
+        clientEndpoint = CLIENT_ENDPOINT_PSK + "_" + randomSuffix.nextInt(10);
+        clientCredentials = new PSKClientCredential();
+        clientCredentials.setEndpoint(clientEndpoint);
+        ((PSKClientCredential)clientCredentials).setIdentity(CLIENT_PSK_IDENTITY);
+        clientCredentials.setKey(CLIENT_PSK_KEY);
+        security = psk(SECURE_URI,
+                shortServerId,
+                CLIENT_PSK_IDENTITY.getBytes(StandardCharsets.UTF_8),
+                Hex.decodeHex(CLIENT_PSK_KEY.toCharArray()));
+        transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITHOUT_PARAMS, getBootstrapServerCredentialsSecure(lwM2MSecurityMode, NONE));
+        deviceCredentials = getDeviceCredentialsSecure(clientCredentials, null, null, lwM2MSecurityMode, false);
+        awaitAlias = "await on client state (Psk_Lwm2m)";
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_Null() throws Exception {
+        testPskDtlsCidLength(null);
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_0() throws Exception {
+        testPskDtlsCidLength(0);
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_2() throws Exception {
+        testPskDtlsCidLength(2);
+    }
+
+}
+

--- a/common/coap-server/src/main/java/org/thingsboard/server/coapserver/TbCoapDtlsSettings.java
+++ b/common/coap-server/src/main/java/org/thingsboard/server/coapserver/TbCoapDtlsSettings.java
@@ -44,6 +44,7 @@ import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CLIENT_AUT
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_ROLE;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole.SERVER_ONLY;
+import static org.thingsboard.common.util.SslUtil.setDtlsConnectorConfigCidLength;
 
 @Slf4j
 @ConditionalOnProperty(prefix = "transport.coap.dtls", value = "enabled", havingValue = "true", matchIfMissing = false)
@@ -55,6 +56,9 @@ public class TbCoapDtlsSettings {
 
     @Value("${transport.coap.dtls.bind_port}")
     private Integer port;
+
+    @Value("${transport.coap.dtls.connection_id_length}")
+    private Integer cIdLength;
 
     @Value("${transport.coap.dtls.retransmission_timeout:9000}")
     private int dtlsRetransmissionTimeout;
@@ -93,6 +97,7 @@ public class TbCoapDtlsSettings {
         configBuilder.set(DTLS_CLIENT_AUTHENTICATION_MODE, WANTED);
         configBuilder.set(DTLS_RETRANSMISSION_TIMEOUT, dtlsRetransmissionTimeout, MILLISECONDS);
         configBuilder.set(DTLS_ROLE, SERVER_ONLY);
+        setDtlsConnectorConfigCidLength(configBuilder, cIdLength);
         configBuilder.setAdvancedCertificateVerifier(
                 new TbCoapDtlsCertificateVerifier(
                         transportService,

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapService.java
@@ -43,6 +43,7 @@ import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RECOMMENDE
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_ROLE;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole.SERVER_ONLY;
+import static org.thingsboard.common.util.SslUtil.setDtlsConnectorConfigCidLength;
 import static org.thingsboard.server.transport.lwm2m.server.DefaultLwM2mTransportService.PSK_CIPHER_SUITES;
 import static org.thingsboard.server.transport.lwm2m.server.DefaultLwM2mTransportService.RPK_OR_X509_CIPHER_SUITES;
 import static org.thingsboard.server.transport.lwm2m.server.LwM2MNetworkConfig.getCoapConfig;
@@ -96,6 +97,7 @@ public class LwM2MTransportBootstrapService {
         dtlsConfig.set(DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, serverConfig.isRecommendedCiphers());
         dtlsConfig.set(DTLS_RETRANSMISSION_TIMEOUT, serverConfig.getDtlsRetransmissionTimeout(), MILLISECONDS);
         dtlsConfig.set(DTLS_ROLE, SERVER_ONLY);
+        setDtlsConnectorConfigCidLength(dtlsConfig, serverConfig.getDtlsCidLength());
         setServerWithCredentials(builder, dtlsConfig);
 
         /* Set DTLS Config */

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/config/LwM2MTransportServerConfig.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/config/LwM2MTransportServerConfig.java
@@ -42,6 +42,10 @@ public class LwM2MTransportServerConfig implements LwM2MSecureServerConfig {
     private int dtlsRetransmissionTimeout;
 
     @Getter
+    @Value("${transport.lwm2m.dtls.connection_id_length:}")
+    private Integer dtlsCidLength;
+
+    @Getter
     @Value("${transport.lwm2m.timeout:}")
     private Long timeout;
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
@@ -52,6 +52,7 @@ import static org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_ECDHE
 import static org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8;
 import static org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_PSK_WITH_AES_128_CBC_SHA256;
 import static org.eclipse.californium.scandium.dtls.cipher.CipherSuite.TLS_PSK_WITH_AES_128_CCM_8;
+import static org.thingsboard.common.util.SslUtil.setDtlsConnectorConfigCidLength;
 import static org.thingsboard.server.transport.lwm2m.server.LwM2MNetworkConfig.getCoapConfig;
 import static org.thingsboard.server.transport.lwm2m.server.ota.DefaultLwM2MOtaUpdateService.FIRMWARE_UPDATE_COAP_RESOURCE;
 
@@ -140,6 +141,7 @@ public class DefaultLwM2mTransportService implements LwM2MTransportService {
         dtlsConfig.set(DTLS_RECOMMENDED_CIPHER_SUITES_ONLY, config.isRecommendedCiphers());
         dtlsConfig.set(DTLS_RETRANSMISSION_TIMEOUT, config.getDtlsRetransmissionTimeout(), MILLISECONDS);
         dtlsConfig.set(DTLS_ROLE, SERVER_ONLY);
+        setDtlsConnectorConfigCidLength(dtlsConfig, config.getDtlsCidLength());
 
         /*  Create credentials */
         this.setServerWithCredentials(builder, dtlsConfig);

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/store/TbLwM2mStoreFactory.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/store/TbLwM2mStoreFactory.java
@@ -40,7 +40,7 @@ public class TbLwM2mStoreFactory {
     @Bean
     private CaliforniumRegistrationStore registrationStore() {
         return redisConfiguration.isPresent() ?
-                new TbLwM2mRedisRegistrationStore(getConnectionFactory()) : new InMemoryRegistrationStore(config.getCleanPeriodInSec());
+                new TbLwM2mRedisRegistrationStore(getConnectionFactory(), config.getDtlsCidLength()) : new InMemoryRegistrationStore(config.getCleanPeriodInSec());
     }
 
     @Bean

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/store/util/LwM2MIdentitySerDes.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/store/util/LwM2MIdentitySerDes.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.server.store.util;
+
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonObject;
+import org.apache.commons.lang3.NotImplementedException;
+import org.eclipse.leshan.core.request.Identity;
+import org.eclipse.leshan.core.util.Hex;
+
+import java.security.PublicKey;
+
+public class LwM2MIdentitySerDes {
+
+    private static final String KEY_ADDRESS = "address";
+    private static final String KEY_PORT = "port";
+    private static final String KEY_ID = "id";
+    private static final String KEY_CN = "cn";
+    private static final String KEY_RPK = "rpk";
+    protected static final String KEY_LWM2MIDENTITY_TYPE = "type";
+    protected static final String LWM2MIDENTITY_TYPE_UNSECURE = "unsecure";
+    protected static final String LWM2MIDENTITY_TYPE_PSK = "psk";
+    protected static final String LWM2MIDENTITY_TYPE_X509 = "x509";
+    protected static final String LWM2MIDENTITY_TYPE_RPK = "rpk";
+
+    public static JsonObject serialize(Identity identity) {
+        JsonObject o = Json.object();
+        if (identity.isPSK()) {
+            o.set(KEY_LWM2MIDENTITY_TYPE, LWM2MIDENTITY_TYPE_PSK);
+            o.set(KEY_ID, identity.getPskIdentity());
+        } else if (identity.isRPK()) {
+            o.set(KEY_LWM2MIDENTITY_TYPE, LWM2MIDENTITY_TYPE_RPK);
+            PublicKey publicKey = identity.getRawPublicKey();
+            o.set(KEY_RPK, Hex.encodeHexString(publicKey.getEncoded()));
+        } else if (identity.isX509()) {
+            o.set(KEY_LWM2MIDENTITY_TYPE, LWM2MIDENTITY_TYPE_X509);
+            o.set(KEY_CN, identity.getX509CommonName());
+        } else {
+            o.set(KEY_LWM2MIDENTITY_TYPE, LWM2MIDENTITY_TYPE_UNSECURE);
+            o.set(KEY_ADDRESS, identity.getPeerAddress().getHostString());
+            o.set(KEY_PORT, identity.getPeerAddress().getPort());
+        }
+        return o;
+    }
+
+    public static Identity deserialize(JsonObject peer) {
+        throw new NotImplementedException();
+    }
+}

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/store/util/LwM2MIdentitySerializer.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/store/util/LwM2MIdentitySerializer.java
@@ -17,46 +17,32 @@ package org.thingsboard.server.transport.lwm2m.server.store.util;
 
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
-import org.apache.commons.lang3.NotImplementedException;
 import org.eclipse.leshan.core.request.Identity;
 import org.eclipse.leshan.core.util.Hex;
 
 import java.security.PublicKey;
 
-public class LwM2MIdentitySerDes {
+public class LwM2MIdentitySerializer {
 
     private static final String KEY_ADDRESS = "address";
     private static final String KEY_PORT = "port";
     private static final String KEY_ID = "id";
     private static final String KEY_CN = "cn";
     private static final String KEY_RPK = "rpk";
-    protected static final String KEY_LWM2MIDENTITY_TYPE = "type";
-    protected static final String LWM2MIDENTITY_TYPE_UNSECURE = "unsecure";
-    protected static final String LWM2MIDENTITY_TYPE_PSK = "psk";
-    protected static final String LWM2MIDENTITY_TYPE_X509 = "x509";
-    protected static final String LWM2MIDENTITY_TYPE_RPK = "rpk";
 
     public static JsonObject serialize(Identity identity) {
         JsonObject o = Json.object();
         if (identity.isPSK()) {
-            o.set(KEY_LWM2MIDENTITY_TYPE, LWM2MIDENTITY_TYPE_PSK);
             o.set(KEY_ID, identity.getPskIdentity());
         } else if (identity.isRPK()) {
-            o.set(KEY_LWM2MIDENTITY_TYPE, LWM2MIDENTITY_TYPE_RPK);
             PublicKey publicKey = identity.getRawPublicKey();
             o.set(KEY_RPK, Hex.encodeHexString(publicKey.getEncoded()));
         } else if (identity.isX509()) {
-            o.set(KEY_LWM2MIDENTITY_TYPE, LWM2MIDENTITY_TYPE_X509);
             o.set(KEY_CN, identity.getX509CommonName());
         } else {
-            o.set(KEY_LWM2MIDENTITY_TYPE, LWM2MIDENTITY_TYPE_UNSECURE);
             o.set(KEY_ADDRESS, identity.getPeerAddress().getHostString());
             o.set(KEY_PORT, identity.getPeerAddress().getPort());
         }
         return o;
-    }
-
-    public static Identity deserialize(JsonObject peer) {
-        throw new NotImplementedException();
     }
 }

--- a/common/util/pom.xml
+++ b/common/util/pom.xml
@@ -104,6 +104,10 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.californium</groupId>
+            <artifactId>scandium</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common/util/src/main/java/org/thingsboard/common/util/SslUtil.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/SslUtil.java
@@ -106,14 +106,18 @@ public class SslUtil {
         return privateKey;
     }
 
-    public static void setDtlsConnectorConfigCidLength (DtlsConnectorConfig.Builder configBuilder, Integer cid) {
-        configBuilder.set(DTLS_CONNECTION_ID_LENGTH, cid);
-        if (cid != null) {
-            if (cid > 4) {
+    public static void setDtlsConnectorConfigCidLength (DtlsConnectorConfig.Builder configBuilder, Integer dtlsCidLength) {
+        configBuilder.set(DTLS_CONNECTION_ID_LENGTH, dtlsCidLength);
+        if (dtlsCidLength != null) {
+            if (dtlsCidLength > 4) {
                 configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, 0);
             } else {
                 configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, null);
             }
         }
+    }
+
+    public static boolean isUsedNodeConnectionIdGenerator(Integer dtlsCidLength){
+        return dtlsCidLength != null && dtlsCidLength > 0;
     }
 }

--- a/common/util/src/main/java/org/thingsboard/common/util/SslUtil.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/SslUtil.java
@@ -30,6 +30,7 @@ import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 import org.bouncycastle.operator.InputDecryptorProvider;
 import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
 import org.bouncycastle.pkcs.jcajce.JcePKCSPBEInputDecryptorProviderBuilder;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.thingsboard.server.common.data.StringUtils;
 
 import java.io.StringReader;
@@ -38,6 +39,9 @@ import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 
 @Slf4j
 public class SslUtil {
@@ -102,4 +106,14 @@ public class SslUtil {
         return privateKey;
     }
 
+    public static void setDtlsConnectorConfigCidLength (DtlsConnectorConfig.Builder configBuilder, Integer cid) {
+        configBuilder.set(DTLS_CONNECTION_ID_LENGTH, cid);
+        if (cid != null) {
+            if (cid > 4) {
+                configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, 0);
+            } else {
+                configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, null);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Pull Request description

### Problem:
[Put your PR description here instead of this sentence  10061.   ](https://github.com/thingsboard/thingsboard/issues/10061)
[Put your PR description here instead of this sentence.   10063](https://github.com/thingsboard/thingsboard/pull/10063)

`When a LwM2M client indicates (in the dtls "Client Hello" message) it wants to use the connection_id extension, its request is ignored by the server (the "Server Hello, Server Hello Done" message does not contain the connection_id extension). As a result, a client that has requested the extension and changes ip address or port (for instance due to a longer sleep period) cannot reuse the dtls session.`

**if  disabled support for connection id.**
<img width="289" alt="testDtlsBefore" src="https://github.com/thingsboard/thingsboard/assets/44275303/f023ab8b-5766-4a10-8ebd-1c35949b01bd">


### Solution
- add DTLS connection id length to DtlsConnectorConfig Servers
#### Coap Transport or LwM2M  Transport:



For the server to use the Connection_id extension:
in **thingsboard.yml:**

```
transport:
  coap:
   dtls:
    connection_id_length: "${COAP_DTLS_CONNECTION_ID_LENGTH:}"
 ...
  lwm2m:
   dtls:
     connection_id_length: "${LWM2M_DTLS_CONNECTION_ID_LENGTH:}"

```

**DTLS connection id length.** 
```
""/null | disabled support for connection id.
0       | enable support for connection id, but don't use it for incoming traffic to this peer.
n       | use connection id of n bytes. 
        |    Note: chose n large enough for the number of considered peers. 
        |    Recommended to have 100 time more values than peers.
        |    E.g. 65000 peers, chose not 2 bytes, chose at lease 3 bytes!
```

**if  enable support for connection id.**
For example : "transport.lwm2m.dtls.cid=6".
<img width="384" alt="testDtlsAfter" src="https://github.com/thingsboard/thingsboard/assets/44275303/0fa1afae-bd70-4366-b7a1-6b212c9d587b">

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



