### PR TITLE
Added new widget action type: Open URL

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/action/widget-action.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/action/widget-action.component.html
@@ -80,6 +80,22 @@
         </mat-form-field>
       </div>
     </ng-template>
+    <ng-template [ngSwitchCase]="widgetActionType.openURL">
+      <div class="tb-form-row">
+        <div class="tb-required">{{ 'widget-action.URL' | translate }}</div>
+        <mat-form-field fxFlex style="margin-left: 9px" appearance="outline" subscriptSizing="dynamic">
+          <input matInput placeholder="{{ 'widget-config.set' | translate }}" formControlName="url">
+          <mat-icon matSuffix
+                    matTooltipPosition="above"
+                    matTooltipClass="tb-error-tooltip"
+                    [matTooltip]="'widget-action.url-required' | translate"
+                    *ngIf="actionTypeFormGroup.get('url').invalid && actionTypeFormGroup.get('url').touched"
+                    class="tb-error">
+            warning
+          </mat-icon>
+        </mat-form-field>
+      </div>
+    </ng-template>
     <ng-template [ngSwitchCase]="widgetActionFormGroup.get('type').value === widgetActionType.openDashboardState ||
                                  widgetActionFormGroup.get('type').value === widgetActionType.updateDashboardState ?
                                  widgetActionFormGroup.get('type').value : ''">
@@ -89,7 +105,8 @@
         </mat-slide-toggle>
       </div>
     </ng-template>
-    <ng-template [ngSwitchCase]="widgetActionFormGroup.get('type').value === widgetActionType.openDashboard ?
+    <ng-template [ngSwitchCase]="widgetActionFormGroup.get('type').value === widgetActionType.openDashboard ||
+                                 widgetActionFormGroup.get('type').value === widgetActionType.openURL ?
                                  widgetActionFormGroup.get('type').value : ''">
       <div class="tb-form-row">
         <mat-slide-toggle class="mat-slide" formControlName="openNewBrowserTab">

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/action/widget-action.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/action/widget-action.component.ts
@@ -279,6 +279,16 @@ export class WidgetActionComponent implements ControlValueAccessor, OnInit, Vali
             this.fb.control(action ? action.mobileAction : null, [Validators.required])
           );
           break;
+        case WidgetActionType.openURL:
+          this.actionTypeFormGroup.addControl(
+            'openNewBrowserTab',
+            this.fb.control(action ? action.openNewBrowserTab : false, [])
+          );
+          this.actionTypeFormGroup.addControl(
+            'url',
+            this.fb.control(action ? action.url : null, [Validators.required])
+          );
+          break;
       }
     }
     this.actionTypeFormGroupSubscriptions.push(

--- a/ui-ngx/src/app/modules/home/components/widget/widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget.component.ts
@@ -1089,6 +1089,9 @@ export class WidgetComponent extends PageComponent implements OnInit, AfterViewI
           this.router.navigateByUrl(url);
         }
         break;
+      case WidgetActionType.openURL:
+        window.open(descriptor.url, descriptor.openNewBrowserTab ? '_blank' : '_self');
+        break;
       case WidgetActionType.custom:
         const customFunction = descriptor.customFunction;
         if (customFunction && customFunction.length > 0) {

--- a/ui-ngx/src/app/shared/models/widget.models.ts
+++ b/ui-ngx/src/app/shared/models/widget.models.ts
@@ -538,7 +538,8 @@ export enum WidgetActionType {
   openDashboard = 'openDashboard',
   custom = 'custom',
   customPretty = 'customPretty',
-  mobileAction = 'mobileAction'
+  mobileAction = 'mobileAction',
+  openURL = 'openURL'
 }
 
 export enum WidgetMobileActionType {
@@ -559,7 +560,8 @@ export const widgetActionTypeTranslationMap = new Map<WidgetActionType, string>(
     [ WidgetActionType.openDashboard, 'widget-action.open-dashboard' ],
     [ WidgetActionType.custom, 'widget-action.custom' ],
     [ WidgetActionType.customPretty, 'widget-action.custom-pretty' ],
-    [ WidgetActionType.mobileAction, 'widget-action.mobile-action' ]
+    [ WidgetActionType.mobileAction, 'widget-action.mobile-action' ],
+    [ WidgetActionType.openURL, 'widget-action.open-URL' ]
   ]
 );
 
@@ -671,6 +673,7 @@ export interface WidgetAction extends CustomActionDescriptor {
   setEntityId?: boolean;
   stateEntityParamName?: string;
   mobileAction?: WidgetMobileActionDescriptor;
+  url?: string;
 }
 
 export interface WidgetActionDescriptor extends WidgetAction {

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -5036,6 +5036,9 @@
         "popover-height": "Popover height",
         "popover-style": "Popover style",
         "open-new-browser-tab": "Open in a new browser tab",
+        "open-URL": "Open URL",
+        "URL": "URL",
+        "url-required": "URL is required.",
         "mobile": {
           "action-type": "Mobile action type",
           "select-action-type": "Select mobile action type",


### PR DESCRIPTION
## Pull Request description

Added new widget action handle type - open URL.
![image](https://github.com/thingsboard/thingsboard/assets/54553744/8fd9e17b-9afc-4f44-a10b-245f7634ff8f)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



