### PR TITLE
lwm2m_coap: DTLS Cid Length

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -365,6 +365,12 @@
             <groupId>com.google.oauth-client</groupId>
             <artifactId>google-oauth-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.leshan</groupId>
+            <artifactId>leshan-core-cf</artifactId>
+            <version>2.0.0-M14</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -1018,6 +1018,16 @@ transport:
       bind_address: "${COAP_DTLS_BIND_ADDRESS:0.0.0.0}"
       # CoAP DTLS bind port
       bind_port: "${COAP_DTLS_BIND_PORT:5684}"
+      # CoAP DTLS connection ID length. RFC 9146, Connection Identifier for DTLS 1.2
+      # Default: off
+      # Control usage of DTLS connection ID length (CID).
+      # - 'off' to deactivate it.
+      # - 'on' to activate Connection ID support (same as CID 0 or more 0).
+      # - A positive value defines generated CID size in bytes.
+      # - A value of 0 means we accept using CID but will not generate one for foreign peer (enables support but not for incoming traffic).
+      # - A value between 0 and <= 4: SingleNodeConnectionIdGenerator is used
+      # - A value that are > 4: MultiNodeConnectionIdGenerator is used
+      connection_id_length: "${COAP_DTLS_CONNECTION_ID_LENGTH:}"
       # Server DTLS credentials
       credentials:
         # Server credentials type (PEM - pem certificate file; KEYSTORE - java keystore)
@@ -1056,6 +1066,16 @@ transport:
     dtls:
       # RFC7925_RETRANSMISSION_TIMEOUT_IN_MILLISECONDS = 9000
       retransmission_timeout: "${LWM2M_DTLS_RETRANSMISSION_TIMEOUT_MS:9000}"
+      # CoAP DTLS connection ID length for LWM2M. RFC 9146, Connection Identifier for DTLS 1.2
+      # Default: off
+      # Control usage of DTLS connection ID length (CID).
+      # - 'off' to deactivate it.
+      # - 'on' to activate Connection ID support (same as CID 0 or more 0).
+      # - A positive value defines generated CID size in bytes.
+      # - A value of 0 means we accept using CID but will not generate one for foreign peer (enables support but not for incoming traffic).
+      # - A value between 0 and <= 4: SingleNodeConnectionIdGenerator is used
+      # - A value that are > 4: MultiNodeConnectionIdGenerator is used
+      connection_id_length: "${LWM2M_DTLS_CONNECTION_ID_LENGTH:}"
     server:
       # LwM2M Server ID
       id: "${LWM2M_SERVER_ID:123}"

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
@@ -236,7 +236,7 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
         getWsClient().waitForReply();
 
         getWsClient().registerWaitForUpdate();
-        createNewClient(security, null, coapConfig, false, endpoint);
+        createNewClient(security, null, coapConfig, false, endpoint, null);
         deviceId = device.getId().getId().toString();
         awaitObserveReadAll(0, deviceId);
         String msg = getWsClient().waitForUpdate();
@@ -254,8 +254,6 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
         int expectedMin = 5;
         Assert.assertTrue(expectedMax >= Long.parseLong(tsValue.getValue()));
         Assert.assertTrue(expectedMin <= Long.parseLong(tsValue.getValue()));
-
-
     }
 
     protected void createDeviceProfile(Lwm2mDeviceProfileTransportConfiguration transportConfiguration) throws Exception {
@@ -304,14 +302,15 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
         this.resources = resources;
     }
 
-    public void createNewClient(Security security, Security securityBs, Configuration coapConfig, boolean isRpc, String endpoint) throws Exception {
+    public void createNewClient(Security security, Security securityBs, Configuration coapConfig,
+                                boolean isRpc, String endpoint, Integer cIdLength) throws Exception {
         this.clientDestroy();
         lwM2MTestClient = new LwM2MTestClient(this.executor, endpoint);
 
         try (ServerSocket socket = new ServerSocket(0)) {
             int clientPort = socket.getLocalPort();
             lwM2MTestClient.init(security, securityBs, coapConfig, clientPort, isRpc,
-                    this.defaultLwM2mUplinkMsgHandlerTest, this.clientContextTest, isWriteAttribute);
+                    this.defaultLwM2mUplinkMsgHandlerTest, this.clientContextTest, isWriteAttribute, cIdLength);
         }
     }
 

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/Lwm2mTestHelper.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/Lwm2mTestHelper.java
@@ -53,7 +53,7 @@ public class Lwm2mTestHelper {
 
     public enum LwM2MClientState {
 
-        ON_INIT(1, "onInit"),
+        ON_INIT(0, "onInit"),
         ON_BOOTSTRAP_STARTED(1, "onBootstrapStarted"),
         ON_BOOTSTRAP_SUCCESS(2, "onBootstrapSuccess"),
         ON_BOOTSTRAP_FAILURE(3, "onBootstrapFailure"),
@@ -70,7 +70,9 @@ public class Lwm2mTestHelper {
         ON_DEREGISTRATION_SUCCESS(13, "onDeregistrationSuccess"),
         ON_DEREGISTRATION_FAILURE(14, "onDeregistrationFailure"),
         ON_DEREGISTRATION_TIMEOUT(15, "onDeregistrationTimeout"),
-        ON_EXPECTED_ERROR(16, "onUnexpectedError");
+        ON_EXPECTED_ERROR(16, "onUnexpectedError"),
+        ON_WRITE_CONNECTION_ID(17, "onWriteConnectionId"),
+        ON_READ_CONNECTION_ID(18, "onReadConnectionId");
 
         public int code;
         public String type;

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/DtlsSessionLogger.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/DtlsSessionLogger.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.californium.scandium.dtls.ClientHandshaker;
+import org.eclipse.californium.scandium.dtls.DTLSContext;
+import org.eclipse.californium.scandium.dtls.HandshakeException;
+import org.eclipse.californium.scandium.dtls.Handshaker;
+import org.eclipse.californium.scandium.dtls.SessionAdapter;
+import org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_READ_CONNECTION_ID;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_WRITE_CONNECTION_ID;
+
+@Slf4j
+public class DtlsSessionLogger extends SessionAdapter {
+
+    private final Set<LwM2MClientState> clientStates;
+    private final Map<LwM2MClientState, Integer> clientDtlsCid;
+
+    public DtlsSessionLogger(Set<LwM2MClientState> clientStates, Map<LwM2MClientState, Integer> clientDtlsCid) {
+        this.clientStates = clientStates;
+        this.clientDtlsCid = clientDtlsCid;
+    }
+
+    @Override
+    public void handshakeStarted(Handshaker handshaker) throws HandshakeException {
+        if (handshaker instanceof ClientHandshaker) {
+            log.info("DTLS Full Handshake initiated by client : STARTED ...");
+        }
+    }
+
+    @Override
+    public void contextEstablished(Handshaker handshaker, DTLSContext establishedContext) throws HandshakeException {
+        if (handshaker instanceof ClientHandshaker) {
+            log.warn("DTLS initiated by client: SUCCEED, WriteConnectionId: [{}], ReadConnectionId: [{}]", establishedContext.getWriteConnectionId(), establishedContext.getReadConnectionId());
+            clientStates.add(ON_WRITE_CONNECTION_ID);
+            clientStates.add(ON_READ_CONNECTION_ID);
+            Integer lenWrite = establishedContext.getWriteConnectionId() == null ? null : establishedContext.getWriteConnectionId().getBytes().length;
+            Integer lenRead = establishedContext.getReadConnectionId() == null ? null : establishedContext.getReadConnectionId().getBytes().length;
+            clientDtlsCid.put(ON_WRITE_CONNECTION_ID, lenWrite);
+            clientDtlsCid.put(ON_READ_CONNECTION_ID, lenRead);
+        }
+    }
+
+    @Override
+    public void handshakeFailed(Handshaker handshaker, Throwable error) {
+        // get cause
+        String cause;
+        if (error != null) {
+            if (error.getMessage() != null) {
+                cause = error.getMessage();
+            } else {
+                cause = error.getClass().getName();
+            }
+        } else {
+            cause = "unknown cause";
+        }
+
+        if (handshaker instanceof ClientHandshaker) {
+            log.info("DTLS Full Handshake initiated by client : FAILED ({})", cause);
+        }
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/sql/OtaLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/sql/OtaLwM2MIntegrationTest.java
@@ -59,7 +59,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_WITHOUT_FW_INFO));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO);
-        createNewClient(SECURITY_NO_SEC,  null, COAP_CONFIG, false, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO);
+        createNewClient(SECURITY_NO_SEC,  null, COAP_CONFIG, false, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO, null);
         awaitObserveReadAll(0, device.getId().getId().toString());
 
         device.setFirmwareId(createFirmware().getId());
@@ -84,7 +84,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_OTA5));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_OTA5);
-        createNewClient(SECURITY_NO_SEC, null,  COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA5);
+        createNewClient(SECURITY_NO_SEC, null,  COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA5, null);
         awaitObserveReadAll(9, device.getId().getId().toString());
 
         device.setFirmwareId(createFirmware().getId());
@@ -114,7 +114,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_OTA9));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_OTA9);
-        createNewClient(SECURITY_NO_SEC, null, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA9);
+        createNewClient(SECURITY_NO_SEC, null, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA9, null);
         awaitObserveReadAll(9, device.getId().getId().toString());
 
         device.setSoftwareId(createSoftware().getId());

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcLwM2MIntegrationTest.java
@@ -91,7 +91,7 @@ public abstract class AbstractRpcLwM2MIntegrationTest extends AbstractLwM2MInteg
 
     private void initRpc () throws Exception {
         String endpoint = DEVICE_ENDPOINT_RPC_PREF + endpointSequence.incrementAndGet();
-        createNewClient(SECURITY_NO_SEC, null, COAP_CONFIG, true, endpoint);
+        createNewClient(SECURITY_NO_SEC, null, COAP_CONFIG, true, endpoint, null);
         expectedObjects = ConcurrentHashMap.newKeySet();
         expectedObjectIdVers = ConcurrentHashMap.newKeySet();
         expectedInstances = ConcurrentHashMap.newKeySet();

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/AbstractSecurityLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/AbstractSecurityLwM2MIntegrationTest.java
@@ -23,6 +23,7 @@ import org.eclipse.leshan.client.object.Security;
 import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.util.Hex;
 import org.junit.Assert;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MvcResult;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.Device;
@@ -74,6 +75,10 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClient
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_ID_1;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_9;
 
+
+@TestPropertySource(properties = {
+        "transport.lwm2m.dtls.connection_id_length=",
+})
 @DaoSqlTest
 @Slf4j
 public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2MIntegrationTest {
@@ -196,7 +201,7 @@ public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2M
                                        boolean isStartLw) throws Exception {
         createDeviceProfile(transportConfiguration);
         final Device device = createDevice(deviceCredentials, endpoint);
-        createNewClient(security, securityBs, coapConfig, true, endpoint);
+        createNewClient(security, securityBs, coapConfig, true, endpoint, null);
         lwM2MTestClient.start(isStartLw);
         if (isAwaitObserveReadAll) {
             awaitObserveReadAll(0, device.getId().getId().toString());
@@ -244,7 +249,7 @@ public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2M
         createDeviceProfile(transportConfiguration);
         final Device device = createDevice(deviceCredentials, endpoint);
         String deviceIdStr = device.getId().getId().toString();
-        createNewClient(security, securityBs, coapConfig, true, endpoint);
+        createNewClient(security, securityBs, coapConfig, true, endpoint, null);
         lwM2MTestClient.start(true);
         awaitObserveReadAll(0, deviceIdStr);
         await(awaitAlias)

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/AbstractSecurityLwM2MIntegrationDtlsCidLength0Test.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/AbstractSecurityLwM2MIntegrationDtlsCidLength0Test.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.test.context.TestPropertySource;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+
+
+@TestPropertySource(properties = {
+        "transport.lwm2m.dtls.connection_id_length=0"
+})
+
+@DaoSqlTest
+@Slf4j
+public abstract class AbstractSecurityLwM2MIntegrationDtlsCidLength0Test extends AbstractSecurityLwM2MIntegrationDtlsCidLengthTest {
+
+
+    protected void  testNoSecDtlsCidLength(Integer dtlsCidLength) throws Exception {
+        testNoSecDtlsCidLength(dtlsCidLength, 0);
+    }
+    protected void  testPskDtlsCidLength(Integer dtlsCidLength) throws Exception {
+        testPskDtlsCidLength(dtlsCidLength, 0);
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/AbstractSecurityLwM2MIntegrationDtlsCidLength3Test.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/AbstractSecurityLwM2MIntegrationDtlsCidLength3Test.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.test.context.TestPropertySource;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+
+
+@TestPropertySource(properties = {
+        "transport.lwm2m.dtls.connection_id_length=3"
+})
+
+@DaoSqlTest
+@Slf4j
+public abstract class AbstractSecurityLwM2MIntegrationDtlsCidLength3Test extends AbstractSecurityLwM2MIntegrationDtlsCidLengthTest {
+
+    protected void  testNoSecDtlsCidLength(Integer dtlsCidLength) throws Exception {
+        testNoSecDtlsCidLength(dtlsCidLength, 3);
+    }
+    protected void  testPskDtlsCidLength(Integer dtlsCidLength) throws Exception {
+        testPskDtlsCidLength(dtlsCidLength, 3);
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/AbstractSecurityLwM2MIntegrationDtlsCidLengthNullTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/AbstractSecurityLwM2MIntegrationDtlsCidLengthNullTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.test.context.TestPropertySource;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+
+
+@TestPropertySource(properties = {
+        "transport.lwm2m.dtls.connection_id_length="
+})
+
+@DaoSqlTest
+@Slf4j
+public abstract class AbstractSecurityLwM2MIntegrationDtlsCidLengthNullTest extends AbstractSecurityLwM2MIntegrationDtlsCidLengthTest {
+
+
+    protected void  testNoSecDtlsCidLength(Integer dtlsCidLength) throws Exception {
+        testNoSecDtlsCidLength(dtlsCidLength, null);
+    }
+    protected void  testPskDtlsCidLength(Integer dtlsCidLength) throws Exception {
+        testPskDtlsCidLength(dtlsCidLength, null);
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/AbstractSecurityLwM2MIntegrationDtlsCidLengthTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/AbstractSecurityLwM2MIntegrationDtlsCidLengthTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.californium.elements.config.Configuration;
+import org.eclipse.leshan.client.californium.endpoint.CaliforniumClientEndpoint;
+import org.eclipse.leshan.client.californium.endpoint.CaliforniumClientEndpointsProvider;
+import org.eclipse.leshan.client.object.Security;
+import org.eclipse.leshan.core.util.Hex;
+import org.junit.Assert;
+import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.device.credentials.lwm2m.AbstractLwM2MClientSecurityCredential;
+import org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MDeviceCredentials;
+import org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MSecurityMode;
+import org.thingsboard.server.common.data.device.credentials.lwm2m.PSKClientCredential;
+import org.thingsboard.server.common.data.device.profile.Lwm2mDeviceProfileTransportConfiguration;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+import org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState;
+import org.thingsboard.server.transport.lwm2m.security.AbstractSecurityLwM2MIntegrationTest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
+import static org.eclipse.leshan.client.object.Security.psk;
+import static org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MSecurityMode.PSK;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_INIT;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_READ_CONNECTION_ID;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_REGISTRATION_STARTED;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_REGISTRATION_SUCCESS;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_UPDATE_SUCCESS;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MClientState.ON_WRITE_CONNECTION_ID;
+
+@DaoSqlTest
+@Slf4j
+public abstract class AbstractSecurityLwM2MIntegrationDtlsCidLengthTest extends AbstractSecurityLwM2MIntegrationTest {
+
+    protected AbstractLwM2MClientSecurityCredential clientCredentials;
+    protected Security security;
+    protected Lwm2mDeviceProfileTransportConfiguration transportConfiguration;
+    protected LwM2MDeviceCredentials deviceCredentials;
+    protected String clientEndpoint;
+    protected LwM2MSecurityMode lwM2MSecurityMode;
+    protected String awaitAlias;
+    protected final Random randomSuffix = new Random();
+
+    protected final Set<LwM2MClientState> expectedStatusesRegistrationLwm2mDtlsCidSuccess = new HashSet<>(Arrays.asList(ON_INIT, ON_REGISTRATION_STARTED, ON_REGISTRATION_SUCCESS, ON_READ_CONNECTION_ID, ON_WRITE_CONNECTION_ID));
+
+
+    protected void testNoSecDtlsCidLength(Integer dtlsCidLength, Integer serverDtlsCidLength) throws Exception {
+        initDeviceCredentialsNoSek();
+        basicTestConnectionDtlsCidLength(dtlsCidLength, serverDtlsCidLength);
+    }
+    protected void testPskDtlsCidLength(Integer dtlsCidLength, Integer serverDtlsCidLength) throws Exception {
+        initDeviceCredentialsPsk();
+        basicTestConnectionDtlsCidLength(dtlsCidLength, serverDtlsCidLength);
+    }
+
+    protected void initDeviceCredentialsNoSek() {
+        clientEndpoint = CLIENT_ENDPOINT_NO_SEC + "_" + randomSuffix.nextInt(100);
+        deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(clientEndpoint));
+    }
+
+    protected void initDeviceCredentialsPsk() {
+        int suf =  randomSuffix.nextInt(10);
+        clientEndpoint = CLIENT_ENDPOINT_PSK + "_" + suf;
+        String identity = CLIENT_PSK_IDENTITY + "_" + suf;
+        clientCredentials = new PSKClientCredential();
+        clientCredentials.setEndpoint(clientEndpoint);
+        ((PSKClientCredential)clientCredentials).setIdentity(identity);
+        clientCredentials.setKey(CLIENT_PSK_KEY);
+        security = psk(SECURE_URI,
+                shortServerId,
+                identity.getBytes(StandardCharsets.UTF_8),
+                Hex.decodeHex(CLIENT_PSK_KEY.toCharArray()));
+        deviceCredentials = getDeviceCredentialsSecure(clientCredentials, null, null, PSK, false);
+    }
+
+    protected void basicTestConnectionDtlsCidLength(Integer clientDtlsCidLength,
+                                                    Integer serverDtlsCidLength) throws Exception {
+        createDeviceProfile(transportConfiguration);
+        final Device device = createDevice(deviceCredentials, clientEndpoint);
+        device.getId().getId().toString();
+        createNewClient(security, null, COAP_CONFIG, true, clientEndpoint, clientDtlsCidLength);
+        lwM2MTestClient.start(true);
+        await(awaitAlias)
+                .atMost(40, TimeUnit.SECONDS)
+                .until(() -> lwM2MTestClient.getClientStates().contains(ON_UPDATE_SUCCESS));
+        Assert.assertTrue(lwM2MTestClient.getClientStates().containsAll(expectedStatusesRegistrationLwm2mSuccess));
+
+        Configuration clientCoapConfig = ((CaliforniumClientEndpoint)((CaliforniumClientEndpointsProvider)lwM2MTestClient
+                .getLeshanClient().getEndpointsProvider().toArray()[0]).getEndpoints().toArray()[0]).getCoapEndpoint().getConfig();
+        Assert.assertEquals(clientDtlsCidLength, clientCoapConfig.get(DTLS_CONNECTION_ID_LENGTH));
+
+        if (security.equals(SECURITY_NO_SEC)) {
+            Assert.assertTrue(lwM2MTestClient.getClientDtlsCid().isEmpty());
+        } else {
+            Assert.assertEquals(2L, lwM2MTestClient.getClientDtlsCid().size());
+            Assert.assertTrue(lwM2MTestClient.getClientDtlsCid().keySet().contains(ON_READ_CONNECTION_ID));
+            Assert.assertTrue(lwM2MTestClient.getClientDtlsCid().keySet().contains(ON_WRITE_CONNECTION_ID));
+            if (serverDtlsCidLength == null) {
+                Assert.assertNull(lwM2MTestClient.getClientDtlsCid().get(ON_WRITE_CONNECTION_ID));
+                Assert.assertNull(lwM2MTestClient.getClientDtlsCid().get(ON_READ_CONNECTION_ID));
+            } else {
+                Assert.assertEquals(clientDtlsCidLength, lwM2MTestClient.getClientDtlsCid().get(ON_READ_CONNECTION_ID));
+                if (clientDtlsCidLength == null) {
+                    Assert.assertNull(lwM2MTestClient.getClientDtlsCid().get(ON_READ_CONNECTION_ID));
+                } else {
+                    Assert.assertEquals(Integer.valueOf(serverDtlsCidLength), lwM2MTestClient.getClientDtlsCid().get(ON_WRITE_CONNECTION_ID));
+                }
+            }
+        }
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_0/NoSecLwM2MIntegrationDtlsCidLengthTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_0/NoSecLwM2MIntegrationDtlsCidLengthTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql.serverDtlsCidLength_0;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.server.transport.lwm2m.security.sql.AbstractSecurityLwM2MIntegrationDtlsCidLength0Test;
+
+import static org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MSecurityMode.NO_SEC;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
+
+public class NoSecLwM2MIntegrationDtlsCidLengthTest extends AbstractSecurityLwM2MIntegrationDtlsCidLength0Test {
+
+    @Before
+    public void setUpNoSecDtlsCidLength() {
+        security = SECURITY_NO_SEC;
+        transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITHOUT_PARAMS, getBootstrapServerCredentialsSecure(NO_SEC, NONE));
+        awaitAlias = "await on client state (NoSec_Lwm2m) DtlsCidLength = 0";
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_Null() throws Exception {
+        testNoSecDtlsCidLength(null);
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_0() throws Exception {
+        testNoSecDtlsCidLength(0);
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_2() throws Exception {
+        testNoSecDtlsCidLength(2);
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_0/PskLwm2mIntegrationDtlsCidLengthTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_0/PskLwm2mIntegrationDtlsCidLengthTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql.serverDtlsCidLength_0;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.server.transport.lwm2m.security.sql.AbstractSecurityLwM2MIntegrationDtlsCidLength0Test;
+
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
+
+public class PskLwm2mIntegrationDtlsCidLengthTest extends AbstractSecurityLwM2MIntegrationDtlsCidLength0Test {
+
+    @Before
+    public void createProfileRpc() {
+        transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITHOUT_PARAMS, getBootstrapServerCredentialsSecure(lwM2MSecurityMode, NONE));
+        awaitAlias = "await on client state (Psk_Lwm2m) DtlsCidLength = 0";
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_Null() throws Exception {
+        testPskDtlsCidLength(null);
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_0() throws Exception {
+        testPskDtlsCidLength(0);
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_2() throws Exception {
+        testPskDtlsCidLength(2);
+    }
+}
+

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_3/NoSecLwM2MIntegrationDtlsCidLengthTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_3/NoSecLwM2MIntegrationDtlsCidLengthTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql.serverDtlsCidLength_3;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.server.transport.lwm2m.security.sql.AbstractSecurityLwM2MIntegrationDtlsCidLength3Test;
+
+import static org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MSecurityMode.NO_SEC;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
+
+public class NoSecLwM2MIntegrationDtlsCidLengthTest extends AbstractSecurityLwM2MIntegrationDtlsCidLength3Test {
+
+    @Before
+    public void setUpNoSecDtlsCidLength() {
+        security = SECURITY_NO_SEC;
+        transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITHOUT_PARAMS, getBootstrapServerCredentialsSecure(NO_SEC, NONE));
+        awaitAlias = "await on client state (NoSec_Lwm2m) DtlsCidLength = 3";
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_Null() throws Exception {
+        testNoSecDtlsCidLength(null);
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_0() throws Exception {
+        testNoSecDtlsCidLength(0);
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_2() throws Exception {
+        testNoSecDtlsCidLength(2);
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_3/PskLwm2mIntegrationDtlsCidLengthTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_3/PskLwm2mIntegrationDtlsCidLengthTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql.serverDtlsCidLength_3;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.server.transport.lwm2m.security.sql.AbstractSecurityLwM2MIntegrationDtlsCidLength3Test;
+
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
+
+public class PskLwm2mIntegrationDtlsCidLengthTest extends AbstractSecurityLwM2MIntegrationDtlsCidLength3Test {
+
+    @Before
+    public void createProfileRpc() {
+        transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITHOUT_PARAMS, getBootstrapServerCredentialsSecure(lwM2MSecurityMode, NONE));
+        awaitAlias = "await on client state (Psk_Lwm2m) DtlsCidLength = 3";
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_Null() throws Exception {
+        testPskDtlsCidLength(null);
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_0() throws Exception {
+        testPskDtlsCidLength(0);
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_2() throws Exception {
+        testPskDtlsCidLength(2);
+    }
+}
+

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_null/NoSecLwM2MIntegrationDtlsCidLengthTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_null/NoSecLwM2MIntegrationDtlsCidLengthTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql.serverDtlsCidLength_null;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.server.transport.lwm2m.security.sql.AbstractSecurityLwM2MIntegrationDtlsCidLengthNullTest;
+
+import static org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MSecurityMode.NO_SEC;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
+
+public class NoSecLwM2MIntegrationDtlsCidLengthTest extends AbstractSecurityLwM2MIntegrationDtlsCidLengthNullTest {
+
+    @Before
+    public void setUpNoSecDtlsCidLength() {
+        security = SECURITY_NO_SEC;
+        transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITHOUT_PARAMS, getBootstrapServerCredentialsSecure(NO_SEC, NONE));
+        awaitAlias = "await on client state (NoSec_Lwm2m) DtlsCidLength = Null";
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_Null() throws Exception {
+        testNoSecDtlsCidLength(null);
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_0() throws Exception {
+        testNoSecDtlsCidLength(0);
+    }
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessClientDtlsCidLength_2() throws Exception {
+        testNoSecDtlsCidLength(2);
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_null/PskLwm2mIntegrationDtlsCidLengthTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/serverDtlsCidLength_null/PskLwm2mIntegrationDtlsCidLengthTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.security.sql.serverDtlsCidLength_null;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.thingsboard.server.transport.lwm2m.security.sql.AbstractSecurityLwM2MIntegrationDtlsCidLengthNullTest;
+
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.LwM2MProfileBootstrapConfigType.NONE;
+
+public class PskLwm2mIntegrationDtlsCidLengthTest extends AbstractSecurityLwM2MIntegrationDtlsCidLengthNullTest {
+
+    @Before
+    public void createProfileRpc() {
+        transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITHOUT_PARAMS, getBootstrapServerCredentialsSecure(lwM2MSecurityMode, NONE));
+        awaitAlias = "await on client state (Psk_Lwm2m) DtlsCidLength = Null";
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_Null() throws Exception {
+        testPskDtlsCidLength(null);
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_0() throws Exception {
+        testPskDtlsCidLength(0);
+    }
+
+    @Test
+    public void testWithPskConnectLwm2mSuccessClientDtlsCidLength_2() throws Exception {
+        testPskDtlsCidLength(2);
+    }
+}
+

--- a/common/coap-server/src/main/java/org/thingsboard/server/coapserver/TbCoapDtlsSettings.java
+++ b/common/coap-server/src/main/java/org/thingsboard/server/coapserver/TbCoapDtlsSettings.java
@@ -41,6 +41,8 @@ import java.util.Collections;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.eclipse.californium.elements.config.CertificateAuthenticationMode.WANTED;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CLIENT_AUTHENTICATION_MODE;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_RETRANSMISSION_TIMEOUT;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_ROLE;
 import static org.eclipse.californium.scandium.config.DtlsConfig.DtlsRole.SERVER_ONLY;
@@ -55,6 +57,9 @@ public class TbCoapDtlsSettings {
 
     @Value("${transport.coap.dtls.bind_port}")
     private Integer port;
+
+    @Value("${transport.coap.dtls.connection_id_length}")
+    private Integer cIdLength;
 
     @Value("${transport.coap.dtls.retransmission_timeout:9000}")
     private int dtlsRetransmissionTimeout;
@@ -93,6 +98,12 @@ public class TbCoapDtlsSettings {
         configBuilder.set(DTLS_CLIENT_AUTHENTICATION_MODE, WANTED);
         configBuilder.set(DTLS_RETRANSMISSION_TIMEOUT, dtlsRetransmissionTimeout, MILLISECONDS);
         configBuilder.set(DTLS_ROLE, SERVER_ONLY);
+        configBuilder.set(DTLS_CONNECTION_ID_LENGTH, cIdLength);
+        if (cIdLength != null && cIdLength > 4) {
+            configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, 0);
+        } else {
+            configBuilder.set(DTLS_CONNECTION_ID_NODE_ID, null);
+        }
         configBuilder.setAdvancedCertificateVerifier(
                 new TbCoapDtlsCertificateVerifier(
                         transportService,

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/config/LwM2MTransportServerConfig.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/config/LwM2MTransportServerConfig.java
@@ -43,6 +43,10 @@ public class LwM2MTransportServerConfig implements LwM2MSecureServerConfig {
     private int dtlsRetransmissionTimeout;
 
     @Getter
+    @Value("${transport.lwm2m.dtls.connection_id_length:}")
+    private Integer dtlsCidLength;
+
+    @Getter
     @Value("${transport.lwm2m.timeout:}")
     private Long timeout;
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
@@ -17,6 +17,7 @@ package org.thingsboard.server.transport.lwm2m.utils;
 
 import com.google.gson.JsonElement;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.leshan.core.model.LwM2mModel;
 import org.eclipse.leshan.core.model.ObjectLoader;
 import org.eclipse.leshan.core.model.ObjectModel;
@@ -55,6 +56,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_LENGTH;
+import static org.eclipse.californium.scandium.config.DtlsConfig.DTLS_CONNECTION_ID_NODE_ID;
 import static org.eclipse.leshan.core.model.ResourceModel.Type.BOOLEAN;
 import static org.eclipse.leshan.core.model.ResourceModel.Type.FLOAT;
 import static org.eclipse.leshan.core.model.ResourceModel.Type.INTEGER;
@@ -424,5 +427,16 @@ public class LwM2MTransportUtil {
             newValueStr = newValue.toString();
         }
         return newValueStr.equals(oldValueStr);
+    }
+
+    public static void setDtlsConnectorConfigCidLength (Configuration serverCoapConfig, Integer cIdLength) {
+        serverCoapConfig.setTransient(DTLS_CONNECTION_ID_LENGTH);
+        serverCoapConfig.setTransient(DTLS_CONNECTION_ID_NODE_ID);
+        serverCoapConfig.set(DTLS_CONNECTION_ID_LENGTH, cIdLength);
+        if ( cIdLength > 4) {
+            serverCoapConfig.set(DTLS_CONNECTION_ID_NODE_ID, 0);
+        } else {
+            serverCoapConfig.set(DTLS_CONNECTION_ID_NODE_ID, null);
+        }
     }
 }


### PR DESCRIPTION
## Pull Request description


### Problem:
[Put your PR description here instead of this sentence  10061.   ](https://github.com/thingsboard/thingsboard/issues/10061)

`When a LwM2M client indicates (in the dtls "Client Hello" message) it wants to use the connection_id extension, its request is ignored by the server (the "Server Hello, Server Hello Done" message does not contain the connection_id extension). As a result, a client that has requested the extension and changes ip address or port (for instance due to a longer sleep period) cannot reuse the dtls session.`

**if  disabled support for connection id.**
<img width="289" alt="testDtlsBefore" src="https://github.com/thingsboard/thingsboard/assets/44275303/f023ab8b-5766-4a10-8ebd-1c35949b01bd">


### Solution
- add DTLS connection id length to DtlsConnectorConfig Servers
#### Coap Transport or LwM2M  Transport:



For the server to use the Connection_id extension:
in **thingsboard.yml:**

```
transport:
  coap:
   dtls:
    connection_id_length: "${COAP_DTLS_CONNECTION_ID_LENGTH:}"
 ...
  lwm2m:
   dtls:
     connection_id_length: "${LWM2M_DTLS_CONNECTION_ID_LENGTH:}"

```

**DTLS connection id length.** 
```
""/null | disabled support for connection id.
0       | enable support for connection id, but don't use it for incoming traffic to this peer.
n       | use connection id of n bytes. 
        |    Note: chose n large enough for the number of considered peers. 
        |    Recommended to have 100 time more values than peers.
        |    E.g. 65000 peers, chose not 2 bytes, chose at lease 3 bytes!
```

**if  enable support for connection id.**
For example : "transport.lwm2m.dtls.cid=6".
<img width="384" alt="testDtlsAfter" src="https://github.com/thingsboard/thingsboard/assets/44275303/0fa1afae-bd70-4366-b7a1-6b212c9d587b">

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



