### PR TITLE
RegistrationOnAwakeCclientQueueMode

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/AbstractLwM2MIntegrationTest.java
@@ -219,7 +219,8 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
     public void basicTestConnectionObserveTelemetry(Security security,
                                                     LwM2MDeviceCredentials deviceCredentials,
                                                     Configuration coapConfig,
-                                                    String endpoint) throws Exception {
+                                                    String endpoint,
+                                                    boolean queueMode) throws Exception {
         Lwm2mDeviceProfileTransportConfiguration transportConfiguration = getTransportConfiguration(OBSERVE_ATTRIBUTES_WITH_PARAMS, getBootstrapServerCredentialsNoSec(NONE));
         createDeviceProfile(transportConfiguration);
         Device device = createDevice(deviceCredentials, endpoint);
@@ -236,7 +237,7 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
         getWsClient().waitForReply();
 
         getWsClient().registerWaitForUpdate();
-        createNewClient(security, null, coapConfig, false, endpoint, null);
+        createNewClient(security, null, coapConfig, false, endpoint, null, queueMode);
         deviceId = device.getId().getId().toString();
         awaitObserveReadAll(0, deviceId);
         String msg = getWsClient().waitForUpdate();
@@ -305,14 +306,25 @@ public abstract class AbstractLwM2MIntegrationTest extends AbstractTransportInte
     }
 
     public void createNewClient(Security security, Security securityBs, Configuration coapConfig, boolean isRpc,
+                                String endpoint) throws Exception {
+        this.createNewClient(security, securityBs, coapConfig, isRpc, endpoint, null, false);
+    }
+
+    public void createNewClient(Security security, Security securityBs, Configuration coapConfig, boolean isRpc,
                                 String endpoint, Integer clientDtlsCidLength) throws Exception {
+        this.createNewClient(security, securityBs, coapConfig, isRpc, endpoint, clientDtlsCidLength, false);
+    }
+
+    public void createNewClient(Security security, Security securityBs, Configuration coapConfig, boolean isRpc,
+                                String endpoint, Integer clientDtlsCidLength, boolean queueMode) throws Exception {
         this.clientDestroy();
         lwM2MTestClient = new LwM2MTestClient(this.executor, endpoint);
 
         try (ServerSocket socket = new ServerSocket(0)) {
             int clientPort = socket.getLocalPort();
             lwM2MTestClient.init(security, securityBs, coapConfig, clientPort, isRpc,
-                    this.defaultLwM2mUplinkMsgHandlerTest, this.clientContextTest, isWriteAttribute, clientDtlsCidLength);
+                    this.defaultLwM2mUplinkMsgHandlerTest, this.clientContextTest, isWriteAttribute
+                    , clientDtlsCidLength, queueMode);
         }
     }
 

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
@@ -129,7 +129,7 @@ public class LwM2MTestClient {
 
     public void init(Security security, Security securityBs,Configuration coapConfig, int port, boolean isRpc,
                      LwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandler,
-                     LwM2mClientContext clientContext, boolean isWriteAttribute, Integer cIdLength) throws InvalidDDFFileException, IOException {
+                     LwM2mClientContext clientContext, boolean isWriteAttribute, Integer cIdLength, boolean queueMode) throws InvalidDDFFileException, IOException {
         Assert.assertNull("client already initialized", leshanClient);
         this.defaultLwM2mUplinkMsgHandlerTest = defaultLwM2mUplinkMsgHandler;
         this.clientContext = clientContext;
@@ -263,11 +263,10 @@ public class LwM2MTestClient {
         boolean reconnectOnUpdate = false;
         engineFactory.setReconnectOnUpdate(reconnectOnUpdate);
         engineFactory.setResumeOnConnect(true);
-            // new
+
         /**
-         * Client use queue mode (not fully implemented).
+         * Client use queue mode.
          */
-        boolean queueMode = false;
         engineFactory.setQueueMode(queueMode);
 
         // Create client

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/sql/OtaLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/sql/OtaLwM2MIntegrationTest.java
@@ -59,7 +59,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_WITHOUT_FW_INFO));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO);
-        createNewClient(SECURITY_NO_SEC,  null, COAP_CONFIG, false, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO, null);
+        createNewClient(SECURITY_NO_SEC,  null, COAP_CONFIG, false, this.CLIENT_ENDPOINT_WITHOUT_FW_INFO);
         awaitObserveReadAll(0, device.getId().getId().toString());
 
         device.setFirmwareId(createFirmware().getId());
@@ -84,7 +84,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_OTA5));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_OTA5);
-        createNewClient(SECURITY_NO_SEC, null,  COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA5, null);
+        createNewClient(SECURITY_NO_SEC, null,  COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA5);
         awaitObserveReadAll(9, device.getId().getId().toString());
 
         device.setFirmwareId(createFirmware().getId());
@@ -114,7 +114,7 @@ public class OtaLwM2MIntegrationTest extends AbstractOtaLwM2MIntegrationTest {
         createDeviceProfile(transportConfiguration);
         LwM2MDeviceCredentials deviceCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(this.CLIENT_ENDPOINT_OTA9));
         final Device device = createDevice(deviceCredentials, this.CLIENT_ENDPOINT_OTA9);
-        createNewClient(SECURITY_NO_SEC, null, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA9, null);
+        createNewClient(SECURITY_NO_SEC, null, COAP_CONFIG, false, this.CLIENT_ENDPOINT_OTA9);
         awaitObserveReadAll(9, device.getId().getId().toString());
 
         device.setSoftwareId(createSoftware().getId());

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/AbstractRpcLwM2MIntegrationTest.java
@@ -91,7 +91,7 @@ public abstract class AbstractRpcLwM2MIntegrationTest extends AbstractLwM2MInteg
 
     private void initRpc () throws Exception {
         String endpoint = DEVICE_ENDPOINT_RPC_PREF + endpointSequence.incrementAndGet();
-        createNewClient(SECURITY_NO_SEC, null, COAP_CONFIG, true, endpoint, null);
+        createNewClient(SECURITY_NO_SEC, null, COAP_CONFIG, true, endpoint);
         expectedObjects = ConcurrentHashMap.newKeySet();
         expectedObjectIdVers = ConcurrentHashMap.newKeySet();
         expectedInstances = ConcurrentHashMap.newKeySet();

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/AbstractSecurityLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/AbstractSecurityLwM2MIntegrationTest.java
@@ -196,7 +196,7 @@ public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2M
                                        boolean isStartLw) throws Exception {
         createDeviceProfile(transportConfiguration);
         final Device device = createDevice(deviceCredentials, endpoint);
-        createNewClient(security, securityBs, coapConfig, true, endpoint, null);
+        createNewClient(security, securityBs, coapConfig, true, endpoint);
         lwM2MTestClient.start(isStartLw);
         if (isAwaitObserveReadAll) {
             awaitObserveReadAll(0, device.getId().getId().toString());
@@ -244,7 +244,7 @@ public abstract class AbstractSecurityLwM2MIntegrationTest extends AbstractLwM2M
         createDeviceProfile(transportConfiguration);
         final Device device = createDevice(deviceCredentials, endpoint);
         String deviceIdStr = device.getId().getId().toString();
-        createNewClient(security, securityBs, coapConfig, true, endpoint, null);
+        createNewClient(security, securityBs, coapConfig, true, endpoint);
         lwM2MTestClient.start(true);
         awaitObserveReadAll(0, deviceIdStr);
         await(awaitAlias)

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/NoSecLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/security/sql/NoSecLwM2MIntegrationTest.java
@@ -32,7 +32,13 @@ public class NoSecLwM2MIntegrationTest extends AbstractSecurityLwM2MIntegrationT
     public void testWithNoSecConnectLwm2mSuccessAndObserveTelemetry() throws Exception {
         String clientEndpoint = CLIENT_ENDPOINT_NO_SEC;
         LwM2MDeviceCredentials clientCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(clientEndpoint));
-        super.basicTestConnectionObserveTelemetry(SECURITY_NO_SEC, clientCredentials, COAP_CONFIG, clientEndpoint);
+        super.basicTestConnectionObserveTelemetry(SECURITY_NO_SEC, clientCredentials, COAP_CONFIG, clientEndpoint, false);
+    }
+    @Test
+    public void testWithNoSecQueueModeConnectLwm2mSuccessAndObserveTelemetry() throws Exception {
+        String clientEndpoint = CLIENT_ENDPOINT_NO_SEC + "_QueueMode";
+        LwM2MDeviceCredentials clientCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(clientEndpoint));
+        super.basicTestConnectionObserveTelemetry(SECURITY_NO_SEC, clientCredentials, COAP_CONFIG, clientEndpoint, true);
     }
 
     // Bootstrap + Lwm2m

--- a/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/client/DefaultCoapClientContext.java
+++ b/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/client/DefaultCoapClientContext.java
@@ -18,7 +18,6 @@ package org.thingsboard.server.transport.coap.client;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.californium.core.coap.CoAP;
-import org.eclipse.californium.core.coap.CoAP.ResponseCode;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.observe.ObserveRelation;
 import org.eclipse.californium.core.server.resources.CoapExchange;
@@ -222,7 +221,7 @@ public class DefaultCoapClientContext implements CoapClientContext {
     private void onUplink(TbCoapClientState client, boolean notifyOtherServers, long uplinkTs) {
         PowerMode powerMode = client.getPowerMode();
         PowerSavingConfiguration profileSettings = null;
-        if (powerMode == null) {
+        if (powerMode == null && client.getProfileId() != null) {
             var clientProfile = getProfile(client.getProfileId());
             if (clientProfile.isPresent()) {
                 profileSettings = clientProfile.get().getClientSettings();
@@ -736,7 +735,7 @@ public class DefaultCoapClientContext implements CoapClientContext {
     private boolean isDownlinkAllowed(TbCoapClientState client) {
         PowerMode powerMode = client.getPowerMode();
         PowerSavingConfiguration profileSettings = null;
-        if (powerMode == null) {
+        if (powerMode == null && client.getProfileId() != null) {
             var clientProfile = getProfile(client.getProfileId());
             if (clientProfile.isPresent()) {
                 profileSettings = clientProfile.get().getClientSettings();
@@ -785,11 +784,12 @@ public class DefaultCoapClientContext implements CoapClientContext {
     private PowerMode getPowerMode(TbCoapClientState client) {
         PowerMode powerMode = client.getPowerMode();
         if (powerMode == null) {
-            Optional<CoapDeviceProfileTransportConfiguration> deviceProfile = getProfile(client.getProfileId());
-            if (deviceProfile.isPresent()) {
-                powerMode = deviceProfile.get().getClientSettings().getPowerMode();
-            } else {
-                powerMode = PowerMode.PSM;
+            powerMode = PowerMode.PSM;
+            if (client.getProfileId() != null) {
+                Optional<CoapDeviceProfileTransportConfiguration> deviceProfile = getProfile(client.getProfileId());
+                if (deviceProfile.isPresent()) {
+                    powerMode = deviceProfile.get().getClientSettings().getPowerMode();
+                }
             }
         }
         return powerMode;

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClientContextImpl.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClientContextImpl.java
@@ -461,11 +461,15 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
         PowerMode powerMode = client.getPowerMode();
         OtherConfiguration profileSettings = null;
         if (powerMode == null) {
-            var clientProfile = getProfile(client.getProfileId());
-            profileSettings = clientProfile.getClientLwM2mSettings();
-            powerMode = profileSettings.getPowerMode();
-            if (powerMode == null) {
+            if (client.getProfileId() == null) {
                 powerMode = PowerMode.DRX;
+            } else {
+                var clientProfile = getProfile(client.getProfileId());
+                profileSettings = clientProfile.getClientLwM2mSettings();
+                powerMode = profileSettings.getPowerMode();
+                if (powerMode == null) {
+                    powerMode = PowerMode.DRX;
+                }
             }
         }
         if (PowerMode.DRX.equals(powerMode)) {

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClientContextImpl.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClientContextImpl.java
@@ -411,15 +411,12 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
     public boolean isDownlinkAllowed(LwM2mClient client) {
         PowerMode powerMode = client.getPowerMode();
         OtherConfiguration profileSettings = null;
-        if (powerMode == null) {
+        if (powerMode == null && client.getProfileId() != null) {
             var clientProfile = getProfile(client.getProfileId());
             profileSettings = clientProfile.getClientLwM2mSettings();
             powerMode = profileSettings.getPowerMode();
-            if (powerMode == null) {
-                powerMode = PowerMode.DRX;
-            }
         }
-        if (PowerMode.DRX.equals(powerMode) || otaUpdateService.isOtaDownloading(client)) {
+        if (powerMode == null || PowerMode.DRX.equals(powerMode) || otaUpdateService.isOtaDownloading(client)) {
             return true;
         }
         client.lock();
@@ -460,19 +457,12 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
     public void onUplink(LwM2mClient client) {
         PowerMode powerMode = client.getPowerMode();
         OtherConfiguration profileSettings = null;
-        if (powerMode == null) {
-            if (client.getProfileId() == null) {
-                powerMode = PowerMode.DRX;
-            } else {
-                var clientProfile = getProfile(client.getProfileId());
-                profileSettings = clientProfile.getClientLwM2mSettings();
-                powerMode = profileSettings.getPowerMode();
-                if (powerMode == null) {
-                    powerMode = PowerMode.DRX;
-                }
-            }
+        if (powerMode == null && client.getProfileId() != null) {
+            var clientProfile = getProfile(client.getProfileId());
+            profileSettings = clientProfile.getClientLwM2mSettings();
+            powerMode = profileSettings.getPowerMode();
         }
-        if (PowerMode.DRX.equals(powerMode)) {
+        if (powerMode == null || PowerMode.DRX.equals(powerMode)) {
             client.updateLastUplinkTime();
             return;
         }


### PR DESCRIPTION
## Pull Request description

Tetsts

before:

```
2024-02-13 14:57:26,988 [test-lwm2m-scheduled-53-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Registered with location '/rd/yUrp8EIjLS'.
2024-02-13 14:57:26,988 [test-lwm2m-scheduled-53-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Next registration update to coap://localhost:5685 in 5s...
2024-02-13 14:57:26,991 [CoapServer(main)#5] ERROR o.e.l.core.response.SendableResponse - Exception while calling the reponse sent callback
java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "key" is null
	at java.base/java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at org.thingsboard.server.transport.lwm2m.server.client.LwM2mClientContextImpl.doGetAndCache(LwM2mClientContextImpl.java:373)
	at org.thingsboard.server.transport.lwm2m.server.client.LwM2mClientContextImpl.getProfile(LwM2mClientContextImpl.java:362)
```

after:
```

2024-02-13 15:00:20,064 [HikariPool-1 housekeeper] WARN  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Thread starvation or clock leap detected (housekeeper delta=51s901ms746µs504ns).
2024-02-13 15:00:20,071 [test-lwm2m-scheduled-53-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Registered with location '/rd/sGJqxvEGYi'.
2024-02-13 15:00:20,073 [test-lwm2m-scheduled-53-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Next registration update to coap://localhost:5685 in 5s...
2024-02-13 15:00:29,643 [test-lwm2m-scheduled-53-thread-5] INFO  o.e.l.c.e.DefaultRegistrationEngine - Trying to update registration to coap://localhost:5685 (response timeout 120000ms)...
2024-02-13 15:00:37,551 [test-lwm2m-scheduled-53-thread-5] INFO  o.e.l.c.e.DefaultRegistrationEngine - Registration update succeed.
2024-02-13 15:00:37,552 [test-lwm2m-scheduled-53-thread-5] INFO  o.e.l.c.e.DefaultRegistrationEngine - Next registration update to coap://localhost:5685 in 5s...
2024-02-13 15:00:38,080 [LwM2M uplink-0-1] INFO  o.t.s.t.l.s.u.DefaultLwM2mUplinkMsgHandler - [LwNoSec00000000_QueueMode] [{sGJqxvEGYi] Client: update after Registration
2024-02-13 15:00:39,211 [LwM2M uplink-0-1] DEBUG o.t.s.t.l.s.u.DefaultLwM2mUplinkMsgHandler - [LwNoSec00000000_QueueMode] [{sGJqxvEGYi] Client: create after Registration
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



