### PR TITLE
fix_bug_lwm2m/coap_client_queue_Mode

### DIFF
--- a/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/client/DefaultCoapClientContext.java
+++ b/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/client/DefaultCoapClientContext.java
@@ -220,7 +220,7 @@ public class DefaultCoapClientContext implements CoapClientContext {
     private void onUplink(TbCoapClientState client, boolean notifyOtherServers, long uplinkTs) {
         PowerMode powerMode = client.getPowerMode();
         PowerSavingConfiguration profileSettings = null;
-        if (powerMode == null) {
+        if (powerMode == null && client.getProfileId() != null) {
             var clientProfile = getProfile(client.getProfileId());
             if (clientProfile.isPresent()) {
                 profileSettings = clientProfile.get().getClientSettings();
@@ -726,7 +726,7 @@ public class DefaultCoapClientContext implements CoapClientContext {
     private boolean isDownlinkAllowed(TbCoapClientState client) {
         PowerMode powerMode = client.getPowerMode();
         PowerSavingConfiguration profileSettings = null;
-        if (powerMode == null) {
+        if (powerMode == null && client.getProfileId() != null) {
             var clientProfile = getProfile(client.getProfileId());
             if (clientProfile.isPresent()) {
                 profileSettings = clientProfile.get().getClientSettings();
@@ -775,11 +775,12 @@ public class DefaultCoapClientContext implements CoapClientContext {
     private PowerMode getPowerMode(TbCoapClientState client) {
         PowerMode powerMode = client.getPowerMode();
         if (powerMode == null) {
-            Optional<CoapDeviceProfileTransportConfiguration> deviceProfile = getProfile(client.getProfileId());
-            if (deviceProfile.isPresent()) {
-                powerMode = deviceProfile.get().getClientSettings().getPowerMode();
-            } else {
-                powerMode = PowerMode.PSM;
+            powerMode = PowerMode.PSM;
+            if (client.getProfileId() != null) {
+                Optional<CoapDeviceProfileTransportConfiguration> deviceProfile = getProfile(client.getProfileId());
+                if (deviceProfile.isPresent()) {
+                    powerMode = deviceProfile.get().getClientSettings().getPowerMode();
+                }
             }
         }
         return powerMode;

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClientContextImpl.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClientContextImpl.java
@@ -411,7 +411,7 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
     public boolean isDownlinkAllowed(LwM2mClient client) {
         PowerMode powerMode = client.getPowerMode();
         OtherConfiguration profileSettings = null;
-        if (powerMode == null) {
+        if (powerMode == null && client.getProfileId() != null) {
             var clientProfile = getProfile(client.getProfileId());
             profileSettings = clientProfile.getClientLwM2mSettings();
             powerMode = profileSettings.getPowerMode();
@@ -419,7 +419,7 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
                 powerMode = PowerMode.DRX;
             }
         }
-        if (PowerMode.DRX.equals(powerMode) || otaUpdateService.isOtaDownloading(client)) {
+        if (powerMode == null || PowerMode.DRX.equals(powerMode) || otaUpdateService.isOtaDownloading(client)) {
             return true;
         }
         client.lock();
@@ -460,7 +460,7 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
     public void onUplink(LwM2mClient client) {
         PowerMode powerMode = client.getPowerMode();
         OtherConfiguration profileSettings = null;
-        if (powerMode == null) {
+        if (powerMode == null && client.getProfileId() != null) {
             var clientProfile = getProfile(client.getProfileId());
             profileSettings = clientProfile.getClientLwM2mSettings();
             powerMode = profileSettings.getPowerMode();
@@ -468,7 +468,7 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
                 powerMode = PowerMode.DRX;
             }
         }
-        if (PowerMode.DRX.equals(powerMode)) {
+        if (powerMode == null || PowerMode.DRX.equals(powerMode)) {
             client.updateLastUplinkTime();
             return;
         }


### PR DESCRIPTION
## Pull Request description

https://thingsboard-portal.atlassian.net/browse/PROD-2892

before:

```
2024-02-13 14:57:26,988 [test-lwm2m-scheduled-53-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Registered with location '/rd/yUrp8EIjLS'.
2024-02-13 14:57:26,988 [test-lwm2m-scheduled-53-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Next registration update to coap://localhost:5685 in 5s...
2024-02-13 14:57:26,991 [CoapServer(main)#5] ERROR o.e.l.core.response.SendableResponse - Exception while calling the reponse sent callback
java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "key" is null
	at java.base/java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at org.thingsboard.server.transport.lwm2m.server.client.LwM2mClientContextImpl.doGetAndCache(LwM2mClientContextImpl.java:373)
	at org.thingsboard.server.transport.lwm2m.server.client.LwM2mClientContextImpl.getProfile(LwM2mClientContextImpl.java:362)
```


after:
```

2024-02-13 15:00:20,064 [HikariPool-1 housekeeper] WARN  com.zaxxer.hikari.pool.HikariPool - HikariPool-1 - Thread starvation or clock leap detected (housekeeper delta=51s901ms746µs504ns).
2024-02-13 15:00:20,071 [test-lwm2m-scheduled-53-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Registered with location '/rd/sGJqxvEGYi'.
2024-02-13 15:00:20,073 [test-lwm2m-scheduled-53-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Next registration update to coap://localhost:5685 in 5s...
2024-02-13 15:00:29,643 [test-lwm2m-scheduled-53-thread-5] INFO  o.e.l.c.e.DefaultRegistrationEngine - Trying to update registration to coap://localhost:5685 (response timeout 120000ms)...
2024-02-13 15:00:37,551 [test-lwm2m-scheduled-53-thread-5] INFO  o.e.l.c.e.DefaultRegistrationEngine - Registration update succeed.
2024-02-13 15:00:37,552 [test-lwm2m-scheduled-53-thread-5] INFO  o.e.l.c.e.DefaultRegistrationEngine - Next registration update to coap://localhost:5685 in 5s...
2024-02-13 15:00:38,080 [LwM2M uplink-0-1] INFO  o.t.s.t.l.s.u.DefaultLwM2mUplinkMsgHandler - [LwNoSec00000000_QueueMode] [{sGJqxvEGYi] Client: update after Registration
2024-02-13 15:00:39,211 [LwM2M uplink-0-1] DEBUG o.t.s.t.l.s.u.DefaultLwM2mUplinkMsgHandler - [LwNoSec00000000_QueueMode] [{sGJqxvEGYi] Client: create after Registration
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
 
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



