### PR TITLE
Mapping of command id to unique sequence number per subscription id

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscription.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscription.java
@@ -36,8 +36,6 @@ public abstract class TbSubscription<T> {
     private final TbSubscriptionType type;
     private final BiConsumer<TbSubscription<T>, T> updateProcessor;
 
-    protected final AtomicInteger sequence = new AtomicInteger();
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/application/src/main/java/org/thingsboard/server/service/ws/DefaultWebSocketService.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/DefaultWebSocketService.java
@@ -259,13 +259,13 @@ public class DefaultWebSocketService implements WebSocketService {
     }
 
     @Override
-    public void sendUpdate(String sessionId, TelemetrySubscriptionUpdate update) {
-        sendUpdate(sessionId, update.getSubscriptionId(), update);
+    public void sendUpdate(String sessionId, int cmdId, TelemetrySubscriptionUpdate update) {
+        doSendUpdate(sessionId, cmdId, update);
     }
 
     @Override
     public void sendUpdate(String sessionId, CmdUpdate update) {
-        sendUpdate(sessionId, update.getCmdId(), update);
+        doSendUpdate(sessionId, update.getCmdId(), update);
     }
 
     @Override
@@ -274,7 +274,7 @@ public class DefaultWebSocketService implements WebSocketService {
         sendUpdate(sessionRef, update);
     }
 
-    private <T> void sendUpdate(String sessionId, int cmdId, T update) {
+    private <T> void doSendUpdate(String sessionId, int cmdId, T update) {
         WsSessionMetaData md = wsSessionsMap.get(sessionId);
         if (md != null) {
             sendUpdate(md.getSessionRef(), cmdId, update);
@@ -288,7 +288,7 @@ public class DefaultWebSocketService implements WebSocketService {
             try {
                 msgEndpoint.close(md.getSessionRef(), status);
             } catch (IOException e) {
-                log.warn("[{}] Failed to send session close: {}", sessionId, e);
+                log.warn("[{}] Failed to send session close", sessionId, e);
             }
         }
     }
@@ -439,7 +439,7 @@ public class DefaultWebSocketService implements WebSocketService {
                 TbAttributeSubscription sub = TbAttributeSubscription.builder()
                         .serviceId(serviceId)
                         .sessionId(sessionId)
-                        .subscriptionId(cmd.getCmdId())
+                        .subscriptionId(sessionRef.getSessionSubIdSeq().incrementAndGet())
                         .tenantId(sessionRef.getSecurityCtx().getTenantId())
                         .entityId(entityId)
                         .queryTs(queryTs)
@@ -449,7 +449,7 @@ public class DefaultWebSocketService implements WebSocketService {
                         .updateProcessor((subscription, update) -> {
                             subLock.lock();
                             try {
-                                sendUpdate(subscription.getSessionId(), update);
+                                sendUpdate(subscription.getSessionId(), cmd.getCmdId(), update);
                             } finally {
                                 subLock.unlock();
                             }
@@ -545,7 +545,7 @@ public class DefaultWebSocketService implements WebSocketService {
                 TbAttributeSubscription sub = TbAttributeSubscription.builder()
                         .serviceId(serviceId)
                         .sessionId(sessionId)
-                        .subscriptionId(cmd.getCmdId())
+                        .subscriptionId(sessionRef.getSessionSubIdSeq().incrementAndGet())
                         .tenantId(sessionRef.getSecurityCtx().getTenantId())
                         .entityId(entityId)
                         .queryTs(queryTs)
@@ -554,7 +554,7 @@ public class DefaultWebSocketService implements WebSocketService {
                         .updateProcessor((subscription, update) -> {
                             subLock.lock();
                             try {
-                                sendUpdate(subscription.getSessionId(), update);
+                                sendUpdate(subscription.getSessionId(), cmd.getCmdId(), update);
                             } finally {
                                 subLock.unlock();
                             }
@@ -643,13 +643,13 @@ public class DefaultWebSocketService implements WebSocketService {
                 TbTimeSeriesSubscription sub = TbTimeSeriesSubscription.builder()
                         .serviceId(serviceId)
                         .sessionId(sessionId)
-                        .subscriptionId(cmd.getCmdId())
+                        .subscriptionId(sessionRef.getSessionSubIdSeq().incrementAndGet())
                         .tenantId(sessionRef.getSecurityCtx().getTenantId())
                         .entityId(entityId)
                         .updateProcessor((subscription, update) -> {
                             subLock.lock();
                             try {
-                                sendUpdate(subscription.getSessionId(), update);
+                                sendUpdate(subscription.getSessionId(), cmd.getCmdId(), update);
                             } finally {
                                 subLock.unlock();
                             }
@@ -698,13 +698,13 @@ public class DefaultWebSocketService implements WebSocketService {
                 TbTimeSeriesSubscription sub = TbTimeSeriesSubscription.builder()
                         .serviceId(serviceId)
                         .sessionId(sessionId)
-                        .subscriptionId(cmd.getCmdId())
+                        .subscriptionId(sessionRef.getSessionSubIdSeq().incrementAndGet())
                         .tenantId(sessionRef.getSecurityCtx().getTenantId())
                         .entityId(entityId)
                         .updateProcessor((subscription, update) -> {
                             subLock.lock();
                             try {
-                                sendUpdate(subscription.getSessionId(), update);
+                                sendUpdate(subscription.getSessionId(), cmd.getCmdId(), update);
                             } finally {
                                 subLock.unlock();
                             }
@@ -836,7 +836,7 @@ public class DefaultWebSocketService implements WebSocketService {
                     try {
                         msgEndpoint.sendPing(md.getSessionRef(), currentTime);
                     } catch (IOException e) {
-                        log.warn("[{}] Failed to send ping: {}", md.getSessionRef().getSessionId(), e);
+                        log.warn("[{}] Failed to send ping:", md.getSessionRef().getSessionId(), e);
                     }
                 }));
     }

--- a/application/src/main/java/org/thingsboard/server/service/ws/WebSocketService.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/WebSocketService.java
@@ -29,7 +29,7 @@ public interface WebSocketService {
 
     void handleCommands(WebSocketSessionRef sessionRef, WsCommandsWrapper commandsWrapper);
 
-    void sendUpdate(String sessionId, TelemetrySubscriptionUpdate update);
+    void sendUpdate(String sessionId, int cmdId, TelemetrySubscriptionUpdate update);
 
     void sendUpdate(String sessionId, CmdUpdate update);
 

--- a/application/src/main/java/org/thingsboard/server/service/ws/notification/DefaultNotificationCommandsHandler.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/notification/DefaultNotificationCommandsHandler.java
@@ -115,7 +115,7 @@ public class DefaultNotificationCommandsHandler implements NotificationCommandsH
     private void fetchUnreadNotificationsCount(NotificationsCountSubscription subscription) {
         log.trace("[{}, subId: {}] Fetching unread notifications count from DB", subscription.getSessionId(), subscription.getSubscriptionId());
         int unreadCount = notificationService.countUnreadNotificationsByRecipientId(subscription.getTenantId(), (UserId) subscription.getEntityId());
-        subscription.getUnreadCounter().set(unreadCount);
+        subscription.getTotalUnreadCounter().set(unreadCount);
     }
 
 
@@ -196,20 +196,20 @@ public class DefaultNotificationCommandsHandler implements NotificationCommandsH
     private void handleNotificationUpdate(NotificationsCountSubscription subscription, NotificationUpdate update) {
         log.trace("[{}, subId: {}] Handling notification update for count sub: {}", subscription.getSessionId(), subscription.getSubscriptionId(), update);
         if (update.isCreated()) {
-            subscription.getUnreadCounter().incrementAndGet();
+            subscription.getTotalUnreadCounter().incrementAndGet();
             sendUpdate(subscription.getSessionId(), subscription.createUpdate());
         } else if (update.isUpdated()) {
             if (update.getNewStatus() == NotificationStatus.READ) {
                 if (update.isAllNotifications()) {
                     fetchUnreadNotificationsCount(subscription);
                 } else {
-                    subscription.getUnreadCounter().decrementAndGet();
+                    subscription.getTotalUnreadCounter().decrementAndGet();
                 }
                 sendUpdate(subscription.getSessionId(), subscription.createUpdate());
             }
         } else if (update.isDeleted()) {
             if (update.getNotification().getStatus() != NotificationStatus.READ) {
-                subscription.getUnreadCounter().decrementAndGet();
+                subscription.getTotalUnreadCounter().decrementAndGet();
                 sendUpdate(subscription.getSessionId(), subscription.createUpdate());
             }
         }

--- a/application/src/main/java/org/thingsboard/server/service/ws/notification/sub/AbstractNotificationSubscription.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/notification/sub/AbstractNotificationSubscription.java
@@ -15,32 +15,24 @@
  */
 package org.thingsboard.server.service.ws.notification.sub;
 
-import lombok.Builder;
+
 import lombok.Getter;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.service.subscription.TbSubscription;
 import org.thingsboard.server.service.subscription.TbSubscriptionType;
-import org.thingsboard.server.service.ws.notification.cmd.UnreadNotificationsCountUpdate;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 @Getter
-public class NotificationsCountSubscription extends AbstractNotificationSubscription<NotificationsSubscriptionUpdate> {
+public abstract class AbstractNotificationSubscription<T> extends TbSubscription<T> {
 
-    @Builder
-    public NotificationsCountSubscription(String serviceId, String sessionId, int subscriptionId, TenantId tenantId, EntityId entityId,
-                                          BiConsumer<TbSubscription<NotificationsSubscriptionUpdate>, NotificationsSubscriptionUpdate> updateProcessor) {
-        super(serviceId, sessionId, subscriptionId, tenantId, entityId, TbSubscriptionType.NOTIFICATIONS_COUNT, updateProcessor);
-    }
+    protected final AtomicInteger sequence = new AtomicInteger();
+    protected final AtomicInteger totalUnreadCounter = new AtomicInteger();
 
-    public UnreadNotificationsCountUpdate createUpdate() {
-        return UnreadNotificationsCountUpdate.builder()
-                .cmdId(getSubscriptionId())
-                .totalUnreadCount(totalUnreadCounter.get())
-                .sequenceNumber(sequence.incrementAndGet())
-                .build();
+    public AbstractNotificationSubscription(String serviceId, String sessionId, int subscriptionId, TenantId tenantId, EntityId entityId, TbSubscriptionType type, BiConsumer<TbSubscription<T>, T> updateProcessor) {
+        super(serviceId, sessionId, subscriptionId, tenantId, entityId, type, updateProcessor);
     }
 
 }

--- a/application/src/main/java/org/thingsboard/server/service/ws/notification/sub/NotificationsSubscription.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/notification/sub/NotificationsSubscription.java
@@ -35,11 +35,10 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 @Getter
-public class NotificationsSubscription extends TbSubscription<NotificationsSubscriptionUpdate> {
+public class NotificationsSubscription extends AbstractNotificationSubscription<NotificationsSubscriptionUpdate> {
 
     private final Map<UUID, Notification> latestUnreadNotifications = new HashMap<>();
     private final int limit;
-    private final AtomicInteger totalUnreadCounter = new AtomicInteger();
 
     @Builder
     public NotificationsSubscription(String serviceId, String sessionId, int subscriptionId, TenantId tenantId, EntityId entityId,


### PR DESCRIPTION
This PR fixes quite a rare bug in our WebSocket API. All new widgets use the new WebSocket commands based on entity data queries and use separate atomic sequence numbers to generate internal subscription commands. Our old widgets used slightly different APIs that used cmdId from the incoming web socket message to generate internal subscription commands. In a rare case, when the dashboard has many widgets of both types, the race condition occurs, and both messages generate the same internal subscription commands. eventually, one of them was ignored. 
