### PR TITLE
Fixed typeList URL query and alarm filter config translation

### DIFF
--- a/ui-ngx/src/app/modules/home/components/alarm/alarm-filter-config.component.ts
+++ b/ui-ngx/src/app/modules/home/components/alarm/alarm-filter-config.component.ts
@@ -45,6 +45,7 @@ import { deepClone } from '@core/utils';
 import { EntityType } from '@shared/models/entity-type.models';
 import { fromEvent, Subscription } from 'rxjs';
 import { POSITION_MAP } from '@shared/models/overlay.models';
+import { UtilsService } from '@core/services/utils.service';
 
 export const ALARM_FILTER_CONFIG_DATA = new InjectionToken<any>('AlarmFilterConfigData');
 
@@ -127,7 +128,8 @@ export class AlarmFilterConfigComponent implements OnInit, OnDestroy, ControlVal
               private translate: TranslateService,
               private overlay: Overlay,
               private nativeElement: ElementRef,
-              private viewContainerRef: ViewContainerRef) {
+              private viewContainerRef: ViewContainerRef,
+              private utils: UtilsService) {
   }
 
   ngOnInit(): void {
@@ -298,7 +300,7 @@ export class AlarmFilterConfigComponent implements OnInit, OnDestroy, ControlVal
           this.translate.instant(alarmSeverityTranslations.get(s))).join(', '));
       }
       if (this.alarmFilterConfig?.typeList?.length) {
-        filterTextParts.push(this.alarmFilterConfig.typeList.join(', '));
+        filterTextParts.push(this.alarmFilterConfig.typeList.map((type) => this.customTranslate(type)).join(', '));
       }
       if (this.alarmFilterConfig?.assignedToCurrentUser) {
         filterTextParts.push(this.translate.instant('alarm.assigned-to-me'));
@@ -311,6 +313,10 @@ export class AlarmFilterConfigComponent implements OnInit, OnDestroy, ControlVal
         this.buttonDisplayValue = this.translate.instant('alarm.filter-title') + `: ${filterTextParts.join(', ')}`;
       }
     }
+  }
+
+  private customTranslate(entity: string) {
+    return this.utils.customTranslation(entity, entity);
   }
 
 }

--- a/ui-ngx/src/app/shared/models/alarm.models.ts
+++ b/ui-ngx/src/app/shared/models/alarm.models.ts
@@ -335,7 +335,7 @@ export class AlarmQueryV2 {
     let query = this.affectedEntityId ? `/${this.affectedEntityId.entityType}/${this.affectedEntityId.id}` : '';
     query += this.pageLink.toQuery();
     if (this.typeList && this.typeList.length) {
-      query += `&typeList=${this.typeList.join(',')}`;
+      query += `&typeList=${this.typeList.map(type => encodeURIComponent(type)).join(',')}`;
     }
     if (this.statusList && this.statusList.length) {
       query += `&statusList=${this.statusList.join(',')}`;


### PR DESCRIPTION
## Pull Request description

**BEFORE:**
<img width="1426" alt="image" src="https://github.com/thingsboard/thingsboard/assets/54553744/45db56ca-9cfa-4129-a4f0-b6b4eae4d0fe">
<img width="817" alt="image" src="https://github.com/thingsboard/thingsboard/assets/54553744/5d8f5447-a7f0-43af-99b5-b946e027c965">

**AFTER:**
<img width="1214" alt="image" src="https://github.com/thingsboard/thingsboard/assets/54553744/cbf751a9-4058-49af-a2e8-293135613c4c">
<img width="948" alt="image" src="https://github.com/thingsboard/thingsboard/assets/54553744/a1f1a23f-5b18-4491-9b57-270c4069b47b">


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



