### PR TITLE
Fixed background settings panel jump when edit content

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/background-settings-panel.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/background-settings-panel.component.html
@@ -17,49 +17,54 @@
 -->
 <div class="tb-background-settings-panel" [formGroup]="backgroundSettingsFormGroup">
   <div class="tb-background-settings-title" translate>widgets.background.background-settings</div>
-  <div class="tb-form-panel tb-background-form-panel">
-    <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="16px">
-      <div class="tb-form-panel-title" translate>widgets.background.background</div>
-      <tb-toggle-select formControlName="type" fxFlex selectMediaBreakpoint="xs">
-        <tb-toggle-option *ngFor="let type of backgroundTypes"
-                          [value]="type">
-          {{ backgroundTypeTranslationsMap.get(type) | translate }}
-        </tb-toggle-option>
-      </tb-toggle-select>
+  <div class="tb-background-settings-panel-content">
+    <div class="tb-form-panel tb-background-form-panel">
+      <div fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="16px">
+        <div class="tb-form-panel-title" translate>widgets.background.background</div>
+        <tb-toggle-select formControlName="type" fxFlex selectMediaBreakpoint="xs">
+          <tb-toggle-option *ngFor="let type of backgroundTypes"
+                            [value]="type">
+            {{ backgroundTypeTranslationsMap.get(type) | translate }}
+          </tb-toggle-option>
+        </tb-toggle-select>
+      </div>
+      <tb-gallery-image-input [fxShow]="backgroundSettingsFormGroup.get('type').value === backgroundType.image"
+                              formControlName="imageUrl"></tb-gallery-image-input>
+      <div [fxShow]="backgroundSettingsFormGroup.get('type').value === backgroundType.color"
+           class="tb-form-row space-between tb-background-color-field">
+        <div translate>widgets.color.color</div>
+        <tb-color-input asBoxInput
+                        formControlName="color">
+        </tb-color-input>
+      </div>
     </div>
-    <tb-gallery-image-input [fxShow]="backgroundSettingsFormGroup.get('type').value === backgroundType.image" formControlName="imageUrl"></tb-gallery-image-input>
-    <div [fxShow]="backgroundSettingsFormGroup.get('type').value === backgroundType.color" class="tb-form-row space-between tb-background-color-field">
-      <div translate>widgets.color.color</div>
-      <tb-color-input asBoxInput
-                      formControlName="color">
-      </tb-color-input>
+    <div class="tb-form-panel" formGroupName="overlay">
+      <div class="tb-form-panel-title" translate>widgets.background.overlay</div>
+      <mat-slide-toggle class="mat-slide" formControlName="enabled">
+        {{ 'widgets.background.enable-overlay' | translate }}
+      </mat-slide-toggle>
+      <div class="tb-form-row space-between">
+        <div translate>widgets.color.color</div>
+        <tb-color-input asBoxInput
+                        formControlName="color">
+        </tb-color-input>
+      </div>
+      <div class="tb-form-row space-between">
+        <div translate>widgets.background.blur</div>
+        <mat-form-field appearance="outline" class="number" subscriptSizing="dynamic">
+          <input matInput formControlName="blur" type="number" min="0" step="1"
+                 placeholder="{{ 'widget-config.set' | translate }}">
+          <div matSuffix>px</div>
+        </mat-form-field>
+      </div>
     </div>
-  </div>
-  <div class="tb-form-panel" formGroupName="overlay">
-    <div class="tb-form-panel-title" translate>widgets.background.overlay</div>
-    <mat-slide-toggle class="mat-slide" formControlName="enabled">
-      {{ 'widgets.background.enable-overlay' | translate }}
-    </mat-slide-toggle>
-    <div class="tb-form-row space-between">
-      <div translate>widgets.color.color</div>
-      <tb-color-input asBoxInput
-                      formControlName="color">
-      </tb-color-input>
-    </div>
-    <div class="tb-form-row space-between">
-      <div translate>widgets.background.blur</div>
-      <mat-form-field appearance="outline" class="number" subscriptSizing="dynamic">
-        <input matInput formControlName="blur" type="number" min="0" step="1" placeholder="{{ 'widget-config.set' | translate }}">
-        <div matSuffix>px</div>
-      </mat-form-field>
-    </div>
-  </div>
-  <div class="tb-background-settings-preview">
-    <div class="tb-background-settings-preview-title" translate>
-      widgets.background.preview
-    </div>
-    <div class="tb-background-settings-preview-box mat-elevation-z4" [style]="backgroundStyle$ | async">
-      <div class="tb-background-settings-preview-overlay" [style]="overlayStyle">
+    <div class="tb-background-settings-preview">
+      <div class="tb-background-settings-preview-title" translate>
+        widgets.background.preview
+      </div>
+      <div class="tb-background-settings-preview-box mat-elevation-z4" [style]="backgroundStyle$ | async">
+        <div class="tb-background-settings-preview-overlay" [style]="overlayStyle">
+        </div>
       </div>
     </div>
   </div>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/background-settings-panel.component.scss
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/background-settings-panel.component.scss
@@ -67,6 +67,14 @@
     left: 7.998px;
     right: 7.998px;
   }
+  .tb-background-settings-panel-content {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    overflow: auto;
+    margin: -10px;
+    padding: 10px;
+  }
   .tb-background-settings-panel-buttons {
     height: 40px;
     display: flex;

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/background-settings.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/background-settings.component.ts
@@ -110,7 +110,7 @@ export class BackgroundSettingsComponent implements OnInit, ControlValueAccessor
         backgroundSettings: this.modelValue
       };
      const backgroundSettingsPanelPopover = this.popoverService.displayPopover(trigger, this.renderer,
-        this.viewContainerRef, BackgroundSettingsPanelComponent, 'left', true, null,
+        this.viewContainerRef, BackgroundSettingsPanelComponent, ['leftOnly', 'leftTopOnly', 'leftBottomOnly'], true, null,
         ctx,
         {},
         {}, {}, true);


### PR DESCRIPTION
## Pull Request description

Fixed that in some cases, editing the background settings on the panel began to change the position.
Responsiveness at small screen sizes has been improved.

**Before:**
![image](https://github.com/thingsboard/thingsboard/assets/18036670/f06ec8a4-6c12-4fa6-a3af-0514a056e4a8)

**After:**
![image](https://github.com/thingsboard/thingsboard/assets/18036670/1007b6a7-75e9-4c49-9136-9c6decee57b6)

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



