### PR TITLE
Fixed recalculation interval for none aggregation data

### DIFF
--- a/ui-ngx/src/app/core/api/data-aggregator.ts
+++ b/ui-ngx/src/app/core/api/data-aggregator.ts
@@ -83,7 +83,7 @@ class AggDataMap {
   }
 
   updateLastInterval(endTs: number) {
-    if (endTs > this.endTs) {
+    if (endTs > this.endTs && this.subsTw.aggregation.type !== AggregationType.NONE) {
       this.endTs = endTs;
       const lastTs = this.map.maxKey();
       if (lastTs) {


### PR DESCRIPTION
## Pull Request description

In the current realization `updateLastInterval` function recalculates the interval even for none aggregation data. As a result, some widgets have visual bugs, for example, bar chart redrawing last bar two times. 

![image](https://github.com/thingsboard/thingsboard/assets/43555187/8bc51c72-e26e-4882-a06d-8baf999b92d7)
Incorrect timestamp for last value

This PR prohibits recalculating last interval for none aggregation data


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



