### PR TITLE
Edge - fix incorrect inline image with cached entities

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/asset/AssetMsgConstructorV1.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/asset/AssetMsgConstructorV1.java
@@ -63,8 +63,8 @@ public class AssetMsgConstructorV1 extends BaseAssetMsgConstructor {
 
     @Override
     public AssetProfileUpdateMsg constructAssetProfileUpdatedMsg(UpdateMsgType msgType, AssetProfile assetProfile) {
-        AssetProfile copy = JacksonUtil.clone(assetProfile);
-        imageService.inlineImageForEdge(copy);
+        assetProfile = JacksonUtil.clone(assetProfile);
+        imageService.inlineImageForEdge(assetProfile);
         AssetProfileUpdateMsg.Builder builder = AssetProfileUpdateMsg.newBuilder()
                 .setMsgType(msgType)
                 .setIdMSB(assetProfile.getId().getId().getMostSignificantBits())
@@ -82,7 +82,7 @@ public class AssetMsgConstructorV1 extends BaseAssetMsgConstructor {
             builder.setDescription(assetProfile.getDescription());
         }
         if (assetProfile.getImage() != null) {
-            builder.setImage(ByteString.copyFrom(copy.getImage().getBytes(StandardCharsets.UTF_8)));
+            builder.setImage(ByteString.copyFrom(assetProfile.getImage().getBytes(StandardCharsets.UTF_8)));
         }
         if (assetProfile.getDefaultEdgeRuleChainId() != null) {
             builder.setDefaultRuleChainIdMSB(assetProfile.getDefaultEdgeRuleChainId().getId().getMostSignificantBits())
@@ -90,4 +90,5 @@ public class AssetMsgConstructorV1 extends BaseAssetMsgConstructor {
         }
         return builder.build();
     }
+
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/dashboard/DashboardMsgConstructorV1.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/dashboard/DashboardMsgConstructorV1.java
@@ -33,8 +33,8 @@ public class DashboardMsgConstructorV1 extends BaseDashboardMsgConstructor {
 
     @Override
     public DashboardUpdateMsg constructDashboardUpdatedMsg(UpdateMsgType msgType, Dashboard dashboard) {
-        Dashboard copy = JacksonUtil.clone(dashboard);
-        imageService.inlineImagesForEdge(copy);
+        dashboard = JacksonUtil.clone(dashboard);
+        imageService.inlineImagesForEdge(dashboard);
         DashboardUpdateMsg.Builder builder = DashboardUpdateMsg.newBuilder()
                 .setMsgType(msgType)
                 .setIdMSB(dashboard.getId().getId().getMostSignificantBits())
@@ -46,11 +46,12 @@ public class DashboardMsgConstructorV1 extends BaseDashboardMsgConstructor {
             builder.setAssignedCustomers(JacksonUtil.toString(dashboard.getAssignedCustomers()));
         }
         if (dashboard.getImage() != null) {
-            builder.setImage(copy.getImage());
+            builder.setImage(dashboard.getImage());
         }
         if (dashboard.getMobileOrder() != null) {
             builder.setMobileOrder(dashboard.getMobileOrder());
         }
         return builder.build();
     }
+
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/device/DeviceMsgConstructorV1.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/device/DeviceMsgConstructorV1.java
@@ -95,8 +95,8 @@ public class DeviceMsgConstructorV1 extends BaseDeviceMsgConstructor {
 
     @Override
     public DeviceProfileUpdateMsg constructDeviceProfileUpdatedMsg(UpdateMsgType msgType, DeviceProfile deviceProfile) {
-        DeviceProfile copy = JacksonUtil.clone(deviceProfile);
-        imageService.inlineImageForEdge(copy);
+        deviceProfile = JacksonUtil.clone(deviceProfile);
+        imageService.inlineImageForEdge(deviceProfile);
         DeviceProfileUpdateMsg.Builder builder = DeviceProfileUpdateMsg.newBuilder()
                 .setMsgType(msgType)
                 .setIdMSB(deviceProfile.getId().getId().getMostSignificantBits())
@@ -121,7 +121,7 @@ public class DeviceMsgConstructorV1 extends BaseDeviceMsgConstructor {
             builder.setProvisionDeviceKey(deviceProfile.getProvisionDeviceKey());
         }
         if (deviceProfile.getImage() != null) {
-            builder.setImage(ByteString.copyFrom(copy.getImage().getBytes(StandardCharsets.UTF_8)));
+            builder.setImage(ByteString.copyFrom(deviceProfile.getImage().getBytes(StandardCharsets.UTF_8)));
         }
         if (deviceProfile.getFirmwareId() != null) {
             builder.setFirmwareIdMSB(deviceProfile.getFirmwareId().getId().getMostSignificantBits())
@@ -141,4 +141,5 @@ public class DeviceMsgConstructorV1 extends BaseDeviceMsgConstructor {
         }
         return builder.build();
     }
+
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/widget/WidgetMsgConstructorV1.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/constructor/widget/WidgetMsgConstructorV1.java
@@ -43,8 +43,8 @@ public class WidgetMsgConstructorV1 extends BaseWidgetMsgConstructor {
 
     @Override
     public WidgetsBundleUpdateMsg constructWidgetsBundleUpdateMsg(UpdateMsgType msgType, WidgetsBundle widgetsBundle, List<String> widgets) {
-        WidgetsBundle copy = JacksonUtil.clone(widgetsBundle);
-        imageService.inlineImageForEdge(copy);
+        widgetsBundle = JacksonUtil.clone(widgetsBundle);
+        imageService.inlineImageForEdge(widgetsBundle);
         WidgetsBundleUpdateMsg.Builder builder = WidgetsBundleUpdateMsg.newBuilder()
                 .setMsgType(msgType)
                 .setIdMSB(widgetsBundle.getId().getId().getMostSignificantBits())
@@ -52,7 +52,7 @@ public class WidgetMsgConstructorV1 extends BaseWidgetMsgConstructor {
                 .setTitle(widgetsBundle.getTitle())
                 .setAlias(widgetsBundle.getAlias());
         if (widgetsBundle.getImage() != null) {
-            builder.setImage(ByteString.copyFrom(copy.getImage().getBytes(StandardCharsets.UTF_8)));
+            builder.setImage(ByteString.copyFrom(widgetsBundle.getImage().getBytes(StandardCharsets.UTF_8)));
         }
         if (widgetsBundle.getDescription() != null) {
             builder.setDescription(widgetsBundle.getDescription());
@@ -69,8 +69,8 @@ public class WidgetMsgConstructorV1 extends BaseWidgetMsgConstructor {
 
     @Override
     public WidgetTypeUpdateMsg constructWidgetTypeUpdateMsg(UpdateMsgType msgType, WidgetTypeDetails widgetTypeDetails, EdgeVersion edgeVersion) {
-        WidgetTypeDetails copy = JacksonUtil.clone(widgetTypeDetails);
-        imageService.inlineImagesForEdge(copy);
+        widgetTypeDetails = JacksonUtil.clone(widgetTypeDetails);
+        imageService.inlineImagesForEdge(widgetTypeDetails);
         WidgetTypeUpdateMsg.Builder builder = WidgetTypeUpdateMsg.newBuilder()
                 .setMsgType(msgType)
                 .setIdMSB(widgetTypeDetails.getId().getId().getMostSignificantBits())
@@ -95,7 +95,7 @@ public class WidgetMsgConstructorV1 extends BaseWidgetMsgConstructor {
             builder.setIsSystem(true);
         }
         if (widgetTypeDetails.getImage() != null) {
-            builder.setImage(copy.getImage());
+            builder.setImage(widgetTypeDetails.getImage());
         }
         if (widgetTypeDetails.getDescription() != null) {
             if (EdgeVersionUtils.isEdgeVersionOlderThan(edgeVersion, EdgeVersion.V_3_6_0) &&
@@ -111,4 +111,5 @@ public class WidgetMsgConstructorV1 extends BaseWidgetMsgConstructor {
         }
         return builder.build();
     }
+
 }


### PR DESCRIPTION
## Pull Request description

When Caffeine cache is used, the cached value is directly updated in the edge processor. In this context, there's a shift to updating the value of images to base64 encoding rather than relying on the logoImageUrl.
![image](https://github.com/thingsboard/thingsboard/assets/50847617/81dbe603-7d2c-48d1-95f6-e7b0016b0b46)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).