### PR TITLE
Fixed TLS Factory error when no password set in configuration

### DIFF
--- a/common/util/src/main/java/org/thingsboard/common/util/SslUtil.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/SslUtil.java
@@ -73,7 +73,7 @@ public class SslUtil {
 
     @SneakyThrows
     public static PrivateKey readPrivateKey(String fileContent, String passStr) {
-        char[] password = StringUtils.isEmpty(passStr) ? EMPTY_PASS : passStr.toCharArray();
+        char[] password = getPassword(passStr);
 
         PrivateKey privateKey = null;
         JcaPEMKeyConverter keyConverter = new JcaPEMKeyConverter();
@@ -100,6 +100,10 @@ public class SslUtil {
             }
         }
         return privateKey;
+    }
+
+    public static char[] getPassword(String passStr) {
+        return StringUtils.isEmpty(passStr) ? EMPTY_PASS : passStr.toCharArray();
     }
 
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/credentials/CertPemCredentials.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/credentials/CertPemCredentials.java
@@ -87,7 +87,7 @@ public class CertPemCredentials implements ClientCredentials {
 
     private KeyManagerFactory createAndInitKeyManagerFactory() throws Exception {
         KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        kmf.init(loadKeyStore(), password.toCharArray());
+        kmf.init(loadKeyStore(), SslUtil.getPassword(password));
         return kmf;
     }
 
@@ -107,7 +107,7 @@ public class CertPemCredentials implements ClientCredentials {
             CertPath certPath = factory.generateCertPath(certificates);
             List<? extends Certificate> path = certPath.getCertificates();
             Certificate[] x509Certificates = path.toArray(new Certificate[0]);
-            keyStore.setKeyEntry(PRIVATE_KEY_ALIAS, privateKey, password.toCharArray(), x509Certificates);
+            keyStore.setKeyEntry(PRIVATE_KEY_ALIAS, privateKey, SslUtil.getPassword(password), x509Certificates);
         }
         return keyStore;
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNode.java
@@ -99,13 +99,13 @@ public class CalculateDeltaNode implements TbNode {
 
                     BigDecimal delta = BigDecimal.valueOf(previousData != null ? currentValue - previousData.value : 0.0);
 
-                    if (config.isOnlyComputeTrueDeltas() && delta.doubleValue() == 0) {
-                        ctx.tellSuccess(msg);
+                    if (config.isTellFailureIfDeltaIsNegative() && delta.doubleValue() < 0) {
+                        ctx.tellFailure(msg, new IllegalArgumentException("Delta value is negative!"));
                         return;
                     }
 
-                    if (config.isTellFailureIfDeltaIsNegative() && delta.doubleValue() < 0) {
-                        ctx.tellFailure(msg, new IllegalArgumentException("Delta value is negative!"));
+                    if (config.isExcludeZeroDeltasFromOutboundMessage() && delta.doubleValue() == 0) {
+                        ctx.tellSuccess(msg);
                         return;
                     }
 
@@ -141,10 +141,10 @@ public class CalculateDeltaNode implements TbNode {
         boolean hasChanges = false;
         switch (fromVersion) {
             case 0:
-                String onlyComputeTrueDeltas = "onlyComputeTrueDeltas";
-                if (!oldConfiguration.has(onlyComputeTrueDeltas)) {
+                String excludeZeroDeltasFromOutboundMessage = "excludeZeroDeltasFromOutboundMessage";
+                if (!oldConfiguration.has(excludeZeroDeltasFromOutboundMessage)) {
                     hasChanges = true;
-                    ((ObjectNode) oldConfiguration).put(onlyComputeTrueDeltas, false);
+                    ((ObjectNode) oldConfiguration).put(excludeZeroDeltasFromOutboundMessage, false);
                 }
                 break;
             default:

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNode.java
@@ -32,6 +32,7 @@ import org.thingsboard.server.common.data.kv.TsKvEntry;
 import org.thingsboard.server.common.data.msg.TbMsgType;
 import org.thingsboard.server.common.data.msg.TbNodeConnectionType;
 import org.thingsboard.server.common.data.plugin.ComponentType;
+import org.thingsboard.server.common.data.util.TbPair;
 import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.dao.timeseries.TimeseriesService;
 
@@ -46,7 +47,9 @@ import static org.thingsboard.common.util.DonAsynchron.withCallback;
 
 @Slf4j
 @RuleNode(type = ComponentType.ENRICHMENT,
-        name = "calculate delta", relationTypes = {TbNodeConnectionType.SUCCESS, TbNodeConnectionType.FAILURE, TbNodeConnectionType.OTHER},
+        name = "calculate delta",
+        version = 1,
+        relationTypes = {TbNodeConnectionType.SUCCESS, TbNodeConnectionType.FAILURE, TbNodeConnectionType.OTHER},
         configClazz = CalculateDeltaNodeConfiguration.class,
         nodeDescription = "Calculates delta and amount of time passed between previous timeseries key reading " +
                 "and current value for this key from the incoming message",
@@ -96,6 +99,11 @@ public class CalculateDeltaNode implements TbNode {
 
                     BigDecimal delta = BigDecimal.valueOf(previousData != null ? currentValue - previousData.value : 0.0);
 
+                    if (config.isOnlyComputeTrueDeltas() && delta.doubleValue() == 0) {
+                        ctx.tellSuccess(msg);
+                        return;
+                    }
+
                     if (config.isTellFailureIfDeltaIsNegative() && delta.doubleValue() < 0) {
                         ctx.tellFailure(msg, new IllegalArgumentException("Delta value is negative!"));
                         return;
@@ -126,6 +134,23 @@ public class CalculateDeltaNode implements TbNode {
         if (useCache) {
             cache.clear();
         }
+    }
+
+    @Override
+    public TbPair<Boolean, JsonNode> upgrade(int fromVersion, JsonNode oldConfiguration) throws TbNodeException {
+        boolean hasChanges = false;
+        switch (fromVersion) {
+            case 0:
+                String onlyComputeTrueDeltas = "onlyComputeTrueDeltas";
+                if (!oldConfiguration.has(onlyComputeTrueDeltas)) {
+                    hasChanges = true;
+                    ((ObjectNode) oldConfiguration).put(onlyComputeTrueDeltas, false);
+                }
+                break;
+            default:
+                break;
+        }
+        return new TbPair<>(hasChanges, oldConfiguration);
     }
 
     private ListenableFuture<ValueWithTs> fetchLatestValueAsync(EntityId entityId) {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNode.java
@@ -104,7 +104,7 @@ public class CalculateDeltaNode implements TbNode {
                         return;
                     }
 
-                    if (config.isExcludeZeroDeltasFromOutboundMessage() && delta.doubleValue() == 0) {
+                    if (config.isExcludeZeroDeltas() && delta.doubleValue() == 0) {
                         ctx.tellSuccess(msg);
                         return;
                     }
@@ -141,10 +141,10 @@ public class CalculateDeltaNode implements TbNode {
         boolean hasChanges = false;
         switch (fromVersion) {
             case 0:
-                String excludeZeroDeltasFromOutboundMessage = "excludeZeroDeltasFromOutboundMessage";
-                if (!oldConfiguration.has(excludeZeroDeltasFromOutboundMessage)) {
+                String excludeZeroDeltas = "excludeZeroDeltas";
+                if (!oldConfiguration.has(excludeZeroDeltas)) {
                     hasChanges = true;
-                    ((ObjectNode) oldConfiguration).put(excludeZeroDeltasFromOutboundMessage, false);
+                    ((ObjectNode) oldConfiguration).put(excludeZeroDeltas, false);
                 }
                 break;
             default:

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNodeConfiguration.java
@@ -30,7 +30,7 @@ public class CalculateDeltaNodeConfiguration implements NodeConfiguration<Calcul
     private String periodValueKey;
     private Integer round;
     private boolean tellFailureIfDeltaIsNegative;
-    private boolean excludeZeroDeltasFromOutboundMessage;
+    private boolean excludeZeroDeltas;
 
     @Override
     public CalculateDeltaNodeConfiguration defaultConfiguration() {
@@ -41,7 +41,7 @@ public class CalculateDeltaNodeConfiguration implements NodeConfiguration<Calcul
         configuration.setAddPeriodBetweenMsgs(false);
         configuration.setPeriodValueKey("periodInMs");
         configuration.setTellFailureIfDeltaIsNegative(true);
-        configuration.setExcludeZeroDeltasFromOutboundMessage(false);
+        configuration.setExcludeZeroDeltas(false);
         return configuration;
     }
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNodeConfiguration.java
@@ -30,7 +30,7 @@ public class CalculateDeltaNodeConfiguration implements NodeConfiguration<Calcul
     private String periodValueKey;
     private Integer round;
     private boolean tellFailureIfDeltaIsNegative;
-    private boolean onlyComputeTrueDeltas;
+    private boolean excludeZeroDeltasFromOutboundMessage;
 
     @Override
     public CalculateDeltaNodeConfiguration defaultConfiguration() {
@@ -41,7 +41,8 @@ public class CalculateDeltaNodeConfiguration implements NodeConfiguration<Calcul
         configuration.setAddPeriodBetweenMsgs(false);
         configuration.setPeriodValueKey("periodInMs");
         configuration.setTellFailureIfDeltaIsNegative(true);
-        configuration.setOnlyComputeTrueDeltas(false);
+        configuration.setExcludeZeroDeltasFromOutboundMessage(false);
         return configuration;
     }
+
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNodeConfiguration.java
@@ -30,6 +30,7 @@ public class CalculateDeltaNodeConfiguration implements NodeConfiguration<Calcul
     private String periodValueKey;
     private Integer round;
     private boolean tellFailureIfDeltaIsNegative;
+    private boolean onlyComputeTrueDeltas;
 
     @Override
     public CalculateDeltaNodeConfiguration defaultConfiguration() {
@@ -40,7 +41,7 @@ public class CalculateDeltaNodeConfiguration implements NodeConfiguration<Calcul
         configuration.setAddPeriodBetweenMsgs(false);
         configuration.setPeriodValueKey("periodInMs");
         configuration.setTellFailureIfDeltaIsNegative(true);
+        configuration.setOnlyComputeTrueDeltas(false);
         return configuration;
     }
-
 }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/CalculateDeltaNodeTest.java
@@ -440,7 +440,7 @@ public class CalculateDeltaNodeTest extends AbstractRuleNodeUpgradeTest {
     public void givenCalculateDeltaConfig_whenOnMsg_thenVerify(CalculateDeltaTestConfig testConfig) throws TbNodeException {
         // GIVEN
         config.setTellFailureIfDeltaIsNegative(testConfig.isTellFailureIfDeltaIsNegative());
-        config.setExcludeZeroDeltasFromOutboundMessage(testConfig.isComputeOnlyTrueDeltas());
+        config.setExcludeZeroDeltas(testConfig.isComputeOnlyTrueDeltas());
         config.setInputValueKey("temperature");
         nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
         node.init(ctxMock, nodeConfiguration);
@@ -460,7 +460,7 @@ public class CalculateDeltaNodeTest extends AbstractRuleNodeUpgradeTest {
 
     static Stream<CalculateDeltaTestConfig> CalculateDeltaTestConfig() {
         return Stream.of(
-                // delta = 0, tell failure if delta is negative is set to true and exclude zero deltas from outbound message is set to true so delta should filter out the message.
+                // delta = 0, tell failure if delta is negative is set to true and exclude zero deltas is set to true so delta should filter out the message.
                 new CalculateDeltaTestConfig(true, true, 40, 40, (ctx, msg) -> {
                     verify(ctx).tellSuccess(eq(msg));
                     verify(ctx).getDbCallbackExecutor();
@@ -474,7 +474,7 @@ public class CalculateDeltaNodeTest extends AbstractRuleNodeUpgradeTest {
                     verifyNoMoreInteractions(ctx);
                     assertThat(errorCaptor.getValue()).isInstanceOf(IllegalArgumentException.class).hasMessage("Delta value is negative!");
                 }),
-                // delta < 0, exclude zero deltas from outbound message is set to true so it should return message with delta if delta is negative is set to false.
+                // delta < 0, exclude zero deltas is set to true so it should return message with delta if delta is negative is set to false.
                 new CalculateDeltaTestConfig(false, true, 40, 41, (ctx, msg) -> {
                     var actualMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
                     verify(ctx).tellSuccess(actualMsgCaptor.capture());
@@ -483,13 +483,13 @@ public class CalculateDeltaNodeTest extends AbstractRuleNodeUpgradeTest {
                     String expectedMsgData = "{\"temperature\":40.0,\"airPressure\":123,\"delta\":-1}";
                     assertEquals(expectedMsgData, actualMsgCaptor.getValue().getData());
                 }),
-                // delta = 0, tell failure if delta is negative is set to false and exclude zero deltas from outbound message is set to true so delta should filter out the message.
+                // delta = 0, tell failure if delta is negative is set to false and exclude zero deltas is set to true so delta should filter out the message.
                 new CalculateDeltaTestConfig(false, true, 40, 40, (ctx, msg) -> {
                     verify(ctx).tellSuccess(eq(msg));
                     verify(ctx).getDbCallbackExecutor();
                     verifyNoMoreInteractions(ctx);
                 }),
-                // delta > 0, exclude zero deltas from outbound message is set to true so it should return message with delta.
+                // delta > 0, exclude zero deltas is set to true so it should return message with delta.
                 new CalculateDeltaTestConfig(false, true, 40, 39, (ctx, msg) -> {
                     var actualMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
                     verify(ctx).tellSuccess(actualMsgCaptor.capture());
@@ -498,7 +498,7 @@ public class CalculateDeltaNodeTest extends AbstractRuleNodeUpgradeTest {
                     String expectedMsgData = "{\"temperature\":40.0,\"airPressure\":123,\"delta\":1}";
                     assertEquals(expectedMsgData, actualMsgCaptor.getValue().getData());
                 }),
-                // delta > 0, exclude zero deltas from outbound message is set to false so it should return message with delta.
+                // delta > 0, exclude zero deltas is set to false so it should return message with delta.
                 new CalculateDeltaTestConfig(false, false, 40, 39, (ctx, msg) -> {
                     var actualMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
                     verify(ctx).tellSuccess(actualMsgCaptor.capture());
@@ -559,12 +559,12 @@ public class CalculateDeltaNodeTest extends AbstractRuleNodeUpgradeTest {
                 Arguments.of(0,
                         "{\"inputValueKey\":\"pulseCounter\",\"outputValueKey\":\"delta\",\"useCache\":true,\"addPeriodBetweenMsgs\":false, \"periodValueKey\":\"periodInMs\", \"round\":null,\"tellFailureIfDeltaIsNegative\":true}",
                         true,
-                        "{\"inputValueKey\":\"pulseCounter\",\"outputValueKey\":\"delta\",\"useCache\":true,\"addPeriodBetweenMsgs\":false, \"periodValueKey\":\"periodInMs\", \"round\":null,\"tellFailureIfDeltaIsNegative\":true, \"excludeZeroDeltasFromOutboundMessage\":false}"),
+                        "{\"inputValueKey\":\"pulseCounter\",\"outputValueKey\":\"delta\",\"useCache\":true,\"addPeriodBetweenMsgs\":false, \"periodValueKey\":\"periodInMs\", \"round\":null,\"tellFailureIfDeltaIsNegative\":true, \"excludeZeroDeltas\":false}"),
                 // default config for version 1 with upgrade from version 0
                 Arguments.of(1,
-                        "{\"inputValueKey\":\"pulseCounter\",\"outputValueKey\":\"delta\",\"useCache\":true,\"addPeriodBetweenMsgs\":false, \"periodValueKey\":\"periodInMs\", \"round\":null,\"tellFailureIfDeltaIsNegative\":true, \"excludeZeroDeltasFromOutboundMessage\":false}",
+                        "{\"inputValueKey\":\"pulseCounter\",\"outputValueKey\":\"delta\",\"useCache\":true,\"addPeriodBetweenMsgs\":false, \"periodValueKey\":\"periodInMs\", \"round\":null,\"tellFailureIfDeltaIsNegative\":true, \"excludeZeroDeltas\":false}",
                         false,
-                        "{\"inputValueKey\":\"pulseCounter\",\"outputValueKey\":\"delta\",\"useCache\":true,\"addPeriodBetweenMsgs\":false, \"periodValueKey\":\"periodInMs\", \"round\":null,\"tellFailureIfDeltaIsNegative\":true, \"excludeZeroDeltasFromOutboundMessage\":false}")
+                        "{\"inputValueKey\":\"pulseCounter\",\"outputValueKey\":\"delta\",\"useCache\":true,\"addPeriodBetweenMsgs\":false, \"periodValueKey\":\"periodInMs\", \"round\":null,\"tellFailureIfDeltaIsNegative\":true, \"excludeZeroDeltas\":false}")
         );
 
     }


### PR DESCRIPTION
## Pull Request description

When no password set in configuration in TbMqttNode, we got TLS Fatory error.

Settings for MQTT node with no password:
![10a07d47-6ebc-4e08-b2e7-1a8b7fc8fd44](https://github.com/thingsboard/thingsboard/assets/101514424/41d383f2-a35a-4630-8e54-dbeacca5ea24)
And we got this:
![ae0e2171-2c4e-4f0b-9ad1-5b9b360dfaa8](https://github.com/thingsboard/thingsboard/assets/101514424/61f1c435-624a-4df9-a99f-cb76438b6cfb)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



