### PR TITLE
Improved CSS styles for copy-code button in code blocks

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/device/device-check-connectivity-dialog.component.scss
+++ b/ui-ngx/src/app/modules/home/pages/device/device-check-connectivity-dialog.component.scss
@@ -139,17 +139,6 @@
         p, div {
           background-color: #F3F6FA;
         }
-        &.small {
-          height: 32px;
-          p {
-            padding: 5px 8px;
-          }
-          div {
-            width: 36px;
-            height: 36px;
-            top: 1px;
-          }
-        }
       }
     }
   }

--- a/ui-ngx/src/app/modules/home/pages/device/device-check-connectivity-dialog.component.scss
+++ b/ui-ngx/src/app/modules/home/pages/device/device-check-connectivity-dialog.component.scss
@@ -124,8 +124,7 @@
           background: #F3F6FA;
           border-color: #305680;
           padding-right: 38px;
-          overflow: scroll;
-          padding-bottom: 4px;
+          overflow: auto;
           min-height: 42px;
           scrollbar-width: thin;
 
@@ -137,25 +136,18 @@
       }
       button.clipboard-btn {
         right: -2px;
-        p {
-          color: #305680;
-        }
         p, div {
           background-color: #F3F6FA;
         }
-        div {
-          img {
-            display: none;
+        &.small {
+          height: 32px;
+          p {
+            padding: 5px 8px;
           }
-          &:after {
-            content: "";
-            position: initial;
-            display: block;
-            width: 18px;
-            height: 18px;
-            background: #305680;
-            mask-image: url(/assets/copy-code-icon.svg);
-            mask-repeat: no-repeat;
+          div {
+            width: 36px;
+            height: 36px;
+            top: 1px;
           }
         }
       }

--- a/ui-ngx/src/app/modules/home/pages/device/device-check-connectivity-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/pages/device/device-check-connectivity-dialog.component.ts
@@ -138,7 +138,7 @@ export class DeviceCheckConnectivityDialogComponent extends
   private createMarkDownSingleCommand(command: string): string {
     return '```bash\n' +
       command +
-      '{:copy-code}\n' +
+      '{:copy-code.small}\n' +
       '```';
   }
 

--- a/ui-ngx/src/app/modules/home/pages/edge/edge-instructions-dialog.component.scss
+++ b/ui-ngx/src/app/modules/home/pages/edge/edge-instructions-dialog.component.scss
@@ -95,9 +95,6 @@
             mask-repeat: no-repeat;
           }
         }
-        &.multiline {
-          right: -2px !important;
-        }
       }
     }
     & > *:not(ul) {

--- a/ui-ngx/src/app/shared/components/markdown.component.scss
+++ b/ui-ngx/src/app/shared/components/markdown.component.scss
@@ -280,10 +280,6 @@
         -ms-user-select: none;
         user-select: none;
 
-        &.multiline {
-          right: 44px;
-        }
-
         p {
           padding: 8px;
           top: 1px;

--- a/ui-ngx/src/app/shared/components/markdown.component.scss
+++ b/ui-ngx/src/app/shared/components/markdown.component.scss
@@ -309,6 +309,18 @@
             filter: invert(51%) sepia(6%) saturate(172%) hue-rotate(177deg) brightness(94%) contrast(92%);
           }
         }
+
+        &.small {
+          height: 32px;
+          p {
+            padding: 5px 8px;
+          }
+          div {
+            width: 36px;
+            height: 36px;
+            top: 1px;
+          }
+        }
       }
 
       &:hover {

--- a/ui-ngx/src/app/shared/components/markdown.component.scss
+++ b/ui-ngx/src/app/shared/components/markdown.component.scss
@@ -313,12 +313,14 @@
         &.small {
           height: 32px;
           p {
-            padding: 5px 8px;
+            top: 9px;
+            padding: 1px 8px;
           }
           div {
             width: 36px;
-            height: 36px;
-            top: 1px;
+            height: 32px;
+            top: 4px;
+            padding-bottom: 2px;
           }
         }
       }

--- a/ui-ngx/src/app/shared/components/marked-options.service.ts
+++ b/ui-ngx/src/app/shared/components/marked-options.service.ts
@@ -123,13 +123,9 @@ export class MarkedOptionsService extends MarkedOptions {
   }
 
   private wrapCopyCode(id: number, content: string, context: CodeContext): string {
-    let copyCodeButtonClass = 'clipboard-btn';
-    if (context.multiline) {
-      copyCodeButtonClass += ' multiline';
-    }
     return `<div class="code-wrapper noChars" id="codeWrapper${id}" onClick="markdownCopyCode(${id})">${content}` +
       `<span id="copyCodeId${id}" style="display: none;">${encodeURIComponent(context.code)}</span>` +
-      `<button class="${copyCodeButtonClass}">\n` +
+      `<button class="clipboard-btn small">\n` +
       `    <p>${this.translate.instant('markdown.copy-code')}</p>\n` +
       `    <div>\n` +
       `       <img src="/assets/copy-code-icon.svg" alt="${this.translate.instant('markdown.copy-code')}">\n` +


### PR DESCRIPTION
## Pull Request description

The common part of the styles for the code copy button has been moved to the base style file, and a class has been added for the button that can overlap the vertical scrollbar.  Removed the class for for the code copy button used in multiline code blocks.
**Before (Chrome)**
![image](https://github.com/thingsboard/thingsboard/assets/143483163/cb707848-deb5-48a6-b574-42350d350467)

**After (Chrome)**
![image](https://github.com/thingsboard/thingsboard/assets/143483163/fd453714-f522-4f07-b2c7-2a7812a8a466)

**Before (Firefox)**
![image](https://github.com/thingsboard/thingsboard/assets/143483163/28489742-4152-4551-b76e-488c2b3b1c3e)

**After (Firefox)**
![image](https://github.com/thingsboard/thingsboard/assets/143483163/b7552a18-6101-4d8a-9120-ab61de9eb3e8)

**Before**
![image](https://github.com/thingsboard/thingsboard/assets/143483163/0e002923-df61-4fcb-b15b-384de36366a0)

**After**
![image](https://github.com/thingsboard/thingsboard/assets/143483163/c5c0c1ec-bc56-47a1-909c-bc976554a5c1)


**Before**
![image](https://github.com/thingsboard/thingsboard/assets/143483163/da85cc9b-be45-4e5a-8b53-5a177af65336)


**After**
![image](https://github.com/thingsboard/thingsboard/assets/143483163/b4710e09-b512-4e46-97b8-3a7eb583ccfc)

Affected pages:

- entities/devices -> device ->  Check connectivity
- ruleChains -> rule chain -> rulenode -> question button
- Notification center -> Send notification -> compose tab -> See documentation
- Dashboards -> Dashboard -> HTML widgets -> Markdown/HTML Card widget -> Appearance tab -> question button

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



