### PR TITLE
Improve bar chart for none aggregation data 

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/chart/bar-chart-with-labels-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/chart/bar-chart-with-labels-widget.component.ts
@@ -196,7 +196,7 @@ export class BarChartWithLabelsWidgetComponent implements OnInit, OnDestroy, Aft
       const lowerLeft = api.coord([startTime, value >= 0 ? value : 0]);
       const size = api.size([delta, value]);
       const height =  size[1];
-      const width = size[0];
+      const width = size[0] >= 1 ? size[0] : 1;
 
       const coordSys: {x: number; y: number; width: number; height: number} = params.coordSys as any;
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/chart/bar-chart-with-labels-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/chart/bar-chart-with-labels-widget.component.ts
@@ -28,16 +28,9 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import { WidgetContext } from '@home/models/widget-component.models';
-import {
-  backgroundStyle,
-  ComponentStyle,
-  DateFormatProcessor,
-  overlayStyle,
-  textStyle
-} from '@shared/models/widget-settings.models';
+import { backgroundStyle, ComponentStyle, DateFormatProcessor, overlayStyle, textStyle } from '@shared/models/widget-settings.models';
 import { ResizeObserver } from '@juggle/resize-observer';
-import { deepClone, formatValue, isDefinedAndNotNull } from '@core/utils';
-import { DataKey } from '@shared/models/widget.models';
+import { formatValue, isDefinedAndNotNull } from '@core/utils';
 import { Observable } from 'rxjs';
 import { ImagePipe } from '@shared/pipe/image.pipe';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -53,12 +46,12 @@ import { CallbackDataParams, CustomSeriesRenderItem, LabelLayoutOptionCallback }
 import {
   ECharts,
   echartsModule,
-  EChartsOption, EChartsSeriesItem,
+  EChartsOption,
+  EChartsSeriesItem,
   echartsTooltipFormatter,
-  NamedDataSet,
   toNamedData
 } from '@home/components/widget/lib/chart/echarts-widget.models';
-import { AggregationType, IntervalMath } from '@shared/models/time/time.models';
+import { IntervalMath } from '@shared/models/time/time.models';
 
 type BarChartDataItem = EChartsSeriesItem;
 
@@ -186,8 +179,6 @@ export class BarChartWithLabelsWidgetComponent implements OnInit, OnDestroy, Aft
       const time = api.value(0) as number;
       let start = api.value(2) as number;
       const end = api.value(3) as number;
-      console.log('time', time);
-      console.log('start', start);
       let interval = end - start;
       if (!start || !end || !interval) {
         interval =  IntervalMath.numberValue(isDefinedAndNotNull(this.settings.defaultBarWidth) ?
@@ -203,11 +194,9 @@ export class BarChartWithLabelsWidgetComponent implements OnInit, OnDestroy, Aft
       const startTime = start + intervalGap + barInterval * index;
       const delta = barInterval;
       const lowerLeft = api.coord([startTime, value >= 0 ? value : 0]);
-      // const size = api.size([delta, value]);
-
-      const height =  api.size([delta, value])[1];
-
-      const width = api.size([delta, 10])[0];
+      const size = api.size([delta, value]);
+      const height =  size[1];
+      const width = size[0];
 
       const coordSys: {x: number; y: number; width: number; height: number} = params.coordSys as any;
 
@@ -300,13 +289,10 @@ export class BarChartWithLabelsWidgetComponent implements OnInit, OnDestroy, Aft
   }
 
   public onDataUpdated() {
-    // console.log('_______________________');
-    // console.log('onDataUpdated', deepClone(this.ctx.data));
     for (const item of this.dataItems) {
       const datasourceData = this.ctx.data ? this.ctx.data.find(d => d.dataKey === item.dataKey) : null;
       item.data = datasourceData?.data ? toNamedData(datasourceData.data) : [];
     }
-    // console.log('afterDataUpdate', deepClone(this.dataItems));
     if (this.barChart) {
       (this.barChartOptions.xAxis as any).min = this.ctx.defaultSubscription.timeWindow.minTime;
       (this.barChartOptions.xAxis as any).max = this.ctx.defaultSubscription.timeWindow.maxTime;
@@ -318,9 +304,6 @@ export class BarChartWithLabelsWidgetComponent implements OnInit, OnDestroy, Aft
 
   private updateSeries(): Array<CustomSeriesOption> {
     const series: Array<CustomSeriesOption> = [];
-    // console.log('-------------------');
-    // console.log('dataItemsTest', deepClone(this.dataItems));
-    // console.log('dataItems', this.dataItems);
     for (const item of this.dataItems) {
       if (item.enabled) {
         const seriesOption: CustomSeriesOption = {
@@ -343,8 +326,6 @@ export class BarChartWithLabelsWidgetComponent implements OnInit, OnDestroy, Aft
         series.push(seriesOption);
       }
     }
-    console.log('Series', series);
-    // console.log('______________');
     return series;
   }
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/chart/bar-chart-with-labels-widget.models.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/chart/bar-chart-with-labels-widget.models.ts
@@ -21,6 +21,7 @@ import { EChartsTooltipWidgetSettings } from '@home/components/widget/lib/chart/
 export interface BarChartWithLabelsWidgetSettings extends EChartsTooltipWidgetSettings {
   showBarLabel: boolean;
   barLabelFont: Font;
+  defaultBarWidth: number;
   barLabelColor: string;
   showBarValue: boolean;
   barValueFont: Font;
@@ -52,6 +53,7 @@ export const barChartWithLabelsDefaultSettings: BarChartWithLabelsWidgetSettings
     weight: '700',
     lineHeight: '12px'
   },
+  defaultBarWidth: 1000,
   barValueColor: 'rgba(0, 0, 0, 0.76)',
   showLegend: true,
   legendPosition: LegendPosition.top,

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/chart/bar-chart-with-labels-widget-settings.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/chart/bar-chart-with-labels-widget-settings.component.html
@@ -50,6 +50,12 @@
         </tb-color-input>
       </div>
     </div>
+    <div class="tb-form-row space-between">
+      <div>{{ 'widgets.chart.default-bar-width' | translate }}</div>
+      <mat-form-field appearance="outline" class="number" subscriptSizing="dynamic">
+        <input matInput formControlName="defaultBarWidth" type="number" min="0" step="1" placeholder="{{ 'widget-config.set' | translate }}">
+      </mat-form-field>
+    </div>
     <div class="tb-form-panel tb-slide-toggle">
       <mat-expansion-panel class="tb-settings" [expanded]="barChartWidgetSettingsForm.get('showLegend').value" [disabled]="!barChartWidgetSettingsForm.get('showLegend').value">
         <mat-expansion-panel-header fxLayout="row wrap">

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/chart/bar-chart-with-labels-widget-settings.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/chart/bar-chart-with-labels-widget-settings.component.ts
@@ -67,6 +67,7 @@ export class BarChartWithLabelsWidgetSettingsComponent extends WidgetSettingsCom
       showBarLabel: [settings.showBarLabel, []],
       barLabelFont: [settings.barLabelFont, []],
       barLabelColor: [settings.barLabelColor, []],
+      defaultBarWidth: [settings.defaultBarWidth, []],
       showBarValue: [settings.showBarValue, []],
       barValueFont: [settings.barValueFont, []],
       barValueColor: [settings.barValueColor, []],


### PR DESCRIPTION
## Pull Request description

Added ability to set bar width for none aggregation data.

Before:
![image](https://github.com/thingsboard/thingsboard/assets/43555187/61004151-0f7b-4063-8197-d5e6279277e0)

After:
![image](https://github.com/thingsboard/thingsboard/assets/43555187/28765ea0-e5e5-4c2e-bc36-0fa545cc0cce)
![image](https://github.com/thingsboard/thingsboard/assets/43555187/246d895b-ea5b-4412-b8d2-607b3a87fee7)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


