### PR TITLE
Fixed key filter dialog when constant key type and boolean value type selected saving null if not touched, added clear of value on value type changed

### DIFF
--- a/ui-ngx/src/app/modules/home/components/filter/key-filter-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/filter/key-filter-dialog.component.ts
@@ -35,7 +35,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { entityFields } from '@shared/models/entity.models';
 import { Observable, of, Subject } from 'rxjs';
 import { filter, map, mergeMap, publishReplay, refCount, startWith, takeUntil } from 'rxjs/operators';
-import { isDefined } from '@core/utils';
+import { isBoolean, isDefined } from '@core/utils';
 import { EntityId } from '@shared/models/id/entity-id';
 import { DeviceProfileService } from '@core/http/device-profile.service';
 
@@ -121,22 +121,30 @@ export class KeyFilterDialogComponent extends
       this.keyFilterFormGroup.get('valueType').valueChanges.pipe(
         takeUntil(this.destroy$)
       ).subscribe((valueType: EntityKeyValueType) => {
-        const prevValue: EntityKeyValueType = this.keyFilterFormGroup.value.valueType;
+        const prevValueType: EntityKeyValueType = this.keyFilterFormGroup.value.valueType;
         const predicates: KeyFilterPredicate[] = this.keyFilterFormGroup.get('predicates').value;
-        if (prevValue && prevValue !== valueType && predicates && predicates.length) {
-          this.dialogs.confirm(this.translate.instant('filter.key-value-type-change-title'),
-            this.translate.instant('filter.key-value-type-change-message')).subscribe(
-            (result) => {
-              if (result) {
-                this.keyFilterFormGroup.get('predicates').setValue([]);
-              } else {
-                this.keyFilterFormGroup.get('valueType').setValue(prevValue, {emitEvent: false});
+        const value = this.keyFilterFormGroup.get('value')?.value;
+        if (prevValueType && prevValueType !== valueType) {
+          if (this.isConstantKeyType && this.data.telemetryKeysOnly) {
+            this.keyFilterFormGroup.get('value').setValue(null);
+          }
+          if (predicates && predicates.length) {
+            this.dialogs.confirm(this.translate.instant('filter.key-value-type-change-title'),
+              this.translate.instant('filter.key-value-type-change-message')).subscribe(
+              (result) => {
+                if (result) {
+                  this.keyFilterFormGroup.get('predicates').setValue([]);
+                } else {
+                  this.keyFilterFormGroup.get('valueType').setValue(prevValueType, {emitEvent: false});
+                  this.keyFilterFormGroup.get('value')?.setValue(value, {emitEvent: false});
+                }
               }
-            }
-          );
+            );
+          }
         }
-        if (valueType === EntityKeyValueType.BOOLEAN && this.isConstantKeyType) {
+        if (valueType === EntityKeyValueType.BOOLEAN && this.isConstantKeyType && this.data.telemetryKeysOnly) {
           this.keyFilterFormGroup.get('value').clearValidators();
+          this.keyFilterFormGroup.get('value').setValue(isBoolean(value) ? value : false);
           this.keyFilterFormGroup.get('value').updateValueAndValidity();
         }
       });

--- a/ui-ngx/src/app/modules/home/components/filter/key-filter-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/filter/key-filter-dialog.component.ts
@@ -142,7 +142,7 @@ export class KeyFilterDialogComponent extends
             );
           }
         }
-        if (valueType === EntityKeyValueType.BOOLEAN && this.isConstantKeyType && this.data.telemetryKeysOnly) {
+        if (this.data.telemetryKeysOnly && this.isConstantKeyType && valueType === EntityKeyValueType.BOOLEAN) {
           this.keyFilterFormGroup.get('value').clearValidators();
           this.keyFilterFormGroup.get('value').setValue(isBoolean(value) ? value : false);
           this.keyFilterFormGroup.get('value').updateValueAndValidity();


### PR DESCRIPTION
1. In alarm rules if add key filter of type 'Constant' and value type 'Boolean' without touching checkbox - null is saved.

**Result before fix**:

![image](https://github.com/thingsboard/thingsboard/assets/87172504/2a29eebd-4c20-4d5b-9470-0888281c4e57)

**Result after fix**:

![image](https://github.com/thingsboard/thingsboard/assets/87172504/d72c2931-f059-4e42-8a33-9fc1acac4221)


2. Additionally added clear of value field on value type change.

**Before:**

[scrnli_3_11_2024_3-12-43 PM.webm](https://github.com/thingsboard/thingsboard/assets/87172504/0730bbf8-7acb-4386-9771-10cffae4233d)

**After:**

[scrnli_3_11_2024_3-13-40 PM.webm](https://github.com/thingsboard/thingsboard/assets/87172504/0eb4a529-ac88-484f-8ed7-cf7d46814b64)


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



