### PR TITLE
Fixed error message with external id when saving rule chain.

### DIFF
--- a/dao/src/test/java/org/thingsboard/server/dao/rule/BaseRuleChainServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/rule/BaseRuleChainServiceTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.rule;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.id.RuleChainId;
+import org.thingsboard.server.common.data.rule.RuleChain;
+import org.thingsboard.server.dao.exception.DataValidationException;
+import org.thingsboard.server.dao.service.AbstractServiceTest;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+@DaoSqlTest
+public class BaseRuleChainServiceTest extends AbstractServiceTest {
+
+    @Autowired
+    private BaseRuleChainService ruleChainService;
+
+    @Test
+    public void givenRuleChain_whenSave_thenReturnsSavedRuleChain() {
+        RuleChain ruleChain = getRuleChain(ruleChainWithoutId);
+        ruleChain.setTenantId(tenantId);
+        RuleChain savedRuleChain = ruleChainService.saveRuleChain(ruleChain);
+
+        Assert.assertNotNull(savedRuleChain);
+        Assert.assertNotNull(savedRuleChain.getId());
+        Assert.assertTrue(savedRuleChain.getCreatedTime() > 0);
+        Assert.assertEquals(ruleChain.getTenantId(), savedRuleChain.getTenantId());
+
+
+        RuleChain foundRuleChain = ruleChainService.findRuleChainById(tenantId, savedRuleChain.getId());
+        Assertions.assertEquals(foundRuleChain.getName(), savedRuleChain.getName());
+
+        ruleChainService.deleteRuleChainsByTenantId(tenantId);
+    }
+
+    @Test
+    public void givenRuleChainWithExistingExternalId_whenSave_thenThrowsException() {
+        RuleChainId externalRuleChainId = new RuleChainId(UUID.fromString("2675d180-e1e5-11ee-9f06-71b6c7dc2cbf"));
+
+        RuleChain ruleChain = getRuleChain(ruleChainWithoutId);
+        ruleChain.setTenantId(tenantId);
+        ruleChain.setExternalId(externalRuleChainId);
+        RuleChain savedRuleChain = ruleChainService.saveRuleChain(ruleChain);
+
+        RuleChain ruleChainForSave = getRuleChain(ruleChainWithExternalId);
+        ruleChainForSave.setTenantId(tenantId);
+
+        String expectedMsg = "Rule Chain with such external id already exists!";
+
+        assertEquals(savedRuleChain.getExternalId(), ruleChainForSave.getExternalId());
+        Exception exception = assertThrows(DataValidationException.class, () -> ruleChainService.saveRuleChain(ruleChainForSave));
+        assertEquals(expectedMsg, exception.getMessage());
+
+        ruleChainService.deleteRuleChainsByTenantId(tenantId);
+    }
+
+    private RuleChain getRuleChain(String ruleChainString) {
+        return JacksonUtil.fromString(ruleChainString, RuleChain.class);
+    }
+
+    private final String ruleChainWithoutId = "{\n" +
+            "  \"name\": \"Root Rule Chain\",\n" +
+            "  \"type\": \"CORE\",\n" +
+            "  \"firstRuleNodeId\": {\n" +
+            "    \"entityType\": \"RULE_NODE\",\n" +
+            "    \"id\": \"91ad0b00-e779-11ee-9cf0-15d8b6079fdb\"\n" +
+            "  },\n" +
+            "  \"debugMode\": false,\n" +
+            "  \"configuration\": null,\n" +
+            "  \"additionalInfo\": null\n" +
+            "}";
+
+    private final String ruleChainWithExternalId = "{\n" +
+            "  \"name\": \"Root Rule Chain\",\n" +
+            "  \"type\": \"CORE\",\n" +
+            "  \"firstRuleNodeId\": {\n" +
+            "    \"entityType\": \"RULE_NODE\",\n" +
+            "    \"id\": \"91ad0b00-e779-11ee-9cf0-15d8b6079fdb\"\n" +
+            "  },\n" +
+            "  \"debugMode\": false,\n" +
+            "  \"externalId\": {\n" +
+            "    \"entityType\": \"RULE_CHAIN\",\n" +
+            "    \"id\": \"2675d180-e1e5-11ee-9f06-71b6c7dc2cbf\"\n" +
+            "  },\n" +
+            "  \"configuration\": null,\n" +
+            "  \"additionalInfo\": null\n" +
+            "}";
+}


### PR DESCRIPTION
## Pull Request description

When we tried to save rule chain with existing external id, we got incorrect and unclear error message: 
![Screenshot from 2024-03-22 10-59-08](https://github.com/thingsboard/thingsboard/assets/101514424/2c689c76-cbb1-4e88-b176-c82fb5a88c87)
Error message has been fixed to be clearer: "Rule Chain with such external id already exists!".

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



