### PR TITLE
Rule Chain Node: added ability to transfer msg to originator's default rule chain

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNode.java
@@ -42,11 +42,9 @@ import java.util.UUID;
         name = "rule chain",
         configClazz = TbRuleChainInputNodeConfiguration.class,
         version = 1,
-        nodeDescription = "transfers the message to another rule chain",
-        nodeDetails = "Allows to nest the rule chain similar to single rule node. " +
-                "The incoming message is forwarded to the input node of the specified target rule chain. " +
-                "The target rule chain may produce multiple labeled outputs. " +
-                "You may use the outputs to forward the results of processing to other rule nodes.",
+        nodeDescription = "Transfers the message to another rule chain",
+        nodeDetails = "The incoming message is forwarded to the input node of the specified target rule chain.<br><br>" +
+                "Output connections: <i>Any connection(s) produced by output node(s) in the target rule chain.</i>",
         uiResources = {"static/rulenode/rulenode-core-config.js"},
         configDirective = "tbFlowNodeRuleChainInputConfig",
         relationTypes = {},

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNode.java
@@ -56,13 +56,13 @@ public class TbRuleChainInputNode implements TbNode {
 
     private TbRuleChainInputNodeConfiguration config;
     private RuleChainId ruleChainId;
-    private boolean forwardMsgToRootRuleChain;
+    private boolean forwardMsgToDefaultRuleChain;
 
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
         this.config = TbNodeUtils.convert(configuration, TbRuleChainInputNodeConfiguration.class);
-        this.forwardMsgToRootRuleChain = config.isForwardMsgToRootRuleChain();
-        if (forwardMsgToRootRuleChain) {
+        this.forwardMsgToDefaultRuleChain = config.isForwardMsgToDefaultRuleChain();
+        if (forwardMsgToDefaultRuleChain) {
             this.ruleChainId = getRootRuleChainId(ctx);
             return;
         }
@@ -86,9 +86,9 @@ public class TbRuleChainInputNode implements TbNode {
         boolean hasChanges = false;
         switch (fromVersion) {
             case 0:
-                if (!oldConfiguration.has("forwardMsgToRootRuleChain")) {
+                if (!oldConfiguration.has("forwardMsgToDefaultRuleChain")) {
                     hasChanges = true;
-                    ((ObjectNode) oldConfiguration).put("forwardMsgToRootRuleChain", false);
+                    ((ObjectNode) oldConfiguration).put("forwardMsgToDefaultRuleChain", false);
                 }
                 break;
             default:
@@ -98,8 +98,8 @@ public class TbRuleChainInputNode implements TbNode {
     }
 
     private RuleChainId getRuleChainId(TbContext ctx, TbMsg msg) {
-        if (!forwardMsgToRootRuleChain) {
-            return this.ruleChainId;
+        if (!forwardMsgToDefaultRuleChain) {
+            return ruleChainId;
         }
         RuleChainId targetRuleChainId = null;
         switch (msg.getOriginator().getEntityType()) {
@@ -111,7 +111,7 @@ public class TbRuleChainInputNode implements TbNode {
                 break;
         }
         if (targetRuleChainId == null) {
-            targetRuleChainId = this.ruleChainId;
+            targetRuleChainId = ruleChainId;
         }
         return targetRuleChainId;
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeConfiguration.java
@@ -22,12 +22,12 @@ import org.thingsboard.rule.engine.api.NodeConfiguration;
 public class TbRuleChainInputNodeConfiguration implements NodeConfiguration<TbRuleChainInputNodeConfiguration> {
 
     private String ruleChainId;
-    private boolean forwardMsgToRootRuleChain;
+    private boolean forwardMsgToDefaultRuleChain;
 
     @Override
     public TbRuleChainInputNodeConfiguration defaultConfiguration() {
         TbRuleChainInputNodeConfiguration configuration = new TbRuleChainInputNodeConfiguration();
-        configuration.setForwardMsgToRootRuleChain(false);
+        configuration.setForwardMsgToDefaultRuleChain(false);
         return configuration;
     }
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeConfiguration.java
@@ -22,10 +22,13 @@ import org.thingsboard.rule.engine.api.NodeConfiguration;
 public class TbRuleChainInputNodeConfiguration implements NodeConfiguration<TbRuleChainInputNodeConfiguration> {
 
     private String ruleChainId;
+    private boolean forwardMsgToRootRuleChain;
 
     @Override
     public TbRuleChainInputNodeConfiguration defaultConfiguration() {
-        return new TbRuleChainInputNodeConfiguration();
+        TbRuleChainInputNodeConfiguration configuration = new TbRuleChainInputNodeConfiguration();
+        configuration.setForwardMsgToRootRuleChain(false);
+        return configuration;
     }
 
 }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
@@ -173,7 +173,7 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
     }
 
     @Test
-    void givenRuleChainIdEqualsCurrentRuleChainId_whenInit_thenThrowsException() {
+    public void givenRuleChainIdEqualsCurrentRuleChainId_whenInit_thenThrowsException() {
         //GIVEN
         String currentRuleChainIdStr = "752b70c2-20e6-4a37-b7f7-4271249fc643";
         RuleChainId currentRuleChainId = new RuleChainId(UUID.fromString(currentRuleChainIdStr));
@@ -370,8 +370,7 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
         RuleChainId currentRuleChainId = new RuleChainId(UUID.fromString(currentRuleChainIdStr));
         RuleNode currentRuleNode = new RuleNode(new RuleNodeId(UUID.fromString("09184b16-f176-4eee-987e-1b0501b38d6e")));
         currentRuleNode.setRuleChainId(currentRuleChainId);
-        RuleChain rootRuleChain = new RuleChain(
-                new RuleChainId(UUID.fromString(currentRuleChainIdStr)));
+        RuleChain rootRuleChain = new RuleChain(currentRuleChainId);
 
         AssetProfile assetProfile = new AssetProfile();
 
@@ -395,8 +394,8 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
         //THEN
         ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
         verify(ctxMock).tellFailure(eq(msg), captor.capture());
-        assertThat(captor.getValue().toString())
-                .isEqualTo("java.lang.RuntimeException: Forwarding messages to the current rule chain is not allowed!");
+        assertThat(captor.getValue()).isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Forwarding messages to the current rule chain is not allowed!");
     }
 
     private static Stream<Arguments> givenFromVersionAndConfig_whenUpgrade_thenVerifyHasChangesAndConfig() {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
@@ -96,13 +96,14 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
     @Test
     public void givenValidConfigWithRuleChainId_whenInit_thenOk() throws TbNodeException {
         //GIVEN
+        RuleChainId currentRuleChainId = new RuleChainId(UUID.fromString("9a4177a7-c178-48da-bce6-b338205779bd"));
+        RuleNode currentRuleNode = new RuleNode(new RuleNodeId(UUID.fromString("84e302d6-e37e-45f9-be65-29c1c610ff2c")));
+        currentRuleNode.setRuleChainId(currentRuleChainId);
         String ruleChainIdStr = "dfdebb47-c672-45ab-8795-97b6f9b3ce21";
         config.setRuleChainId(ruleChainIdStr);
         nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
 
-        when(ctxMock.getTenantProfile()).thenReturn(tenantProfileMock);
-        when(tenantProfileMock.getProfileData()).thenReturn(tenantProfileDataMock);
-        when(tenantProfileDataMock.getConfiguration()).thenReturn(tenantProfileConfigurationMock);
+        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
 
         //WHEN
         assertThatCode(() -> node.init(ctxMock, nodeConfiguration))
@@ -128,14 +129,15 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
     @Test
     public void givenForwardMsgToDefaultIsTrue_whenInit_thenOk() throws TbNodeException {
         //GIVEN
+        RuleChainId currentRuleChainId = new RuleChainId(UUID.fromString("36b32314-2d91-4d96-a785-54c1f6998cee"));
+        RuleNode currentRuleNode = new RuleNode(new RuleNodeId(UUID.fromString("123c0d71-0ce2-421d-a268-8ae9f1d167e0")));
+        currentRuleNode.setRuleChainId(currentRuleChainId);
         String ruleChainIdFromConfigStr = "e1771a4e-4457-44f0-97a0-f03fd25e50b9";
         config.setRuleChainId(ruleChainIdFromConfigStr);
         config.setForwardMsgToDefaultRuleChain(true);
         nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
 
-        when(ctxMock.getTenantProfile()).thenReturn(tenantProfileMock);
-        when(tenantProfileMock.getProfileData()).thenReturn(tenantProfileDataMock);
-        when(tenantProfileDataMock.getConfiguration()).thenReturn(tenantProfileConfigurationMock);
+        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
 
         //WHEN
         assertThatCode(() -> node.init(ctxMock, nodeConfiguration))
@@ -143,6 +145,24 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
 
         //THEN
         verify(ctxMock).checkTenantEntity(eq(new RuleChainId(UUID.fromString(ruleChainIdFromConfigStr))));
+    }
+
+    @Test
+    public void givenTargetRuleChainIsCurrentRuleChain_whenInit_thenThrowsException() {
+        //GIVEN
+        String currentRuleChainIdStr = "83ad1000-3303-4d52-97e0-b85c544c4ffa";
+        RuleChainId currentRuleChainId = new RuleChainId(UUID.fromString(currentRuleChainIdStr));
+        RuleNode currentRuleNode = new RuleNode(new RuleNodeId(UUID.fromString("84e302d6-e37e-45f9-be65-29c1c610ff2c")));
+        currentRuleNode.setRuleChainId(currentRuleChainId);
+        config.setRuleChainId(currentRuleChainIdStr);
+        nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+
+        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
+
+        //WHEN-THEN
+        Assertions.assertThatThrownBy(() -> node.init(ctxMock, nodeConfiguration))
+                .isInstanceOf(TbNodeException.class)
+                .hasMessage("Forwarding messages to the current rule chain is not allowed!");
     }
 
     @Test
@@ -172,13 +192,10 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
         config.setForwardMsgToDefaultRuleChain(true);
         nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
 
-        when(ctxMock.getTenantProfile()).thenReturn(tenantProfileMock);
-        when(tenantProfileMock.getProfileData()).thenReturn(tenantProfileDataMock);
-        when(tenantProfileDataMock.getConfiguration()).thenReturn(tenantProfileConfigurationMock);
+        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
         when(ctxMock.getTenantId()).thenReturn(TENANT_ID);
         when(ctxMock.getDeviceProfileCache()).thenReturn(deviceProfileCacheMock);
         when(deviceProfileCacheMock.get(any(), any(DeviceId.class))).thenReturn(deviceProfile);
-        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
 
         node.init(ctxMock, nodeConfiguration);
 
@@ -213,14 +230,10 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
         config.setForwardMsgToDefaultRuleChain(true);
         nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
 
-        when(ctxMock.getTenantProfile()).thenReturn(tenantProfileMock);
-        when(tenantProfileMock.getProfileData()).thenReturn(tenantProfileDataMock);
-        when(tenantProfileDataMock.getConfiguration()).thenReturn(tenantProfileConfigurationMock);
+        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
         when(ctxMock.getTenantId()).thenReturn(TENANT_ID);
         when(ctxMock.getAssetProfileCache()).thenReturn(assetProfileCacheMock);
         when(assetProfileCacheMock.get(any(), any(AssetId.class))).thenReturn(assetProfile);
-        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
-
 
         node.init(ctxMock, nodeConfiguration);
 
@@ -252,9 +265,7 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
         config.setForwardMsgToDefaultRuleChain(true);
         nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
 
-        when(ctxMock.getTenantProfile()).thenReturn(tenantProfileMock);
-        when(tenantProfileMock.getProfileData()).thenReturn(tenantProfileDataMock);
-        when(tenantProfileDataMock.getConfiguration()).thenReturn(tenantProfileConfigurationMock);
+        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
         when(ctxMock.getTenantId()).thenReturn(TENANT_ID);
         when(ctxMock.getDeviceProfileCache()).thenReturn(deviceProfileCacheMock);
         when(deviceProfileCacheMock.get(any(), any(DeviceId.class))).thenReturn(deviceProfile);
@@ -288,9 +299,7 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
         config.setForwardMsgToDefaultRuleChain(true);
         nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
 
-        when(ctxMock.getTenantProfile()).thenReturn(tenantProfileMock);
-        when(tenantProfileMock.getProfileData()).thenReturn(tenantProfileDataMock);
-        when(tenantProfileDataMock.getConfiguration()).thenReturn(tenantProfileConfigurationMock);
+        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
         when(ctxMock.getTenantId()).thenReturn(TENANT_ID);
         when(ctxMock.getAssetProfileCache()).thenReturn(assetProfileCacheMock);
         when(assetProfileCacheMock.get(any(), any(AssetId.class))).thenReturn(assetProfile);
@@ -310,6 +319,9 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
     @Test
     public void givenRuleChainInConfig_whenOnMsg_thenShouldTransferToRuleChainFromConfig() throws TbNodeException {
         //GIVEN
+        RuleChainId currentRuleChainId = new RuleChainId(UUID.fromString("97e7133c-2c20-414d-b2ce-923418bd25d6"));
+        RuleNode currentRuleNode = new RuleNode(new RuleNodeId(UUID.fromString("09184b16-f176-4eee-987e-1b0501b38d6e")));
+        currentRuleNode.setRuleChainId(currentRuleChainId);
         String ruleChainIdStr = "3c02c8b3-645c-4e67-aac5-f984f59471d1";
         RuleChainId targetRuleChainId = new RuleChainId(UUID.fromString(ruleChainIdStr));
 
@@ -318,9 +330,7 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
         config.setRuleChainId(ruleChainIdStr);
         nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
 
-        when(ctxMock.getTenantProfile()).thenReturn(tenantProfileMock);
-        when(tenantProfileMock.getProfileData()).thenReturn(tenantProfileDataMock);
-        when(tenantProfileDataMock.getConfiguration()).thenReturn(tenantProfileConfigurationMock);
+        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
         node.init(ctxMock, nodeConfiguration);
 
         //WHEN
@@ -333,27 +343,26 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
     }
 
     @Test
-    public void givenForwardMsgToDefaultIsTrueWithoutAssetDefaultRuleChainAndRuleChainInConfigIsCurrentRuleChain_whenOnMsg_thenThrowsException() throws TbNodeException {
+    public void givenForwardMsgToDefaultIsTrueWithDeviceDefaultRuleChainIsCurrentRuleChain_whenOnMsg_thenThrowsException() throws TbNodeException {
         //GIVEN
-        String currentRuleChainIdStr = "752b70c2-20e6-4a37-b7f7-4271249fc643";
-        RuleChainId currentRuleChainId = new RuleChainId(UUID.fromString(currentRuleChainIdStr));
+        RuleChainId currentRuleChainId = new RuleChainId(UUID.fromString("97e7133c-2c20-414d-b2ce-923418bd25d6"));
         RuleNode currentRuleNode = new RuleNode(new RuleNodeId(UUID.fromString("09184b16-f176-4eee-987e-1b0501b38d6e")));
         currentRuleNode.setRuleChainId(currentRuleChainId);
 
-        AssetProfile assetProfile = new AssetProfile();
+        DeviceProfile deviceProfile = new DeviceProfile();
+        deviceProfile.setDefaultRuleChainId(currentRuleChainId);
 
-        TbMsg msg = getMsg(ASSET_ID);
+        TbMsg msg = getMsg(DEVICE_ID);
 
-        config.setRuleChainId(currentRuleChainIdStr);
+        String ruleChainIdFromConfigStr = "357c2785-e7cc-46a8-9797-957180dabdeb";
+        config.setRuleChainId(ruleChainIdFromConfigStr);
         config.setForwardMsgToDefaultRuleChain(true);
         nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
 
-        when(ctxMock.getTenantProfile()).thenReturn(tenantProfileMock);
-        when(tenantProfileMock.getProfileData()).thenReturn(tenantProfileDataMock);
-        when(tenantProfileDataMock.getConfiguration()).thenReturn(tenantProfileConfigurationMock);
+        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
         when(ctxMock.getTenantId()).thenReturn(TENANT_ID);
-        when(ctxMock.getAssetProfileCache()).thenReturn(assetProfileCacheMock);
-        when(assetProfileCacheMock.get(any(), any(AssetId.class))).thenReturn(assetProfile);
+        when(ctxMock.getDeviceProfileCache()).thenReturn(deviceProfileCacheMock);
+        when(deviceProfileCacheMock.get(any(), any(DeviceId.class))).thenReturn(deviceProfile);
         when(ctxMock.getSelf()).thenReturn(currentRuleNode);
 
         node.init(ctxMock, nodeConfiguration);
@@ -364,45 +373,9 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
         //THEN
         ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
         verify(ctxMock).tellFailure(eq(msg), captor.capture());
-        assertThat(captor.getValue()).isInstanceOf(RuntimeException.class)
-                .hasMessage("Forwarding messages to the current rule chain is blocked. " +
-                        "Rule node per message executions is unlimited, which could cause an infinite loop.");
-    }
-
-    @Test
-    public void givenRuleChainInConfigIsCurrentRuleChainAndTenantProfileMaxExecutionsPerMessageIs5_whenOnMsg_thenShouldTransferToRuleChain() throws TbNodeException {
-        //GIVEN
-        String currentRuleChainIdStr = "752b70c2-20e6-4a37-b7f7-4271249fc643";
-        RuleChainId currentRuleChainId = new RuleChainId(UUID.fromString(currentRuleChainIdStr));
-        RuleNode currentRuleNode = new RuleNode(new RuleNodeId(UUID.fromString("09184b16-f176-4eee-987e-1b0501b38d6e")));
-        currentRuleNode.setRuleChainId(currentRuleChainId);
-
-        AssetProfile assetProfile = new AssetProfile();
-
-        TbMsg msg = getMsg(ASSET_ID);
-
-        config.setRuleChainId(currentRuleChainIdStr);
-        config.setForwardMsgToDefaultRuleChain(true);
-        nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
-
-        when(ctxMock.getTenantProfile()).thenReturn(tenantProfileMock);
-        when(tenantProfileMock.getProfileData()).thenReturn(tenantProfileDataMock);
-        when(tenantProfileDataMock.getConfiguration()).thenReturn(tenantProfileConfigurationMock);
-        when(tenantProfileConfigurationMock.getMaxRuleNodeExecutionsPerMessage()).thenReturn(5);
-        when(ctxMock.getTenantId()).thenReturn(TENANT_ID);
-        when(ctxMock.getAssetProfileCache()).thenReturn(assetProfileCacheMock);
-        when(assetProfileCacheMock.get(any(), any(AssetId.class))).thenReturn(assetProfile);
-        when(ctxMock.getSelf()).thenReturn(currentRuleNode);
-
-        node.init(ctxMock, nodeConfiguration);
-
-        //WHEN
-        node.onMsg(ctxMock, msg);
-
-        //THEN
-        ArgumentCaptor<RuleChainId> ruleChainArgumentCaptor = ArgumentCaptor.forClass(RuleChainId.class);
-        verify(ctxMock).input(eq(msg), ruleChainArgumentCaptor.capture());
-        assertThat(ruleChainArgumentCaptor.getValue()).isEqualTo(currentRuleChainId);
+        Throwable throwable = captor.getValue();
+        assertThat(throwable).isInstanceOf(RuntimeException.class)
+                .hasMessage("Forwarding messages to the current rule chain is not allowed!");
     }
 
     private static Stream<Arguments> givenFromVersionAndConfig_whenUpgrade_thenVerifyHasChangesAndConfig() {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
@@ -1,0 +1,259 @@
+package org.thingsboard.rule.engine.flow;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.rule.engine.AbstractRuleNodeUpgradeTest;
+import org.thingsboard.rule.engine.api.RuleEngineDeviceProfileCache;
+import org.thingsboard.rule.engine.api.TbContext;
+import org.thingsboard.rule.engine.api.TbNode;
+import org.thingsboard.rule.engine.api.TbNodeConfiguration;
+import org.thingsboard.rule.engine.api.TbNodeException;
+import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.DeviceProfile;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.DeviceProfileId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.RuleChainId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.msg.TbMsgType;
+import org.thingsboard.server.common.data.rule.RuleChain;
+import org.thingsboard.server.common.msg.TbMsg;
+import org.thingsboard.server.common.msg.TbMsgMetaData;
+import org.thingsboard.server.common.msg.queue.TbMsgCallback;
+import org.thingsboard.server.dao.rule.RuleChainService;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
+
+@ExtendWith(MockitoExtension.class)
+public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
+
+    private final String EXISTING_RULE_CHAIN_ID = "a5b09dbb-e7c4-4cb2-8037-39de145a2cd6";
+    private final String INVALID_RULE_CHAIN_ID = "91acbce0-079fdb";
+    private final String DEFAULT_RULE_CHAIN_ID = "79acbce0-e789-11ee-9cf0-33d8b6079fba";
+    private final String EXISTING_TENANT_ID = "83bcece0-e709-11ee-9cf0-15d8b6079acb";
+    private final String DEVICE_ID = "14bbaba0-e709-11ee-9cf0-25d8b6079aff";
+    private final String DEVICE_PROFILE_ID = "26aaaba0-e611-11ee-9cf0-83d8b6079acc";
+
+    private final RuleChainId ruleChainId = new RuleChainId(UUID.fromString(EXISTING_RULE_CHAIN_ID));
+    private final RuleChainId defaultRuleChainId = new RuleChainId(UUID.fromString(DEFAULT_RULE_CHAIN_ID));
+    private final TenantId tenantId = new TenantId(UUID.fromString(EXISTING_TENANT_ID));
+    private final DeviceId deviceId = new DeviceId(UUID.fromString(DEVICE_ID));
+    private final DeviceProfileId deviceProfileId = new DeviceProfileId(UUID.fromString(DEVICE_PROFILE_ID));
+
+    private final RuleChain ruleChain = new RuleChain(ruleChainId);
+    private final RuleChain defaultRuleChain = new RuleChain(defaultRuleChainId);
+    private final Device device = new Device(deviceId);
+    private final DeviceProfile deviceProfile = new DeviceProfile(deviceProfileId);
+    private TbRuleChainInputNode node;
+    private TbRuleChainInputNodeConfiguration config;
+    private TbNodeConfiguration nodeConfiguration;
+    private TbMsg msg = getMsg(deviceId);
+    @Mock
+    private TbContext ctx;
+    @Mock
+    private RuleChainService ruleChainService;
+    @Mock
+    private TbMsgCallback callback;
+    @Mock
+    private RuleEngineDeviceProfileCache deviceProfileCache;
+
+    @BeforeEach
+    public void setUp() {
+        node = spy(new TbRuleChainInputNode());
+        config = new TbRuleChainInputNodeConfiguration().defaultConfiguration();
+        nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+    }
+
+    @Test
+    public void givenValidConfigWithRuleChainId_whenInit_thenOk() throws TbNodeException {
+        //GIVEN
+        config.setRuleChainId(EXISTING_RULE_CHAIN_ID);
+        nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+
+        //WHEN
+        assertThatCode(() -> node.init(ctx, nodeConfiguration))
+                .doesNotThrowAnyException();
+
+        //THEN
+        verify(ctx).checkTenantEntity(ruleChainId);
+    }
+
+    @Test
+    public void givenInvalidRuleChainId_whenInit_thenThrowException() {
+        //GIVEN
+        config.setRuleChainId(INVALID_RULE_CHAIN_ID);
+        nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+
+        //WHEN
+        Assertions.assertThatThrownBy(() -> node.init(ctx, nodeConfiguration))
+                .isInstanceOf(TbNodeException.class)
+                .hasMessage("Failed to parse rule chain id: " + INVALID_RULE_CHAIN_ID);
+
+        //THEN
+        verify(ctx, never()).tellSuccess(msg);
+    }
+
+    @Test
+    public void givenForwardMsgToRootIsTrue_whenInit_thenOk() {
+        //GIVEN
+        config.setForwardMsgToRootRuleChain(true);
+        nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+
+        when(ctx.getTenantId()).thenReturn(tenantId);
+        when(ctx.getRuleChainService()).thenReturn(ruleChainService);
+        when(ruleChainService.getRootTenantRuleChain(any())).thenReturn(ruleChain);
+
+        //WHEN
+        assertThatCode(() -> node.init(ctx, nodeConfiguration))
+                .doesNotThrowAnyException();
+
+        //THEN
+        verify(ctx).getTenantId();
+        verify(ruleChainService, never()).findRuleChainById(eq(tenantId), eq(ruleChainId));
+        verify(ruleChainService).getRootTenantRuleChain(eq(tenantId));
+        verifyNoMoreInteractions(ruleChainService);
+    }
+
+    @Test
+    public void givenForwardMsgToRootIsTrueAndNoTenantRootRuleChain_whenInit_thenThrowException() {
+        //GIVEN
+        config.setForwardMsgToRootRuleChain(true);
+        nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+
+        when(ctx.getTenantId()).thenReturn(tenantId);
+        when(ctx.getRuleChainService()).thenReturn(ruleChainService);
+        when(ruleChainService.getRootTenantRuleChain(any())).thenReturn(null);
+
+        //WHEN
+        Assertions.assertThatThrownBy(() -> node.init(ctx, nodeConfiguration))
+                .isInstanceOf(TbNodeException.class)
+                .hasMessage("Failed to find root rule chain for tenant with id: " + tenantId.getId());
+
+        //THEN
+        verify(ctx, never()).tellSuccess(msg);
+        verify(ctx).getTenantId();
+        verify(ruleChainService).getRootTenantRuleChain(eq(tenantId));
+        verifyNoMoreInteractions(ruleChainService);
+    }
+
+    @Test
+    public void givenForwardMsgToRootIsTrue_whenOnMsg_thenShouldTransferToDefaultRuleChain() throws TbNodeException {
+        //GIVEN
+        config.setForwardMsgToRootRuleChain(true);
+        nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+        deviceProfile.setDefaultRuleChainId(defaultRuleChainId);
+        device.setDeviceProfileId(deviceProfileId);
+
+        when(ctx.getTenantId()).thenReturn(tenantId);
+        when(ctx.getRuleChainService()).thenReturn(ruleChainService);
+        when(ruleChainService.getRootTenantRuleChain(any())).thenReturn(ruleChain);
+        when(ctx.getDeviceProfileCache()).thenReturn(deviceProfileCache);
+        when(deviceProfileCache.get(any(), (DeviceId) any())).thenReturn(deviceProfile);
+
+        node.init(ctx, nodeConfiguration);
+
+        //WHEN
+        node.onMsg(ctx, msg);
+
+        //THEN
+        ArgumentCaptor<TbMsg> newMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        ArgumentCaptor<RuleChainId> ruleChainArgumentCaptor = ArgumentCaptor.forClass(RuleChainId.class);
+        verify(ctx).input(newMsgCaptor.capture(), ruleChainArgumentCaptor.capture());
+        RuleChainId expectedRuleChainId = ruleChainArgumentCaptor.getValue();
+        assertThat(expectedRuleChainId).isNotEqualTo(ruleChain.getId());
+        assertThat(expectedRuleChainId).isEqualTo(defaultRuleChain.getId());
+    }
+
+    @Test
+    public void givenForwardMsgToRootIsTrueWithoutDeviceProfile_whenOnMsg_thenShouldTransferToRootRuleChain() throws TbNodeException {
+        //GIVEN
+        config.setForwardMsgToRootRuleChain(true);
+        nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+        device.setDeviceProfileId(deviceProfileId);
+
+        when(ctx.getTenantId()).thenReturn(tenantId);
+        when(ctx.getRuleChainService()).thenReturn(ruleChainService);
+        when(ruleChainService.getRootTenantRuleChain(any())).thenReturn(ruleChain);
+        when(ctx.getDeviceProfileCache()).thenReturn(deviceProfileCache);
+        when(deviceProfileCache.get(any(), (DeviceId) any())).thenReturn(deviceProfile);
+
+        node.init(ctx, nodeConfiguration);
+
+        //WHEN
+        node.onMsg(ctx, msg);
+
+        //THEN
+        ArgumentCaptor<TbMsg> newMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        ArgumentCaptor<RuleChainId> ruleChainArgumentCaptor = ArgumentCaptor.forClass(RuleChainId.class);
+        verify(ctx).input(newMsgCaptor.capture(), ruleChainArgumentCaptor.capture());
+        assertThat(ruleChainArgumentCaptor.getValue()).isEqualTo(ruleChain.getId());
+    }
+
+    @Test
+    public void givenRuleChainId_whenOnMsg_thenShouldTransferToRuleChainById() throws TbNodeException {
+        //GIVEN
+        config.setRuleChainId(EXISTING_RULE_CHAIN_ID);
+        nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+
+        node.init(ctx, nodeConfiguration);
+
+        //WHEN
+        node.onMsg(ctx, msg);
+
+        //THEN
+        ArgumentCaptor<TbMsg> newMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        ArgumentCaptor<RuleChainId> ruleChainArgumentCaptor = ArgumentCaptor.forClass(RuleChainId.class);
+        verify(ctx).input(newMsgCaptor.capture(), ruleChainArgumentCaptor.capture());
+        assertThat(ruleChainArgumentCaptor.getValue()).isEqualTo(ruleChain.getId());
+    }
+
+    private static Stream<Arguments> givenFromVersionAndConfig_whenUpgrade_thenVerifyHasChangesAndConfig() {
+        return Stream.of(
+                //config for version 0
+                Arguments.of(0,
+                        "{\"ruleChainId\": null}",
+                        true,
+                        "{\"ruleChainId\": null, \"forwardMsgToRootRuleChain\": false}"
+                ),
+                //config for version 1 with upgrade from version 0
+                Arguments.of(1,
+                        "{\"ruleChainId\": null, \"forwardMsgToRootRuleChain\": false}",
+                        false,
+                        "{\"ruleChainId\": null, \"forwardMsgToRootRuleChain\": false}"
+                )
+        );
+    }
+
+    @Override
+    protected TbNode getTestNode() {
+        return node;
+    }
+
+    private TbMsg getMsg(EntityId entityId) {
+        final Map<String, String> metaDataMap = Map.of(
+                "data", "40"
+        );
+        final TbMsgMetaData metaData = new TbMsgMetaData(metaDataMap);
+        final String data = "{ temp: 42, humidity: 77 }";
+        return TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, entityId, metaData, data, callback);
+    }
+}

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
@@ -34,7 +34,6 @@ import org.thingsboard.rule.engine.api.TbNode;
 import org.thingsboard.rule.engine.api.TbNodeConfiguration;
 import org.thingsboard.rule.engine.api.TbNodeException;
 import org.thingsboard.server.common.data.DeviceProfile;
-import org.thingsboard.server.common.data.TenantProfile;
 import org.thingsboard.server.common.data.asset.AssetProfile;
 import org.thingsboard.server.common.data.id.AssetId;
 import org.thingsboard.server.common.data.id.DeviceId;
@@ -45,8 +44,6 @@ import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.msg.TbMsgType;
 import org.thingsboard.server.common.data.rule.RuleChain;
 import org.thingsboard.server.common.data.rule.RuleNode;
-import org.thingsboard.server.common.data.tenant.profile.DefaultTenantProfileConfiguration;
-import org.thingsboard.server.common.data.tenant.profile.TenantProfileData;
 import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
 
@@ -79,12 +76,6 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
     private RuleEngineDeviceProfileCache deviceProfileCacheMock;
     @Mock
     private RuleEngineAssetProfileCache assetProfileCacheMock;
-    @Mock
-    private TenantProfile tenantProfileMock;
-    @Mock
-    private TenantProfileData tenantProfileDataMock;
-    @Mock
-    private DefaultTenantProfileConfiguration tenantProfileConfigurationMock;
 
     @BeforeEach
     public void setUp() {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
@@ -395,7 +395,7 @@ public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
         ArgumentCaptor<Throwable> captor = ArgumentCaptor.forClass(Throwable.class);
         verify(ctxMock).tellFailure(eq(msg), captor.capture());
         assertThat(captor.getValue()).isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Forwarding messages to the current rule chain is not allowed!");
+                .hasMessage("Forwarding messages to the current rule chain is not allowed!");
     }
 
     private static Stream<Arguments> givenFromVersionAndConfig_whenUpgrade_thenVerifyHasChangesAndConfig() {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.thingsboard.rule.engine.flow;
 
 import org.assertj.core.api.Assertions;


### PR DESCRIPTION
## Pull Request description

Issue: #7923 

Requires rule node UI changes:

Please add toggle for "Forward message to the originator's default rule chain".
Also add tool tip: "If enabled, message will be forwarded to the originator's default rule chain, or rule chain from configuration, if originator has no default rule chain defined in the entity profile."

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).
