### PR TITLE
[3.7] Http Transport log optimization

### DIFF
--- a/common/transport/http/src/main/java/org/thingsboard/server/transport/http/DeviceApiController.java
+++ b/common/transport/http/src/main/java/org/thingsboard/server/transport/http/DeviceApiController.java
@@ -461,15 +461,15 @@ public class DeviceApiController implements TbTransportService {
             String body = null;
             if (e instanceof HttpMessageNotReadableException || e instanceof JsonParseException) {
                 body = e.getMessage();
-                log.debug("Failed to process request: {}", body);
+                log.debug("Failed to process request in DeviceAuthCallback: {}", body);
             } else {
-                log.warn("Failed to process request", e);
+                log.warn("Failed to process request in DeviceAuthCallback", e);
             }
             responseWriter.setResult(new ResponseEntity<>(body, HttpStatus.INTERNAL_SERVER_ERROR));
         }
     }
 
-    private static class DeviceProvisionCallback implements TransportServiceCallback<ProvisionDeviceResponseMsg> {
+    static class DeviceProvisionCallback implements TransportServiceCallback<ProvisionDeviceResponseMsg> {
         private final DeferredResult<ResponseEntity> responseWriter;
 
         DeviceProvisionCallback(DeferredResult<ResponseEntity> responseWriter) {
@@ -486,9 +486,9 @@ public class DeviceApiController implements TbTransportService {
             String body = null;
             if (e instanceof HttpMessageNotReadableException || e instanceof JsonParseException) {
                 body = e.getMessage();
-                log.debug("Failed to process request: {}", body);
+                log.debug("Failed to process request in DeviceProvisionCallback: {}", body);
             } else {
-                log.warn("Failed to process request", e);
+                log.warn("Failed to process request in DeviceProvisionCallback", e);
             }
             responseWriter.setResult(new ResponseEntity<>(body, HttpStatus.INTERNAL_SERVER_ERROR));
         }
@@ -533,9 +533,9 @@ public class DeviceApiController implements TbTransportService {
             String body = null;
             if (e instanceof HttpMessageNotReadableException || e instanceof JsonParseException) {
                 body = e.getMessage();
-                log.debug("Failed to process request: {}", body);
+                log.debug("Failed to process request in GetOtaPackageCallback: {}", body);
             } else {
-                log.warn("Failed to process request", e);
+                log.warn("Failed to process request in GetOtaPackageCallback", e);
             }
             responseWriter.setResult(new ResponseEntity<>(body, HttpStatus.INTERNAL_SERVER_ERROR));
         }

--- a/common/transport/http/src/main/java/org/thingsboard/server/transport/http/DeviceApiController.java
+++ b/common/transport/http/src/main/java/org/thingsboard/server/transport/http/DeviceApiController.java
@@ -16,6 +16,7 @@
 package org.thingsboard.server.transport.http;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,6 +32,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -434,7 +436,7 @@ public class DeviceApiController implements TbTransportService {
         return responseWriter;
     }
 
-    private static class DeviceAuthCallback implements TransportServiceCallback<ValidateDeviceCredentialsResponse> {
+    static class DeviceAuthCallback implements TransportServiceCallback<ValidateDeviceCredentialsResponse> {
         private final TransportContext transportContext;
         private final DeferredResult<ResponseEntity> responseWriter;
         private final Consumer<SessionInfoProto> onSuccess;
@@ -456,8 +458,14 @@ public class DeviceApiController implements TbTransportService {
 
         @Override
         public void onError(Throwable e) {
-            log.warn("Failed to process request", e);
-            responseWriter.setResult(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+            String body = null;
+            if (e instanceof HttpMessageNotReadableException || e instanceof JsonParseException) {
+                body = e.getMessage();
+                log.debug("Failed to process request: {}", body);
+            } else {
+                log.warn("Failed to process request", e);
+            }
+            responseWriter.setResult(new ResponseEntity<>(body, HttpStatus.INTERNAL_SERVER_ERROR));
         }
     }
 
@@ -475,8 +483,14 @@ public class DeviceApiController implements TbTransportService {
 
         @Override
         public void onError(Throwable e) {
-            log.warn("Failed to process request", e);
-            responseWriter.setResult(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+            String body = null;
+            if (e instanceof HttpMessageNotReadableException || e instanceof JsonParseException) {
+                body = e.getMessage();
+                log.debug("Failed to process request: {}", body);
+            } else {
+                log.warn("Failed to process request", e);
+            }
+            responseWriter.setResult(new ResponseEntity<>(body, HttpStatus.INTERNAL_SERVER_ERROR));
         }
     }
 
@@ -516,8 +530,14 @@ public class DeviceApiController implements TbTransportService {
 
         @Override
         public void onError(Throwable e) {
-            log.warn("Failed to process request", e);
-            responseWriter.setResult(new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));
+            String body = null;
+            if (e instanceof HttpMessageNotReadableException || e instanceof JsonParseException) {
+                body = e.getMessage();
+                log.debug("Failed to process request: {}", body);
+            } else {
+                log.warn("Failed to process request", e);
+            }
+            responseWriter.setResult(new ResponseEntity<>(body, HttpStatus.INTERNAL_SERVER_ERROR));
         }
     }
 

--- a/common/transport/http/src/main/java/org/thingsboard/server/transport/http/DeviceApiController.java
+++ b/common/transport/http/src/main/java/org/thingsboard/server/transport/http/DeviceApiController.java
@@ -20,9 +20,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +56,7 @@ import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.gen.transport.TransportProtos.AttributeUpdateNotificationMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.GetAttributeRequestMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.GetAttributeResponseMsg;
+import org.thingsboard.server.gen.transport.TransportProtos.GetOtaPackageResponseMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.ProvisionDeviceResponseMsg;
 import org.thingsboard.server.gen.transport.TransportProtos.SessionCloseNotificationProto;
 import org.thingsboard.server.gen.transport.TransportProtos.SessionInfoProto;
@@ -487,7 +486,7 @@ public class DeviceApiController implements TbTransportService {
     }
 
     @RequiredArgsConstructor
-    static class GetOtaPackageCallback implements TransportServiceCallback<TransportProtos.GetOtaPackageResponseMsg> {
+    static class GetOtaPackageCallback implements TransportServiceCallback<GetOtaPackageResponseMsg> {
         private final TransportContext transportContext;
         private final DeferredResult<ResponseEntity> responseWriter;
         private final String title;

--- a/common/transport/http/src/main/java/org/thingsboard/server/transport/http/DeviceApiController.java
+++ b/common/transport/http/src/main/java/org/thingsboard/server/transport/http/DeviceApiController.java
@@ -431,7 +431,7 @@ public class DeviceApiController implements TbTransportService {
                             .setDeviceIdMSB(sessionInfo.getDeviceIdMSB())
                             .setDeviceIdLSB(sessionInfo.getDeviceIdLSB())
                             .setType(firmwareType.name()).build();
-                    transportContext.getTransportService().process(sessionInfo, requestMsg, new GetOtaPackageCallback(responseWriter, title, version, size, chunk));
+                    transportContext.getTransportService().process(sessionInfo, requestMsg, new GetOtaPackageCallback(transportContext,responseWriter, title, version, size, chunk));
                 }));
         return responseWriter;
     }
@@ -494,14 +494,16 @@ public class DeviceApiController implements TbTransportService {
         }
     }
 
-    private class GetOtaPackageCallback implements TransportServiceCallback<TransportProtos.GetOtaPackageResponseMsg> {
+    static class GetOtaPackageCallback implements TransportServiceCallback<TransportProtos.GetOtaPackageResponseMsg> {
+        private final TransportContext transportContext;
         private final DeferredResult<ResponseEntity> responseWriter;
         private final String title;
         private final String version;
         private final int chuckSize;
         private final int chuck;
 
-        GetOtaPackageCallback(DeferredResult<ResponseEntity> responseWriter, String title, String version, int chuckSize, int chuck) {
+        GetOtaPackageCallback(TransportContext transportContext, DeferredResult<ResponseEntity> responseWriter, String title, String version, int chuckSize, int chuck) {
+            this.transportContext = transportContext;
             this.responseWriter = responseWriter;
             this.title = title;
             this.version = version;

--- a/common/transport/http/src/test/java/org/thingsboard/server/transport/http/DeviceApiControllerTest.java
+++ b/common/transport/http/src/test/java/org/thingsboard/server/transport/http/DeviceApiControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/common/transport/http/src/test/java/org/thingsboard/server/transport/http/DeviceApiControllerTest.java
+++ b/common/transport/http/src/test/java/org/thingsboard/server/transport/http/DeviceApiControllerTest.java
@@ -16,7 +16,6 @@
 package org.thingsboard.server.transport.http;
 
 import com.google.gson.JsonParseException;
-import com.google.gson.JsonSyntaxException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.ResponseEntity;
@@ -28,12 +27,10 @@ import org.thingsboard.server.gen.transport.TransportProtos;
 import java.io.IOException;
 import java.util.function.Consumer;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class DeviceApiControllerTest {
 
     @Test
-    void DeviceAuthCallbackTest() {
+    void deviceAuthCallbackTest() {
         TransportContext transportContext = Mockito.mock(TransportContext.class);
         DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
         Consumer<TransportProtos.SessionInfoProto> onSuccess = x -> {};
@@ -49,7 +46,7 @@ class DeviceApiControllerTest {
     }
 
     @Test
-    void DeviceProvisionCallbackTest() {
+    void deviceProvisionCallbackTest() {
         DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
         var callback = new DeviceApiController.DeviceProvisionCallback(responseWriter);
 
@@ -62,14 +59,23 @@ class DeviceApiControllerTest {
         callback.onError(new RuntimeException("oops it is run time error"));
     }
 
-//@Test
-//    void GetOtaPackageCallback() {
-//          DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
-//          String title = "Title";
-//          String version = "version";
-//          int chuckSize = 11;
-//          int chuck = 3;
-//
-//          var callback = new DeviceApiController.GetOtaPackageCallback(responseWriter, title, version, chuckSize, chuck);
-//    }
+@Test
+    void getOtaPackageCallback() {
+          TransportContext transportContext = Mockito.mock(TransportContext.class);
+          DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
+          String title = "Title";
+          String version = "version";
+          int chuckSize = 11;
+          int chuck = 3;
+
+          var callback = new DeviceApiController.GetOtaPackageCallback(transportContext, responseWriter, title, version, chuckSize, chuck);
+
+          callback.onError(new HttpMessageNotReadableException("JSON incorrect syntax"));
+
+          callback.onError(new JsonParseException("Json ; expected"));
+
+          callback.onError(new IOException("not found"));
+
+          callback.onError(new RuntimeException("oops it is run time error"));
+    }
 }

--- a/common/transport/http/src/test/java/org/thingsboard/server/transport/http/DeviceApiControllerTest.java
+++ b/common/transport/http/src/test/java/org/thingsboard/server/transport/http/DeviceApiControllerTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.thingsboard.server.transport.http;
 
 import com.google.gson.JsonParseException;
@@ -18,13 +33,13 @@ import static org.junit.jupiter.api.Assertions.*;
 class DeviceApiControllerTest {
 
     @Test
-    void callbackOnErrorTest() {
+    void DeviceAuthCallbackTest() {
         TransportContext transportContext = Mockito.mock(TransportContext.class);
         DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
         Consumer<TransportProtos.SessionInfoProto> onSuccess = x -> {};
         var callback = new DeviceApiController.DeviceAuthCallback(transportContext, responseWriter, onSuccess);
 
-        callback.onError(new HttpMessageNotReadableException("JSON incorect syntax"));
+        callback.onError(new HttpMessageNotReadableException("JSON incorrect syntax"));
 
         callback.onError(new JsonParseException("Json ; expected"));
 
@@ -32,4 +47,29 @@ class DeviceApiControllerTest {
 
         callback.onError(new RuntimeException("oops it is run time error"));
     }
+
+    @Test
+    void DeviceProvisionCallbackTest() {
+        DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
+        var callback = new DeviceApiController.DeviceProvisionCallback(responseWriter);
+
+        callback.onError(new HttpMessageNotReadableException("JSON incorrect syntax"));
+
+        callback.onError(new JsonParseException("Json ; expected"));
+
+        callback.onError(new IOException("not found"));
+
+        callback.onError(new RuntimeException("oops it is run time error"));
+    }
+
+//@Test
+//    void GetOtaPackageCallback() {
+//          DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
+//          String title = "Title";
+//          String version = "version";
+//          int chuckSize = 11;
+//          int chuck = 3;
+//
+//          var callback = new DeviceApiController.GetOtaPackageCallback(responseWriter, title, version, chuckSize, chuck);
+//    }
 }

--- a/common/transport/http/src/test/java/org/thingsboard/server/transport/http/DeviceApiControllerTest.java
+++ b/common/transport/http/src/test/java/org/thingsboard/server/transport/http/DeviceApiControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,8 @@ class DeviceApiControllerTest {
     void deviceAuthCallbackTest() {
         TransportContext transportContext = Mockito.mock(TransportContext.class);
         DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
-        Consumer<TransportProtos.SessionInfoProto> onSuccess = x -> {};
+        Consumer<TransportProtos.SessionInfoProto> onSuccess = x -> {
+        };
         var callback = new DeviceApiController.DeviceAuthCallback(transportContext, responseWriter, onSuccess);
 
         callback.onError(new HttpMessageNotReadableException("JSON incorrect syntax"));
@@ -59,23 +60,23 @@ class DeviceApiControllerTest {
         callback.onError(new RuntimeException("oops it is run time error"));
     }
 
-@Test
+    @Test
     void getOtaPackageCallback() {
-          TransportContext transportContext = Mockito.mock(TransportContext.class);
-          DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
-          String title = "Title";
-          String version = "version";
-          int chuckSize = 11;
-          int chuck = 3;
+        TransportContext transportContext = Mockito.mock(TransportContext.class);
+        DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
+        String title = "Title";
+        String version = "version";
+        int chunkSize = 11;
+        int chunk = 3;
 
-          var callback = new DeviceApiController.GetOtaPackageCallback(transportContext, responseWriter, title, version, chuckSize, chuck);
+        var callback = new DeviceApiController.GetOtaPackageCallback(transportContext, responseWriter, title, version, chunkSize, chunk);
 
-          callback.onError(new HttpMessageNotReadableException("JSON incorrect syntax"));
+        callback.onError(new HttpMessageNotReadableException("JSON incorrect syntax"));
 
-          callback.onError(new JsonParseException("Json ; expected"));
+        callback.onError(new JsonParseException("Json ; expected"));
 
-          callback.onError(new IOException("not found"));
+        callback.onError(new IOException("not found"));
 
-          callback.onError(new RuntimeException("oops it is run time error"));
+        callback.onError(new RuntimeException("oops it is run time error"));
     }
 }

--- a/common/transport/http/src/test/java/org/thingsboard/server/transport/http/DeviceApiControllerTest.java
+++ b/common/transport/http/src/test/java/org/thingsboard/server/transport/http/DeviceApiControllerTest.java
@@ -1,0 +1,35 @@
+package org.thingsboard.server.transport.http;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSyntaxException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.context.request.async.DeferredResult;
+import org.thingsboard.server.common.transport.TransportContext;
+import org.thingsboard.server.gen.transport.TransportProtos;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DeviceApiControllerTest {
+
+    @Test
+    void callbackOnErrorTest() {
+        TransportContext transportContext = Mockito.mock(TransportContext.class);
+        DeferredResult<ResponseEntity> responseWriter = Mockito.mock(DeferredResult.class);
+        Consumer<TransportProtos.SessionInfoProto> onSuccess = x -> {};
+        var callback = new DeviceApiController.DeviceAuthCallback(transportContext, responseWriter, onSuccess);
+
+        callback.onError(new HttpMessageNotReadableException("JSON incorect syntax"));
+
+        callback.onError(new JsonParseException("Json ; expected"));
+
+        callback.onError(new IOException("not found"));
+
+        callback.onError(new RuntimeException("oops it is run time error"));
+    }
+}

--- a/common/transport/http/src/test/resources/logback-test.xml
+++ b/common/transport/http/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="TRACE">
+        <appender-ref ref="console"/>
+    </root>
+
+</configuration>

--- a/common/transport/http/src/test/resources/logback-test.xml
+++ b/common/transport/http/src/test/resources/logback-test.xml
@@ -7,7 +7,9 @@
         </encoder>
     </appender>
 
-    <root level="TRACE">
+    logger name="org.thingsboard.server.transport.http.DeviceApiController" level="DEBUG" />
+
+    <root level="INFO">
         <appender-ref ref="console"/>
     </root>
 


### PR DESCRIPTION


## Pull Request description

Issue: #10303

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



