### PR TITLE
Check alarm status node: log severity reduced for "Failed to parse alarm" for known runtime exceptions

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbCheckAlarmStatusNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbCheckAlarmStatusNode.java
@@ -80,9 +80,9 @@ public class TbCheckAlarmStatusNode implements TbNode {
             }, ctx.getDbCallbackExecutor());
         } catch (Exception e) {
             if (e instanceof IllegalArgumentException || e instanceof NullPointerException) {
-                log.debug("Failed to parse alarm: [{}] error [{}]", msg.getData(), e.getMessage());
+                log.debug("[{}][{}] Failed to parse alarm: [{}] error [{}]", ctx.getTenantId(), ctx.getRuleChainName(), msg.getData(), e.getMessage());
             } else {
-                log.error("Failed to parse alarm: [{}]", msg.getData(), e);
+                log.error("[{}][{}] Failed to parse alarm: [{}]", ctx.getTenantId(), ctx.getRuleChainName(), msg.getData(), e);
             }
             throw new TbNodeException(e);
         }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbCheckAlarmStatusNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/filter/TbCheckAlarmStatusNode.java
@@ -32,6 +32,7 @@ import org.thingsboard.server.common.data.plugin.ComponentType;
 import org.thingsboard.server.common.msg.TbMsg;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 @Slf4j
 @RuleNode(
@@ -57,7 +58,7 @@ public class TbCheckAlarmStatusNode implements TbNode {
     public void onMsg(TbContext ctx, TbMsg msg) throws TbNodeException {
         try {
             Alarm alarm = JacksonUtil.fromString(msg.getData(), Alarm.class);
-
+            Objects.requireNonNull(alarm, "alarm is null");
             ListenableFuture<Alarm> latest = ctx.getAlarmService().findAlarmByIdAsync(ctx.getTenantId(), alarm.getId());
 
             Futures.addCallback(latest, new FutureCallback<>() {
@@ -78,7 +79,11 @@ public class TbCheckAlarmStatusNode implements TbNode {
                 }
             }, ctx.getDbCallbackExecutor());
         } catch (Exception e) {
-            log.error("Failed to parse alarm: [{}]", msg.getData());
+            if (e instanceof IllegalArgumentException || e instanceof NullPointerException) {
+                log.debug("Failed to parse alarm: [{}] error [{}]", msg.getData(), e.getMessage());
+            } else {
+                log.error("Failed to parse alarm: [{}]", msg.getData(), e);
+            }
             throw new TbNodeException(e);
         }
     }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbCheckAlarmStatusNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbCheckAlarmStatusNodeTest.java
@@ -38,6 +38,7 @@ import org.thingsboard.server.common.msg.TbMsgMetaData;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -156,6 +157,18 @@ class TbCheckAlarmStatusNodeTest {
         assertThat(newMsg).isSameAs(msg);
         Throwable value = throwableCaptor.getValue();
         assertThat(value).isInstanceOf(TbNodeException.class).hasMessage("No such alarm found.");
+    }
+
+    @Test
+    void givenUnparseableAlarm_whenOnMsg_then_Failure() {
+        String msgData = "{\"Number\":1113718,\"id\":8.1}";
+        TbMsg msg = getTbMsg(msgData);
+
+        assertThatThrownBy(() -> node.onMsg(ctx, msg))
+                .as("onMsg")
+                .isInstanceOf(TbNodeException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessage("java.lang.IllegalArgumentException: The given string value cannot be transformed to Json object: {\"Number\":1113718,\"id\":8.1}");
     }
 
     private TbMsg getTbMsg(String msgData) {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbCheckAlarmStatusNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbCheckAlarmStatusNodeTest.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -163,6 +164,7 @@ class TbCheckAlarmStatusNodeTest {
     void givenUnparseableAlarm_whenOnMsg_then_Failure() {
         String msgData = "{\"Number\":1113718,\"id\":8.1}";
         TbMsg msg = getTbMsg(msgData);
+        willReturn("Default Rule Chain").given(ctx).getRuleChainName();
 
         assertThatThrownBy(() -> node.onMsg(ctx, msg))
                 .as("onMsg")

--- a/rule-engine/rule-engine-components/src/test/resources/logback-test.xml
+++ b/rule-engine/rule-engine-components/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.thingsboard.rule.engine.filter.TbCheckAlarmStatusNode" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Check alarm status node: log severity DEBUG for "Failed to parse alarm" for known runtime exceptions. 

The ERROR severity will fire only on unexpected exception types. This will prevent flooding the error logger.

![image](https://github.com/thingsboard/thingsboard/assets/79898499/da5c9680-78cc-447c-aff3-efbe1973f91c)

The test added:

![image](https://github.com/thingsboard/thingsboard/assets/79898499/24d5e522-5477-4063-a9c2-1cc1a3e79fe9)

The rule-node behavior with no change.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



