### PR TITLE
Nashorn js executor sandbox memory limit

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -866,6 +866,8 @@ js:
     monitor_thread_pool_size: "${LOCAL_JS_SANDBOX_MONITOR_THREAD_POOL_SIZE:4}"
     # Maximum CPU time in milliseconds allowed for script execution
     max_cpu_time: "${LOCAL_JS_SANDBOX_MAX_CPU_TIME:8000}"
+    # Maximum memory in Bytes which JS executor thread can allocate (approximate calculation). A zero memory limit in combination with a non-zero CPU limit is not recommended due to the implementation of Nashorn 0.4.2. 100MiB is effectively unlimited for most cases
+    max_memory: "${LOCAL_JS_SANDBOX_MAX_MEMORY:104857600}"
     # Maximum allowed JavaScript execution errors before JavaScript will be blacklisted
     max_errors: "${LOCAL_JS_SANDBOX_MAX_ERRORS:3}"
     # JS Eval max request timeout. 0 - no timeout

--- a/application/src/test/java/org/thingsboard/server/service/script/NashornJsInvokeServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/script/NashornJsInvokeServiceTest.java
@@ -15,6 +15,8 @@
  */
 package org.thingsboard.server.service.script;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
@@ -28,9 +30,12 @@ import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.controller.AbstractControllerTest;
 import org.thingsboard.server.dao.service.DaoSqlTest;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -72,6 +77,44 @@ class NashornJsInvokeServiceTest extends AbstractControllerTest {
             boolean expected = i > 20;
             boolean result = Boolean.parseBoolean(invokeScript(scriptId, "{\"temperature\":" + i + "}"));
             log.debug("asserting result");
+            Assert.assertEquals(expected, result);
+        }
+        long duration = watch.stopAndGetTotalTimeMillis();
+        log.info("Performance test with {} invocations took: {} ms", iterations, duration);
+        assertThat(duration).as("duration ms")
+                .isLessThan(TimeUnit.MINUTES.toMillis(1)); // effective exec time is about 500ms
+    }
+
+    @Test
+    void givenSimpleScriptMultiThreadTestPerformance() throws ExecutionException, InterruptedException, TimeoutException {
+        int iterations = 1000*4;
+        List<ListenableFuture<Object>> futures = new ArrayList<>(iterations);
+        UUID scriptId = evalScript("return msg.temperature > 20 ;");
+        // warmup
+        log.info("Warming up 1000 times...");
+
+        var warmupWatch = TbStopWatch.create();
+        for (int i = 0; i < 1000; i++) {
+            futures.add(invokeScriptAsync(scriptId, "{\"temperature\":" + i + "}"));
+        }
+        List<Object> results = Futures.allAsList(futures).get(1, TimeUnit.MINUTES);
+        for (int i = 0; i < 1000; i++) {
+            boolean expected = i > 20;
+            boolean result = Boolean.parseBoolean(results.get(i).toString());
+            Assert.assertEquals(expected, result);
+        }
+        log.info("Warming up finished in {} ms", warmupWatch.stopAndGetTotalTimeMillis());
+        futures.clear();
+
+        log.info("Starting performance test...");
+        var watch = TbStopWatch.create();
+        for (int i = 0; i < iterations; i++) {
+            futures.add(invokeScriptAsync(scriptId, "{\"temperature\":" + i + "}"));
+        }
+        results = Futures.allAsList(futures).get(1, TimeUnit.MINUTES);
+        for (int i = 0; i < iterations; i++) {
+            boolean expected = i > 20;
+            boolean result = Boolean.parseBoolean(results.get(i).toString());
             Assert.assertEquals(expected, result);
         }
         long duration = watch.stopAndGetTotalTimeMillis();
@@ -127,7 +170,11 @@ class NashornJsInvokeServiceTest extends AbstractControllerTest {
     }
 
     private String invokeScript(UUID scriptId, String msg) throws ExecutionException, InterruptedException {
-        return invokeService.invokeScript(TenantId.SYS_TENANT_ID, null, scriptId, msg, "{}", POST_TELEMETRY_REQUEST.name()).get().toString();
+        return invokeScriptAsync(scriptId, msg).get().toString();
+    }
+
+    private ListenableFuture<Object> invokeScriptAsync(UUID scriptId, String msg) {
+        return invokeService.invokeScript(TenantId.SYS_TENANT_ID, null, scriptId, msg, "{}", POST_TELEMETRY_REQUEST.name());
     }
 
 }

--- a/application/src/test/resources/logback-test.xml
+++ b/application/src/test/resources/logback-test.xml
@@ -16,7 +16,7 @@
     <logger name="org.testcontainers" level="INFO" />
     <logger name="org.eclipse.leshan" level="INFO"/>
     <logger name="org.thingsboard.server.controller.AbstractWebTest" level="INFO"/>
-
+    <logger name="org.thingsboard.server.service.script" level="INFO"/>
 
     <!-- mute TelemetryEdgeSqlTest that causes a lot of randomly generated errors -->
     <logger name="org.thingsboard.server.service.edge.rpc.EdgeGrpcSession" level="OFF"/>

--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/AbstractScriptInvokeService.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/AbstractScriptInvokeService.java
@@ -145,14 +145,14 @@ public abstract class AbstractScriptInvokeService implements ScriptInvokeService
                 log.trace("[{}] InvokeScript uuid {} with timeout {}ms", tenantId, scriptId, getMaxInvokeRequestsTimeout());
                 var task = doInvokeFunction(scriptId, args);
 
-                var resultFuture = Futures.transformAsync(task.getResultFuture(), output -> {
+                var resultFuture = Futures.transform(task.getResultFuture(), output -> {
                     String result = JacksonUtil.toString(output);
                     if (resultSizeExceeded(result)) {
                         throw new TbScriptException(scriptId, TbScriptException.ErrorCode.OTHER, null, new RuntimeException(
                                 format("Script invocation result exceeds maximum allowed size of %s symbols", getMaxResultSize())
                         ));
                     }
-                    return Futures.immediateFuture(output);
+                    return output;
                 }, MoreExecutors.directExecutor());
 
                 return withTimeoutAndStatsCallback(scriptId, task, resultFuture, invokeCallback, getMaxInvokeRequestsTimeout());

--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/js/NashornJsInvokeService.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/js/NashornJsInvokeService.java
@@ -61,10 +61,10 @@ public class NashornJsInvokeService extends AbstractJsInvokeService {
     @Value("${js.local.monitor_thread_pool_size}")
     private int monitorThreadPoolSize;
 
-    @Value("${js.local.max_cpu_time}")
+    @Value("${js.local.max_cpu_time:8000}") // 8 seconds
     private long maxCpuTime;
 
-    @Value("${js.local.max_memory}")
+    @Value("${js.local.max_memory:104857600}") // 100 MiB
     private long maxMemory;
 
     @Getter

--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/js/NashornJsInvokeService.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/js/NashornJsInvokeService.java
@@ -41,7 +41,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReentrantLock;
 
 @Slf4j
@@ -64,6 +63,9 @@ public class NashornJsInvokeService extends AbstractJsInvokeService {
 
     @Value("${js.local.max_cpu_time}")
     private long maxCpuTime;
+
+    @Value("${js.local.max_memory}")
+    private long maxMemory;
 
     @Getter
     @Value("${js.local.max_errors}")
@@ -107,12 +109,13 @@ public class NashornJsInvokeService extends AbstractJsInvokeService {
     @Override
     public void init() {
         super.init();
-        jsExecutor = MoreExecutors.listeningDecorator(Executors.newWorkStealingPool(jsExecutorThreadPoolSize));
+        jsExecutor = MoreExecutors.listeningDecorator(ThingsBoardExecutors.newWorkStealingPool(jsExecutorThreadPoolSize, "nashorn-js-executor"));
         if (useJsSandbox) {
             sandbox = NashornSandboxes.create();
             monitorExecutorService = ThingsBoardExecutors.newWorkStealingPool(monitorThreadPoolSize, "nashorn-js-monitor");
             sandbox.setExecutor(monitorExecutorService);
             sandbox.setMaxCPUTime(maxCpuTime);
+            sandbox.setMaxMemory(maxMemory);
             sandbox.allowNoBraces(false);
             sandbox.allowLoadFunctions(true);
             sandbox.setMaxPreparedStatements(30);

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
             org/thingsboard/server/extensions/core/plugin/telemetry/gen/**/*
         </sonar.exclusions>
         <elasticsearch.version>5.0.2</elasticsearch.version>
-        <delight-nashorn-sandbox.version>0.2.1</delight-nashorn-sandbox.version>
+        <delight-nashorn-sandbox.version>0.4.2</delight-nashorn-sandbox.version>
         <nashorn-core.version>15.4</nashorn-core.version>
         <!-- IMPORTANT: If you change the version of the kafka client, make sure to synchronize our overwritten implementation of the
         org.apache.kafka.common.network.NetworkReceive class in the application module. It addresses the issue https://issues.apache.org/jira/browse/KAFKA-4090.


### PR DESCRIPTION
## Nashorn js executor sandbox memory limit

The rare issue I noticed on the build machine is a failed NashornJsInvokeServiceTest.givenSimpleScript**TestPerformance**
It runs 1000 js executions, but sometimes it takes more than **4 minutes**
It becomes **well reproducible** when it does 2000 executions
![image](https://github.com/thingsboard/thingsboard/assets/79898499/0191213c-a589-4ba8-a786-a0fa8fd42826)


### Investigation
The profiling shows that JS executions do nothing but waits

![2024-03-26_17-01](https://github.com/thingsboard/thingsboard/assets/79898499/c349d59f-f270-4d24-b229-40bb9bba4d6a)
![2024-03-26_17-37](https://github.com/thingsboard/thingsboard/assets/79898499/cd2ba5b3-70ea-47f4-a2fd-bfffae3d84fc)

### Root cause

Eventually, under the high load, the `delight.nashornsandbox.internal.ThreadMonitor` waits `maxCPUTime` when `maxMemory` is 0.
We set as default maxCPUTime 8000 ms. And the sandbox sometimes waits all 8000ms. 
The Nashorn's source code with this condition is below.

The easiest way to address the issue is to set the CPU limit to 0 or the memory limit to MAX_LONG.
The limit suggested is 100MiB, which is effectively infinite.

![2024-03-26_18-22](https://github.com/thingsboard/thingsboard/assets/79898499/92d2f5a5-7245-4a9c-a307-c2e3e6d13cf7)
![2024-03-26_18-19](https://github.com/thingsboard/thingsboard/assets/79898499/a9d1ab27-b95a-4c35-bfae-56080a3a79c7)

### Results
![image](https://github.com/thingsboard/thingsboard/assets/79898499/dfa1eab8-3c3c-48f3-9afc-efce027a5ad5)

Execution time reduced by x1000 for x2 more iterations

### VERSION UPGRADE

* Sandbox **version bumped** to the latest according to https://github.com/javadelight/delight-nashorn-sandbox?tab=readme-ov-file#version-history
![image](https://github.com/thingsboard/thingsboard/assets/79898499/c855799b-83db-49eb-8e09-bfafc8557331)

### Additional contexts

* Test refactored

### Further testing with million invocations

Single-thread test runs:
Performance test with 1 000 000 invocations took: 33456 ms  
Performance test with 10 000 000 invocations took: 265634 ms

![image](https://github.com/thingsboard/thingsboard/assets/79898499/62a75c52-7e85-41d2-af1e-245b0b003aef)

**UPDATE**: **Multithread** test added, defaults added to `@Value` for better deployment experience

![image](https://github.com/thingsboard/thingsboard/assets/79898499/df8b2443-71f6-43e7-aae3-0e8d86d5793e)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



