### PR TITLE
Create alarm node: fix `AlarmModificationRequest` validation, handle null UUID alarm originator, minor code style refactoring

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
@@ -456,15 +456,18 @@ public class BaseAlarmService extends AbstractCachedEntityService<TenantId, Page
     private void validateAlarmRequest(AlarmModificationRequest request) {
         ConstraintValidator.validateFields(request);
         if (request.getEndTs() > 0 && request.getStartTs() > request.getEndTs()) {
-            throw new DataValidationException("Alarm start ts can't be greater then alarm end ts!");
+            throw new DataValidationException("Alarm start ts can't be greater than alarm end ts!");
         }
         if (!tenantService.tenantExists(request.getTenantId())) {
             throw new DataValidationException("Alarm is referencing to non-existent tenant!");
         }
-        if (request.getStartTs() == 0L) {
-            request.setStartTs(System.currentTimeMillis());
-        }
-        if (request.getEndTs() == 0L) {
+        if (request.getStartTs() == 0L && request.getEndTs() == 0L) {
+            long currentTs = System.currentTimeMillis();
+            request.setStartTs(currentTs);
+            request.setEndTs(currentTs);
+        } else if (request.getStartTs() == 0L) {
+            request.setStartTs(request.getEndTs());
+        } else if (request.getEndTs() == 0L) {
             request.setEndTs(request.getStartTs());
         }
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbAbstractAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbAbstractAlarmNode.java
@@ -45,7 +45,7 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
 
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
-        this.config = loadAlarmNodeConfig(configuration);
+        config = loadAlarmNodeConfig(configuration);
         scriptEngine = ctx.createScriptEngine(config.getScriptLang(),
                 ScriptLanguage.TBEL.equals(config.getScriptLang()) ? config.getAlarmDetailsBuildTbel() : config.getAlarmDetailsBuildJs());
     }
@@ -56,13 +56,13 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
     public void onMsg(TbContext ctx, TbMsg msg) {
         withCallback(processAlarm(ctx, msg),
                 alarmResult -> {
-                    if (alarmResult.alarm == null) {
+                    if (alarmResult.getAlarm() == null) {
                         ctx.tellNext(msg, TbNodeConnectionType.FALSE);
-                    } else if (alarmResult.isCreated) {
+                    } else if (alarmResult.isCreated()) {
                         tellNext(ctx, msg, alarmResult, TbMsgType.ENTITY_CREATED, "Created");
-                    } else if (alarmResult.isUpdated || alarmResult.isSeverityUpdated) {
+                    } else if (alarmResult.isUpdated() || alarmResult.isSeverityUpdated()) {
                         tellNext(ctx, msg, alarmResult, TbMsgType.ENTITY_UPDATED, "Updated");
-                    } else if (alarmResult.isCleared) {
+                    } else if (alarmResult.isCleared()) {
                         tellNext(ctx, msg, alarmResult, TbMsgType.ALARM_CLEAR, "Cleared");
                     } else {
                         ctx.tellSuccess(msg);
@@ -73,7 +73,7 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
 
     protected abstract ListenableFuture<TbAlarmResult> processAlarm(TbContext ctx, TbMsg msg);
 
-    protected ListenableFuture<JsonNode> buildAlarmDetails(TbMsg msg, JsonNode previousDetails) {
+    protected ListenableFuture<JsonNode> buildAlarmDetails(TbContext ctx, TbMsg msg, JsonNode previousDetails) {
         try {
             TbMsg dummyMsg = msg;
             if (previousDetails != null) {
@@ -81,24 +81,25 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
                 metaData.putValue(PREV_ALARM_DETAILS, JacksonUtil.toString(previousDetails));
                 dummyMsg = TbMsg.transformMsgMetadata(msg, metaData);
             }
-            return scriptEngine.executeJsonAsync(dummyMsg);
+            ctx.logJsEvalRequest();
+            ListenableFuture<JsonNode> alarmDetailsFuture = scriptEngine.executeJsonAsync(dummyMsg);
+            withCallback(alarmDetailsFuture, alarmDetails -> ctx.logJsEvalResponse(), t -> ctx.logJsEvalFailure());
+            return alarmDetailsFuture;
         } catch (Exception e) {
             return Futures.immediateFailedFuture(e);
         }
     }
 
     public static TbMsg toAlarmMsg(TbContext ctx, TbAlarmResult alarmResult, TbMsg originalMsg) {
-        JsonNode jsonNodes = JacksonUtil.valueToTree(alarmResult.alarm);
-        String data = jsonNodes.toString();
         TbMsgMetaData metaData = originalMsg.getMetaData().copy();
-        if (alarmResult.isCreated) {
+        if (alarmResult.isCreated()) {
             metaData.putValue(DataConstants.IS_NEW_ALARM, Boolean.TRUE.toString());
-        } else if (alarmResult.isUpdated || alarmResult.isSeverityUpdated) {
+        } else if (alarmResult.isUpdated() || alarmResult.isSeverityUpdated()) {
             metaData.putValue(DataConstants.IS_EXISTING_ALARM, Boolean.TRUE.toString());
-        } else if (alarmResult.isCleared) {
+        } else if (alarmResult.isCleared()) {
             metaData.putValue(DataConstants.IS_CLEARED_ALARM, Boolean.TRUE.toString());
         }
-        return ctx.transformMsg(originalMsg, TbMsgType.ALARM, originalMsg.getOriginator(), metaData, data);
+        return ctx.transformMsg(originalMsg, TbMsgType.ALARM, originalMsg.getOriginator(), metaData, JacksonUtil.toString(alarmResult.getAlarm()));
     }
 
     @Override
@@ -109,7 +110,7 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
     }
 
     private void tellNext(TbContext ctx, TbMsg msg, TbAlarmResult alarmResult, TbMsgType actionMsgType, String alarmAction) {
-        ctx.enqueue(ctx.alarmActionMsg(alarmResult.alarm, ctx.getSelfId(), actionMsgType),
+        ctx.enqueue(ctx.alarmActionMsg(alarmResult.getAlarm(), ctx.getSelfId(), actionMsgType),
                 () -> ctx.tellNext(toAlarmMsg(ctx, alarmResult, msg), alarmAction),
                 throwable -> ctx.tellFailure(toAlarmMsg(ctx, alarmResult, msg), throwable));
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNode.java
@@ -70,10 +70,8 @@ public class TbClearAlarmNode extends TbAbstractAlarmNode<TbClearAlarmNodeConfig
     }
 
     private ListenableFuture<TbAlarmResult> clearAlarm(TbContext ctx, TbMsg msg, Alarm alarm) {
-        ctx.logJsEvalRequest();
-        ListenableFuture<JsonNode> asyncDetails = buildAlarmDetails(msg, alarm.getDetails());
+        ListenableFuture<JsonNode> asyncDetails = buildAlarmDetails(ctx, msg, alarm.getDetails());
         return Futures.transform(asyncDetails, details -> {
-            ctx.logJsEvalResponse();
             AlarmApiCallResult result = ctx.getAlarmService().clearAlarm(ctx.getTenantId(), alarm.getId(), System.currentTimeMillis(), details);
             if (result.isSuccessful()) {
                 return new TbAlarmResult(false, false, result.isCleared(), result.getAlarm());

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
@@ -32,12 +32,10 @@ import org.thingsboard.server.common.data.alarm.AlarmApiCallResult;
 import org.thingsboard.server.common.data.alarm.AlarmCreateOrUpdateActiveRequest;
 import org.thingsboard.server.common.data.alarm.AlarmSeverity;
 import org.thingsboard.server.common.data.alarm.AlarmUpdateRequest;
+import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.plugin.ComponentType;
 import org.thingsboard.server.common.msg.TbMsg;
-
-import java.io.IOException;
-import java.util.List;
 
 @Slf4j
 @RuleNode(
@@ -57,16 +55,15 @@ import java.util.List;
 )
 public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConfiguration> {
 
-    private List<String> relationTypes;
     private AlarmSeverity notDynamicAlarmSeverity;
 
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
         super.init(ctx, configuration);
-        if (!this.config.isDynamicSeverity()) {
-            this.notDynamicAlarmSeverity = EnumUtils.getEnum(AlarmSeverity.class, this.config.getSeverity());
-            if (this.notDynamicAlarmSeverity == null) {
-                throw new TbNodeException("Incorrect Alarm Severity value: " + this.config.getSeverity(), true);
+        if (!config.isDynamicSeverity()) {
+            notDynamicAlarmSeverity = EnumUtils.getEnum(AlarmSeverity.class, config.getSeverity());
+            if (notDynamicAlarmSeverity == null) {
+                throw new TbNodeException("Incorrect Alarm Severity value: " + config.getSeverity(), true);
             }
         }
     }
@@ -74,9 +71,7 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
 
     @Override
     protected TbCreateAlarmNodeConfiguration loadAlarmNodeConfig(TbNodeConfiguration configuration) throws TbNodeException {
-        TbCreateAlarmNodeConfiguration nodeConfiguration = TbNodeUtils.convert(configuration, TbCreateAlarmNodeConfiguration.class);
-        relationTypes = nodeConfiguration.getRelationTypes();
-        return nodeConfiguration;
+        return TbNodeUtils.convert(configuration, TbCreateAlarmNodeConfiguration.class);
     }
 
     @Override
@@ -85,31 +80,30 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         final Alarm msgAlarm;
 
         if (!config.isUseMessageAlarmData()) {
-            alarmType = TbNodeUtils.processPattern(this.config.getAlarmType(), msg);
+            alarmType = TbNodeUtils.processPattern(config.getAlarmType(), msg);
             msgAlarm = null;
         } else {
             try {
-                msgAlarm = getAlarmFromMessage(ctx, msg);
+                msgAlarm = getAlarmFromMessage(ctx.getTenantId(), msg);
                 alarmType = msgAlarm.getType();
-            } catch (IOException e) {
-                ctx.tellFailure(msg, e);
-                return null;
+            } catch (IllegalArgumentException e) {
+                return Futures.immediateFailedFuture(e);
             }
         }
 
         Alarm existingAlarm = ctx.getAlarmService().findLatestActiveByOriginatorAndType(ctx.getTenantId(), msg.getOriginator(), alarmType);
-        if (existingAlarm == null || existingAlarm.getStatus().isCleared()) {
+        if (existingAlarm == null || existingAlarm.isCleared()) {
             return createNewAlarm(ctx, msg, msgAlarm);
         } else {
             return updateAlarm(ctx, msg, existingAlarm, msgAlarm);
         }
     }
 
-    private Alarm getAlarmFromMessage(TbContext ctx, TbMsg msg) throws IOException {
-        Alarm msgAlarm;
-        msgAlarm = JacksonUtil.fromString(msg.getData(), Alarm.class);
-        msgAlarm.setTenantId(ctx.getTenantId());
-        if (msgAlarm.getOriginator() == null) {
+    private Alarm getAlarmFromMessage(TenantId tenantId, TbMsg msg) throws IllegalArgumentException {
+        Alarm msgAlarm = JacksonUtil.fromString(msg.getData(), Alarm.class);
+        msgAlarm.setTenantId(tenantId);
+        EntityId msgAlarmOriginator = msgAlarm.getOriginator();
+        if (msgAlarmOriginator == null || msgAlarmOriginator.isNullUid()) {
             msgAlarm.setOriginator(msg.getOriginator());
         }
         return msgAlarm;
@@ -119,15 +113,11 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         ListenableFuture<JsonNode> asyncDetails;
         boolean buildDetails = !config.isUseMessageAlarmData() || config.isOverwriteAlarmDetails();
         if (buildDetails) {
-            ctx.logJsEvalRequest();
-            asyncDetails = buildAlarmDetails(msg, null);
+            asyncDetails = buildAlarmDetails(ctx, msg, null);
         } else {
             asyncDetails = Futures.immediateFuture(null);
         }
         ListenableFuture<Alarm> asyncAlarm = Futures.transform(asyncDetails, details -> {
-            if (buildDetails) {
-                ctx.logJsEvalResponse();
-            }
             Alarm newAlarm;
             if (msgAlarm != null) {
                 newAlarm = msgAlarm;
@@ -148,15 +138,11 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         ListenableFuture<JsonNode> asyncDetails;
         boolean buildDetails = !config.isUseMessageAlarmData() || config.isOverwriteAlarmDetails();
         if (buildDetails) {
-            ctx.logJsEvalRequest();
-            asyncDetails = buildAlarmDetails(msg, existingAlarm.getDetails());
+            asyncDetails = buildAlarmDetails(ctx, msg, existingAlarm.getDetails());
         } else {
             asyncDetails = Futures.immediateFuture(null);
         }
         ListenableFuture<AlarmApiCallResult> asyncUpdated = Futures.transform(asyncDetails, details -> {
-            if (buildDetails) {
-                ctx.logJsEvalResponse();
-            }
             if (msgAlarm != null) {
                 existingAlarm.setSeverity(msgAlarm.getSeverity());
                 existingAlarm.setPropagate(msgAlarm.isPropagate());
@@ -173,7 +159,7 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
                 existingAlarm.setPropagate(config.isPropagate());
                 existingAlarm.setPropagateToOwner(config.isPropagateToOwner());
                 existingAlarm.setPropagateToTenant(config.isPropagateToTenant());
-                existingAlarm.setPropagateRelationTypes(relationTypes);
+                existingAlarm.setPropagateRelationTypes(config.getRelationTypes());
                 existingAlarm.setDetails(details);
             }
             existingAlarm.setEndTs(currentTimeMillis());
@@ -189,12 +175,12 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
                 .originator(msg.getOriginator())
                 .cleared(false)
                 .acknowledged(false)
-                .severity(this.config.isDynamicSeverity() ? processAlarmSeverity(msg) : notDynamicAlarmSeverity)
+                .severity(config.isDynamicSeverity() ? processAlarmSeverity(msg) : notDynamicAlarmSeverity)
                 .propagate(config.isPropagate())
                 .propagateToOwner(config.isPropagateToOwner())
                 .propagateToTenant(config.isPropagateToTenant())
-                .type(TbNodeUtils.processPattern(this.config.getAlarmType(), msg))
-                .propagateRelationTypes(relationTypes)
+                .type(TbNodeUtils.processPattern(config.getAlarmType(), msg))
+                .propagateRelationTypes(config.getRelationTypes())
                 .startTs(ts)
                 .endTs(ts)
                 .details(details)
@@ -202,7 +188,7 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
     }
 
     private AlarmSeverity processAlarmSeverity(TbMsg msg) {
-        AlarmSeverity severity = EnumUtils.getEnum(AlarmSeverity.class, TbNodeUtils.processPattern(this.config.getSeverity(), msg));
+        AlarmSeverity severity = EnumUtils.getEnum(AlarmSeverity.class, TbNodeUtils.processPattern(config.getSeverity(), msg));
         if (severity == null) {
             throw new RuntimeException("Used incorrect pattern or Alarm Severity not included in message");
         }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateAlarmNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateAlarmNodeTest.java
@@ -245,6 +245,7 @@ class TbCreateAlarmNodeTest {
         then(ctxMock).should().logJsEvalRequest();
         then(alarmDetailsScriptMock).should().executeJsonAsync(incomingMsg);
         then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called createAlarm() with correct AlarmCreateOrUpdateActiveRequest
         then(alarmServiceMock).should().createAlarm(expectedCreateAlarmRequest);
@@ -414,6 +415,7 @@ class TbCreateAlarmNodeTest {
         then(ctxMock).should().logJsEvalRequest();
         then(alarmDetailsScriptMock).should().executeJsonAsync(incomingMsg);
         then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called createAlarm() with correct AlarmCreateOrUpdateActiveRequest
         then(alarmServiceMock).should().createAlarm(expectedCreateAlarmRequest);
@@ -607,8 +609,9 @@ class TbCreateAlarmNodeTest {
         TbMsg actualDummyMsg = dummyMsgCaptor.getValue();
         assertThat(actualDummyMsg.getType()).isEqualTo(incomingMsg.getType());
         assertThat(actualDummyMsg.getData()).isEqualTo(incomingMsg.getData());
-        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry("prevAlarmDetails", JacksonUtil.toString(oldAlarmDetails));
+        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry(TbAbstractAlarmNode.PREV_ALARM_DETAILS, JacksonUtil.toString(oldAlarmDetails));
         then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called updateAlarm() with correct AlarmUpdateRequest
         then(alarmServiceMock).should().updateAlarm(expectedUpdateAlarmRequest);
@@ -637,6 +640,162 @@ class TbCreateAlarmNodeTest {
         // verify wrong processing paths were not taken
         then(ctxMock).should(never()).tellNext(any(), eq(TbNodeConnectionType.FALSE));
         then(ctxMock).should(never()).tellNext(any(), eq("Created"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Cleared"));
+        then(ctxMock).should(never()).tellSuccess(any());
+        then(ctxMock).should(never()).tellFailure(any(), any());
+    }
+
+    @Test
+    @DisplayName(
+            "When node is taking alarm data from incoming message and originator specified in alarm data has null UUID and alarm does not exists, " +
+                    "then should create new alarm using info from incoming message."
+    )
+    void whenAlarmDataIsTakenFromMsgAndAlarmDataOriginatorHasNullUuidAndAlarmDoesNotExist_thenNewAlarmIsCreated() throws Exception {
+        // GIVEN
+
+        // node configuration
+        config = config.defaultConfiguration();
+        config.setUseMessageAlarmData(true);
+        config.setOverwriteAlarmDetails(false);
+
+        // other values
+        String alarmType = "High Temperature";
+        AlarmSeverity alarmSeverity = AlarmSeverity.MAJOR;
+        JsonNode alarmDetails = JacksonUtil.newObjectNode().put("alarmDetails", "Some alarm details");
+
+        // alarm that is inside an incoming message
+        var alarmFromIncomingMessage = Alarm.builder()
+                .tenantId(tenantId)
+                .originator(new DeviceId(EntityId.NULL_UUID))
+                .cleared(false)
+                .acknowledged(false)
+                .severity(alarmSeverity)
+                .propagate(true)
+                .propagateToOwner(true)
+                .propagateToTenant(true)
+                .propagateRelationTypes(Collections.emptyList())
+                .type(alarmType)
+                .startTs(100L)
+                .endTs(300L)
+                .details(alarmDetails)
+                .build();
+
+        long metadataTs = 1711631716127L;
+        metadata.putValue("ts", Long.toString(metadataTs));
+        metadata.putValue("location", "Company office");
+
+        var ruleNodeSelfId = new RuleNodeId(Uuids.timeBased());
+
+        var incomingMsg = TbMsg.newMsg(TbMsgType.ALARM, msgOriginator, metadata, JacksonUtil.toString(alarmFromIncomingMessage));
+
+        Alarm existingAlarm = null;
+
+        // expected values
+        var expectedCreatedAlarm = Alarm.builder()
+                .tenantId(tenantId)
+                .originator(msgOriginator)
+                .cleared(false)
+                .acknowledged(false)
+                .severity(alarmSeverity)
+                .propagate(true)
+                .propagateToOwner(true)
+                .propagateToTenant(true)
+                .propagateRelationTypes(Collections.emptyList())
+                .type(alarmType)
+                .startTs(100L)
+                .endTs(300L)
+                .details(alarmDetails)
+                .build();
+        var expectedCreatedAlarmInfo = new AlarmInfo(expectedCreatedAlarm);
+        expectedCreatedAlarmInfo.setId(new AlarmId(Uuids.timeBased()));
+
+        var expectedCreateAlarmRequest = AlarmCreateOrUpdateActiveRequest.builder()
+                .tenantId(tenantId)
+                .customerId(null)
+                .type(alarmType)
+                .originator(msgOriginator)
+                .severity(alarmSeverity)
+                .startTs(100L)
+                .endTs(300L)
+                .details(alarmDetails)
+                .propagation(AlarmPropagationInfo.builder()
+                        .propagate(true)
+                        .propagateToOwner(true)
+                        .propagateToTenant(true)
+                        .propagateRelationTypes(Collections.emptyList()).build())
+                .userId(null)
+                .edgeAlarmId(null)
+                .build();
+
+        // mocks
+        given(ctxMock.getTenantId()).willReturn(tenantId);
+        given(ctxMock.getAlarmService()).willReturn(alarmServiceMock);
+        given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
+        given(ctxMock.getSelfId()).willReturn(ruleNodeSelfId);
+        given(alarmServiceMock.findLatestActiveByOriginatorAndType(tenantId, msgOriginator, alarmType)).willReturn(existingAlarm);
+        var apiCallResult = AlarmApiCallResult.builder()
+                .successful(true)
+                .created(true)
+                .modified(false)
+                .cleared(false)
+                .deleted(false)
+                .alarm(expectedCreatedAlarmInfo)
+                .old(null)
+                .propagatedEntitiesList(List.of(TenantId.fromUUID(Uuids.timeBased()), new CustomerId(Uuids.timeBased()), new AssetId(Uuids.timeBased())))
+                .build();
+        given(alarmServiceMock.createAlarm(expectedCreateAlarmRequest)).willReturn(apiCallResult);
+        given(ctxMock.alarmActionMsg(expectedCreatedAlarmInfo, ruleNodeSelfId, TbMsgType.ENTITY_CREATED)).willReturn(alarmActionMsgMock);
+        given(ctxMock.transformMsg(any(TbMsg.class), any(TbMsgType.class), any(EntityId.class), any(TbMsgMetaData.class), anyString()))
+                .willAnswer(answer -> TbMsg.transformMsg(
+                        answer.getArgument(0, TbMsg.class),
+                        answer.getArgument(1, TbMsgType.class),
+                        answer.getArgument(2, EntityId.class),
+                        answer.getArgument(3, TbMsgMetaData.class),
+                        answer.getArgument(4, String.class))
+                );
+        given(ctxMock.createScriptEngine(ScriptLanguage.TBEL, config.getAlarmDetailsBuildTbel())).willReturn(alarmDetailsScriptMock);
+
+        // node initialization
+        nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        // WHEN
+        nodeSpy.onMsg(ctxMock, incomingMsg);
+
+        // THEN
+
+        // verify alarm details script was not evaluated
+        then(ctxMock).should(never()).logJsEvalRequest();
+        then(alarmDetailsScriptMock).should(never()).executeJsonAsync(any());
+        then(ctxMock).should(never()).logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
+
+        // verify we called createAlarm() with correct AlarmCreateOrUpdateActiveRequest
+        then(alarmServiceMock).should().createAlarm(expectedCreateAlarmRequest);
+        then(alarmServiceMock).should(never()).updateAlarm(any());
+
+        // verify that we created a correct alarm action message and enqueued it
+        then(ctxMock).should().alarmActionMsg(expectedCreatedAlarmInfo, ruleNodeSelfId, TbMsgType.ENTITY_CREATED);
+        then(ctxMock).should().enqueue(eq(alarmActionMsgMock), successCaptor.capture(), any());
+
+        // run success captor to emulate successful sending and to trigger further processing on the success path
+        successCaptor.getValue().run();
+
+        // capture and verify an outgoing message
+        var outgoingMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        then(ctxMock).should().tellNext(outgoingMsgCaptor.capture(), eq("Created"));
+        var actualOutgoingMsg = outgoingMsgCaptor.getValue();
+        assertThat(actualOutgoingMsg.getType()).isEqualTo(TbMsgType.ALARM.name());
+        assertThat(actualOutgoingMsg.getOriginator()).isEqualTo(msgOriginator);
+        assertThat(actualOutgoingMsg.getData()).isEqualTo(JacksonUtil.valueToTree(expectedCreatedAlarmInfo).toString());
+
+        Map<String, String> actualOutgoingMsgMetadataContent = actualOutgoingMsg.getMetaData().getData();
+        assertThat(actualOutgoingMsgMetadataContent).containsAllEntriesOf(metadata.getData());
+        assertThat(actualOutgoingMsgMetadataContent).containsEntry(DataConstants.IS_NEW_ALARM, Boolean.TRUE.toString());
+        assertThat(actualOutgoingMsgMetadataContent).size().isEqualTo(metadata.getData().size() + 1);
+
+        // verify wrong processing paths were not taken
+        then(ctxMock).should(never()).tellNext(any(), eq(TbNodeConnectionType.FALSE));
+        then(ctxMock).should(never()).tellNext(any(), eq("Updated"));
         then(ctxMock).should(never()).tellNext(any(), eq("Cleared"));
         then(ctxMock).should(never()).tellSuccess(any());
         then(ctxMock).should(never()).tellFailure(any(), any());
@@ -776,6 +935,7 @@ class TbCreateAlarmNodeTest {
         then(ctxMock).should(never()).logJsEvalRequest();
         then(alarmDetailsScriptMock).should(never()).executeJsonAsync(any());
         then(ctxMock).should(never()).logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called createAlarm() with correct AlarmCreateOrUpdateActiveRequest
         then(alarmServiceMock).should().createAlarm(expectedCreateAlarmRequest);
@@ -966,8 +1126,9 @@ class TbCreateAlarmNodeTest {
         TbMsg actualDummyMsg = dummyMsgCaptor.getValue();
         assertThat(actualDummyMsg.getType()).isEqualTo(incomingMsg.getType());
         assertThat(actualDummyMsg.getData()).isEqualTo(incomingMsg.getData());
-        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry("prevAlarmDetails", JacksonUtil.toString(oldAlarmDetails));
+        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry(TbAbstractAlarmNode.PREV_ALARM_DETAILS, JacksonUtil.toString(oldAlarmDetails));
         then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called updateAlarm() with correct AlarmUpdateRequest
         then(alarmServiceMock).should().updateAlarm(expectedUpdateAlarmRequest);
@@ -1147,8 +1308,9 @@ class TbCreateAlarmNodeTest {
         TbMsg actualDummyMsg = dummyMsgCaptor.getValue();
         assertThat(actualDummyMsg.getType()).isEqualTo(incomingMsg.getType());
         assertThat(actualDummyMsg.getData()).isEqualTo(incomingMsg.getData());
-        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry("prevAlarmDetails", JacksonUtil.toString(alarmDetails));
+        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry(TbAbstractAlarmNode.PREV_ALARM_DETAILS, JacksonUtil.toString(alarmDetails));
         then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called updateAlarm() with correct AlarmUpdateRequest
         then(alarmServiceMock).should().updateAlarm(expectedUpdateAlarmRequest);
@@ -1205,6 +1367,9 @@ class TbCreateAlarmNodeTest {
         nodeSpy.onMsg(ctxMock, incomingMsg);
 
         // THEN
+        then(ctxMock).should().logJsEvalRequest();
+        then(ctxMock).should().logJsEvalFailure();
+
         var exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);
         then(ctxMock).should().tellFailure(eq(incomingMsg), exceptionCaptor.capture());
         Throwable actualException = exceptionCaptor.getValue();


### PR DESCRIPTION
## Pull Request description

- Changed `validateAlarmRequest(AlarmModificationRequest request)` logic: previously it was possible to pass validation and end up with `startTs` greater than `endTs` - if `startTs` was not set (0) and `endTs` was set to some positive value, `startTs` would be set to current timestamp and it could be greater than already present `endTs`. Now if both are not set then they are set to current timestamp, if only `startTs` is missing then it is set to `endTs` value and vice versa
Refactored script evaluation logs: now they are one place and script failures are logged as well
- When alarm data from incoming message is used and alarm data parsing failed, catch correct exception and report failure via futures, instead of directly throwing it to `RuleNodeActorMessageProcessor`
- Now it is not possible to create alarm with null UUID originator, when alarm data from incoming message is used. Message originator will be used in such case.
- Various minor code style changes

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



