### PR TITLE
[WIP] Clear alarm node refactor: async alarm searching, optimize alarm type pattern evaluation, throw error on unsuccessful alarm API response

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/alarm/BaseAlarmService.java
@@ -456,15 +456,18 @@ public class BaseAlarmService extends AbstractCachedEntityService<TenantId, Page
     private void validateAlarmRequest(AlarmModificationRequest request) {
         ConstraintValidator.validateFields(request);
         if (request.getEndTs() > 0 && request.getStartTs() > request.getEndTs()) {
-            throw new DataValidationException("Alarm start ts can't be greater then alarm end ts!");
+            throw new DataValidationException("Alarm start ts can't be greater than alarm end ts!");
         }
         if (!tenantService.tenantExists(request.getTenantId())) {
             throw new DataValidationException("Alarm is referencing to non-existent tenant!");
         }
-        if (request.getStartTs() == 0L) {
-            request.setStartTs(System.currentTimeMillis());
-        }
-        if (request.getEndTs() == 0L) {
+        if (request.getStartTs() == 0L && request.getEndTs() == 0L) {
+            long currentTs = System.currentTimeMillis();
+            request.setStartTs(currentTs);
+            request.setEndTs(currentTs);
+        } else if (request.getStartTs() == 0L) {
+            request.setStartTs(request.getEndTs());
+        } else if (request.getEndTs() == 0L) {
             request.setEndTs(request.getStartTs());
         }
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbAbstractAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbAbstractAlarmNode.java
@@ -114,4 +114,9 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
                 () -> ctx.tellNext(toAlarmMsg(ctx, alarmResult, msg), alarmAction),
                 throwable -> ctx.tellFailure(toAlarmMsg(ctx, alarmResult, msg), throwable));
     }
+
+    long currentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbAbstractAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbAbstractAlarmNode.java
@@ -45,7 +45,7 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
 
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
-        this.config = loadAlarmNodeConfig(configuration);
+        config = loadAlarmNodeConfig(configuration);
         scriptEngine = ctx.createScriptEngine(config.getScriptLang(),
                 ScriptLanguage.TBEL.equals(config.getScriptLang()) ? config.getAlarmDetailsBuildTbel() : config.getAlarmDetailsBuildJs());
     }
@@ -56,13 +56,13 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
     public void onMsg(TbContext ctx, TbMsg msg) {
         withCallback(processAlarm(ctx, msg),
                 alarmResult -> {
-                    if (alarmResult.alarm == null) {
+                    if (alarmResult.getAlarm() == null) {
                         ctx.tellNext(msg, TbNodeConnectionType.FALSE);
-                    } else if (alarmResult.isCreated) {
+                    } else if (alarmResult.isCreated()) {
                         tellNext(ctx, msg, alarmResult, TbMsgType.ENTITY_CREATED, "Created");
-                    } else if (alarmResult.isUpdated || alarmResult.isSeverityUpdated) {
+                    } else if (alarmResult.isUpdated() || alarmResult.isSeverityUpdated()) {
                         tellNext(ctx, msg, alarmResult, TbMsgType.ENTITY_UPDATED, "Updated");
-                    } else if (alarmResult.isCleared) {
+                    } else if (alarmResult.isCleared()) {
                         tellNext(ctx, msg, alarmResult, TbMsgType.ALARM_CLEAR, "Cleared");
                     } else {
                         ctx.tellSuccess(msg);
@@ -73,7 +73,7 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
 
     protected abstract ListenableFuture<TbAlarmResult> processAlarm(TbContext ctx, TbMsg msg);
 
-    protected ListenableFuture<JsonNode> buildAlarmDetails(TbMsg msg, JsonNode previousDetails) {
+    protected ListenableFuture<JsonNode> buildAlarmDetails(TbContext ctx, TbMsg msg, JsonNode previousDetails) {
         try {
             TbMsg dummyMsg = msg;
             if (previousDetails != null) {
@@ -81,24 +81,25 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
                 metaData.putValue(PREV_ALARM_DETAILS, JacksonUtil.toString(previousDetails));
                 dummyMsg = TbMsg.transformMsgMetadata(msg, metaData);
             }
-            return scriptEngine.executeJsonAsync(dummyMsg);
+            ctx.logJsEvalRequest();
+            ListenableFuture<JsonNode> alarmDetailsFuture = scriptEngine.executeJsonAsync(dummyMsg);
+            withCallback(alarmDetailsFuture, alarmDetails -> ctx.logJsEvalResponse(), t -> ctx.logJsEvalFailure());
+            return alarmDetailsFuture;
         } catch (Exception e) {
             return Futures.immediateFailedFuture(e);
         }
     }
 
     public static TbMsg toAlarmMsg(TbContext ctx, TbAlarmResult alarmResult, TbMsg originalMsg) {
-        JsonNode jsonNodes = JacksonUtil.valueToTree(alarmResult.alarm);
-        String data = jsonNodes.toString();
         TbMsgMetaData metaData = originalMsg.getMetaData().copy();
-        if (alarmResult.isCreated) {
+        if (alarmResult.isCreated()) {
             metaData.putValue(DataConstants.IS_NEW_ALARM, Boolean.TRUE.toString());
-        } else if (alarmResult.isUpdated || alarmResult.isSeverityUpdated) {
+        } else if (alarmResult.isUpdated() || alarmResult.isSeverityUpdated()) {
             metaData.putValue(DataConstants.IS_EXISTING_ALARM, Boolean.TRUE.toString());
-        } else if (alarmResult.isCleared) {
+        } else if (alarmResult.isCleared()) {
             metaData.putValue(DataConstants.IS_CLEARED_ALARM, Boolean.TRUE.toString());
         }
-        return ctx.transformMsg(originalMsg, TbMsgType.ALARM, originalMsg.getOriginator(), metaData, data);
+        return ctx.transformMsg(originalMsg, TbMsgType.ALARM, originalMsg.getOriginator(), metaData, JacksonUtil.toString(alarmResult.getAlarm()));
     }
 
     @Override
@@ -109,7 +110,7 @@ public abstract class TbAbstractAlarmNode<C extends TbAbstractAlarmNodeConfigura
     }
 
     private void tellNext(TbContext ctx, TbMsg msg, TbAlarmResult alarmResult, TbMsgType actionMsgType, String alarmAction) {
-        ctx.enqueue(ctx.alarmActionMsg(alarmResult.alarm, ctx.getSelfId(), actionMsgType),
+        ctx.enqueue(ctx.alarmActionMsg(alarmResult.getAlarm(), ctx.getSelfId(), actionMsgType),
                 () -> ctx.tellNext(toAlarmMsg(ctx, alarmResult, msg), alarmAction),
                 throwable -> ctx.tellFailure(toAlarmMsg(ctx, alarmResult, msg), throwable));
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNode.java
@@ -72,7 +72,7 @@ public class TbClearAlarmNode extends TbAbstractAlarmNode<TbClearAlarmNodeConfig
     private ListenableFuture<TbAlarmResult> clearAlarm(TbContext ctx, TbMsg msg, Alarm alarm) {
         ListenableFuture<JsonNode> asyncDetails = buildAlarmDetails(ctx, msg, alarm.getDetails());
         return Futures.transform(asyncDetails, details -> {
-            AlarmApiCallResult result = ctx.getAlarmService().clearAlarm(ctx.getTenantId(), alarm.getId(), System.currentTimeMillis(), details);
+            AlarmApiCallResult result = ctx.getAlarmService().clearAlarm(ctx.getTenantId(), alarm.getId(), currentTimeMillis(), details);
             if (result.isSuccessful()) {
                 return new TbAlarmResult(false, false, result.isCleared(), result.getAlarm());
             } else {

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNode.java
@@ -18,6 +18,7 @@ package org.thingsboard.rule.engine.action;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.rule.engine.api.RuleNode;
 import org.thingsboard.rule.engine.api.TbContext;
@@ -56,17 +57,20 @@ public class TbClearAlarmNode extends TbAbstractAlarmNode<TbClearAlarmNodeConfig
 
     @Override
     protected ListenableFuture<TbAlarmResult> processAlarm(TbContext ctx, TbMsg msg) {
-        String alarmType = TbNodeUtils.processPattern(this.config.getAlarmType(), msg);
-        Alarm alarm;
-        if (msg.getOriginator().getEntityType().equals(EntityType.ALARM)) {
-            alarm = ctx.getAlarmService().findAlarmById(ctx.getTenantId(), new AlarmId(msg.getOriginator().getId()));
+        var originator = msg.getOriginator();
+        ListenableFuture<Alarm> alarmFuture;
+        if (originator.getEntityType().equals(EntityType.ALARM)) {
+            alarmFuture = ctx.getDbCallbackExecutor().submit(() -> ctx.getAlarmService().findAlarmById(ctx.getTenantId(), new AlarmId(originator.getId())));
         } else {
-            alarm = ctx.getAlarmService().findLatestActiveByOriginatorAndType(ctx.getTenantId(), msg.getOriginator(), alarmType);
+            String alarmType = TbNodeUtils.processPattern(config.getAlarmType(), msg);
+            alarmFuture = ctx.getDbCallbackExecutor().submit(() -> ctx.getAlarmService().findLatestActiveByOriginatorAndType(ctx.getTenantId(), originator, alarmType));
         }
-        if (alarm != null && !alarm.getStatus().isCleared()) {
-            return clearAlarm(ctx, msg, alarm);
-        }
-        return Futures.immediateFuture(new TbAlarmResult(false, false, false, null));
+        return Futures.transformAsync(alarmFuture, alarm -> {
+            if (alarm != null && !alarm.isCleared()) {
+                return clearAlarm(ctx, msg, alarm);
+            }
+            return Futures.immediateFuture(new TbAlarmResult(false, false, false, null));
+        }, MoreExecutors.directExecutor());
     }
 
     private ListenableFuture<TbAlarmResult> clearAlarm(TbContext ctx, TbMsg msg, Alarm alarm) {
@@ -75,9 +79,8 @@ public class TbClearAlarmNode extends TbAbstractAlarmNode<TbClearAlarmNodeConfig
             AlarmApiCallResult result = ctx.getAlarmService().clearAlarm(ctx.getTenantId(), alarm.getId(), currentTimeMillis(), details);
             if (result.isSuccessful()) {
                 return new TbAlarmResult(false, false, result.isCleared(), result.getAlarm());
-            } else {
-                return new TbAlarmResult(false, false, false, alarm);
             }
+            throw new RuntimeException("Failed to clear alarm: API returned unsuccessful result. Probably alarm was already deleted.");
         }, ctx.getDbCallbackExecutor());
     }
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNode.java
@@ -60,7 +60,7 @@ public class TbClearAlarmNode extends TbAbstractAlarmNode<TbClearAlarmNodeConfig
         var originator = msg.getOriginator();
         ListenableFuture<Alarm> alarmFuture;
         if (originator.getEntityType().equals(EntityType.ALARM)) {
-            alarmFuture = ctx.getDbCallbackExecutor().submit(() -> ctx.getAlarmService().findAlarmById(ctx.getTenantId(), new AlarmId(originator.getId())));
+            alarmFuture = ctx.getAlarmService().findAlarmByIdAsync(ctx.getTenantId(), new AlarmId(originator.getId()));
         } else {
             String alarmType = TbNodeUtils.processPattern(config.getAlarmType(), msg);
             alarmFuture = ctx.getDbCallbackExecutor().submit(() -> ctx.getAlarmService().findLatestActiveByOriginatorAndType(ctx.getTenantId(), originator, alarmType));

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNode.java
@@ -70,10 +70,8 @@ public class TbClearAlarmNode extends TbAbstractAlarmNode<TbClearAlarmNodeConfig
     }
 
     private ListenableFuture<TbAlarmResult> clearAlarm(TbContext ctx, TbMsg msg, Alarm alarm) {
-        ctx.logJsEvalRequest();
-        ListenableFuture<JsonNode> asyncDetails = buildAlarmDetails(msg, alarm.getDetails());
+        ListenableFuture<JsonNode> asyncDetails = buildAlarmDetails(ctx, msg, alarm.getDetails());
         return Futures.transform(asyncDetails, details -> {
-            ctx.logJsEvalResponse();
             AlarmApiCallResult result = ctx.getAlarmService().clearAlarm(ctx.getTenantId(), alarm.getId(), System.currentTimeMillis(), details);
             if (result.isSuccessful()) {
                 return new TbAlarmResult(false, false, result.isCleared(), result.getAlarm());

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbClearAlarmNodeConfiguration.java
@@ -16,15 +16,17 @@
 package org.thingsboard.rule.engine.action;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.thingsboard.rule.engine.api.NodeConfiguration;
 import org.thingsboard.server.common.data.script.ScriptLanguage;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class TbClearAlarmNodeConfiguration extends TbAbstractAlarmNodeConfiguration implements NodeConfiguration<TbClearAlarmNodeConfiguration> {
 
     @Override
     public TbClearAlarmNodeConfiguration defaultConfiguration() {
-        TbClearAlarmNodeConfiguration configuration = new TbClearAlarmNodeConfiguration();
+        var configuration = new TbClearAlarmNodeConfiguration();
         configuration.setScriptLang(ScriptLanguage.TBEL);
         configuration.setAlarmDetailsBuildJs(ALARM_DETAILS_BUILD_JS_TEMPLATE);
         configuration.setAlarmDetailsBuildTbel(ALARM_DETAILS_BUILD_TBEL_TEMPLATE);

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
@@ -32,12 +32,10 @@ import org.thingsboard.server.common.data.alarm.AlarmApiCallResult;
 import org.thingsboard.server.common.data.alarm.AlarmCreateOrUpdateActiveRequest;
 import org.thingsboard.server.common.data.alarm.AlarmSeverity;
 import org.thingsboard.server.common.data.alarm.AlarmUpdateRequest;
+import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.plugin.ComponentType;
 import org.thingsboard.server.common.msg.TbMsg;
-
-import java.io.IOException;
-import java.util.List;
 
 @Slf4j
 @RuleNode(
@@ -57,16 +55,15 @@ import java.util.List;
 )
 public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConfiguration> {
 
-    private List<String> relationTypes;
     private AlarmSeverity notDynamicAlarmSeverity;
 
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
         super.init(ctx, configuration);
-        if (!this.config.isDynamicSeverity()) {
-            this.notDynamicAlarmSeverity = EnumUtils.getEnum(AlarmSeverity.class, this.config.getSeverity());
-            if (this.notDynamicAlarmSeverity == null) {
-                throw new TbNodeException("Incorrect Alarm Severity value: " + this.config.getSeverity(), true);
+        if (!config.isDynamicSeverity()) {
+            notDynamicAlarmSeverity = EnumUtils.getEnum(AlarmSeverity.class, config.getSeverity());
+            if (notDynamicAlarmSeverity == null) {
+                throw new TbNodeException("Incorrect Alarm Severity value: " + config.getSeverity(), true);
             }
         }
     }
@@ -74,9 +71,7 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
 
     @Override
     protected TbCreateAlarmNodeConfiguration loadAlarmNodeConfig(TbNodeConfiguration configuration) throws TbNodeException {
-        TbCreateAlarmNodeConfiguration nodeConfiguration = TbNodeUtils.convert(configuration, TbCreateAlarmNodeConfiguration.class);
-        relationTypes = nodeConfiguration.getRelationTypes();
-        return nodeConfiguration;
+        return TbNodeUtils.convert(configuration, TbCreateAlarmNodeConfiguration.class);
     }
 
     @Override
@@ -85,31 +80,30 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         final Alarm msgAlarm;
 
         if (!config.isUseMessageAlarmData()) {
-            alarmType = TbNodeUtils.processPattern(this.config.getAlarmType(), msg);
+            alarmType = TbNodeUtils.processPattern(config.getAlarmType(), msg);
             msgAlarm = null;
         } else {
             try {
-                msgAlarm = getAlarmFromMessage(ctx, msg);
+                msgAlarm = getAlarmFromMessage(ctx.getTenantId(), msg);
                 alarmType = msgAlarm.getType();
-            } catch (IOException e) {
-                ctx.tellFailure(msg, e);
-                return null;
+            } catch (IllegalArgumentException e) {
+                return Futures.immediateFailedFuture(e);
             }
         }
 
         Alarm existingAlarm = ctx.getAlarmService().findLatestActiveByOriginatorAndType(ctx.getTenantId(), msg.getOriginator(), alarmType);
-        if (existingAlarm == null || existingAlarm.getStatus().isCleared()) {
+        if (existingAlarm == null || existingAlarm.isCleared()) {
             return createNewAlarm(ctx, msg, msgAlarm);
         } else {
             return updateAlarm(ctx, msg, existingAlarm, msgAlarm);
         }
     }
 
-    private Alarm getAlarmFromMessage(TbContext ctx, TbMsg msg) throws IOException {
-        Alarm msgAlarm;
-        msgAlarm = JacksonUtil.fromString(msg.getData(), Alarm.class);
-        msgAlarm.setTenantId(ctx.getTenantId());
-        if (msgAlarm.getOriginator() == null) {
+    private Alarm getAlarmFromMessage(TenantId tenantId, TbMsg msg) throws IllegalArgumentException {
+        Alarm msgAlarm = JacksonUtil.fromString(msg.getData(), Alarm.class);
+        msgAlarm.setTenantId(tenantId);
+        EntityId msgAlarmOriginator = msgAlarm.getOriginator();
+        if (msgAlarmOriginator == null || msgAlarmOriginator.isNullUid()) {
             msgAlarm.setOriginator(msg.getOriginator());
         }
         return msgAlarm;
@@ -119,15 +113,11 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         ListenableFuture<JsonNode> asyncDetails;
         boolean buildDetails = !config.isUseMessageAlarmData() || config.isOverwriteAlarmDetails();
         if (buildDetails) {
-            ctx.logJsEvalRequest();
-            asyncDetails = buildAlarmDetails(msg, null);
+            asyncDetails = buildAlarmDetails(ctx, msg, null);
         } else {
             asyncDetails = Futures.immediateFuture(null);
         }
         ListenableFuture<Alarm> asyncAlarm = Futures.transform(asyncDetails, details -> {
-            if (buildDetails) {
-                ctx.logJsEvalResponse();
-            }
             Alarm newAlarm;
             if (msgAlarm != null) {
                 newAlarm = msgAlarm;
@@ -148,15 +138,11 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         ListenableFuture<JsonNode> asyncDetails;
         boolean buildDetails = !config.isUseMessageAlarmData() || config.isOverwriteAlarmDetails();
         if (buildDetails) {
-            ctx.logJsEvalRequest();
-            asyncDetails = buildAlarmDetails(msg, existingAlarm.getDetails());
+            asyncDetails = buildAlarmDetails(ctx, msg, existingAlarm.getDetails());
         } else {
             asyncDetails = Futures.immediateFuture(null);
         }
         ListenableFuture<AlarmApiCallResult> asyncUpdated = Futures.transform(asyncDetails, details -> {
-            if (buildDetails) {
-                ctx.logJsEvalResponse();
-            }
             if (msgAlarm != null) {
                 existingAlarm.setSeverity(msgAlarm.getSeverity());
                 existingAlarm.setPropagate(msgAlarm.isPropagate());
@@ -173,7 +159,7 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
                 existingAlarm.setPropagate(config.isPropagate());
                 existingAlarm.setPropagateToOwner(config.isPropagateToOwner());
                 existingAlarm.setPropagateToTenant(config.isPropagateToTenant());
-                existingAlarm.setPropagateRelationTypes(relationTypes);
+                existingAlarm.setPropagateRelationTypes(config.getRelationTypes());
                 existingAlarm.setDetails(details);
             }
             existingAlarm.setEndTs(currentTimeMillis());
@@ -189,12 +175,12 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
                 .originator(msg.getOriginator())
                 .cleared(false)
                 .acknowledged(false)
-                .severity(this.config.isDynamicSeverity() ? processAlarmSeverity(msg) : notDynamicAlarmSeverity)
+                .severity(config.isDynamicSeverity() ? processAlarmSeverity(msg) : notDynamicAlarmSeverity)
                 .propagate(config.isPropagate())
                 .propagateToOwner(config.isPropagateToOwner())
                 .propagateToTenant(config.isPropagateToTenant())
-                .type(TbNodeUtils.processPattern(this.config.getAlarmType(), msg))
-                .propagateRelationTypes(relationTypes)
+                .type(TbNodeUtils.processPattern(config.getAlarmType(), msg))
+                .propagateRelationTypes(config.getRelationTypes())
                 .startTs(ts)
                 .endTs(ts)
                 .details(details)
@@ -202,7 +188,7 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
     }
 
     private AlarmSeverity processAlarmSeverity(TbMsg msg) {
-        AlarmSeverity severity = EnumUtils.getEnum(AlarmSeverity.class, TbNodeUtils.processPattern(this.config.getSeverity(), msg));
+        AlarmSeverity severity = EnumUtils.getEnum(AlarmSeverity.class, TbNodeUtils.processPattern(config.getSeverity(), msg));
         if (severity == null) {
             throw new RuntimeException("Used incorrect pattern or Alarm Severity not included in message");
         }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
@@ -32,7 +32,6 @@ import org.thingsboard.server.common.data.alarm.AlarmApiCallResult;
 import org.thingsboard.server.common.data.alarm.AlarmCreateOrUpdateActiveRequest;
 import org.thingsboard.server.common.data.alarm.AlarmSeverity;
 import org.thingsboard.server.common.data.alarm.AlarmUpdateRequest;
-import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.plugin.ComponentType;
 import org.thingsboard.server.common.msg.TbMsg;
@@ -102,10 +101,7 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
     private Alarm getAlarmFromMessage(TenantId tenantId, TbMsg msg) throws IllegalArgumentException {
         Alarm msgAlarm = JacksonUtil.fromString(msg.getData(), Alarm.class);
         msgAlarm.setTenantId(tenantId);
-        EntityId msgAlarmOriginator = msgAlarm.getOriginator();
-        if (msgAlarmOriginator == null || msgAlarmOriginator.isNullUid()) {
-            msgAlarm.setOriginator(msg.getOriginator());
-        }
+        msgAlarm.setOriginator(msg.getOriginator());
         return msgAlarm;
     }
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/action/TbCreateAlarmNode.java
@@ -191,8 +191,4 @@ public class TbCreateAlarmNode extends TbAbstractAlarmNode<TbCreateAlarmNodeConf
         return severity;
     }
 
-    long currentTimeMillis() {
-        return System.currentTimeMillis();
-    }
-
 }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbClearAlarmNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbClearAlarmNodeTest.java
@@ -19,11 +19,13 @@ import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.util.concurrent.Futures;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.common.util.ListeningExecutor;
@@ -32,7 +34,6 @@ import org.thingsboard.rule.engine.api.RuleEngineAlarmService;
 import org.thingsboard.rule.engine.api.ScriptEngine;
 import org.thingsboard.rule.engine.api.TbContext;
 import org.thingsboard.rule.engine.api.TbNodeConfiguration;
-import org.thingsboard.rule.engine.api.TbNodeException;
 import org.thingsboard.server.common.data.DataConstants;
 import org.thingsboard.server.common.data.alarm.Alarm;
 import org.thingsboard.server.common.data.alarm.AlarmApiCallResult;
@@ -41,21 +42,26 @@ import org.thingsboard.server.common.data.alarm.AlarmSeverity;
 import org.thingsboard.server.common.data.id.AlarmId;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.RuleNodeId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.msg.TbMsgType;
+import org.thingsboard.server.common.data.msg.TbNodeConnectionType;
 import org.thingsboard.server.common.data.script.ScriptLanguage;
 import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
 
-import java.util.function.Consumer;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class TbClearAlarmNodeTest {
@@ -66,153 +72,703 @@ class TbClearAlarmNodeTest {
     RuleEngineAlarmService alarmServiceMock;
     @Mock
     ScriptEngine alarmDetailsScriptMock;
+    @Mock
+    TbMsg alarmActionMsgMock;
 
     @Captor
     ArgumentCaptor<Runnable> successCaptor;
-    @Captor
-    ArgumentCaptor<Consumer<Throwable>> failureCaptor;
 
-    TbClearAlarmNode node;
+    @Spy
+    TbClearAlarmNode nodeSpy;
+    TbClearAlarmNodeConfiguration config;
 
     final TenantId tenantId = TenantId.fromUUID(Uuids.timeBased());
     final EntityId msgOriginator = new DeviceId(Uuids.timeBased());
-    final EntityId alarmOriginator = new AlarmId(Uuids.timeBased());
+    final AlarmId msgAlarmOriginator = new AlarmId(Uuids.timeBased());
     TbMsgMetaData metadata;
 
     ListeningExecutor dbExecutor;
 
     @BeforeEach
     void before() {
-        dbExecutor = new TestDbCallbackExecutor();
+        config = new TbClearAlarmNodeConfiguration();
         metadata = new TbMsgMetaData();
+        dbExecutor = new TestDbCallbackExecutor();
     }
 
     @Test
-    void alarmCanBeCleared() {
-        initWithClearAlarmScript();
-        metadata.putValue("key", "value");
-        TbMsg msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, msgOriginator, metadata, "{\"temperature\": 50}");
+    @DisplayName("When defaultConfiguration() is called, then correct values are set.")
+    void whenDefaultConfiguration_thenShouldSetCorrectValues() {
+        // GIVEN-WHEN
+        config = config.defaultConfiguration();
 
-        long oldEndDate = System.currentTimeMillis();
-        Alarm activeAlarm = Alarm.builder().type("SomeType").tenantId(tenantId).originator(msgOriginator).severity(AlarmSeverity.WARNING).endTs(oldEndDate).build();
+        // THEN
+        assertThat(config.getAlarmType()).isEqualTo("General Alarm");
+        assertThat(config.getScriptLang()).isEqualTo(ScriptLanguage.TBEL);
+        assertThat(config.getAlarmDetailsBuildJs()).isEqualTo("""
+                \
+                var details = {};
+                if (metadata.prevAlarmDetails) {
+                    details = JSON.parse(metadata.prevAlarmDetails);
+                    //remove prevAlarmDetails from metadata
+                    delete metadata.prevAlarmDetails;
+                    //now metadata is the same as it comes IN this rule node
+                }
 
-        Alarm expectedAlarm = Alarm.builder()
-                .tenantId(tenantId)
-                .originator(msgOriginator)
-                .cleared(true)
-                .severity(AlarmSeverity.WARNING)
-                .propagate(false)
-                .type("SomeType")
-                .details(null)
-                .endTs(oldEndDate)
-                .build();
 
-        when(alarmDetailsScriptMock.executeJsonAsync(msg)).thenReturn(Futures.immediateFuture(null));
-        when(alarmServiceMock.findLatestActiveByOriginatorAndType(tenantId, msgOriginator, "SomeType")).thenReturn(activeAlarm);
-        when(alarmServiceMock.clearAlarm(eq(activeAlarm.getTenantId()), eq(activeAlarm.getId()), anyLong(), nullable(JsonNode.class)))
-                .thenReturn(AlarmApiCallResult.builder()
-                        .successful(true)
-                        .cleared(true)
-                        .alarm(new AlarmInfo(expectedAlarm))
-                        .build());
+                return details;""");
+        assertThat(config.getAlarmDetailsBuildTbel()).isEqualTo("""
+                \
+                var details = {};
+                if (metadata.prevAlarmDetails != null) {
+                    details = JSON.parse(metadata.prevAlarmDetails);
+                    //remove prevAlarmDetails from metadata
+                    metadata.remove('prevAlarmDetails');
+                    //now metadata is the same as it comes IN this rule node
+                }
 
-        node.onMsg(ctxMock, msg);
 
-        verify(ctxMock).enqueue(any(), successCaptor.capture(), failureCaptor.capture());
-        successCaptor.getValue().run();
-        verify(ctxMock).tellNext(any(), eq("Cleared"));
-
-        ArgumentCaptor<TbMsg> msgCaptor = ArgumentCaptor.forClass(TbMsg.class);
-        ArgumentCaptor<TbMsgType> typeCaptor = ArgumentCaptor.forClass(TbMsgType.class);
-        ArgumentCaptor<EntityId> originatorCaptor = ArgumentCaptor.forClass(EntityId.class);
-        ArgumentCaptor<TbMsgMetaData> metadataCaptor = ArgumentCaptor.forClass(TbMsgMetaData.class);
-        ArgumentCaptor<String> dataCaptor = ArgumentCaptor.forClass(String.class);
-        verify(ctxMock).transformMsg(msgCaptor.capture(), typeCaptor.capture(), originatorCaptor.capture(), metadataCaptor.capture(), dataCaptor.capture());
-
-        assertThat(TbMsgType.ALARM).isEqualTo(typeCaptor.getValue());
-        assertThat(msgOriginator).isEqualTo(originatorCaptor.getValue());
-        assertThat("value").isEqualTo(metadataCaptor.getValue().getValue("key"));
-        assertThat(Boolean.TRUE.toString()).isEqualTo(metadataCaptor.getValue().getValue(DataConstants.IS_CLEARED_ALARM));
-        assertThat(metadata).isNotSameAs(metadataCaptor.getValue());
-
-        Alarm actualAlarm = JacksonUtil.fromBytes(dataCaptor.getValue().getBytes(), Alarm.class);
-        assertThat(actualAlarm).isEqualTo(expectedAlarm);
+                return details;""");
     }
 
     @Test
-    void alarmCanBeClearedWithAlarmOriginator() {
-        initWithClearAlarmScript();
-        metadata.putValue("key", "value");
-        TbMsg msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, alarmOriginator, metadata, "{\"temperature\": 50}");
+    @DisplayName(
+            "Given message originator type is ALARM and alarm does not exist, " +
+                    "when onMsg(), " +
+                    "then tell next 'False' with original message."
+    )
+    void whenMsgOriginatorIsAlarmAndAlarmDoesNotExist_thenShouldTellFalseWithOriginalMsg() throws Exception {
+        // GIVEN
 
-        long oldEndDate = System.currentTimeMillis();
-        AlarmId id = new AlarmId(alarmOriginator.getId());
-        Alarm activeAlarm = Alarm.builder().type("SomeType").tenantId(tenantId).originator(msgOriginator).severity(AlarmSeverity.WARNING).endTs(oldEndDate).build();
-        activeAlarm.setId(id);
+        // node configuration
+        config = config.defaultConfiguration();
 
-        Alarm expectedAlarm = Alarm.builder()
+        String alarmType = config.getAlarmType();
+        ScriptLanguage scriptLang = config.getScriptLang();
+        String alarmDetailsScript = config.getAlarmDetailsBuildTbel();
+        JsonNode alarmDetails = JacksonUtil.newObjectNode().put("alarmDetailsProperty", "alarmDetailsValue");
+        long clearTs = 500L;
+
+        var alarmId = new AlarmId(Uuids.timeBased());
+        var clearedAlarm = Alarm.builder()
+                .type(alarmType)
                 .tenantId(tenantId)
-                .originator(msgOriginator)
-                .cleared(true)
+                .originator(new DeviceId(Uuids.timeBased()))
                 .severity(AlarmSeverity.WARNING)
-                .propagate(false)
-                .type("SomeType")
-                .details(null)
-                .endTs(oldEndDate)
+                .cleared(true)
+                .clearTs(clearTs)
+                .startTs(100L)
+                .endTs(200L)
+                .details(alarmDetails)
                 .build();
-        expectedAlarm.setId(id);
+        clearedAlarm.setId(alarmId);
 
-        when(alarmDetailsScriptMock.executeJsonAsync(msg)).thenReturn(Futures.immediateFuture(null));
-        when(alarmServiceMock.findAlarmById(tenantId, id)).thenReturn(activeAlarm);
-        when(alarmServiceMock.clearAlarm(eq(activeAlarm.getTenantId()), eq(activeAlarm.getId()), anyLong(), nullable(JsonNode.class)))
-                .thenReturn(AlarmApiCallResult.builder()
-                        .successful(true)
-                        .cleared(true)
-                        .alarm(new AlarmInfo(expectedAlarm))
-                        .build());
+        metadata.putValue("metadataKey", "metadataValue");
+        var msg = TbMsg.newMsg(TbMsgType.ENTITY_UPDATED, msgAlarmOriginator, metadata, JacksonUtil.toString(clearedAlarm));
 
-        node.onMsg(ctxMock, msg);
+        // mocks
+        given(ctxMock.getTenantId()).willReturn(tenantId);
+        given(ctxMock.getAlarmService()).willReturn(alarmServiceMock);
+        given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
+        given(ctxMock.createScriptEngine(scriptLang, alarmDetailsScript)).willReturn(alarmDetailsScriptMock);
 
-        verify(ctxMock).enqueue(any(), successCaptor.capture(), failureCaptor.capture());
-        successCaptor.getValue().run();
-        verify(ctxMock).tellNext(any(), eq("Cleared"));
+        given(alarmServiceMock.findAlarmById(tenantId, msgAlarmOriginator)).willReturn(null);
 
-        ArgumentCaptor<TbMsg> msgCaptor = ArgumentCaptor.forClass(TbMsg.class);
-        ArgumentCaptor<TbMsgType> typeCaptor = ArgumentCaptor.forClass(TbMsgType.class);
-        ArgumentCaptor<EntityId> originatorCaptor = ArgumentCaptor.forClass(EntityId.class);
-        ArgumentCaptor<TbMsgMetaData> metadataCaptor = ArgumentCaptor.forClass(TbMsgMetaData.class);
-        ArgumentCaptor<String> dataCaptor = ArgumentCaptor.forClass(String.class);
-        verify(ctxMock).transformMsg(msgCaptor.capture(), typeCaptor.capture(), originatorCaptor.capture(), metadataCaptor.capture(), dataCaptor.capture());
+        // node initialization
+        nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
 
-        assertThat(TbMsgType.ALARM).isEqualTo(typeCaptor.getValue());
-        assertThat(alarmOriginator).isEqualTo(originatorCaptor.getValue());
-        assertThat("value").isEqualTo(metadataCaptor.getValue().getValue("key"));
-        assertThat(Boolean.TRUE.toString()).isEqualTo(metadataCaptor.getValue().getValue(DataConstants.IS_CLEARED_ALARM));
-        assertThat(metadata).isNotSameAs(metadataCaptor.getValue());
+        // WHEN
+        nodeSpy.onMsg(ctxMock, msg);
 
-        Alarm actualAlarm = JacksonUtil.fromBytes(dataCaptor.getValue().getBytes(), Alarm.class);
-        assertThat(actualAlarm).isEqualTo(expectedAlarm);
+        // THEN
+        then(alarmServiceMock).should(never()).clearAlarm(any(), any(), anyLong(), any());
+
+        then(ctxMock).should().tellNext(msg, TbNodeConnectionType.FALSE);
+        then(ctxMock).should(never()).enqueue(any(), any(), any());
+        then(ctxMock).should(never()).tellNext(any(), eq("Created"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Updated"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Cleared"));
+        then(ctxMock).should(never()).tellSuccess(any());
+        then(ctxMock).should(never()).tellFailure(any(), any());
     }
 
-    private void initWithClearAlarmScript() {
-        try {
-            TbClearAlarmNodeConfiguration config = new TbClearAlarmNodeConfiguration();
-            config.setAlarmType("SomeType");
-            config.setScriptLang(ScriptLanguage.JS);
-            config.setAlarmDetailsBuildJs("DETAILS");
-            TbNodeConfiguration nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
+    @Test
+    @DisplayName(
+            "Given message originator type is ALARM and already cleared alarm exists, " +
+                    "when onMsg(), " +
+                    "then tell next 'False' with original message."
+    )
+    void whenMsgOriginatorIsAlarmAndClearedAlarmExists_thenShouldTellFalseWithOriginalMsg() throws Exception {
+        // GIVEN
 
-            when(ctxMock.createScriptEngine(ScriptLanguage.JS, "DETAILS")).thenReturn(alarmDetailsScriptMock);
+        // node configuration
+        config = config.defaultConfiguration();
 
-            when(ctxMock.getTenantId()).thenReturn(tenantId);
-            when(ctxMock.getAlarmService()).thenReturn(alarmServiceMock);
-            when(ctxMock.getDbCallbackExecutor()).thenReturn(dbExecutor);
+        String alarmType = config.getAlarmType();
+        ScriptLanguage scriptLang = config.getScriptLang();
+        String alarmDetailsScript = config.getAlarmDetailsBuildTbel();
+        JsonNode alarmDetails = JacksonUtil.newObjectNode().put("alarmDetailsProperty", "alarmDetailsValue");
+        long clearTs = 500L;
 
-            node = new TbClearAlarmNode();
-            node.init(ctxMock, nodeConfiguration);
-        } catch (TbNodeException ex) {
-            throw new IllegalStateException(ex);
-        }
+        var alarmId = new AlarmId(Uuids.timeBased());
+        var clearedAlarm = Alarm.builder()
+                .type(alarmType)
+                .tenantId(tenantId)
+                .originator(new DeviceId(Uuids.timeBased()))
+                .severity(AlarmSeverity.WARNING)
+                .cleared(true)
+                .clearTs(clearTs)
+                .startTs(100L)
+                .endTs(200L)
+                .details(alarmDetails)
+                .build();
+        clearedAlarm.setId(alarmId);
+
+        metadata.putValue("metadataKey", "metadataValue");
+        var msg = TbMsg.newMsg(TbMsgType.ENTITY_UPDATED, msgAlarmOriginator, metadata, JacksonUtil.toString(clearedAlarm));
+
+        // mocks
+        given(ctxMock.getTenantId()).willReturn(tenantId);
+        given(ctxMock.getAlarmService()).willReturn(alarmServiceMock);
+        given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
+        given(ctxMock.createScriptEngine(scriptLang, alarmDetailsScript)).willReturn(alarmDetailsScriptMock);
+
+        given(alarmServiceMock.findAlarmById(tenantId, msgAlarmOriginator)).willReturn(clearedAlarm);
+
+        // node initialization
+        nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        // WHEN
+        nodeSpy.onMsg(ctxMock, msg);
+
+        // THEN
+        then(alarmServiceMock).should(never()).clearAlarm(any(), any(), anyLong(), any());
+
+        then(ctxMock).should().tellNext(msg, TbNodeConnectionType.FALSE);
+        then(ctxMock).should(never()).enqueue(any(), any(), any());
+        then(ctxMock).should(never()).tellNext(any(), eq("Created"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Updated"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Cleared"));
+        then(ctxMock).should(never()).tellSuccess(any());
+        then(ctxMock).should(never()).tellFailure(any(), any());
+    }
+
+    @Test
+    @DisplayName(
+            "Given message originator type is ALARM and active alarm exists, " +
+                    "when onMsg(), " +
+                    "then should clear active alarm, update alarm details, enqueue ALARM_CLEAR message, tell next 'Cleared' with cleared alarm in message body and 'isClearedAlarm = true' in metadata"
+    )
+    void whenMsgOriginatorIsAlarmAndActiveAlarmExists_thenShouldCorrectlyClear() throws Exception {
+        // GIVEN
+
+        // node configuration
+        config = config.defaultConfiguration();
+
+        String alarmType = "High Temperature";
+        ScriptLanguage scriptLang = config.getScriptLang();
+        String alarmDetailsScript = config.getAlarmDetailsBuildTbel();
+        JsonNode oldAlarmDetails = JacksonUtil.newObjectNode().put("oldAlarmDetailsProperty", "oldAlarmDetailsValue");
+        JsonNode newAlarmDetails = JacksonUtil.newObjectNode().put("newAlarmDetailsProperty", "newAlarmDetailsValue");
+        long clearTs = 500L;
+
+        var alarmId = new AlarmId(Uuids.timeBased());
+        var activeAlarm = Alarm.builder()
+                .type(alarmType)
+                .tenantId(tenantId)
+                .originator(new DeviceId(Uuids.timeBased()))
+                .severity(AlarmSeverity.WARNING)
+                .startTs(100L)
+                .endTs(200L)
+                .details(oldAlarmDetails)
+                .build();
+        activeAlarm.setId(alarmId);
+
+        metadata.putValue("metadataKey", "metadataValue");
+        var msg = TbMsg.newMsg(TbMsgType.ENTITY_UPDATED, msgAlarmOriginator, metadata, JacksonUtil.toString(activeAlarm));
+
+        var ruleNodeSelfId = new RuleNodeId(Uuids.timeBased());
+
+        // mocks
+        given(ctxMock.getTenantId()).willReturn(tenantId);
+        given(ctxMock.getAlarmService()).willReturn(alarmServiceMock);
+        given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
+        given(ctxMock.getSelfId()).willReturn(ruleNodeSelfId);
+        doReturn(clearTs).when(nodeSpy).currentTimeMillis();
+        given(ctxMock.createScriptEngine(scriptLang, alarmDetailsScript)).willReturn(alarmDetailsScriptMock);
+        given(alarmDetailsScriptMock.executeJsonAsync(any())).willReturn(Futures.immediateFuture(newAlarmDetails));
+
+        var expectedAlarm = new Alarm(activeAlarm);
+        expectedAlarm.setCleared(true);
+        expectedAlarm.setDetails(newAlarmDetails);
+
+        var expectedAlarmInfo = new AlarmInfo(expectedAlarm);
+
+        given(alarmServiceMock.findAlarmById(tenantId, msgAlarmOriginator)).willReturn(activeAlarm);
+        given(alarmServiceMock.clearAlarm(tenantId, alarmId, clearTs, newAlarmDetails))
+                .willReturn(AlarmApiCallResult.builder()
+                        .successful(true)
+                        .cleared(true)
+                        .alarm(expectedAlarmInfo)
+                        .build());
+        given(ctxMock.alarmActionMsg(expectedAlarmInfo, ruleNodeSelfId, TbMsgType.ALARM_CLEAR)).willReturn(alarmActionMsgMock);
+        given(ctxMock.transformMsg(any(TbMsg.class), any(TbMsgType.class), any(EntityId.class), any(TbMsgMetaData.class), anyString()))
+                .willAnswer(answer -> TbMsg.transformMsg(
+                        answer.getArgument(0, TbMsg.class),
+                        answer.getArgument(1, TbMsgType.class),
+                        answer.getArgument(2, EntityId.class),
+                        answer.getArgument(3, TbMsgMetaData.class),
+                        answer.getArgument(4, String.class))
+                );
+
+        // node initialization
+        nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        // WHEN
+        nodeSpy.onMsg(ctxMock, msg);
+
+        // THEN
+
+        // verify alarm details script evaluation
+        then(ctxMock).should().logJsEvalRequest();
+        var dummyMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        then(alarmDetailsScriptMock).should().executeJsonAsync(dummyMsgCaptor.capture());
+        TbMsg actualDummyMsg = dummyMsgCaptor.getValue();
+        assertThat(actualDummyMsg.getType()).isEqualTo(msg.getType());
+        assertThat(actualDummyMsg.getData()).isEqualTo(msg.getData());
+        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry(TbAbstractAlarmNode.PREV_ALARM_DETAILS, JacksonUtil.toString(oldAlarmDetails));
+        then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
+
+        // verify we called clearAlarm() with correct parameters
+        then(alarmServiceMock).should().clearAlarm(tenantId, alarmId, clearTs, newAlarmDetails);
+
+        // verify that we created a correct alarm action message and enqueued it
+        then(ctxMock).should().alarmActionMsg(expectedAlarmInfo, ruleNodeSelfId, TbMsgType.ALARM_CLEAR);
+        then(ctxMock).should().enqueue(eq(alarmActionMsgMock), successCaptor.capture(), any());
+
+        // run success captor to emulate successful enqueueing and to trigger further processing on the success path
+        successCaptor.getValue().run();
+
+        // capture and verify an outgoing message
+        var outgoingMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        then(ctxMock).should().tellNext(outgoingMsgCaptor.capture(), eq("Cleared"));
+        var actualOutgoingMsg = outgoingMsgCaptor.getValue();
+        assertThat(actualOutgoingMsg.getType()).isEqualTo(TbMsgType.ALARM.name());
+        assertThat(actualOutgoingMsg.getOriginator()).isEqualTo(msgAlarmOriginator);
+        assertThat(actualOutgoingMsg.getData()).isEqualTo(JacksonUtil.toString(expectedAlarmInfo));
+
+        Map<String, String> actualOutgoingMsgMetadataContent = actualOutgoingMsg.getMetaData().getData();
+        assertThat(actualOutgoingMsgMetadataContent).containsAllEntriesOf(metadata.getData());
+        assertThat(actualOutgoingMsgMetadataContent).containsEntry(DataConstants.IS_CLEARED_ALARM, Boolean.TRUE.toString());
+        assertThat(actualOutgoingMsgMetadataContent).size().isEqualTo(metadata.getData().size() + 1);
+
+        // verify wrong processing paths were not taken
+        then(ctxMock).should(never()).tellNext(any(), eq(TbNodeConnectionType.FALSE));
+        then(ctxMock).should(never()).tellNext(any(), eq("Created"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Updated"));
+        then(ctxMock).should(never()).tellSuccess(any());
+        then(ctxMock).should(never()).tellFailure(any(), any());
+    }
+
+    @Test
+    @DisplayName(
+            "Given message originator type is not ALARM and alarm does not exist, " +
+                    "when onMsg(), " +
+                    "then tell next 'False' with original message."
+    )
+    void whenMsgOriginatorNotAlarmAndAlarmDoesNotExist_thenShouldTellFalseWithOriginalMsg() throws Exception {
+        // GIVEN
+
+        // node configuration
+        config = config.defaultConfiguration();
+
+        String alarmType = config.getAlarmType();
+        ScriptLanguage scriptLang = config.getScriptLang();
+        String alarmDetailsScript = config.getAlarmDetailsBuildTbel();
+
+        metadata.putValue("metadataKey", "metadataValue");
+        var msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, msgOriginator, metadata, "{\"temperature\": 50}");
+
+        // mocks
+        given(ctxMock.getTenantId()).willReturn(tenantId);
+        given(ctxMock.getAlarmService()).willReturn(alarmServiceMock);
+        given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
+        given(ctxMock.createScriptEngine(scriptLang, alarmDetailsScript)).willReturn(alarmDetailsScriptMock);
+
+        given(alarmServiceMock.findLatestActiveByOriginatorAndType(tenantId, msgOriginator, alarmType)).willReturn(null);
+
+        // node initialization
+        nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        // WHEN
+        nodeSpy.onMsg(ctxMock, msg);
+
+        // THEN
+        then(alarmServiceMock).should(never()).clearAlarm(any(), any(), anyLong(), any());
+
+        then(ctxMock).should().tellNext(msg, TbNodeConnectionType.FALSE);
+        then(ctxMock).should(never()).enqueue(any(), any(), any());
+        then(ctxMock).should(never()).tellNext(any(), eq("Created"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Updated"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Cleared"));
+        then(ctxMock).should(never()).tellSuccess(any());
+        then(ctxMock).should(never()).tellFailure(any(), any());
+    }
+
+    @Test
+    @DisplayName(
+            "Given message originator type is not ALARM and already cleared alarm exists, " +
+                    "when onMsg(), " +
+                    "then tell next 'False' with original message."
+    )
+    void whenMsgOriginatorNotAlarmAndClearedAlarmExists_thenShouldTellFalseWithOriginalMsg() throws Exception {
+        // GIVEN
+
+        // node configuration
+        config = config.defaultConfiguration();
+
+        String alarmType = config.getAlarmType();
+        ScriptLanguage scriptLang = config.getScriptLang();
+        String alarmDetailsScript = config.getAlarmDetailsBuildTbel();
+        JsonNode alarmDetails = JacksonUtil.newObjectNode().put("alarmDetailsProperty", "alarmDetailsValue");
+        long clearTs = 500L;
+
+        metadata.putValue("metadataKey", "metadataValue");
+        var msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, msgOriginator, metadata, "{\"temperature\": 50}");
+
+        // mocks
+        given(ctxMock.getTenantId()).willReturn(tenantId);
+        given(ctxMock.getAlarmService()).willReturn(alarmServiceMock);
+        given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
+        given(ctxMock.createScriptEngine(scriptLang, alarmDetailsScript)).willReturn(alarmDetailsScriptMock);
+
+        var alarmId = new AlarmId(Uuids.timeBased());
+        var clearedAlarm = Alarm.builder()
+                .type(alarmType)
+                .tenantId(tenantId)
+                .originator(msgOriginator)
+                .severity(AlarmSeverity.WARNING)
+                .cleared(true)
+                .clearTs(clearTs)
+                .startTs(100L)
+                .endTs(200L)
+                .details(alarmDetails)
+                .build();
+        clearedAlarm.setId(alarmId);
+
+        given(alarmServiceMock.findLatestActiveByOriginatorAndType(tenantId, msgOriginator, alarmType)).willReturn(clearedAlarm);
+
+        // node initialization
+        nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        // WHEN
+        nodeSpy.onMsg(ctxMock, msg);
+
+        // THEN
+        then(alarmServiceMock).should(never()).clearAlarm(any(), any(), anyLong(), any());
+
+        then(ctxMock).should().tellNext(msg, TbNodeConnectionType.FALSE);
+        then(ctxMock).should(never()).enqueue(any(), any(), any());
+        then(ctxMock).should(never()).tellNext(any(), eq("Created"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Updated"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Cleared"));
+        then(ctxMock).should(never()).tellSuccess(any());
+        then(ctxMock).should(never()).tellFailure(any(), any());
+    }
+
+    @Test
+    @DisplayName(
+            "Given message originator type is not ALARM, active alarm exists and alarm type is using a message body pattern, " +
+                    "when onMsg(), " +
+                    "then should clear active alarm, update alarm details, enqueue ALARM_CLEAR message, tell next 'Cleared' with cleared alarm in message body and 'isClearedAlarm = true' in metadata"
+    )
+    void whenMsgOriginatorNotAlarmAndActiveAlarmExistsAndAlarmTypeIsMsgBodyPattern_thenShouldCorrectlyClear() throws Exception {
+        // GIVEN
+
+        // node configuration
+        config = config.defaultConfiguration();
+        config.setAlarmType("$[alarmType]");
+
+        String alarmType = "High Temperature";
+        ScriptLanguage scriptLang = config.getScriptLang();
+        String alarmDetailsScript = config.getAlarmDetailsBuildTbel();
+        JsonNode oldAlarmDetails = JacksonUtil.newObjectNode().put("oldAlarmDetailsProperty", "oldAlarmDetailsValue");
+        JsonNode newAlarmDetails = JacksonUtil.newObjectNode().put("newAlarmDetailsProperty", "newAlarmDetailsValue");
+        long clearTs = 500L;
+
+        metadata.putValue("metadataKey", "metadataValue");
+        var msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, msgOriginator, metadata, "{\"temperature\": 50, \"alarmType\": \"" + alarmType + "\"}");
+
+        var ruleNodeSelfId = new RuleNodeId(Uuids.timeBased());
+
+        // mocks
+        given(ctxMock.getTenantId()).willReturn(tenantId);
+        given(ctxMock.getAlarmService()).willReturn(alarmServiceMock);
+        given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
+        given(ctxMock.getSelfId()).willReturn(ruleNodeSelfId);
+        doReturn(clearTs).when(nodeSpy).currentTimeMillis();
+        given(ctxMock.createScriptEngine(scriptLang, alarmDetailsScript)).willReturn(alarmDetailsScriptMock);
+        given(alarmDetailsScriptMock.executeJsonAsync(any())).willReturn(Futures.immediateFuture(newAlarmDetails));
+
+        var alarmId = new AlarmId(Uuids.timeBased());
+        var activeAlarm = Alarm.builder()
+                .type(alarmType)
+                .tenantId(tenantId)
+                .originator(msgOriginator)
+                .severity(AlarmSeverity.WARNING)
+                .startTs(100L)
+                .endTs(200L)
+                .details(oldAlarmDetails)
+                .build();
+        activeAlarm.setId(alarmId);
+
+        var expectedAlarm = new Alarm(activeAlarm);
+        expectedAlarm.setCleared(true);
+        expectedAlarm.setDetails(newAlarmDetails);
+
+        var expectedAlarmInfo = new AlarmInfo(expectedAlarm);
+
+        given(alarmServiceMock.findLatestActiveByOriginatorAndType(tenantId, msgOriginator, alarmType)).willReturn(activeAlarm);
+        given(alarmServiceMock.clearAlarm(tenantId, alarmId, clearTs, newAlarmDetails))
+                .willReturn(AlarmApiCallResult.builder()
+                        .successful(true)
+                        .cleared(true)
+                        .alarm(expectedAlarmInfo)
+                        .build());
+        given(ctxMock.alarmActionMsg(expectedAlarmInfo, ruleNodeSelfId, TbMsgType.ALARM_CLEAR)).willReturn(alarmActionMsgMock);
+        given(ctxMock.transformMsg(any(TbMsg.class), any(TbMsgType.class), any(EntityId.class), any(TbMsgMetaData.class), anyString()))
+                .willAnswer(answer -> TbMsg.transformMsg(
+                        answer.getArgument(0, TbMsg.class),
+                        answer.getArgument(1, TbMsgType.class),
+                        answer.getArgument(2, EntityId.class),
+                        answer.getArgument(3, TbMsgMetaData.class),
+                        answer.getArgument(4, String.class))
+                );
+
+        // node initialization
+        nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        // WHEN
+        nodeSpy.onMsg(ctxMock, msg);
+
+        // THEN
+
+        // verify alarm details script evaluation
+        then(ctxMock).should().logJsEvalRequest();
+        var dummyMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        then(alarmDetailsScriptMock).should().executeJsonAsync(dummyMsgCaptor.capture());
+        TbMsg actualDummyMsg = dummyMsgCaptor.getValue();
+        assertThat(actualDummyMsg.getType()).isEqualTo(msg.getType());
+        assertThat(actualDummyMsg.getData()).isEqualTo(msg.getData());
+        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry(TbAbstractAlarmNode.PREV_ALARM_DETAILS, JacksonUtil.toString(oldAlarmDetails));
+        then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
+
+        // verify we called clearAlarm() with correct parameters
+        then(alarmServiceMock).should().clearAlarm(tenantId, alarmId, clearTs, newAlarmDetails);
+
+        // verify that we created a correct alarm action message and enqueued it
+        then(ctxMock).should().alarmActionMsg(expectedAlarmInfo, ruleNodeSelfId, TbMsgType.ALARM_CLEAR);
+        then(ctxMock).should().enqueue(eq(alarmActionMsgMock), successCaptor.capture(), any());
+
+        // run success captor to emulate successful enqueueing and to trigger further processing on the success path
+        successCaptor.getValue().run();
+
+        // capture and verify an outgoing message
+        var outgoingMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        then(ctxMock).should().tellNext(outgoingMsgCaptor.capture(), eq("Cleared"));
+        var actualOutgoingMsg = outgoingMsgCaptor.getValue();
+        assertThat(actualOutgoingMsg.getType()).isEqualTo(TbMsgType.ALARM.name());
+        assertThat(actualOutgoingMsg.getOriginator()).isEqualTo(msgOriginator);
+        assertThat(actualOutgoingMsg.getData()).isEqualTo(JacksonUtil.toString(expectedAlarmInfo));
+
+        Map<String, String> actualOutgoingMsgMetadataContent = actualOutgoingMsg.getMetaData().getData();
+        assertThat(actualOutgoingMsgMetadataContent).containsAllEntriesOf(metadata.getData());
+        assertThat(actualOutgoingMsgMetadataContent).containsEntry(DataConstants.IS_CLEARED_ALARM, Boolean.TRUE.toString());
+        assertThat(actualOutgoingMsgMetadataContent).size().isEqualTo(metadata.getData().size() + 1);
+
+        // verify wrong processing paths were not taken
+        then(ctxMock).should(never()).tellNext(any(), eq(TbNodeConnectionType.FALSE));
+        then(ctxMock).should(never()).tellNext(any(), eq("Created"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Updated"));
+        then(ctxMock).should(never()).tellSuccess(any());
+        then(ctxMock).should(never()).tellFailure(any(), any());
+    }
+
+    @Test
+    @DisplayName(
+            "Given message originator type is not ALARM, active alarm exists and alarm type is using a metadata pattern, " +
+                    "when onMsg(), " +
+                    "then should clear active alarm, update alarm details, enqueue ALARM_CLEAR message, tell next 'Cleared' with cleared alarm in message body and 'isClearedAlarm = true' in metadata"
+    )
+    void whenMsgOriginatorNotAlarmAndActiveAlarmExistsAndAlarmTypeIsMetadataPattern_thenShouldCorrectlyClear() throws Exception {
+        // GIVEN
+
+        // node configuration
+        config = config.defaultConfiguration();
+        config.setAlarmType("${alarmType}");
+
+        String alarmType = "High Temperature";
+        ScriptLanguage scriptLang = config.getScriptLang();
+        String alarmDetailsScript = config.getAlarmDetailsBuildTbel();
+        JsonNode oldAlarmDetails = JacksonUtil.newObjectNode().put("oldAlarmDetailsProperty", "oldAlarmDetailsValue");
+        JsonNode newAlarmDetails = JacksonUtil.newObjectNode().put("newAlarmDetailsProperty", "newAlarmDetailsValue");
+        long clearTs = 500L;
+
+        metadata.putValue("metadataKey", "metadataValue");
+        metadata.putValue("alarmType", alarmType);
+        var msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, msgOriginator, metadata, "{\"temperature\": 50}");
+
+        var ruleNodeSelfId = new RuleNodeId(Uuids.timeBased());
+
+        // mocks
+        given(ctxMock.getTenantId()).willReturn(tenantId);
+        given(ctxMock.getAlarmService()).willReturn(alarmServiceMock);
+        given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
+        given(ctxMock.getSelfId()).willReturn(ruleNodeSelfId);
+        doReturn(clearTs).when(nodeSpy).currentTimeMillis();
+        given(ctxMock.createScriptEngine(scriptLang, alarmDetailsScript)).willReturn(alarmDetailsScriptMock);
+        given(alarmDetailsScriptMock.executeJsonAsync(any())).willReturn(Futures.immediateFuture(newAlarmDetails));
+
+        var alarmId = new AlarmId(Uuids.timeBased());
+        var activeAlarm = Alarm.builder()
+                .type(alarmType)
+                .tenantId(tenantId)
+                .originator(msgOriginator)
+                .severity(AlarmSeverity.WARNING)
+                .startTs(100L)
+                .endTs(200L)
+                .details(oldAlarmDetails)
+                .build();
+        activeAlarm.setId(alarmId);
+
+        var expectedAlarm = new Alarm(activeAlarm);
+        expectedAlarm.setCleared(true);
+        expectedAlarm.setDetails(newAlarmDetails);
+
+        var expectedAlarmInfo = new AlarmInfo(expectedAlarm);
+
+        given(alarmServiceMock.findLatestActiveByOriginatorAndType(tenantId, msgOriginator, alarmType)).willReturn(activeAlarm);
+        given(alarmServiceMock.clearAlarm(tenantId, alarmId, clearTs, newAlarmDetails))
+                .willReturn(AlarmApiCallResult.builder()
+                        .successful(true)
+                        .cleared(true)
+                        .alarm(expectedAlarmInfo)
+                        .build());
+        given(ctxMock.alarmActionMsg(expectedAlarmInfo, ruleNodeSelfId, TbMsgType.ALARM_CLEAR)).willReturn(alarmActionMsgMock);
+        given(ctxMock.transformMsg(any(TbMsg.class), any(TbMsgType.class), any(EntityId.class), any(TbMsgMetaData.class), anyString()))
+                .willAnswer(answer -> TbMsg.transformMsg(
+                        answer.getArgument(0, TbMsg.class),
+                        answer.getArgument(1, TbMsgType.class),
+                        answer.getArgument(2, EntityId.class),
+                        answer.getArgument(3, TbMsgMetaData.class),
+                        answer.getArgument(4, String.class))
+                );
+
+        // node initialization
+        nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        // WHEN
+        nodeSpy.onMsg(ctxMock, msg);
+
+        // THEN
+
+        // verify alarm details script evaluation
+        then(ctxMock).should().logJsEvalRequest();
+        var dummyMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        then(alarmDetailsScriptMock).should().executeJsonAsync(dummyMsgCaptor.capture());
+        TbMsg actualDummyMsg = dummyMsgCaptor.getValue();
+        assertThat(actualDummyMsg.getType()).isEqualTo(msg.getType());
+        assertThat(actualDummyMsg.getData()).isEqualTo(msg.getData());
+        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry(TbAbstractAlarmNode.PREV_ALARM_DETAILS, JacksonUtil.toString(oldAlarmDetails));
+        then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
+
+        // verify we called clearAlarm() with correct parameters
+        then(alarmServiceMock).should().clearAlarm(tenantId, alarmId, clearTs, newAlarmDetails);
+
+        // verify that we created a correct alarm action message and enqueued it
+        then(ctxMock).should().alarmActionMsg(expectedAlarmInfo, ruleNodeSelfId, TbMsgType.ALARM_CLEAR);
+        then(ctxMock).should().enqueue(eq(alarmActionMsgMock), successCaptor.capture(), any());
+
+        // run success captor to emulate successful enqueueing and to trigger further processing on the success path
+        successCaptor.getValue().run();
+
+        // capture and verify an outgoing message
+        var outgoingMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        then(ctxMock).should().tellNext(outgoingMsgCaptor.capture(), eq("Cleared"));
+        var actualOutgoingMsg = outgoingMsgCaptor.getValue();
+        assertThat(actualOutgoingMsg.getType()).isEqualTo(TbMsgType.ALARM.name());
+        assertThat(actualOutgoingMsg.getOriginator()).isEqualTo(msgOriginator);
+        assertThat(actualOutgoingMsg.getData()).isEqualTo(JacksonUtil.toString(expectedAlarmInfo));
+
+        Map<String, String> actualOutgoingMsgMetadataContent = actualOutgoingMsg.getMetaData().getData();
+        assertThat(actualOutgoingMsgMetadataContent).containsAllEntriesOf(metadata.getData());
+        assertThat(actualOutgoingMsgMetadataContent).containsEntry(DataConstants.IS_CLEARED_ALARM, Boolean.TRUE.toString());
+        assertThat(actualOutgoingMsgMetadataContent).size().isEqualTo(metadata.getData().size() + 1);
+
+        // verify wrong processing paths were not taken
+        then(ctxMock).should(never()).tellNext(any(), eq(TbNodeConnectionType.FALSE));
+        then(ctxMock).should(never()).tellNext(any(), eq("Created"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Updated"));
+        then(ctxMock).should(never()).tellSuccess(any());
+        then(ctxMock).should(never()).tellFailure(any(), any());
+    }
+
+    @Test
+    @DisplayName(
+            "When the alarm details script throws an exception, " +
+                    "node should tell failure with that exception, and it should neither clear any alarms, nor should it send any other messages."
+    )
+    void whenAlarmDetailsScriptThrowsException_thenShouldTellFailureAndNoOtherActions() throws Exception {
+        // GIVEN
+        config = config.defaultConfiguration();
+
+        var msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, msgOriginator, metadata, "{\"temperature\": 50}");
+
+        given(ctxMock.getTenantId()).willReturn(tenantId);
+        given(ctxMock.getAlarmService()).willReturn(alarmServiceMock);
+        given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
+        given(ctxMock.createScriptEngine(ScriptLanguage.TBEL, config.getAlarmDetailsBuildTbel())).willReturn(alarmDetailsScriptMock);
+
+        var alarmId = new AlarmId(Uuids.timeBased());
+        var activeAlarm = Alarm.builder()
+                .type(config.getAlarmType())
+                .tenantId(tenantId)
+                .originator(msgOriginator)
+                .severity(AlarmSeverity.WARNING)
+                .startTs(100L)
+                .endTs(200L)
+                .details(JacksonUtil.newObjectNode())
+                .build();
+        activeAlarm.setId(alarmId);
+        given(alarmServiceMock.findLatestActiveByOriginatorAndType(tenantId, msgOriginator, activeAlarm.getType())).willReturn(activeAlarm);
+
+        var expectedException = new ExecutionException("Failed to execute script.", new RuntimeException("Something went wrong!"));
+        given(alarmDetailsScriptMock.executeJsonAsync(any())).willReturn(Futures.immediateFailedFuture(expectedException));
+
+        nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        // WHEN
+        nodeSpy.onMsg(ctxMock, msg);
+
+        // THEN
+        then(ctxMock).should().logJsEvalRequest();
+        then(ctxMock).should().logJsEvalFailure();
+
+        var exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);
+        then(ctxMock).should().tellFailure(eq(msg), exceptionCaptor.capture());
+        Throwable actualException = exceptionCaptor.getValue();
+        assertThat(actualException).isEqualTo(expectedException);
+
+        then(alarmServiceMock).should(never()).clearAlarm(any(), any(), anyLong(), any());
+
+        then(ctxMock).should(never()).tellNext(any(), eq(TbNodeConnectionType.FALSE));
+        then(ctxMock).should(never()).tellNext(any(), eq("Created"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Updated"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Cleared"));
+        then(ctxMock).should(never()).tellSuccess(any());
     }
 
 }

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbClearAlarmNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbClearAlarmNodeTest.java
@@ -172,7 +172,7 @@ class TbClearAlarmNodeTest {
         given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
         given(ctxMock.createScriptEngine(scriptLang, alarmDetailsScript)).willReturn(alarmDetailsScriptMock);
 
-        given(alarmServiceMock.findAlarmById(tenantId, msgAlarmOriginator)).willReturn(null);
+        given(alarmServiceMock.findAlarmByIdAsync(tenantId, msgAlarmOriginator)).willReturn(Futures.immediateFuture(null));
 
         // node initialization
         nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
@@ -233,7 +233,7 @@ class TbClearAlarmNodeTest {
         given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
         given(ctxMock.createScriptEngine(scriptLang, alarmDetailsScript)).willReturn(alarmDetailsScriptMock);
 
-        given(alarmServiceMock.findAlarmById(tenantId, msgAlarmOriginator)).willReturn(clearedAlarm);
+        given(alarmServiceMock.findAlarmByIdAsync(tenantId, msgAlarmOriginator)).willReturn(Futures.immediateFuture(clearedAlarm));
 
         // node initialization
         nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
@@ -304,7 +304,7 @@ class TbClearAlarmNodeTest {
 
         var expectedAlarmInfo = new AlarmInfo(expectedAlarm);
 
-        given(alarmServiceMock.findAlarmById(tenantId, msgAlarmOriginator)).willReturn(activeAlarm);
+        given(alarmServiceMock.findAlarmByIdAsync(tenantId, msgAlarmOriginator)).willReturn(Futures.immediateFuture(activeAlarm));
         given(alarmServiceMock.clearAlarm(tenantId, alarmId, clearTs, newAlarmDetails))
                 .willReturn(AlarmApiCallResult.builder()
                         .successful(true)

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateAlarmNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateAlarmNodeTest.java
@@ -245,6 +245,7 @@ class TbCreateAlarmNodeTest {
         then(ctxMock).should().logJsEvalRequest();
         then(alarmDetailsScriptMock).should().executeJsonAsync(incomingMsg);
         then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called createAlarm() with correct AlarmCreateOrUpdateActiveRequest
         then(alarmServiceMock).should().createAlarm(expectedCreateAlarmRequest);
@@ -414,6 +415,7 @@ class TbCreateAlarmNodeTest {
         then(ctxMock).should().logJsEvalRequest();
         then(alarmDetailsScriptMock).should().executeJsonAsync(incomingMsg);
         then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called createAlarm() with correct AlarmCreateOrUpdateActiveRequest
         then(alarmServiceMock).should().createAlarm(expectedCreateAlarmRequest);
@@ -607,8 +609,9 @@ class TbCreateAlarmNodeTest {
         TbMsg actualDummyMsg = dummyMsgCaptor.getValue();
         assertThat(actualDummyMsg.getType()).isEqualTo(incomingMsg.getType());
         assertThat(actualDummyMsg.getData()).isEqualTo(incomingMsg.getData());
-        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry("prevAlarmDetails", JacksonUtil.toString(oldAlarmDetails));
+        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry(TbAbstractAlarmNode.PREV_ALARM_DETAILS, JacksonUtil.toString(oldAlarmDetails));
         then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called updateAlarm() with correct AlarmUpdateRequest
         then(alarmServiceMock).should().updateAlarm(expectedUpdateAlarmRequest);
@@ -637,6 +640,162 @@ class TbCreateAlarmNodeTest {
         // verify wrong processing paths were not taken
         then(ctxMock).should(never()).tellNext(any(), eq(TbNodeConnectionType.FALSE));
         then(ctxMock).should(never()).tellNext(any(), eq("Created"));
+        then(ctxMock).should(never()).tellNext(any(), eq("Cleared"));
+        then(ctxMock).should(never()).tellSuccess(any());
+        then(ctxMock).should(never()).tellFailure(any(), any());
+    }
+
+    @Test
+    @DisplayName(
+            "When node is taking alarm data from incoming message and originator specified in alarm data has null UUID and alarm does not exists, " +
+                    "then should create new alarm using info from incoming message."
+    )
+    void whenAlarmDataIsTakenFromMsgAndAlarmDataOriginatorHasNullUuidAndAlarmDoesNotExist_thenNewAlarmIsCreated() throws Exception {
+        // GIVEN
+
+        // node configuration
+        config = config.defaultConfiguration();
+        config.setUseMessageAlarmData(true);
+        config.setOverwriteAlarmDetails(false);
+
+        // other values
+        String alarmType = "High Temperature";
+        AlarmSeverity alarmSeverity = AlarmSeverity.MAJOR;
+        JsonNode alarmDetails = JacksonUtil.newObjectNode().put("alarmDetails", "Some alarm details");
+
+        // alarm that is inside an incoming message
+        var alarmFromIncomingMessage = Alarm.builder()
+                .tenantId(tenantId)
+                .originator(new DeviceId(EntityId.NULL_UUID))
+                .cleared(false)
+                .acknowledged(false)
+                .severity(alarmSeverity)
+                .propagate(true)
+                .propagateToOwner(true)
+                .propagateToTenant(true)
+                .propagateRelationTypes(Collections.emptyList())
+                .type(alarmType)
+                .startTs(100L)
+                .endTs(300L)
+                .details(alarmDetails)
+                .build();
+
+        long metadataTs = 1711631716127L;
+        metadata.putValue("ts", Long.toString(metadataTs));
+        metadata.putValue("location", "Company office");
+
+        var ruleNodeSelfId = new RuleNodeId(Uuids.timeBased());
+
+        var incomingMsg = TbMsg.newMsg(TbMsgType.ALARM, msgOriginator, metadata, JacksonUtil.toString(alarmFromIncomingMessage));
+
+        Alarm existingAlarm = null;
+
+        // expected values
+        var expectedCreatedAlarm = Alarm.builder()
+                .tenantId(tenantId)
+                .originator(msgOriginator)
+                .cleared(false)
+                .acknowledged(false)
+                .severity(alarmSeverity)
+                .propagate(true)
+                .propagateToOwner(true)
+                .propagateToTenant(true)
+                .propagateRelationTypes(Collections.emptyList())
+                .type(alarmType)
+                .startTs(100L)
+                .endTs(300L)
+                .details(alarmDetails)
+                .build();
+        var expectedCreatedAlarmInfo = new AlarmInfo(expectedCreatedAlarm);
+        expectedCreatedAlarmInfo.setId(new AlarmId(Uuids.timeBased()));
+
+        var expectedCreateAlarmRequest = AlarmCreateOrUpdateActiveRequest.builder()
+                .tenantId(tenantId)
+                .customerId(null)
+                .type(alarmType)
+                .originator(msgOriginator)
+                .severity(alarmSeverity)
+                .startTs(100L)
+                .endTs(300L)
+                .details(alarmDetails)
+                .propagation(AlarmPropagationInfo.builder()
+                        .propagate(true)
+                        .propagateToOwner(true)
+                        .propagateToTenant(true)
+                        .propagateRelationTypes(Collections.emptyList()).build())
+                .userId(null)
+                .edgeAlarmId(null)
+                .build();
+
+        // mocks
+        given(ctxMock.getTenantId()).willReturn(tenantId);
+        given(ctxMock.getAlarmService()).willReturn(alarmServiceMock);
+        given(ctxMock.getDbCallbackExecutor()).willReturn(dbExecutor);
+        given(ctxMock.getSelfId()).willReturn(ruleNodeSelfId);
+        given(alarmServiceMock.findLatestActiveByOriginatorAndType(tenantId, msgOriginator, alarmType)).willReturn(existingAlarm);
+        var apiCallResult = AlarmApiCallResult.builder()
+                .successful(true)
+                .created(true)
+                .modified(false)
+                .cleared(false)
+                .deleted(false)
+                .alarm(expectedCreatedAlarmInfo)
+                .old(null)
+                .propagatedEntitiesList(List.of(TenantId.fromUUID(Uuids.timeBased()), new CustomerId(Uuids.timeBased()), new AssetId(Uuids.timeBased())))
+                .build();
+        given(alarmServiceMock.createAlarm(expectedCreateAlarmRequest)).willReturn(apiCallResult);
+        given(ctxMock.alarmActionMsg(expectedCreatedAlarmInfo, ruleNodeSelfId, TbMsgType.ENTITY_CREATED)).willReturn(alarmActionMsgMock);
+        given(ctxMock.transformMsg(any(TbMsg.class), any(TbMsgType.class), any(EntityId.class), any(TbMsgMetaData.class), anyString()))
+                .willAnswer(answer -> TbMsg.transformMsg(
+                        answer.getArgument(0, TbMsg.class),
+                        answer.getArgument(1, TbMsgType.class),
+                        answer.getArgument(2, EntityId.class),
+                        answer.getArgument(3, TbMsgMetaData.class),
+                        answer.getArgument(4, String.class))
+                );
+        given(ctxMock.createScriptEngine(ScriptLanguage.TBEL, config.getAlarmDetailsBuildTbel())).willReturn(alarmDetailsScriptMock);
+
+        // node initialization
+        nodeSpy.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(config)));
+
+        // WHEN
+        nodeSpy.onMsg(ctxMock, incomingMsg);
+
+        // THEN
+
+        // verify alarm details script was not evaluated
+        then(ctxMock).should(never()).logJsEvalRequest();
+        then(alarmDetailsScriptMock).should(never()).executeJsonAsync(any());
+        then(ctxMock).should(never()).logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
+
+        // verify we called createAlarm() with correct AlarmCreateOrUpdateActiveRequest
+        then(alarmServiceMock).should().createAlarm(expectedCreateAlarmRequest);
+        then(alarmServiceMock).should(never()).updateAlarm(any());
+
+        // verify that we created a correct alarm action message and enqueued it
+        then(ctxMock).should().alarmActionMsg(expectedCreatedAlarmInfo, ruleNodeSelfId, TbMsgType.ENTITY_CREATED);
+        then(ctxMock).should().enqueue(eq(alarmActionMsgMock), successCaptor.capture(), any());
+
+        // run success captor to emulate successful sending and to trigger further processing on the success path
+        successCaptor.getValue().run();
+
+        // capture and verify an outgoing message
+        var outgoingMsgCaptor = ArgumentCaptor.forClass(TbMsg.class);
+        then(ctxMock).should().tellNext(outgoingMsgCaptor.capture(), eq("Created"));
+        var actualOutgoingMsg = outgoingMsgCaptor.getValue();
+        assertThat(actualOutgoingMsg.getType()).isEqualTo(TbMsgType.ALARM.name());
+        assertThat(actualOutgoingMsg.getOriginator()).isEqualTo(msgOriginator);
+        assertThat(actualOutgoingMsg.getData()).isEqualTo(JacksonUtil.valueToTree(expectedCreatedAlarmInfo).toString());
+
+        Map<String, String> actualOutgoingMsgMetadataContent = actualOutgoingMsg.getMetaData().getData();
+        assertThat(actualOutgoingMsgMetadataContent).containsAllEntriesOf(metadata.getData());
+        assertThat(actualOutgoingMsgMetadataContent).containsEntry(DataConstants.IS_NEW_ALARM, Boolean.TRUE.toString());
+        assertThat(actualOutgoingMsgMetadataContent).size().isEqualTo(metadata.getData().size() + 1);
+
+        // verify wrong processing paths were not taken
+        then(ctxMock).should(never()).tellNext(any(), eq(TbNodeConnectionType.FALSE));
+        then(ctxMock).should(never()).tellNext(any(), eq("Updated"));
         then(ctxMock).should(never()).tellNext(any(), eq("Cleared"));
         then(ctxMock).should(never()).tellSuccess(any());
         then(ctxMock).should(never()).tellFailure(any(), any());
@@ -776,6 +935,7 @@ class TbCreateAlarmNodeTest {
         then(ctxMock).should(never()).logJsEvalRequest();
         then(alarmDetailsScriptMock).should(never()).executeJsonAsync(any());
         then(ctxMock).should(never()).logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called createAlarm() with correct AlarmCreateOrUpdateActiveRequest
         then(alarmServiceMock).should().createAlarm(expectedCreateAlarmRequest);
@@ -966,8 +1126,9 @@ class TbCreateAlarmNodeTest {
         TbMsg actualDummyMsg = dummyMsgCaptor.getValue();
         assertThat(actualDummyMsg.getType()).isEqualTo(incomingMsg.getType());
         assertThat(actualDummyMsg.getData()).isEqualTo(incomingMsg.getData());
-        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry("prevAlarmDetails", JacksonUtil.toString(oldAlarmDetails));
+        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry(TbAbstractAlarmNode.PREV_ALARM_DETAILS, JacksonUtil.toString(oldAlarmDetails));
         then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called updateAlarm() with correct AlarmUpdateRequest
         then(alarmServiceMock).should().updateAlarm(expectedUpdateAlarmRequest);
@@ -1147,8 +1308,9 @@ class TbCreateAlarmNodeTest {
         TbMsg actualDummyMsg = dummyMsgCaptor.getValue();
         assertThat(actualDummyMsg.getType()).isEqualTo(incomingMsg.getType());
         assertThat(actualDummyMsg.getData()).isEqualTo(incomingMsg.getData());
-        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry("prevAlarmDetails", JacksonUtil.toString(alarmDetails));
+        assertThat(actualDummyMsg.getMetaData().getData()).containsEntry(TbAbstractAlarmNode.PREV_ALARM_DETAILS, JacksonUtil.toString(alarmDetails));
         then(ctxMock).should().logJsEvalResponse();
+        then(ctxMock).should(never()).logJsEvalFailure();
 
         // verify we called updateAlarm() with correct AlarmUpdateRequest
         then(alarmServiceMock).should().updateAlarm(expectedUpdateAlarmRequest);
@@ -1205,6 +1367,9 @@ class TbCreateAlarmNodeTest {
         nodeSpy.onMsg(ctxMock, incomingMsg);
 
         // THEN
+        then(ctxMock).should().logJsEvalRequest();
+        then(ctxMock).should().logJsEvalFailure();
+
         var exceptionCaptor = ArgumentCaptor.forClass(Throwable.class);
         then(ctxMock).should().tellFailure(eq(incomingMsg), exceptionCaptor.capture());
         Throwable actualException = exceptionCaptor.getValue();

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateAlarmNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateAlarmNodeTest.java
@@ -647,10 +647,10 @@ class TbCreateAlarmNodeTest {
 
     @Test
     @DisplayName(
-            "When node is taking alarm data from incoming message and originator specified in alarm data has null UUID and alarm does not exists, " +
+            "When node is taking alarm data from incoming message and originator specified in alarm data is different from message originator UUID and alarm does not exists, " +
                     "then should create new alarm using info from incoming message."
     )
-    void whenAlarmDataIsTakenFromMsgAndAlarmDataOriginatorHasNullUuidAndAlarmDoesNotExist_thenNewAlarmIsCreated() throws Exception {
+    void whenAlarmDataIsTakenFromMsgAndAlarmDataOriginatorIsDifferentFromMsgOriginatorAndAlarmDoesNotExist_thenNewAlarmIsCreated() throws Exception {
         // GIVEN
 
         // node configuration
@@ -666,7 +666,7 @@ class TbCreateAlarmNodeTest {
         // alarm that is inside an incoming message
         var alarmFromIncomingMessage = Alarm.builder()
                 .tenantId(tenantId)
-                .originator(new DeviceId(EntityId.NULL_UUID))
+                .originator(new DeviceId(Uuids.timeBased()))
                 .cleared(false)
                 .acknowledged(false)
                 .severity(alarmSeverity)


### PR DESCRIPTION
## Pull Request description

- Alarm searching is now async, previously was blocking dispatcher thread
- Alarm type pattern is evaluated only when it is actually needed in the originator type not ALARM branch, previously alarm type pattern was always evaluated
- If alarm API call was unsuccessful, then throw error instead of `tellSuccess()`, currently alarm API returns unsuccessful result only when alarm was not found, which is very unlikely in the case of this rule node, because we fetch alarm right before clearing it.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description contains human-readable scope of changes.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).