### PR TITLE
JUnit5 migration in rule-engine-api

### DIFF
--- a/rule-engine/rule-engine-api/pom.xml
+++ b/rule-engine/rule-engine-api/pom.xml
@@ -104,11 +104,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/rule-engine/rule-engine-api/src/test/java/org/thingsboard/rule/engine/api/util/TbNodeUtilsTest.java
+++ b/rule-engine/rule-engine-api/src/test/java/org/thingsboard/rule/engine/api/util/TbNodeUtilsTest.java
@@ -16,10 +16,10 @@
 package org.thingsboard.rule.engine.api.util;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.msg.TbMsgType;
@@ -29,7 +29,7 @@ import org.thingsboard.server.common.msg.TbMsgMetaData;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TbNodeUtilsTest {
 
     private static final String DATA_VARIABLE_TEMPLATE = "$[%s]";
@@ -46,7 +46,7 @@ public class TbNodeUtilsTest {
 
         TbMsg msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, TenantId.SYS_TENANT_ID, md, JacksonUtil.toString(node));
         String result = TbNodeUtils.processPattern(pattern, msg);
-        Assert.assertEquals("ABC metadata_value data_value", result);
+        Assertions.assertEquals("ABC metadata_value data_value", result);
     }
 
     @Test
@@ -60,7 +60,7 @@ public class TbNodeUtilsTest {
 
         TbMsg msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, TenantId.SYS_TENANT_ID, md, JacksonUtil.toString(node));
         String result = TbNodeUtils.processPattern(pattern, msg);
-        Assert.assertEquals(pattern, result);
+        Assertions.assertEquals(pattern, result);
     }
 
     @Test
@@ -74,7 +74,7 @@ public class TbNodeUtilsTest {
 
         TbMsg msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, TenantId.SYS_TENANT_ID, md, JacksonUtil.toString(node));
         String result = TbNodeUtils.processPattern(pattern, msg);
-        Assert.assertEquals("ABC metadata_value data_value", result);
+        Assertions.assertEquals("ABC metadata_value data_value", result);
     }
 
     @Test
@@ -95,7 +95,7 @@ public class TbNodeUtilsTest {
 
         TbMsg msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, TenantId.SYS_TENANT_ID, md, JacksonUtil.toString(node));
         String result = TbNodeUtils.processPattern(pattern, msg);
-        Assert.assertEquals("ABC metadata_value value3", result);
+        Assertions.assertEquals("ABC metadata_value value3", result);
     }
 
     @Test
@@ -116,7 +116,7 @@ public class TbNodeUtilsTest {
 
         TbMsg msg = TbMsg.newMsg(TbMsgType.POST_TELEMETRY_REQUEST, TenantId.SYS_TENANT_ID, md, JacksonUtil.toString(node));
         String result = TbNodeUtils.processPattern(pattern, msg);
-        Assert.assertEquals("ABC metadata_value $[key1.key2[0].key3]", result);
+        Assertions.assertEquals("ABC metadata_value $[key1.key2[0].key3]", result);
     }
 
     @Test

--- a/rule-engine/rule-engine-api/src/test/resources/junit-platform.properties
+++ b/rule-engine/rule-engine-api/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.execution.parallel.mode.classes.default = concurrent

--- a/rule-engine/rule-engine-api/src/test/resources/logback-test.xml
+++ b/rule-engine/rule-engine-api/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="console"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Pull Request description

JUnit5 migration in rule-engine-api 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



