### PR TITLE
fix_bug: if setSupportedClientObjectsis is not supported LwM2m.Version

### DIFF
--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClient.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClient.java
@@ -460,7 +460,7 @@ public class LwM2mClient {
             if (lwM2mPath.isObject()) {
                 LwM2m.Version ver;
                 if (link.getAttributes().get("ver")!= null) {
-                    ver = (Version) link.getAttributes().get("ver").getValue();
+                    ver = new LwM2m.Version(link.getAttributes().get("ver").getValue().toString());
                 } else {
                     ver = getDefaultObjectIDVer();
                 }

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/transport/TransportHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/transport/TransportHealthChecker.java
@@ -145,7 +145,7 @@ public abstract class TransportHealthChecker<C extends TransportMonitoringConfig
             profileData.setTransportConfiguration(new DefaultDeviceProfileTransportConfiguration());
             deviceProfile.setProfileData(profileData);
         } else {
-            tbClient.getResources(new PageLink(1, 0, "lwm2m monitoring")).getData()
+            tbClient.getResources(new PageLink(1, 0, "LwM2M Monitoring id=3 v1.0")).getData()
                     .stream().findFirst()
                     .orElseGet(() -> {
                         TbResource newResource = ResourceUtils.getResource("lwm2m/resource.json", TbResource.class);


### PR DESCRIPTION
## Pull Request description

 LwM2MClientSerDesTest:

```
String s = "7b226e6f64654964223a2274622d6c776d326d2d7472616e73706f72742d30222c22656e64706f696e74223a2253675a4467564b5a617274704a4a717a64647052222c227265736f7572636573223a7b222f335f312e302f302f30223a7b226c774d326d5265736f75726365223a7b226964223a302c2274797065223a22535452494e47222c226d756c7469496e7374616e636573223a66616c73652c2276616c7565223a2230366433633734372d633533342d346661362d383165352d613432623039666339353966227d2c227265736f757263654d6f64656c223a7b226964223a302c226e616d65223a22546573742064617461222c226f7065726174696f6e73223a2252222c226d756c7469706c65223a66616c73652c226d616e6461746f7279223a66616c73652c2274797065223a22535452494e47222c2272616e6765456e756d65726174696f6e223a22222c22756e697473223a22222c226465736372697074696f6e223a22546573742064617461227d7d7d2c2273686172656441747472696275746573223a7b7d2c226b657954734c61746573744d6170223a7b227472616e73706f72744c6f67223a313731353237313336303335367d2c227374617465223a2252454749535445524544222c2273657373696f6e223a227b5c6e20205c226e6f646549645c223a205c2274622d6c776d326d2d7472616e73706f72742d305c222c5c6e20205c2273657373696f6e49644d53425c223a205c22383938373533333632393633333231373939385c222c5c6e20205c2273657373696f6e49644c53425c223a205c222d353230353537383933393033353230393934395c222c5c6e20205c2274656e616e7449644d53425c223a205c22323036383936313230333333363338353030365c222c5c6e20205c2274656e616e7449644c53425c223a205c222d363639313333333539363233333837323431365c222c5c6e20205c2264657669636549644d53425c223a205c22333231303330303836323134303235363735315c222c5c6e20205c2264657669636549644c53425c223a205c222d373630353538343634333830353633333237335c222c5c6e20205c226465766963654e616d655c223a205c224c774d324d20284d61696e29202d20636f61703a2f2f33342e3231342e3139382e3138393a353638355c222c5c6e20205c22646576696365547970655c223a205c224c774d324d20284d61696e295c222c5c6e20205c2264657669636550726f66696c6549644d53425c223a205c22333138323539383332333038313035363735315c222c5c6e20205c2264657669636550726f66696c6549644c53425c223a205c222d373630353538343634333830353633333237335c222c5c6e20205c22637573746f6d657249644d53425c223a205c22313430353437343932373936303738393432365c222c5c6e20205c22637573746f6d657249644c53425c223a205c222d393138373230313935303433353733373437325c225c6e7d222c2274656e616e744964223a2231636236366434302d616165652d313165652d613332332d396238626532643763626530222c226465766963654964223a2232633864343761302d306530302d313165662d393637332d383931303034636361353037222c2270726f66696c654964223a2232633261646335302d306530302d313165662d393637332d383931303034636361353037222c2264656661756c744f626a6563744944566572223a22312e30222c22726567697374726174696f6e223a227b5c22726567446174655c223a313731353235373934373933302c5c227472616e73706f7274646174615c223a7b5c22616464726573735c223a5c222f3139322e3136382e322e3138345c222c5c22706f72745c223a34313334392c5c22747970655c223a5c2269705c222c5c226964656e746974795c223a7b5c22747970655c223a5c22756e7365637572655c222c5c22616464726573735c223a5c222f3139322e3136382e322e3138345c222c5c22706f72745c223a34313334397d7d2c5c226c745c223a333630302c5c227665725c223a5c22312e315c222c5c22626e645c223a5c22555c222c5c22716d5c223a66616c73652c5c2265705c223a5c2253675a4467564b5a617274704a4a717a646470525c222c5c2272656749645c223a5c2258684d376347655146525c222c5c2265705572695c223a5c22636f61703a2f2f5b303a303a303a303a303a303a303a305d3a353638355c222c5c226f626a4c696e6b5c223a5b7b5c2275726c5c223a5c222f5c222c5c2261745c223a7b5c2263745c223a5c225c5c5c22363020313130203131322031313534322031313534335c5c5c225c222c5c2272745c223a5c225c5c5c226f6d612e6c776d326d5c5c5c225c227d7d2c7b5c2275726c5c223a5c222f315c222c5c2261745c223a7b5c227665725c223a5c22312e325c227d7d2c7b5c2275726c5c223a5c222f312f305c222c5c2261745c223a7b7d7d2c7b5c2275726c5c223a5c222f325c222c5c2261745c223a7b5c227665725c223a5c22312e315c227d7d2c7b5c2275726c5c223a5c222f332f305c222c5c2261745c223a7b7d7d5d2c5c22616464417474725c223a7b7d2c5c22726f6f745c223a5c222f5c222c5c226c61737455705c223a313731353237313336303334322c5c2263745c223a5b31313534322c31313534332c34302c34322c36302c3131302c3131322c305d2c5c22737570704f626a735c223a7b5c22315c223a5c22312e325c222c5c22325c223a5c22312e315c222c5c22335c223a5c22312e315c227d2c5c226f626a496e7374616e6365735c223a5b5c222f312f305c222c5c222f332f305c225d2c5c22617070646174615c223a7b7d7d222c2261736c656570223a66616c73652c226c61737455706c696e6b54696d65223a313731353237313337383537372c22666972737445647278446f776e6c696e6b223a747275652c227265747279417474656d707473223a307d";
byte[] old = Hex.decodeHex(s);
LwM2mClient desClient2 = LwM2MClientSerDes.deserialize(old);
```

Before:

```
java.lang.ClassCastException: class java.lang.String cannot be cast to class org.eclipse.leshan.core.LwM2m$Version (java.lang.String is in module java.base of loader 'bootstrap'; org.eclipse.leshan.core.LwM2m$Version is in unnamed module of loader 'app')

	at org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient.setSupportedClientObjects(LwM2mClient.java:478)
	at org.thingsboard.server.transport.lwm2m.server.client.LwM2mClient.setRegistration(LwM2mClient.java:188)
	at org.thingsboard.server.transport.lwm2m.server.store.util.LwM2MClientSerDes.deserialize(LwM2MClientSerDes.java:369)
	at org.thingsboard.server.transport.lwm2m.server.store.util.LwM2MClientSerDesTest.serializeDeserialize(LwM2MClientSerDesTest.java:141)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

after:
![image (4)](https://github.com/thingsboard/thingsboard/assets/44275303/0a5be330-1778-45ef-9004-1aff544cfbc0)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



