### PR TITLE
Include bundle widget checkbox enabled by default

### DIFF
--- a/ui-ngx/src/app/shared/import-export/export-widgets-bundle-dialog.component.ts
+++ b/ui-ngx/src/app/shared/import-export/export-widgets-bundle-dialog.component.ts
@@ -22,6 +22,7 @@ import { FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
 import { DialogComponent } from '@app/shared/components/dialog.component';
 import { WidgetsBundle } from '@shared/models/widgets-bundle.model';
+import { isDefinedAndNotNull } from '@core/utils';
 
 export interface ExportWidgetsBundleDialogData {
   widgetsBundle: WidgetsBundle;
@@ -43,7 +44,7 @@ export class ExportWidgetsBundleDialogComponent extends DialogComponent<ExportWi
 
   widgetsBundle: WidgetsBundle;
 
-  exportWidgetsFormControl = new FormControl(false);
+  exportWidgetsFormControl = new FormControl(true);
 
   constructor(protected store: Store<AppState>,
               protected router: Router,
@@ -51,7 +52,7 @@ export class ExportWidgetsBundleDialogComponent extends DialogComponent<ExportWi
               public dialogRef: MatDialogRef<ExportWidgetsBundleDialogComponent, ExportWidgetsBundleDialogResult>) {
     super(store, router, dialogRef);
     this.widgetsBundle = data.widgetsBundle;
-    if (data.includeBundleWidgetsInExport) {
+    if (isDefinedAndNotNull(data.includeBundleWidgetsInExport)) {
       this.exportWidgetsFormControl.patchValue(data.includeBundleWidgetsInExport, {emitEvent: false});
     }
   }


### PR DESCRIPTION
## Pull Request description

'Include bundle widgets' checkbox now enabled by default
![image](https://github.com/thingsboard/thingsboard/assets/43555187/a80503af-4043-4342-8462-8669e363d49d)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

