### PR TITLE
[Check connectivity]  Fixed mqtt basic credentials connectivity command

### DIFF
--- a/application/src/test/java/org/thingsboard/server/controller/DeviceConnectivityControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/DeviceConnectivityControllerTest.java
@@ -462,8 +462,7 @@ public class DeviceConnectivityControllerTest extends AbstractControllerTest {
         basicMqttCredentials.setUserName(userName);
         basicMqttCredentials.setPassword(password);
         credentials.setCredentialsValue(JacksonUtil.toString(basicMqttCredentials));
-        doPost("/api/device/credentials", credentials)
-                .andExpect(status().isOk());
+        credentials = doPost("/api/device/credentials", credentials, DeviceCredentials.class);
 
         JsonNode commands =
                 doGetTyped("/api/device-connectivity/" + savedDevice.getId().getId(), new TypeReference<>() {
@@ -485,6 +484,33 @@ public class DeviceConnectivityControllerTest extends AbstractControllerTest {
                         "/bin/sh -c \"curl -f -S -o " + CA_ROOT_CERT_PEM + " http://localhost:80/api/device-connectivity/mqtts/certificate/download && " +
                         "mosquitto_pub -d -q 1 --cafile " + CA_ROOT_CERT_PEM + " -h host.docker.internal -p 8883 -t %s -i \"%s\" -u \"%s\" -P \"%s\" -m \"{temperature:25}\"\"",
                 DEVICE_TELEMETRY_TOPIC, clientId, userName, password));
+
+        basicMqttCredentials.setClientId("");
+        credentials.setCredentialsValue(JacksonUtil.toString(basicMqttCredentials));
+
+        doPost("/api/device/credentials", credentials)
+                .andExpect(status().isOk());
+
+        commands =
+                doGetTyped("/api/device-connectivity/" + savedDevice.getId().getId(), new TypeReference<>() {
+                });
+        assertThat(commands).hasSize(1);
+
+        mqttCommands = commands.get(MQTT);
+        assertThat(mqttCommands.get(MQTT).asText()).isEqualTo(String.format("mosquitto_pub -d -q 1 -h localhost -p 1883 -t %s " +
+                "-u \"%s\" -P \"%s\" -m \"{temperature:25}\"", DEVICE_TELEMETRY_TOPIC, userName, password));
+        assertThat(mqttCommands.get(MQTTS).get(0).asText()).isEqualTo("curl -f -S -o " + CA_ROOT_CERT_PEM + " http://localhost:80/api/device-connectivity/mqtts/certificate/download");
+        assertThat(mqttCommands.get(MQTTS).get(1).asText()).isEqualTo(String.format("mosquitto_pub -d -q 1 --cafile " + CA_ROOT_CERT_PEM + " -h localhost -p 8883 " +
+                "-t %s -u \"%s\" -P \"%s\" -m \"{temperature:25}\"", DEVICE_TELEMETRY_TOPIC, userName, password));
+
+        dockerMqttCommands = commands.get(MQTT).get(DOCKER);
+        assertThat(dockerMqttCommands.get(MQTT).asText()).isEqualTo(String.format("docker run --rm -it --add-host=host.docker.internal:host-gateway thingsboard/mosquitto-clients mosquitto_pub -d -q 1 -h host.docker.internal" +
+                        " -p 1883 -t %s -u \"%s\" -P \"%s\" -m \"{temperature:25}\"",
+                DEVICE_TELEMETRY_TOPIC, userName, password));
+        assertThat(dockerMqttCommands.get(MQTTS).asText()).isEqualTo(String.format("docker run --rm -it --add-host=host.docker.internal:host-gateway thingsboard/mosquitto-clients " +
+                        "/bin/sh -c \"curl -f -S -o " + CA_ROOT_CERT_PEM + " http://localhost:80/api/device-connectivity/mqtts/certificate/download && " +
+                        "mosquitto_pub -d -q 1 --cafile " + CA_ROOT_CERT_PEM + " -h host.docker.internal -p 8883 -t %s -u \"%s\" -P \"%s\" -m \"{temperature:25}\"\"",
+                DEVICE_TELEMETRY_TOPIC, userName, password));
     }
 
     @Test

--- a/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/DeviceConnectivityUtil.java
@@ -72,13 +72,13 @@ public class DeviceConnectivityUtil {
                 BasicMqttCredentials credentials = JacksonUtil.fromString(deviceCredentials.getCredentialsValue(),
                         BasicMqttCredentials.class);
                 if (credentials != null) {
-                    if (credentials.getClientId() != null) {
+                    if (StringUtils.isNotEmpty(credentials.getClientId())) {
                         command.append(" -i \"").append(credentials.getClientId()).append("\"");
                     }
-                    if (credentials.getUserName() != null) {
+                    if (StringUtils.isNotEmpty(credentials.getUserName())) {
                         command.append(" -u \"").append(credentials.getUserName()).append("\"");
                     }
-                    if (credentials.getPassword() != null) {
+                    if (StringUtils.isNotEmpty(credentials.getPassword())) {
                         command.append(" -P \"").append(credentials.getPassword()).append("\"");
                     }
                 } else {
@@ -129,13 +129,13 @@ public class DeviceConnectivityUtil {
                 BasicMqttCredentials credentials = JacksonUtil.fromString(deviceCredentials.getCredentialsValue(),
                         BasicMqttCredentials.class);
                 if (credentials != null) {
-                    if (credentials.getClientId() != null) {
+                    if (StringUtils.isNotEmpty(credentials.getClientId())) {
                         dockerComposeBuilder.append("      - clientId=").append(credentials.getClientId()).append("\n");
                     }
-                    if (credentials.getUserName() != null) {
+                    if (StringUtils.isNotEmpty(credentials.getUserName())) {
                         dockerComposeBuilder.append("      - username=").append(credentials.getUserName()).append("\n");
                     }
-                    if (credentials.getPassword() != null) {
+                    if (StringUtils.isNotEmpty(credentials.getPassword())) {
                         dockerComposeBuilder.append("      - password=").append(credentials.getPassword()).append("\n");
                     }
                 }


### PR DESCRIPTION
## Pull Request description

https://thingsboard-portal.atlassian.net/browse/PROD-3498
If you change the credentials in MQTT Basic, the command in "Check connectivity" is formed incorrectly.

![image](https://github.com/thingsboard/thingsboard/assets/56396344/f837c443-b564-4e92-8418-72760f862554)
![image](https://github.com/thingsboard/thingsboard/assets/56396344/8cc1bf45-b193-4cf2-9169-cb91bb4cb589)
![image](https://github.com/thingsboard/thingsboard/assets/56396344/de7c6fe7-1875-4b4d-bd7b-45080b83a6bf)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



