### PR TITLE
Rule nodes upgrade: moved try-catch into loop over versioned node types

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/install/update/DefaultDataUpdateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/update/DefaultDataUpdateService.java
@@ -203,14 +203,14 @@ public class DefaultDataUpdateService implements DataUpdateService {
 
     @Override
     public void upgradeRuleNodes() {
-        try {
-            int totalRuleNodesUpgraded = 0;
-            log.info("Starting rule nodes upgrade ...");
-            var nodeClassToVersionMap = componentDiscoveryService.getVersionedNodes();
-            log.debug("Found {} versioned nodes to check for upgrade!", nodeClassToVersionMap.size());
-            for (var ruleNodeClassInfo : nodeClassToVersionMap) {
-                var ruleNodeTypeForLogs = ruleNodeClassInfo.getSimpleName();
-                var toVersion = ruleNodeClassInfo.getCurrentVersion();
+        int totalRuleNodesUpgraded = 0;
+        log.info("Starting rule nodes upgrade ...");
+        var nodeClassToVersionMap = componentDiscoveryService.getVersionedNodes();
+        log.debug("Found {} versioned nodes to check for upgrade!", nodeClassToVersionMap.size());
+        for (var ruleNodeClassInfo : nodeClassToVersionMap) {
+            var ruleNodeTypeForLogs = ruleNodeClassInfo.getSimpleName();
+            var toVersion = ruleNodeClassInfo.getCurrentVersion();
+            try {
                 log.debug("Going to check for nodes with type: {} to upgrade to version: {}.", ruleNodeTypeForLogs, toVersion);
                 var ruleNodesIdsToUpgrade = getRuleNodesIdsWithTypeAndVersionLessThan(ruleNodeClassInfo.getClassName(), toVersion);
                 if (ruleNodesIdsToUpgrade.isEmpty()) {
@@ -222,11 +222,11 @@ public class DefaultDataUpdateService implements DataUpdateService {
                     totalRuleNodesUpgraded += processRuleNodePack(ruleNodePack, ruleNodeClassInfo);
                     log.info("{} upgraded rule nodes so far ...", totalRuleNodesUpgraded);
                 }
+            } catch (Exception e) {
+                log.error("Unexpected error during {} rule nodes upgrade: ", ruleNodeTypeForLogs, e);
             }
-            log.info("Finished rule nodes upgrade. Upgraded rule nodes count: {}", totalRuleNodesUpgraded);
-        } catch (Exception e) {
-            log.error("Unexpected error during rule nodes upgrade: ", e);
         }
+        log.info("Finished rule nodes upgrade. Upgraded rule nodes count: {}", totalRuleNodesUpgraded);
     }
 
     private int processRuleNodePack(List<RuleNodeId> ruleNodeIdsBatch, RuleNodeClassInfo ruleNodeClassInfo) {


### PR DESCRIPTION
## Pull Request description

During upgrade next situation was observed:

For each rule node type that is a versioned node, we try to get a list of rule node ids with versions less than the current version. For some reason, the query was timed out for one of the versionned node type. This exception is unhandled in the current logic of upgrade and this stops the process of upgrade for other types of rule nodes.

The solution is to move the try-catch block that is currently outside the loop over versioned node types into the loop logic to have the ability to upgrade other types even if some exception was thrown for the previous type. Additionally, add the rule node type to the error log to have the ability to understand for which rule node type the upgrade failed.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



