### PR TITLE
Rest API call node: removed deprecated 'useRedisQueueForMessagePersistence' parameter 

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/rest/TbRestApiCallNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/rest/TbRestApiCallNode.java
@@ -28,6 +28,8 @@ import org.thingsboard.server.common.data.plugin.ComponentType;
 import org.thingsboard.server.common.data.util.TbPair;
 import org.thingsboard.server.common.msg.TbMsg;
 
+import java.util.List;
+
 @Slf4j
 @RuleNode(
         type = ComponentType.EXTERNAL,
@@ -88,7 +90,7 @@ public class TbRestApiCallNode extends TbAbstractExternalNode {
             case 1:
                 if (oldConfiguration.has("useRedisQueueForMsgPersistence")) {
                     hasChanges = true;
-                    ((ObjectNode) oldConfiguration).remove("useRedisQueueForMsgPersistence");
+                    ((ObjectNode) oldConfiguration).remove(List.of("useRedisQueueForMsgPersistence", "trimQueue", "maxQueueSize"));
                 }
                 break;
             default:

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/rest/TbRestApiCallNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/rest/TbRestApiCallNode.java
@@ -33,7 +33,7 @@ import org.thingsboard.server.common.msg.TbMsg;
         type = ComponentType.EXTERNAL,
         name = "rest api call",
         configClazz = TbRestApiCallNodeConfiguration.class,
-        version = 1,
+        version = 2,
         nodeDescription = "Invoke REST API calls to external REST server",
         nodeDetails = "Will invoke REST API call <code>GET | POST | PUT | DELETE</code> to external REST server. " +
                 "Message payload added into Request body. Configured attributes can be added into Headers from Message Metadata." +
@@ -58,9 +58,6 @@ public class TbRestApiCallNode extends TbAbstractExternalNode {
         super.init(ctx);
         TbRestApiCallNodeConfiguration config = TbNodeUtils.convert(configuration, TbRestApiCallNodeConfiguration.class);
         httpClient = new TbHttpClient(config, ctx.getSharedEventLoop());
-        if (config.isUseRedisQueueForMsgPersistence()) {
-            log.warn("[{}][{}] Usage of Redis Template is deprecated starting 2.5 and will have no affect", ctx.getTenantId(), ctx.getSelfId());
-        }
     }
 
     @Override
@@ -87,6 +84,11 @@ public class TbRestApiCallNode extends TbAbstractExternalNode {
                     hasChanges = true;
                     ((ObjectNode) oldConfiguration).put(PARSE_TO_PLAIN_TEXT, oldConfiguration.get(TRIM_DOUBLE_QUOTES).booleanValue());
                     ((ObjectNode) oldConfiguration).remove(TRIM_DOUBLE_QUOTES);
+                }
+            case 1:
+                if (oldConfiguration.has("useRedisQueueForMsgPersistence")) {
+                    hasChanges = true;
+                    ((ObjectNode) oldConfiguration).remove("useRedisQueueForMsgPersistence");
                 }
                 break;
             default:

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/rest/TbRestApiCallNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/rest/TbRestApiCallNodeConfiguration.java
@@ -36,7 +36,6 @@ public class TbRestApiCallNodeConfiguration implements NodeConfiguration<TbRestA
     private boolean useSimpleClientHttpFactory;
     private int readTimeoutMs;
     private int maxParallelRequestsCount;
-    private boolean useRedisQueueForMsgPersistence;
     private boolean parseToPlainText;
     private boolean enableProxy;
     private boolean useSystemProxyProperties;
@@ -57,7 +56,6 @@ public class TbRestApiCallNodeConfiguration implements NodeConfiguration<TbRestA
         configuration.setUseSimpleClientHttpFactory(false);
         configuration.setReadTimeoutMs(0);
         configuration.setMaxParallelRequestsCount(0);
-        configuration.setUseRedisQueueForMsgPersistence(false);
         configuration.setParseToPlainText(false);
         configuration.setEnableProxy(false);
         configuration.setCredentials(new AnonymousCredentials());

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/rest/TbRestApiCallNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/rest/TbRestApiCallNodeTest.java
@@ -233,7 +233,7 @@ public class TbRestApiCallNodeTest extends AbstractRuleNodeUpgradeTest {
                                 "\"enableProxy\": false,\"useSystemProxyProperties\": false,\"proxyScheme\": null,\"proxyHost\": null," +
                                 "\"proxyPort\": 0,\"proxyUser\": null,\"proxyPassword\": null,\"readTimeoutMs\": 0," +
                                 "\"maxParallelRequestsCount\": 0,\"headers\": {\"Content-Type\": \"application/json\"}," +
-                                "\"trimQueue\": null,\"maxQueueSize\": null,\"credentials\": {\"type\": \"anonymous\"}}"),
+                                "\"credentials\": {\"type\": \"anonymous\"}}"),
                 // config for version 2 with upgrade from version 1
                 Arguments.of(1,
                         "{\"restEndpointUrlPattern\":\"http://localhost/api\",\"requestMethod\": \"POST\"," +
@@ -249,7 +249,7 @@ public class TbRestApiCallNodeTest extends AbstractRuleNodeUpgradeTest {
                                 "\"enableProxy\": false,\"useSystemProxyProperties\": false,\"proxyScheme\": null,\"proxyHost\": null," +
                                 "\"proxyPort\": 0,\"proxyUser\": null,\"proxyPassword\": null,\"readTimeoutMs\": 0," +
                                 "\"maxParallelRequestsCount\": 0,\"headers\": {\"Content-Type\": \"application/json\"}," +
-                                "\"trimQueue\": null,\"maxQueueSize\": null,\"credentials\": {\"type\": \"anonymous\"}}")
+                                "\"credentials\": {\"type\": \"anonymous\"}}")
         );
     }
 


### PR DESCRIPTION
## Pull Request description

The parameter "Use redis queue for message persistence" has been deprecated since ThingsBoard version 2.5. Enabling this parameter no longer has any effect, so it has been removed.

There are no conflicts with PE.

Issue: #3086  

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



