### PR TITLE
[FIX] inconsistent default kafka setting (compression)

### DIFF
--- a/msa/js-executor/config/default.yml
+++ b/msa/js-executor/config/default.yml
@@ -34,7 +34,7 @@ kafka:
   partitions_consumed_concurrently: "1" # (EXPERIMENTAL) increase this value if you are planning to handle more than one partition (scale up, scale down) - this will decrease the latency
   requestTimeout: "30000" # The default value in kafkajs is: 30000
   connectionTimeout: "1000" # The default value in kafkajs is: 1000
-  compression: "gzip" # gzip or uncompressed
+  compression: "none" # gzip or uncompressed
   topic_properties: "retention.ms:604800000;segment.bytes:52428800;retention.bytes:104857600;partitions:100;min.insync.replicas:1"
   use_confluent_cloud: false
   client_id: "kafkajs" #inject pod name to easy identify the client using /opt/kafka/bin/kafka-consumer-groups.sh


### PR DESCRIPTION
## Pull Request description

changes the default for kafka.compression to "none", to align with the default setting of the main applications thingsboard.yml 

Fixes #9613 



