### PR TITLE
Handle TenantNotFoundException for stale subscriptions

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbLocalSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbLocalSubscriptionService.java
@@ -155,7 +155,7 @@ public class DefaultTbLocalSubscriptionService implements TbLocalSubscriptionSer
                 }
             });
             if (!staleSubs.isEmpty()) {
-                subscriptionsByEntityId.keySet().removeAll(staleSubs);
+                staleSubs.forEach(subscriptionsByEntityId::remove);
             }
         }
     }

--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbLocalSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbLocalSubscriptionService.java
@@ -15,6 +15,8 @@
  */
 package org.thingsboard.server.service.subscription;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
@@ -24,9 +26,9 @@ import org.thingsboard.common.util.ThingsBoardExecutors;
 import org.thingsboard.common.util.ThingsBoardThreadFactory;
 import org.thingsboard.server.cluster.TbClusterService;
 import org.thingsboard.server.common.data.AttributeScope;
-import org.thingsboard.server.common.data.DataConstants;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.alarm.AlarmInfo;
+import org.thingsboard.server.common.data.exception.TenantNotFoundException;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.kv.Aggregation;
@@ -51,8 +53,6 @@ import org.thingsboard.server.service.ws.notification.sub.NotificationsSubscript
 import org.thingsboard.server.service.ws.telemetry.sub.AlarmSubscriptionUpdate;
 import org.thingsboard.server.service.ws.telemetry.sub.TelemetrySubscriptionUpdate;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -143,7 +143,20 @@ public class DefaultTbLocalSubscriptionService implements TbLocalSubscriptionSer
              * Even if we cache locally the list of active subscriptions by entity id, it is still time-consuming operation to get them from cache
              * Since number of subscriptions is usually much less than number of devices that are pushing data.
              */
-            subscriptionsByEntityId.values().forEach(sub -> pushSubEventToManagerService(sub.getTenantId(), sub.getEntityId(), sub.toEvent(ComponentLifecycleEvent.UPDATED)));
+            Set<UUID> staleSubs = new HashSet<>();
+            subscriptionsByEntityId.forEach((id, sub) -> {
+                try {
+                    pushSubEventToManagerService(sub.getTenantId(), sub.getEntityId(), sub.toEvent(ComponentLifecycleEvent.UPDATED));
+                } catch (TenantNotFoundException e) {
+                    staleSubs.add(id);
+                    log.warn("Cleaning up stale subscription {} for tenant {} due to TenantNotFoundException", id, sub.getTenantId());
+                } catch (Exception e) {
+                    log.error("Failed to push subscription {} to manager service", sub, e);
+                }
+            });
+            if (!staleSubs.isEmpty()) {
+                subscriptionsByEntityId.keySet().removeAll(staleSubs);
+            }
         }
     }
 


### PR DESCRIPTION
## Pull Request description

This fixes the following error on partitions recalculation, caused by some subscription of deleted tenant left in the subs map:

```
2024-06-10 13:05:47,850 [Curator-PathChildrenCache-0] WARN  o.t.s.q.discovery.ZkDiscoveryService - Failed to recalculate partitions
org.thingsboard.server.common.data.exception.TenantNotFoundException: Tenant with id xxx not found
	at org.thingsboard.server.service.queue.DefaultTenantRoutingInfoService.getRoutingInfo(DefaultTenantRoutingInfoService.java:60)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1737)
	at org.thingsboard.server.queue.discovery.HashPartitionService.getRoutingInfo(HashPartitionService.java:552)
	at org.thingsboard.server.queue.discovery.HashPartitionService.isIsolated(HashPartitionService.java:535)
	at org.thingsboard.server.queue.discovery.HashPartitionService.getIsolatedOrSystemTenantId(HashPartitionService.java:556)
	at org.thingsboard.server.queue.discovery.HashPartitionService.resolve(HashPartitionService.java:289)
	at org.thingsboard.server.queue.discovery.HashPartitionService.resolve(HashPartitionService.java:310)
	at org.thingsboard.server.service.subscription.DefaultTbLocalSubscriptionService.pushSubEventToManagerService(DefaultTbLocalSubscriptionService.java:470)
	at org.thingsboard.server.service.subscription.DefaultTbLocalSubscriptionService.lambda$onApplicationEvent$1(DefaultTbLocalSubscriptionService.java:160)
	at java.base/java.util.concurrent.ConcurrentHashMap$ValuesView.forEach(ConcurrentHashMap.java:4770)
	at org.thingsboard.server.service.subscription.DefaultTbLocalSubscriptionService.onApplicationEvent(DefaultTbLocalSubscriptionService.java:160)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.context.event.ApplicationListenerMethodAdapter.doInvoke(ApplicationListenerMethodAdapter.java:344)
	at org.springframework.context.event.ApplicationListenerMethodAdapter.processEvent(ApplicationListenerMethodAdapter.java:229)
	at org.springframework.context.event.ApplicationListenerMethodAdapter.onApplicationEvent(ApplicationListenerMethodAdapter.java:166)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:176)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:169)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:143)
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:421)
	at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:378)
	at org.thingsboard.server.queue.discovery.HashPartitionService.recalculatePartitions(HashPartitionService.java:421)
	at org.thingsboard.server.queue.discovery.ZkDiscoveryService.recalculatePartitions(ZkDiscoveryService.java:367)
	at org.thingsboard.server.queue.discovery.ZkDiscoveryService.childEvent(ZkDiscoveryService.java:339)
	at org.apache.curator.framework.recipes.cache.PathChildrenCache.lambda$callListeners$1(PathChildrenCache.java:535)
	at org.apache.curator.framework.listen.MappingListenerManager.lambda$forEach$0(MappingListenerManager.java:93)
	at org.apache.curator.framework.listen.MappingListenerManager.forEach(MappingListenerManager.java:90)
	at org.apache.curator.framework.listen.StandardListenerManager.forEach(StandardListenerManager.java:90)
	at org.apache.curator.framework.recipes.cache.PathChildrenCache.callListeners(PathChildrenCache.java:532)
	at org.apache.curator.framework.recipes.cache.EventOperation.invoke(EventOperation.java:36)
	at org.apache.curator.framework.recipes.cache.PathChildrenCache$8.run(PathChildrenCache.java:802)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



