### PR TITLE
fix_bug: lwm2m monitoring

### DIFF
--- a/monitoring/src/main/java/org/thingsboard/monitoring/client/Lwm2mClient.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/client/Lwm2mClient.java
@@ -30,10 +30,12 @@ import org.eclipse.leshan.client.californium.LeshanClientBuilder;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.object.Security;
 import org.eclipse.leshan.client.object.Server;
+import org.eclipse.leshan.client.observer.LwM2mClientObserver;
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.client.resource.DummyInstanceEnabler;
 import org.eclipse.leshan.client.resource.ObjectsInitializer;
 import org.eclipse.leshan.client.servers.ServerIdentity;
+import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.californium.EndpointFactory;
 import org.eclipse.leshan.core.model.InvalidDDFFileException;
 import org.eclipse.leshan.core.model.LwM2mModel;
@@ -42,6 +44,10 @@ import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.StaticModel;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mDecoder;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mEncoder;
+import org.eclipse.leshan.core.request.BootstrapRequest;
+import org.eclipse.leshan.core.request.DeregisterRequest;
+import org.eclipse.leshan.core.request.RegisterRequest;
+import org.eclipse.leshan.core.request.UpdateRequest;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.thingsboard.monitoring.util.ResourceUtils;
 
@@ -96,7 +102,7 @@ public class Lwm2mClient extends BaseInstanceEnabler implements Destroyable {
         LwM2mModel model = new StaticModel(models);
         ObjectsInitializer initializer = new ObjectsInitializer(model);
         initializer.setInstancesForObject(SECURITY, security);
-        initializer.setInstancesForObject(SERVER, new Server(123, TimeUnit.MINUTES.toSeconds(60)));
+        initializer.setInstancesForObject(SERVER, new Server(123, TimeUnit.MINUTES.toSeconds(5)));
         initializer.setInstancesForObject(DEVICE, this);
         initializer.setClassForObject(ACCESS_CONTROL, DummyInstanceEnabler.class);
         DtlsConnectorConfig.Builder dtlsConfig = new DtlsConnectorConfig.Builder();
@@ -138,6 +144,89 @@ public class Lwm2mClient extends BaseInstanceEnabler implements Destroyable {
         builder.setDecoder(new DefaultLwM2mDecoder(false));
         builder.setEncoder(new DefaultLwM2mEncoder(false));
         leshanClient = builder.build();
+
+        LwM2mClientObserver observer = new LwM2mClientObserver() {
+
+            @Override
+            public void onBootstrapStarted(ServerIdentity bsserver, BootstrapRequest request) {}
+
+            @Override
+            public void onBootstrapSuccess(ServerIdentity bsserver, BootstrapRequest request) {}
+
+            @Override
+            public void onBootstrapFailure(ServerIdentity bsserver, BootstrapRequest request,
+                                           ResponseCode responseCode, String errorMessage, Exception cause) {}
+
+            @Override
+            public void onBootstrapTimeout(ServerIdentity bsserver, BootstrapRequest request) {}
+
+            @Override
+            public void onRegistrationStarted(ServerIdentity server, RegisterRequest request) {
+                log.debug("onRegistrationStarted [{}]", request.getEndpointName());
+            }
+
+            @Override
+            public void onRegistrationSuccess(ServerIdentity server, RegisterRequest request, String registrationID) {
+                log.debug("onRegistrationSuccess [{}] [{}]", request.getEndpointName(), registrationID);
+            }
+
+            @Override
+            public void onRegistrationFailure(ServerIdentity server, RegisterRequest request, ResponseCode responseCode, String errorMessage, Exception cause) {
+                log.debug("onRegistrationFailure [{}] [{}] [{}]", request.getEndpointName(), responseCode, errorMessage);
+            }
+
+            @Override
+            public void onRegistrationTimeout(ServerIdentity server, RegisterRequest request) {
+                log.debug("onRegistrationTimeout [{}]", request.getEndpointName());
+            }
+
+            @Override
+            public void onUpdateStarted(ServerIdentity server, UpdateRequest request) {
+                log.debug("onUpdateStarted [{}]", request.getRegistrationId());
+            }
+
+            @Override
+            public void onUpdateSuccess(ServerIdentity server, UpdateRequest request) {
+                log.debug("onUpdateSuccess [{}]", request.getRegistrationId());
+            }
+
+            @Override
+            public void onUpdateFailure(ServerIdentity server, UpdateRequest request, ResponseCode responseCode, String errorMessage, Exception cause) {
+                log.debug("onUpdateFailure [{}]", request.getRegistrationId());
+            }
+
+            @Override
+            public void onUpdateTimeout(ServerIdentity server, UpdateRequest request) {
+                log.debug("onUpdateTimeout [{}]", request.getRegistrationId());
+            }
+
+            @Override
+            public void onDeregistrationStarted(ServerIdentity server, DeregisterRequest request) {
+                log.debug("onDeregistrationStarted [{}]", request.getRegistrationId());
+            }
+
+            @Override
+            public void onDeregistrationSuccess(ServerIdentity server, DeregisterRequest request) {
+                log.debug("onDeregistrationStarted [{}]", request.getRegistrationId());
+            }
+
+            @Override
+            public void onDeregistrationFailure(ServerIdentity server, DeregisterRequest request, ResponseCode responseCode, String errorMessage, Exception cause) {
+                log.debug("onDeregistrationFailure [{}] [{}] [{}]", request.getRegistrationId(), responseCode, errorMessage);
+            }
+
+            @Override
+            public void onDeregistrationTimeout(ServerIdentity server, DeregisterRequest request) {
+                log.debug("onDeregistrationTimeout [{}]", request.getRegistrationId());
+            }
+
+            @Override
+            public void onUnexpectedError(Throwable unexpectedError) {
+                log.debug("onUnexpectedError [{}]", unexpectedError.toString());
+            }
+
+        };
+        leshanClient.addObserver(observer);
 
         setLeshanClient(leshanClient);
 


### PR DESCRIPTION
## Pull Request description


https://thingsboard-portal.atlassian.net/browse/PROD-3848

### Before:
![зображення](https://github.com/thingsboard/thingsboard/assets/44275303/a8f3308b-e85c-490b-be46-17caf661f5b7)

### After:
- **Restart** TbLwm2mTransport _without_ **redis-cli flushall**
```
2024-06-14 15:14:24,949 [monitoring-executor-1-thread-1] ERROR o.t.m.service.MonitoringReporter - Monitoring - Failure: I/O error on POST request for "http://localhost:8080/api/auth/login": Connect to http://localhost:8080/ [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (number of subsequent failures: 3)
2024-06-14 15:14:26,229 [RegistrationEngine#0] INFO  o.t.monitoring.client.Lwm2mClient - onUpdateStarted [/rd/FCuGoWCfEQ]
2024-06-14 15:14:35,946 [monitoring-executor-1-thread-1] INFO  o.t.m.service.MonitoringReporter - *LwM2M* (coap://localhost:5685) is OK
2024-06-14 15:14:36,390 [monitoring-executor-1-thread-1] INFO  o.t.m.service.MonitoringReporter - *MQTT* (tcp://localhost:1883) is OK
```
- **Restart** TbLwm2mTransport _with_ **redis-cli flushal**l
```
2024-06-14 15:23:08,299 [monitoring-executor-1-thread-1] ERROR o.t.m.service.MonitoringReporter - Monitoring - Failure: I/O error on POST request for "http://localhost:8080/api/auth/login": Connect to http://localhost:8080/ [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (number of subsequent failures: 2)
2024-06-14 15:23:18,299 [monitoring-executor-1-thread-1] INFO  o.t.m.service.BaseMonitoringService - Starting transports check
2024-06-14 15:23:18,301 [monitoring-executor-1-thread-1] ERROR o.t.m.service.MonitoringReporter - Monitoring - Failure: I/O error on POST request for "http://localhost:8080/api/auth/login": Connect to http://localhost:8080/ [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (number of subsequent failures: 3)
2024-06-14 15:23:25,106 [RegistrationEngine#0] INFO  o.t.monitoring.client.Lwm2mClient - onUpdateStarted [/rd/FCuGoWCfEQ]
2024-06-14 15:23:28,056 [RegistrationEngine#0] INFO  o.t.monitoring.client.Lwm2mClient - onUpdateFailure [/rd/FCuGoWCfEQ]
2024-06-14 15:23:28,057 [RegistrationEngine#0] INFO  o.t.monitoring.client.Lwm2mClient - onRegistrationStarted [TjXuIESovZgcCtSWIBiy]
2024-06-14 15:23:28,258 [RegistrationEngine#0] INFO  o.t.monitoring.client.Lwm2mClient - onRegistrationSuccess [TjXuIESovZgcCtSWIBiy] [/rd/6u6aaleYkD]
2024-06-14 15:23:28,301 [monitoring-executor-1-thread-1] INFO  o.t.m.service.BaseMonitoringService - Starting transports check
2024-06-14 15:23:29,066 [monitoring-executor-1-thread-1] INFO  o.t.m.service.MonitoringReporter - *LwM2M* (coap://localhost:5685) is OK
2024-06-14 15:23:29,469 [monitoring-executor-1-thread-1] INFO  o.t.m.service.MonitoringReporter - *MQTT* (tcp://localhost:1883) is OK
2024-06-14 15:23:39,864 [monitoring-executor-1-thread-1] INFO  o.t.m.service.BaseMonitoringService - Starting transports check
2024-06-14 15:23:40,052 [monitoring-executor-1-thread-1] INFO  o.t.m.service.MonitoringReporter - *LwM2M* (coap://localhost:5685) is OK
2024-06-14 15:23:40,070 [monitoring-executor-1-thread-1] INFO  o.t.m.service.MonitoringReporter - *MQTT* (tcp://localhost:1883) is OK
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



