### PR TITLE
Fixed jumping rows when updating data in Gateway Logs table

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/gateway/gateway-logs.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/gateway/gateway-logs.component.html
@@ -21,7 +21,7 @@
      [active]="activeLink.name === link.name"> {{ link.name }} </a>
 </nav>
 <mat-tab-nav-panel #tabPanel></mat-tab-nav-panel>
-<table mat-table [dataSource]="dataSource"
+<table mat-table [dataSource]="dataSource" [trackBy]="trackByLogTs"
        matSort [matSortActive]="pageLink.sortOrder.property" [matSortDirection]="pageLink.sortDirection()"
        matSortDisableClear>
   <ng-container matColumnDef="ts">

--- a/ui-ngx/src/app/modules/home/components/widget/lib/gateway/gateway-logs.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/gateway/gateway-logs.component.ts
@@ -164,6 +164,10 @@ export class GatewayLogsComponent implements AfterViewInit {
     }
   }
 
+  trackByLogTs(_: number, log: GatewayLogData): number {
+    return log.ts;
+  }
+
   private changeSubscription() {
     if (this.ctx.datasources && this.ctx.datasources[0].entity && this.ctx.defaultSubscription.options.datasources) {
       this.ctx.defaultSubscription.options.datasources[0].dataKeys = [{
@@ -178,5 +182,4 @@ export class GatewayLogsComponent implements AfterViewInit {
       };
     }
   }
-
 }


### PR DESCRIPTION
## Pull Request description

Fixed jumping rows when updating data in Gateway Logs table

before:
[Screencast from 17.06.24 17:40:38.webm](https://github.com/thingsboard/thingsboard/assets/93397261/0df7f61b-b342-42cc-9699-c304b6341470)

after:
[Screencast from 17.06.24 17:39:34.webm](https://github.com/thingsboard/thingsboard/assets/93397261/add2fbe2-07ae-44c1-bbd1-a01f044b07f6)

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



