### PR TITLE
Device profile node: improvements

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/profile/TbDeviceProfileNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/profile/TbDeviceProfileNode.java
@@ -36,6 +36,7 @@ import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
 import org.thingsboard.server.common.data.plugin.ComponentType;
 import org.thingsboard.server.common.data.rule.RuleNodeState;
+import org.thingsboard.server.common.data.util.TbPair;
 import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
 import org.thingsboard.server.common.msg.queue.PartitionChangeMsg;
@@ -52,6 +53,7 @@ import java.util.concurrent.TimeUnit;
         name = "device profile",
         customRelations = true,
         relationTypes = {"Alarm Created", "Alarm Updated", "Alarm Severity Updated", "Alarm Cleared", "Success", "Failure"},
+        version = 1,
         configClazz = TbDeviceProfileNodeConfiguration.class,
         nodeDescription = "Process device messages based on device profile settings",
         nodeDetails = "Create and clear alarms based on alarm rules defined in device profile. The output relation type is either " +
@@ -241,4 +243,28 @@ public class TbDeviceProfileNode implements TbNode {
             ctx.removeRuleNodeStateForEntity(deviceId);
         }
     }
+
+    @Override
+    public TbPair<Boolean, JsonNode> upgrade(int fromVersion, JsonNode oldConfiguration) throws TbNodeException {
+        boolean hasChanges = false;
+        switch (fromVersion) {
+            case 0:
+                String persistAlarmRulesState = "persistAlarmRulesState";
+                String fetchAlarmRulesStateOnStart = "fetchAlarmRulesStateOnStart";
+                if (oldConfiguration.has(persistAlarmRulesState)) {
+
+                }
+                if (oldConfiguration.has(fetchAlarmRulesStateOnStart)) {
+                    if (!oldConfiguration.get(persistAlarmRulesState).asBoolean()) {
+                        hasChanges = true;
+                        ((ObjectNode) oldConfiguration).put(fetchAlarmRulesStateOnStart, false);
+                    }
+                }
+                break;
+            default:
+                break;
+        }
+        return new TbPair<>(hasChanges, oldConfiguration);
+    }
+
 }


### PR DESCRIPTION
## Pull Request description

Currently we have the ability to set the 'fetchAlarmRulesStateOnStart' parameter to true, even when 'persistAlarmRulesState' is set to false. However, this is detrimental to performance. If the persistAlarmRulesState parameter is set to false, no data will be saved to the table, and all states will be deleted.  Therefore, if we attempt to fetch the state after a restart, there will be nothing to retrieve since nothing was recorded in the table prior to this. Consequently, we are unnecessarily querying the database.

So we decided not to provide the ability to set 'fetchAlarmRulesStateOnStart' to true if persistAlarmRulesState is set to false. An upgrade was also provided that changed the value of 'fetchAlarmRulesStateOnStart' to false if 'persistAlarmRulesState' is set to false. There are no breaking changes here because nothing was written to the DB before in any way.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



