### PR TITLE
Redis - disable caching in case maxSize is 0

### DIFF
--- a/common/cache/src/main/java/org/thingsboard/server/cache/CacheSpecsMap.java
+++ b/common/cache/src/main/java/org/thingsboard/server/cache/CacheSpecsMap.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.cache;
 
+import jakarta.annotation.PostConstruct;
 import lombok.Data;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +23,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.thingsboard.server.common.data.CacheConstants;
 
-import jakarta.annotation.PostConstruct;
 import java.util.Map;
 
 @Configuration

--- a/common/cache/src/main/java/org/thingsboard/server/cache/TbTransactionalCache.java
+++ b/common/cache/src/main/java/org/thingsboard/server/cache/TbTransactionalCache.java
@@ -60,15 +60,20 @@ public interface TbTransactionalCache<K extends Serializable, V extends Serializ
     }
 
     default V getAndPutInTransaction(K key, Supplier<V> dbCall, boolean cacheNullValue) {
+        return getAndPutInTransaction(key, dbCall, Function.identity(), Function.identity(), cacheNullValue);
+    }
+
+    default <R> R getAndPutInTransaction(K key, Supplier<R> dbCall, Function<V, R> cacheValueToResult, Function<R, V> dbValueToCacheValue, boolean cacheNullValue) {
         TbCacheValueWrapper<V> cacheValueWrapper = get(key);
         if (cacheValueWrapper != null) {
-            return cacheValueWrapper.get();
+            V cacheValue = cacheValueWrapper.get();
+            return cacheValue != null ? cacheValueToResult.apply(cacheValue) : null;
         }
         var cacheTransaction = newTransactionForKey(key);
         try {
-            V dbValue = dbCall.get();
+            R dbValue = dbCall.get();
             if (dbValue != null || cacheNullValue) {
-                cacheTransaction.putIfAbsent(key, dbValue);
+                cacheTransaction.putIfAbsent(key, dbValueToCacheValue.apply(dbValue));
                 cacheTransaction.commit();
                 return dbValue;
             } else {
@@ -91,29 +96,6 @@ public interface TbTransactionalCache<K extends Serializable, V extends Serializ
                 return cacheValue == null ? null : cacheValueToResult.apply(cacheValue);
             }
             return dbCall.get();
-        }
-    }
-
-    default <R> R getAndPutInTransaction(K key, Supplier<R> dbCall, Function<V, R> cacheValueToResult, Function<R, V> dbValueToCacheValue, boolean cacheNullValue) {
-        TbCacheValueWrapper<V> cacheValueWrapper = get(key);
-        if (cacheValueWrapper != null) {
-            var cacheValue = cacheValueWrapper.get();
-            return cacheValue == null ? null : cacheValueToResult.apply(cacheValue);
-        }
-        var cacheTransaction = newTransactionForKey(key);
-        try {
-            R dbValue = dbCall.get();
-            if (dbValue != null || cacheNullValue) {
-                cacheTransaction.putIfAbsent(key, dbValueToCacheValue.apply(dbValue));
-                cacheTransaction.commit();
-                return dbValue;
-            } else {
-                cacheTransaction.rollback();
-                return null;
-            }
-        } catch (Throwable e) {
-            cacheTransaction.rollback();
-            throw e;
         }
     }
 

--- a/common/cache/src/test/java/org/thingsboard/server/cache/CacheSpecsMapTest.java
+++ b/common/cache/src/test/java/org/thingsboard/server/cache/CacheSpecsMapTest.java
@@ -62,4 +62,5 @@ public class CacheSpecsMapTest {
     public void givenCacheConfig_whenCacheManagerReady_thenVerifyNonExistedCaches() {
         assertThat(cacheManager.getCache("rainbows_and_unicorns")).isNull();
     }
+
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/cache/RedisTbTransactionalCacheTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/cache/RedisTbTransactionalCacheTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.cache;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.thingsboard.server.cache.CacheSpecsMap;
+import org.thingsboard.server.cache.RedisSslCredentials;
+import org.thingsboard.server.cache.TBRedisCacheConfiguration;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.relation.RelationTypeGroup;
+import org.thingsboard.server.dao.relation.RelationCacheKey;
+import org.thingsboard.server.dao.relation.RelationRedisCache;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {RelationRedisCache.class, CacheSpecsMap.class, TBRedisCacheConfiguration.class})
+@TestPropertySource(properties = {
+        "cache.type=redis",
+        "cache.specs.relations.timeToLiveInMinutes=1440",
+        "cache.specs.relations.maxSize=0",
+})
+@Slf4j
+public class RedisTbTransactionalCacheTest {
+
+    @MockBean
+    private RelationRedisCache relationRedisCache;
+    @MockBean
+    private RedisConnectionFactory connectionFactory;
+    @MockBean
+    private RedisConnection redisConnection;
+    @MockBean
+    private RedisSslCredentials redisSslCredentials;
+
+
+    @BeforeEach
+    public void setup() {
+        when(connectionFactory.getConnection()).thenReturn(redisConnection);
+    }
+
+    @Test
+    public void testEvictNoOpWhenCacheDisabled() {
+        relationRedisCache.evict(List.of(createRelationCacheKey()));
+
+        verify(connectionFactory, never()).getConnection();
+        verifyNoInteractions(redisConnection);
+    }
+
+    @Test
+    public void testEvictOrPutNoOpWhenCacheDisabled() {
+        relationRedisCache.evictOrPut(createRelationCacheKey(), null);
+
+        verify(connectionFactory, never()).getConnection();
+        verifyNoInteractions(redisConnection);
+    }
+
+    private RelationCacheKey createRelationCacheKey() {
+        return new RelationCacheKey(new DeviceId(UUID.randomUUID()), new DeviceId(UUID.randomUUID()), null, RelationTypeGroup.COMMON);
+    }
+
+}

--- a/dao/src/test/java/org/thingsboard/server/dao/cache/RedisTbTransactionalCacheTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/cache/RedisTbTransactionalCacheTest.java
@@ -16,7 +16,6 @@
 package org.thingsboard.server.dao.cache;
 
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -60,23 +59,17 @@ public class RedisTbTransactionalCacheTest {
     @MockBean
     private RedisSslCredentials redisSslCredentials;
 
-
-    @BeforeEach
-    public void setup() {
+    @Test
+    public void testNoOpWhenCacheDisabled() {
         when(connectionFactory.getConnection()).thenReturn(redisConnection);
-    }
 
-    @Test
-    public void testEvictNoOpWhenCacheDisabled() {
+        relationRedisCache.put(createRelationCacheKey(), null);
+        relationRedisCache.putIfAbsent(createRelationCacheKey(), null);
+        relationRedisCache.evict(createRelationCacheKey());
         relationRedisCache.evict(List.of(createRelationCacheKey()));
-
-        verify(connectionFactory, never()).getConnection();
-        verifyNoInteractions(redisConnection);
-    }
-
-    @Test
-    public void testEvictOrPutNoOpWhenCacheDisabled() {
-        relationRedisCache.evictOrPut(createRelationCacheKey(), null);
+        relationRedisCache.getAndPutInTransaction(createRelationCacheKey(), null, false);
+        relationRedisCache.getAndPutInTransaction(createRelationCacheKey(), null, null, null, false);
+        relationRedisCache.getOrFetchFromDB(createRelationCacheKey(), null, false, false);
 
         verify(connectionFactory, never()).getConnection();
         verifyNoInteractions(redisConnection);

--- a/dao/src/test/java/org/thingsboard/server/dao/service/AlarmServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/AlarmServiceTest.java
@@ -58,7 +58,6 @@ import org.thingsboard.server.dao.device.DeviceService;
 import org.thingsboard.server.dao.relation.RelationService;
 import org.thingsboard.server.dao.user.UserService;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -245,8 +244,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         // Check child relation
         PageData<AlarmInfo> alarms = alarmService.findAlarmsV2(tenantId, AlarmQueryV2.builder()
                 .affectedEntityId(childId)
-                .severityList(Arrays.asList(AlarmSeverity.CRITICAL))
-                .statusList(Arrays.asList(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.UNACK)).pageLink(
+                .severityList(List.of(AlarmSeverity.CRITICAL))
+                .statusList(List.of(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.UNACK)).pageLink(
                         new TimePageLink(1, 0, "",
                                 new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
                 ).build());
@@ -257,8 +256,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         // Check parent relation
         alarms = alarmService.findAlarmsV2(tenantId, AlarmQueryV2.builder()
                 .affectedEntityId(parentId)
-                .severityList(Arrays.asList(AlarmSeverity.CRITICAL))
-                .statusList(Arrays.asList(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.UNACK)).pageLink(
+                .severityList(List.of(AlarmSeverity.CRITICAL))
+                .statusList(List.of(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.UNACK)).pageLink(
                         new TimePageLink(1, 0, "",
                                 new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
                 ).build());
@@ -272,8 +271,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         // Check child relation
         alarms = alarmService.findAlarmsV2(tenantId, AlarmQueryV2.builder()
                 .affectedEntityId(childId)
-                .severityList(Arrays.asList(AlarmSeverity.CRITICAL))
-                .statusList(Arrays.asList(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.UNACK)).pageLink(
+                .severityList(List.of(AlarmSeverity.CRITICAL))
+                .statusList(List.of(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.UNACK)).pageLink(
                         new TimePageLink(1, 0, "",
                                 new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
                 ).build());
@@ -284,8 +283,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         // Check parent relation
         alarms = alarmService.findAlarmsV2(tenantId, AlarmQueryV2.builder()
                 .affectedEntityId(parentId)
-                .severityList(Arrays.asList(AlarmSeverity.CRITICAL))
-                .statusList(Arrays.asList(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.UNACK)).pageLink(
+                .severityList(List.of(AlarmSeverity.CRITICAL))
+                .statusList(List.of(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.UNACK)).pageLink(
                         new TimePageLink(1, 0, "",
                                 new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
                 ).build());
@@ -298,8 +297,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
 
         alarms = alarmService.findAlarmsV2(tenantId, AlarmQueryV2.builder()
                 .affectedEntityId(childId)
-                .severityList(Arrays.asList(AlarmSeverity.CRITICAL))
-                .statusList(Arrays.asList(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.ACK)).pageLink(
+                .severityList(List.of(AlarmSeverity.CRITICAL))
+                .statusList(List.of(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.ACK)).pageLink(
                         new TimePageLink(1, 0, "",
                                 new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
                 ).build());
@@ -310,8 +309,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         // Check not existing relation
         alarms = alarmService.findAlarmsV2(tenantId, AlarmQueryV2.builder()
                 .affectedEntityId(childId)
-                .severityList(Arrays.asList(AlarmSeverity.CRITICAL))
-                .statusList(Arrays.asList(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.UNACK)).pageLink(
+                .severityList(List.of(AlarmSeverity.CRITICAL))
+                .statusList(List.of(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.UNACK)).pageLink(
                         new TimePageLink(1, 0, "",
                                 new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
                 ).build());
@@ -323,8 +322,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
 
         alarms = alarmService.findAlarmsV2(tenantId, AlarmQueryV2.builder()
                 .affectedEntityId(childId)
-                .severityList(Arrays.asList(AlarmSeverity.CRITICAL))
-                .statusList(Arrays.asList(AlarmSearchStatus.CLEARED, AlarmSearchStatus.ACK)).pageLink(
+                .severityList(List.of(AlarmSeverity.CRITICAL))
+                .statusList(List.of(AlarmSearchStatus.CLEARED, AlarmSearchStatus.ACK)).pageLink(
                         new TimePageLink(1, 0, "",
                                 new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
                 ).build());
@@ -334,7 +333,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
     }
 
     @Test
-    public void testFindAssignedAlarm() throws ExecutionException, InterruptedException {
+    public void testFindAssignedAlarm() {
 
         AssetId parentId = new AssetId(Uuids.timeBased());
         AssetId childId = new AssetId(Uuids.timeBased());
@@ -368,7 +367,6 @@ public class AlarmServiceTest extends AbstractServiceTest {
 
         PageData<AlarmInfo> alarms = alarmService.findAlarms(tenantId, AlarmQuery.builder()
                 .assigneeId(tenantUser.getId())
-                .fetchOriginator(true)
                 .pageLink(new TimePageLink(1, 0, "",
                         new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
                 ).build());
@@ -405,7 +403,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
     }
 
     @Test
-    public void testFindCustomerAlarm() throws ExecutionException, InterruptedException {
+    public void testFindCustomerAlarm() {
         Customer customer = new Customer();
         customer.setTitle("TestCustomer");
         customer.setTenantId(tenantId);
@@ -451,10 +449,10 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStartTs(0L);
         pageLink.setEndTs(System.currentTimeMillis());
         pageLink.setSearchPropagatedAlarms(true);
-        pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
-        pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
+        pageLink.setSeverityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
+        pageLink.setStatusList(List.of(AlarmSearchStatus.ACTIVE));
 
-        PageData<AlarmData> tenantAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Arrays.asList(tenantDevice.getId(), customerDevice.getId()));
+        PageData<AlarmData> tenantAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), List.of(tenantDevice.getId(), customerDevice.getId()));
         Assert.assertEquals(2, tenantAlarms.getData().size());
 
         PageData<AlarmData> customerAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(customerDevice.getId()));
@@ -473,7 +471,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
     }
 
     @Test
-    public void testFindPropagatedCustomerAssetAlarm() throws ExecutionException, InterruptedException {
+    public void testFindPropagatedCustomerAssetAlarm() {
         Customer customer = new Customer();
         customer.setTitle("TestCustomer");
         customer.setTenantId(tenantId);
@@ -525,8 +523,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStartTs(0L);
         pageLink.setEndTs(System.currentTimeMillis());
         pageLink.setSearchPropagatedAlarms(true);
-        pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
-        pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
+        pageLink.setSeverityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
+        pageLink.setStatusList(List.of(AlarmSearchStatus.ACTIVE));
 
         //TEST that propagated alarms are visible on the asset level.
         PageData<AlarmData> customerAlarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(customerAsset.getId()));
@@ -576,7 +574,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStartTs(0L);
         pageLink.setEndTs(System.currentTimeMillis());
         pageLink.setSearchPropagatedAlarms(true);
-        pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
+        pageLink.setSeverityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
         pageLink.setStatusList(Collections.singletonList(AlarmSearchStatus.ACTIVE));
 
         //TEST that propagated alarms are visible on the asset level.
@@ -599,7 +597,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
     }
 
     @Test
-    public void testFindHighestAlarmSeverity() throws ExecutionException, InterruptedException {
+    public void testFindHighestAlarmSeverity() {
         Customer customer = new Customer();
         customer.setTitle("TestCustomer");
         customer.setTenantId(tenantId);
@@ -679,8 +677,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStartTs(0L);
         pageLink.setEndTs(System.currentTimeMillis());
         pageLink.setSearchPropagatedAlarms(false);
-        pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
-        pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
+        pageLink.setSeverityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
+        pageLink.setStatusList(List.of(AlarmSearchStatus.ACTIVE));
 
         PageData<AlarmData> alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(childId));
 
@@ -695,8 +693,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStartTs(0L);
         pageLink.setEndTs(System.currentTimeMillis());
         pageLink.setSearchPropagatedAlarms(false);
-        pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
-        pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
+        pageLink.setSeverityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
+        pageLink.setStatusList(List.of(AlarmSearchStatus.ACTIVE));
 
         alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(childId));
         Assert.assertNotNull(alarms.getData());
@@ -722,8 +720,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStartTs(0L);
         pageLink.setEndTs(System.currentTimeMillis());
         pageLink.setSearchPropagatedAlarms(true);
-        pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
-        pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
+        pageLink.setSeverityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
+        pageLink.setStatusList(List.of(AlarmSearchStatus.ACTIVE));
 
         alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(childId));
         Assert.assertNotNull(alarms.getData());
@@ -738,8 +736,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStartTs(0L);
         pageLink.setEndTs(System.currentTimeMillis());
         pageLink.setSearchPropagatedAlarms(true);
-        pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
-        pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
+        pageLink.setSeverityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
+        pageLink.setStatusList(List.of(AlarmSearchStatus.ACTIVE));
 
         alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(parentId));
         Assert.assertNotNull(alarms.getData());
@@ -748,7 +746,6 @@ public class AlarmServiceTest extends AbstractServiceTest {
 
         PageData<AlarmInfo> alarmsInfoData = alarmService.findAlarms(tenantId, AlarmQuery.builder()
                 .affectedEntityId(childId)
-                .fetchOriginator(true)
                 .status(AlarmStatus.ACTIVE_UNACK).pageLink(
                         new TimePageLink(10, 0, "",
                                 new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
@@ -759,7 +756,6 @@ public class AlarmServiceTest extends AbstractServiceTest {
 
         alarmsInfoData = alarmService.findAlarms(tenantId, AlarmQuery.builder()
                 .affectedEntityId(parentId)
-                .fetchOriginator(true)
                 .status(AlarmStatus.ACTIVE_UNACK).pageLink(
                         new TimePageLink(10, 0, "",
                                 new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
@@ -770,7 +766,6 @@ public class AlarmServiceTest extends AbstractServiceTest {
 
         alarmsInfoData = alarmService.findAlarms(tenantId, AlarmQuery.builder()
                 .affectedEntityId(parentId2)
-                .fetchOriginator(true)
                 .status(AlarmStatus.ACTIVE_UNACK).pageLink(
                         new TimePageLink(10, 0, "",
                                 new SortOrder("createdTime", SortOrder.Direction.DESC), 0L, System.currentTimeMillis())
@@ -786,8 +781,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStartTs(0L);
         pageLink.setEndTs(System.currentTimeMillis());
         pageLink.setSearchPropagatedAlarms(true);
-        pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
-        pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
+        pageLink.setSeverityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
+        pageLink.setStatusList(List.of(AlarmSearchStatus.ACTIVE));
 
         alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(parentId));
         Assert.assertNotNull(alarms.getData());
@@ -803,8 +798,8 @@ public class AlarmServiceTest extends AbstractServiceTest {
         pageLink.setStartTs(0L);
         pageLink.setEndTs(System.currentTimeMillis());
         pageLink.setSearchPropagatedAlarms(true);
-        pageLink.setSeverityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
-        pageLink.setStatusList(Arrays.asList(AlarmSearchStatus.ACTIVE));
+        pageLink.setSeverityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING));
+        pageLink.setStatusList(List.of(AlarmSearchStatus.ACTIVE));
 
         alarms = alarmService.findAlarmDataByQueryForEntities(tenantId, toQuery(pageLink), Collections.singletonList(childId));
         Assert.assertNotNull(alarms.getData());
@@ -813,7 +808,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
     }
 
     @Test
-    public void testCountAlarmsUsingAlarmDataQuery() throws ExecutionException, InterruptedException {
+    public void testCountAlarmsUsingAlarmDataQuery() {
         AssetId childId = new AssetId(Uuids.timeBased());
 
         long ts = System.currentTimeMillis();
@@ -829,7 +824,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
                 .startTs(0L)
                 .endTs(System.currentTimeMillis())
                 .searchPropagatedAlarms(false)
-                .severityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING))
+                .severityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING))
                 .statusList(List.of(AlarmSearchStatus.ACTIVE))
                 .build();
 
@@ -841,7 +836,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
                 .startTs(0L)
                 .endTs(System.currentTimeMillis())
                 .searchPropagatedAlarms(true)
-                .severityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING))
+                .severityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING))
                 .statusList(List.of(AlarmSearchStatus.ACTIVE))
                 .build();
 
@@ -866,7 +861,7 @@ public class AlarmServiceTest extends AbstractServiceTest {
                 .startTs(0L)
                 .endTs(System.currentTimeMillis())
                 .searchPropagatedAlarms(true)
-                .severityList(Arrays.asList(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING))
+                .severityList(List.of(AlarmSeverity.CRITICAL, AlarmSeverity.WARNING))
                 .statusList(List.of(AlarmSearchStatus.ACTIVE, AlarmSearchStatus.CLEARED))
                 .build();
 
@@ -939,6 +934,6 @@ public class AlarmServiceTest extends AbstractServiceTest {
                 ).build());
         Assert.assertNotNull(alarms.getData());
         Assert.assertEquals(0, alarms.getData().size());
-
     }
+
 }


### PR DESCRIPTION
## Pull Request description

Redis: add ability to disable caching, in case, maxSize specs config is set to 0
![image](https://github.com/user-attachments/assets/a82ca05d-56ae-4e4a-9d3c-a197a3847d7d)


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).