### PR TITLE
Prevent action on preview/edit mode for notification widget

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/cards/unread-notification-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/cards/unread-notification-widget.component.ts
@@ -203,23 +203,29 @@ export class UnreadNotificationWidgetComponent implements OnInit, OnDestroy {
   }
 
   markAsRead(id: string) {
-    const cmd = NotificationSubscriber.createMarkAsReadCommand(this.notificationWsService, [id]);
-    cmd.subscribe();
+    if (!this.ctx.isEdit && !this.ctx.isPreview) {
+      const cmd = NotificationSubscriber.createMarkAsReadCommand(this.notificationWsService, [id]);
+      cmd.subscribe();
+    }
   }
 
   markAsAllRead($event: Event) {
-    if ($event) {
-      $event.stopPropagation();
+    if (!this.ctx.isEdit && !this.ctx.isPreview) {
+      if ($event) {
+        $event.stopPropagation();
+      }
+      const cmd = NotificationSubscriber.createMarkAllAsReadCommand(this.notificationWsService);
+      cmd.subscribe();
     }
-    const cmd = NotificationSubscriber.createMarkAllAsReadCommand(this.notificationWsService);
-    cmd.subscribe();
   }
 
   viewAll($event: Event) {
-    if ($event) {
-      $event.stopPropagation();
+    if (!this.ctx.isEdit && !this.ctx.isPreview) {
+      if ($event) {
+        $event.stopPropagation();
+      }
+      this.router.navigateByUrl(this.router.parseUrl('/notification/inbox')).then(() => {});
     }
-    this.router.navigateByUrl(this.router.parseUrl('/notification/inbox')).then(() => {});
   }
 
   trackById(index: number, item: NotificationRequest): string {


### PR DESCRIPTION
## Pull Request description

After fix: action prevented on preview and edit mode.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




