### PR TITLE
Fix 'Home dasboards' widget

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/home-page/recent-dashboards-widget.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/home-page/recent-dashboards-widget.component.html
@@ -48,7 +48,7 @@
                 {{ 'widgets.recent-dashboards.name' | translate }}
               </mat-header-cell>
               <mat-cell class="title" *matCellDef="let lastVisitedDashboard">
-                <a routerLink="/dashboards/{{lastVisitedDashboard.id}}">{{ lastVisitedDashboard.title }}</a>
+                <a [routerLink]="createDashboardUrl(lastVisitedDashboard.id)">{{ lastVisitedDashboard.title }}</a>
               </mat-cell>
             </ng-container>
             <ng-container matColumnDef="lastVisited">
@@ -78,7 +78,7 @@
                         class="star" [ngClass]="{'starred': dashboard.starred}">{{ dashboard.starred ? 'star' : 'star_border' }}</mat-icon>
             </div>
             <div class="tb-cell title">
-              <a routerLink="/dashboards/{{dashboard.id}}">{{ dashboard.title }}</a>
+              <a [routerLink]="createDashboardUrl(dashboard.id)">{{ dashboard.title }}</a>
             </div>
           </div>
         </div>
@@ -87,6 +87,7 @@
                                    subscriptSizing="dynamic"
                                    appearance="outline"
                                    [useIdValue]="false"
+                                   [customerId]="customerId"
                                    label=""
                                    placeholder="{{ 'dashboard.select-dashboard' | translate }}"
                                    [(ngModel)]="starredDashboardValue" (ngModelChange)="onStarDashboard($event)"></tb-dashboard-autocomplete>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/home-page/recent-dashboards-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/home-page/recent-dashboards-widget.component.ts
@@ -30,7 +30,7 @@ import { Store } from '@ngrx/store';
 import { AppState } from '@core/core.state';
 import { Authority } from '@shared/models/authority.enum';
 import { BehaviorSubject, Observable, of } from 'rxjs';
-import { getCurrentAuthUser } from '@core/auth/auth.selectors';
+import { getCurrentAuthState, getCurrentAuthUser } from '@core/auth/auth.selectors';
 import { WidgetContext } from '@home/models/widget-component.models';
 import {
   AbstractUserDashboardInfo,
@@ -48,8 +48,6 @@ import { Direction, SortOrder } from '@shared/models/page/sort-order';
 import { MatSort } from '@angular/material/sort';
 import { DashboardInfo } from '@shared/models/dashboard.models';
 import { DashboardAutocompleteComponent } from '@shared/components/dashboard-autocomplete.component';
-import { UserService } from '@core/http/user.service';
-import { User } from '@shared/models/user.model';
 
 @Component({
   selector: 'tb-recent-dashboards-widget',
@@ -82,19 +80,15 @@ export class RecentDashboardsWidgetComponent extends PageComponent implements On
 
   dirty = false;
   public customerId: string;
-  private isFullscreenMode = false;
+  private isFullscreenMode = getCurrentAuthState(this.store).forceFullscreen;
 
   constructor(protected store: Store<AppState>,
               private cd: ChangeDetectorRef,
-              private userService: UserService,
               private userSettingService: UserSettingsService) {
     super(store);
   }
 
   ngOnInit() {
-    this.userService.getUser(this.authUser.userId).subscribe((userInfo: User) => {
-      this.isFullscreenMode = userInfo.additionalInfo.defaultDashboardFullscreen;
-    });
     if (this.authUser.authority === Authority.CUSTOMER_USER) {
       this.customerId = this.authUser.customerId;
     }

--- a/ui-ngx/src/app/modules/home/components/widget/lib/home-page/recent-dashboards-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/home-page/recent-dashboards-widget.component.ts
@@ -14,7 +14,17 @@
 /// limitations under the License.
 ///
 
-import { AfterViewInit, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnDestroy,
+  OnInit,
+  QueryList,
+  ViewChild,
+  ViewChildren
+} from '@angular/core';
 import { PageComponent } from '@shared/components/page.component';
 import { Store } from '@ngrx/store';
 import { AppState } from '@core/core.state';


### PR DESCRIPTION
## Pull Request description

In case the customer user has ‘always fullscreen’ mode, the ‘home dashboards’ widget works incorrectly.

It may not navigate at all in case it is used from default dashboard or redirected to the default dashboard if the widget is used from other places. Also, dashboard autocomplete wasn't working at the customer level.

This PR fixes autocomplete and navigation for this widget at the customer level

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)


