### PR TITLE
TBEL: added parseBinaryArrayToInt

### DIFF
--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbUtils.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbUtils.java
@@ -17,6 +17,7 @@ package org.thingsboard.script.api.tbel;
 
 import com.google.common.primitives.Bytes;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 import org.apache.commons.lang3.ArrayUtils;
 import org.mvel2.ExecutionContext;
 import org.mvel2.ParserConfiguration;
@@ -335,6 +336,8 @@ public class TbUtils {
                 byte.class)));
         parserConfig.addImport("parseByteToBinaryArray", new MethodStub(TbUtils.class.getMethod("parseByteToBinaryArray",
                 byte.class, int.class)));
+         parserConfig.addImport("parseByteToBinaryArray", new MethodStub(TbUtils.class.getMethod("parseByteToBinaryArray",
+                byte.class, int.class, boolean.class)));
         parserConfig.addImport("parseBytesToBinaryArray", new MethodStub(TbUtils.class.getMethod("parseBytesToBinaryArray",
                 List.class)));
         parserConfig.addImport("parseBytesToBinaryArray", new MethodStub(TbUtils.class.getMethod("parseBytesToBinaryArray",
@@ -1299,14 +1302,23 @@ public class TbUtils {
         return parseByteToBinaryArray(byteValue, BIN_LEN_MAX);
     }
 
+    public static byte[] parseByteToBinaryArray(byte byteValue, int binLength) {
+        return parseByteToBinaryArray(byteValue, binLength, true);
+    }
+
     /**
+     * bigEndian = true
      * Writes the bit value to the appropriate location in the bins array, starting at the end of the array,
      * to ensure proper alignment (highest bit to low end).
      */
-    public static byte[] parseByteToBinaryArray(byte byteValue, int binLength) {
+    public static byte[] parseByteToBinaryArray(byte byteValue, int binLength, boolean bigEndian) {
         byte[] bins = new byte[binLength];
         for (int i = 0; i < binLength; i++) {
-            bins[binLength - 1 - i] = (byte) ((byteValue >> i) & 1);
+            if(bigEndian) {
+                bins[binLength - 1 - i] = (byte) ((byteValue >> i) & 1);
+            } else {
+                bins[i] = (byte) ((byteValue >> i) & 1);
+            }
         }
         return bins;
     }

--- a/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
+++ b/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
@@ -944,20 +944,19 @@ public class TbUtilsTest {
         Assertions.assertEquals(expected, TbUtils.padEnd(last4Digits, fullNumber.length(), '*'));
     }
 
-
     @Test
     public void parseByteToBinaryArray_Test() {
         byte byteVal = 0x39;
-        int[] bitArray = {1, 0, 0, 1, 1, 1, 0, 0};
-        List expected = Arrays.stream(bitArray).boxed().toList();
-        int[] actualArray = TbUtils.parseByteToBinaryArray(byteVal);
-        List<Integer> actual = Arrays.stream(actualArray).boxed().toList();
+        byte[] bitArray = {0, 0, 1, 1, 1, 0, 0, 1};
+        List expected = toList(bitArray);
+        byte[] actualArray = TbUtils.parseByteToBinaryArray(byteVal);
+        List actual = toList(actualArray);
         Assertions.assertEquals(expected, actual);
 
-        bitArray = new int[]{1, 0, 0, 1, 1, 1};
-        expected = Arrays.stream(bitArray).boxed().toList();
+        bitArray = new byte[]{1, 1, 1, 0, 0, 1};
+        expected = toList(bitArray);
         actualArray = TbUtils.parseByteToBinaryArray(byteVal, bitArray.length);
-        actual = Arrays.stream(actualArray).boxed().toList();
+        actual = toList(actualArray);
         Assertions.assertEquals(expected, actual);
     }
 
@@ -966,47 +965,78 @@ public class TbUtilsTest {
         long longValue = 57L;
         byte[] bytesValue = new byte[]{0x39};   // 57
         List<Byte> listValue = toList(bytesValue);
-        int[] bitArray = {1, 0, 0, 1, 1, 1, 0, 0};
-        List expected = Arrays.stream(bitArray).boxed().toList();
-        int[] actualArray = TbUtils.parseBytesToBinaryArray(listValue);
-        List<Integer> actual = Arrays.stream(actualArray).boxed().toList();
+        byte[] bitArray = {0, 0, 1, 1, 1, 0, 0, 1};
+        List expected = toList(bitArray);
+        byte[] actualArray = TbUtils.parseBytesToBinaryArray(listValue);
+        List actual = toList(actualArray);
         Assertions.assertEquals(expected, actual);
 
         actualArray = TbUtils.parseLongToBinaryArray(longValue, listValue.size() * 8);
-        actual = Arrays.stream(actualArray).boxed().toList();
+        actual = toList(actualArray);
         Assertions.assertEquals(expected, actual);
 
-        bitArray = new int[]{1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-        expected = Arrays.stream(bitArray).boxed().toList();
+        bitArray = new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1};
+        expected = toList(bitArray);
         actualArray = TbUtils.parseLongToBinaryArray(longValue);
-        actual = Arrays.stream(actualArray).boxed().toList();
+        actual = toList(actualArray);
         Assertions.assertEquals(expected, actual);
 
         longValue = 52914L;
         bytesValue = new byte[]{(byte) 0xCE, (byte) 0xB2};   // 52914
         listValue = toList(bytesValue);
-        bitArray = new int[]{0, 1, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0, 0, 1, 1};
-        expected = Arrays.stream(bitArray).boxed().toList();
+        bitArray = new byte[]{1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0};
+        expected = toList(bitArray);
         actualArray = TbUtils.parseBytesToBinaryArray(listValue);
-        actual = Arrays.stream(actualArray).boxed().toList();
+        actual = toList(actualArray);
         Assertions.assertEquals(expected, actual);
 
         actualArray = TbUtils.parseLongToBinaryArray(longValue, listValue.size() * 8);
-        actual = Arrays.stream(actualArray).boxed().toList();
+        actual = toList(actualArray);
         Assertions.assertEquals(expected, actual);
 
-        bitArray = new int[]{0, 1, 0, 0};
-        expected = Arrays.stream(bitArray).boxed().toList();
+        bitArray = new byte[]{0, 0, 1, 0};
+        expected = toList(bitArray);
         actualArray = TbUtils.parseLongToBinaryArray(longValue, 4);
-        actual = Arrays.stream(actualArray).boxed().toList();
+        actual = toList(actualArray);
         Assertions.assertEquals(expected, actual);
 
-        bitArray = new int[]{0, 1, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-        expected = Arrays.stream(bitArray).boxed().toList();
+        bitArray = new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0};
+        expected = toList(bitArray);
         actualArray = TbUtils.parseLongToBinaryArray(longValue);
-        actual = Arrays.stream(actualArray).boxed().toList();
+        actual = toList(actualArray);
         Assertions.assertEquals(expected, actual);
+    }
 
+    @Test
+    public void parseBinaryArrayToInt_Test() {
+        byte byteVal = (byte) 0x9F;
+        int expectedVolt = 31;
+        byte[] actualArray = TbUtils.parseByteToBinaryArray(byteVal);
+        int actual = TbUtils.parseBinaryArrayToInt(actualArray);
+        Assertions.assertEquals(byteVal, actual);
+        int actualVolt = TbUtils.parseBinaryArrayToInt(actualArray, 1, 7);
+        Assertions.assertEquals(expectedVolt, actualVolt);
+        boolean expectedLowVoltage = true;
+        boolean actualLowVoltage = actualArray[7] == 1;
+        Assertions.assertEquals(expectedLowVoltage, actualLowVoltage);
+        int expectedLowCurrent1Alarm = 1;  //  0x39 = 00 11 10 01 (Bin0): 0 == 1
+        int expectedHighCurrent1Alarm = 0;  //  0x39 = 00 11 10 01 (Bin1): 0 == 0
+        int expectedLowCurrent2Alarm = 0;  //  0x39 = 00 11 10 01 (Bin2): 0 == 0
+        int expectedHighCurrent2Alarm = 1; //  0x39 = 00 11 10 01 (Bin3): 0 == 1
+        int expectedLowCurrent3Alarm = 1;  //  0x39 = 00 11 10 01 (Bin4): 0 == 1
+        int expectedHighCurrent3Alarm = 1;  //  0x39 = 00 11 10 01 (Bin5): 0 == 1
+        int actualLowCurrent1Alarm = actualArray[0];
+        int actualHighCurrent1Alarm = actualArray[1];
+        int actualLowCurrent2Alarm = actualArray[2];
+        int actualHighCurrent2Alarm = actualArray[3];
+        int actualLowCurrent3Alarm = actualArray[4];
+        int actualHighCurrent3Alarm = actualArray[5];
+        Assertions.assertEquals(expectedLowCurrent1Alarm, actualLowCurrent1Alarm);
+        Assertions.assertEquals(expectedHighCurrent1Alarm, actualHighCurrent1Alarm);
+        Assertions.assertEquals(expectedLowCurrent2Alarm, actualLowCurrent2Alarm);
+        Assertions.assertEquals(expectedHighCurrent2Alarm, actualHighCurrent2Alarm);
+        Assertions.assertEquals(expectedLowCurrent3Alarm, actualLowCurrent3Alarm);
+        Assertions.assertEquals(expectedHighCurrent3Alarm, actualHighCurrent3Alarm);
     }
 
     private static List<Byte> toList(byte[] data) {

--- a/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
+++ b/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
@@ -1060,6 +1060,14 @@ public class TbUtilsTest {
         Assertions.assertEquals(expectedMultiplier3, actualMultiplier3);
     }
 
+    @Test
+    public void hexToBase64_Test() {
+        String hex = "014A000A02202007060000014A019F03E800C81B5801014A029F030A0000000000014A032405DD05D41B5836014A049F39000000000000";
+        String expected = "AUoACgIgIAcGAAABSgGfA+gAyBtYAQFKAp8DCgAAAAAAAUoDJAXdBdQbWDYBSgSfOQAAAAAAAA==";
+        String actual = TbUtils.hexToBase64(hex);
+        Assertions.assertEquals(expected, actual);
+    }
+
     private static List<Byte> toList(byte[] data) {
         List<Byte> result = new ArrayList<>(data.length);
         for (Byte b : data) {

--- a/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
+++ b/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
@@ -958,6 +958,12 @@ public class TbUtilsTest {
         actualArray = TbUtils.parseByteToBinaryArray(byteVal, bitArray.length);
         actual = toList(actualArray);
         Assertions.assertEquals(expected, actual);
+
+        bitArray = new byte[]{1, 0, 0, 1, 1, 1};
+        expected = toList(bitArray);
+        actualArray = TbUtils.parseByteToBinaryArray(byteVal, bitArray.length, false);
+        actual = toList(actualArray);
+        Assertions.assertEquals(expected, actual);
     }
 
     @Test
@@ -1021,19 +1027,19 @@ public class TbUtilsTest {
         Assertions.assertEquals(expectedLowVoltage, actualLowVoltage);
 
         byteVal = (byte) 0x39;
-        actualArray = TbUtils.parseByteToBinaryArray(byteVal);
+        actualArray = TbUtils.parseByteToBinaryArray(byteVal, 6, false);
         int expectedLowCurrent1Alarm = 1;  //  0x39 = 00 11 10 01 (Bin0): 0 == 1
         int expectedHighCurrent1Alarm = 0; //  0x39 = 00 11 10 01 (Bin1): 0 == 0
         int expectedLowCurrent2Alarm = 0;  //  0x39 = 00 11 10 01 (Bin2): 0 == 0
         int expectedHighCurrent2Alarm = 1; //  0x39 = 00 11 10 01 (Bin3): 0 == 1
         int expectedLowCurrent3Alarm = 1;  //  0x39 = 00 11 10 01 (Bin4): 0 == 1
         int expectedHighCurrent3Alarm = 1; //  0x39 = 00 11 10 01 (Bin5): 0 == 1
-        int actualLowCurrent1Alarm = actualArray[7];
-        int actualHighCurrent1Alarm = actualArray[6];
-        int actualLowCurrent2Alarm = actualArray[5];
-        int actualHighCurrent2Alarm = actualArray[4];
-        int actualLowCurrent3Alarm = actualArray[3];
-        int actualHighCurrent3Alarm = actualArray[2];
+        int actualLowCurrent1Alarm = actualArray[0];
+        int actualHighCurrent1Alarm = actualArray[1];
+        int actualLowCurrent2Alarm = actualArray[2];
+        int actualHighCurrent2Alarm = actualArray[3];
+        int actualLowCurrent3Alarm = actualArray[4];
+        int actualHighCurrent3Alarm = actualArray[5];
         Assertions.assertEquals(expectedLowCurrent1Alarm, actualLowCurrent1Alarm);
         Assertions.assertEquals(expectedHighCurrent1Alarm, actualHighCurrent1Alarm);
         Assertions.assertEquals(expectedLowCurrent2Alarm, actualLowCurrent2Alarm);

--- a/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
+++ b/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
@@ -1019,24 +1019,39 @@ public class TbUtilsTest {
         boolean expectedLowVoltage = true;
         boolean actualLowVoltage = actualArray[7] == 1;
         Assertions.assertEquals(expectedLowVoltage, actualLowVoltage);
+
+        byteVal = (byte) 0x39;
+        actualArray = TbUtils.parseByteToBinaryArray(byteVal);
         int expectedLowCurrent1Alarm = 1;  //  0x39 = 00 11 10 01 (Bin0): 0 == 1
-        int expectedHighCurrent1Alarm = 0;  //  0x39 = 00 11 10 01 (Bin1): 0 == 0
+        int expectedHighCurrent1Alarm = 0; //  0x39 = 00 11 10 01 (Bin1): 0 == 0
         int expectedLowCurrent2Alarm = 0;  //  0x39 = 00 11 10 01 (Bin2): 0 == 0
         int expectedHighCurrent2Alarm = 1; //  0x39 = 00 11 10 01 (Bin3): 0 == 1
         int expectedLowCurrent3Alarm = 1;  //  0x39 = 00 11 10 01 (Bin4): 0 == 1
-        int expectedHighCurrent3Alarm = 1;  //  0x39 = 00 11 10 01 (Bin5): 0 == 1
-        int actualLowCurrent1Alarm = actualArray[0];
-        int actualHighCurrent1Alarm = actualArray[1];
-        int actualLowCurrent2Alarm = actualArray[2];
-        int actualHighCurrent2Alarm = actualArray[3];
-        int actualLowCurrent3Alarm = actualArray[4];
-        int actualHighCurrent3Alarm = actualArray[5];
+        int expectedHighCurrent3Alarm = 1; //  0x39 = 00 11 10 01 (Bin5): 0 == 1
+        int actualLowCurrent1Alarm = actualArray[7];
+        int actualHighCurrent1Alarm = actualArray[6];
+        int actualLowCurrent2Alarm = actualArray[5];
+        int actualHighCurrent2Alarm = actualArray[4];
+        int actualLowCurrent3Alarm = actualArray[3];
+        int actualHighCurrent3Alarm = actualArray[2];
         Assertions.assertEquals(expectedLowCurrent1Alarm, actualLowCurrent1Alarm);
         Assertions.assertEquals(expectedHighCurrent1Alarm, actualHighCurrent1Alarm);
         Assertions.assertEquals(expectedLowCurrent2Alarm, actualLowCurrent2Alarm);
         Assertions.assertEquals(expectedHighCurrent2Alarm, actualHighCurrent2Alarm);
         Assertions.assertEquals(expectedLowCurrent3Alarm, actualLowCurrent3Alarm);
         Assertions.assertEquals(expectedHighCurrent3Alarm, actualHighCurrent3Alarm);
+
+        byteVal = (byte) 0x36;
+        actualArray = TbUtils.parseByteToBinaryArray(byteVal);
+        int expectedMultiplier1 = 2;
+        int expectedMultiplier2 = 1;
+        int expectedMultiplier3 = 3;
+        int actualMultiplier1 = TbUtils.parseBinaryArrayToInt(actualArray, 6, 2);
+        int actualMultiplier2 = TbUtils.parseBinaryArrayToInt(actualArray, 4, 2);
+        int actualMultiplier3 = TbUtils.parseBinaryArrayToInt(actualArray, 2, 2);
+        Assertions.assertEquals(expectedMultiplier1, actualMultiplier1);
+        Assertions.assertEquals(expectedMultiplier2, actualMultiplier2);
+        Assertions.assertEquals(expectedMultiplier3, actualMultiplier3);
     }
 
     private static List<Byte> toList(byte[] data) {


### PR DESCRIPTION
## Pull Request description

### Added new
-  parseBinaryArrayToInt
```
((byte) 0x9F;
TbUtils.parseBinaryArrayToInt([1, 0, 0, 1, 1, 1, 1, 1], 1, 7); return 31;
TbUtils.parseBinaryArrayToInt([1, 0, 0, 1, 1, 1, 1, 1]); return -97;
[(byte) 0xCE, (byte) 0xB2] == 52914
TbUtils.parseBinaryArrayToInt([1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0]); return 52914;
```
- hexToBase64

### fix bug: 
- parseLongToBinaryArray
`Writes the bit value to the appropriate location in the bins array, starting at the end of the array, to ensure proper alignment (highest bit to low end).`

### refactoring:
- parseByteToBinaryArray add Endian
```
       byteVal = (byte) 0x39;
        int expectedLowCurrent1Alarm = 1;  //  0x39 = 00 11 10 01 (Bin0): 0 == 1
        int expectedHighCurrent1Alarm = 0; //  0x39 = 00 11 10 01 (Bin1): 0 == 0
        int expectedLowCurrent2Alarm = 0;  //  0x39 = 00 11 10 01 (Bin2): 0 == 0
        int expectedHighCurrent2Alarm = 1; //  0x39 = 00 11 10 01 (Bin3): 0 == 1
        int expectedLowCurrent3Alarm = 1;  //  0x39 = 00 11 10 01 (Bin4): 0 == 1
        int expectedHighCurrent3Alarm = 1; //  0x39 = 00 11 10 01 (Bin5): 0 == 1

```

```
        actualArray = TbUtils.parseByteToBinaryArray(byteVal, 6, false);
        int actualLowCurrent1Alarm = actualArray[0];
        int actualHighCurrent1Alarm = actualArray[1];
        int actualLowCurrent2Alarm = actualArray[2];
        int actualHighCurrent2Alarm = actualArray[3];
        int actualLowCurrent3Alarm = actualArray[4];
        int actualHighCurrent3Alarm = actualArray[5]
```

```
        byteVal = (byte) 0x39;
        actualArray = TbUtils.parseByteToBinaryArray(byteVal);
        int actualLowCurrent1Alarm = actualArray[7];
        int actualHighCurrent1Alarm = actualArray[6];
        int actualLowCurrent2Alarm = actualArray[5];
        int actualHighCurrent2Alarm = actualArray[4];
        int actualLowCurrent3Alarm = actualArray[3];
        int actualHighCurrent3Alarm = actualArray[2]
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



