### PR TITLE
Fix zero attribute key 

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/sqlts/dictionary/JpaKeyDictionaryDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sqlts/dictionary/JpaKeyDictionaryDao.java
@@ -15,11 +15,13 @@
  */
 package org.thingsboard.server.dao.sqlts.dictionary;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.thingsboard.server.dao.dictionary.KeyDictionaryDao;
 import org.thingsboard.server.dao.model.sqlts.dictionary.KeyDictionaryCompositeKey;
 import org.thingsboard.server.dao.model.sqlts.dictionary.KeyDictionaryEntry;
@@ -34,14 +36,15 @@ import java.util.concurrent.locks.ReentrantLock;
 @Component
 @Slf4j
 @SqlDao
+@RequiredArgsConstructor
 public class JpaKeyDictionaryDao extends JpaAbstractDaoListeningExecutorService implements KeyDictionaryDao {
 
+    private final KeyDictionaryRepository keyDictionaryRepository;
+
     private final ConcurrentMap<String, Integer> keyDictionaryMap = new ConcurrentHashMap<>();
-    protected static final ReentrantLock creationLock = new ReentrantLock();
+    private static final ReentrantLock creationLock = new ReentrantLock();
 
-    @Autowired
-    private KeyDictionaryRepository keyDictionaryRepository;
-
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @Override
     public Integer getOrSaveKeyId(String strKey) {
         Integer keyId = keyDictionaryMap.get(strKey);


### PR DESCRIPTION
## Pull Request description

If `KeyDictionaryDao.getOrSaveKeyId` was executed in transaction, after calling `keyDictionaryRepository.save` Hibernate wouldn't return newly generated keyId (only after **flush**), thus it returned 0 by default.

The solution is to execute this code outside transaction. This is also helpful when there is a key conflict DB error - won't rollback parent transaction.


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



