### PR TITLE
DefaultTbLocalSubscriptionService WS single lock refactored by tenantId; TbEntityLocalSubsInfo performance optimizations for remove subscription

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbAlarmsSubscription.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbAlarmsSubscription.java
@@ -36,12 +36,8 @@ public class TbAlarmsSubscription extends TbSubscription<AlarmSubscriptionUpdate
     }
 
     @Override
-    public boolean equals(Object o) {
-        return super.equals(o);
+    protected boolean canEqual(final Object other) {
+        return other instanceof TbAlarmsSubscription;
     }
 
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
 }

--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbAttributeSubscription.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbAttributeSubscription.java
@@ -43,12 +43,8 @@ public class TbAttributeSubscription extends TbSubscription<TelemetrySubscriptio
     }
 
     @Override
-    public boolean equals(Object o) {
-        return super.equals(o);
+    protected boolean canEqual(final Object other) {
+        return other instanceof TbAttributeSubscription;
     }
 
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
 }

--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscription.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscription.java
@@ -15,41 +15,25 @@
  */
 package org.thingsboard.server.service.subscription;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 @Data
-@AllArgsConstructor
+@EqualsAndHashCode(cacheStrategy = EqualsAndHashCode.CacheStrategy.LAZY, doNotUseGetters = true)
 public abstract class TbSubscription<T> {
 
+    @EqualsAndHashCode.Exclude
     private final String serviceId;
     private final String sessionId;
     private final int subscriptionId;
     private final TenantId tenantId;
     private final EntityId entityId;
     private final TbSubscriptionType type;
+    @EqualsAndHashCode.Exclude
     private final BiConsumer<TbSubscription<T>, T> updateProcessor;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TbSubscription that = (TbSubscription) o;
-        return subscriptionId == that.subscriptionId &&
-                sessionId.equals(that.sessionId) &&
-                tenantId.equals(that.tenantId) &&
-                entityId.equals(that.entityId) &&
-                type == that.type;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(sessionId, subscriptionId, tenantId, entityId, type);
-    }
 }

--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscriptionUtils.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscriptionUtils.java
@@ -107,8 +107,9 @@ public class TbSubscriptionUtils {
                 .type(event);
         if (!ComponentLifecycleEvent.DELETED.equals(event)) {
             builder.info(new TbSubscriptionsInfo(proto.getNotifications(), proto.getAlarms(),
-                    proto.getTsAllKeys(), proto.getTsKeysCount() > 0 ? new HashSet<>(proto.getTsKeysList()) : null,
-                    proto.getAttrAllKeys(), proto.getAttrKeysCount() > 0 ? new HashSet<>(proto.getAttrKeysList()) : null,
+                    proto.getTsAllKeys(), proto.getAttrAllKeys(),
+                    proto.getTsKeysCount() > 0 ? new HashSet<>(proto.getTsKeysList()) : null,
+                    proto.getAttrKeysCount() > 0 ? new HashSet<>(proto.getAttrKeysList()) : null,
                     proto.getSeqNumber()));
         }
         return builder.build();

--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscriptionsInfo.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscriptionsInfo.java
@@ -20,25 +20,24 @@ import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
-import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Information about the local websocket subscriptions.
  */
 @RequiredArgsConstructor
 @AllArgsConstructor
-@EqualsAndHashCode(exclude = {"seqNumber"})
+@EqualsAndHashCode
 @ToString
 public class TbSubscriptionsInfo {
 
     protected boolean notifications;
     protected boolean alarms;
     protected boolean tsAllKeys;
+    protected boolean attrAllKeys; // primitives first for equals performance
     protected Set<String> tsKeys;
-    protected boolean attrAllKeys;
     protected Set<String> attrKeys;
+    @EqualsAndHashCode.Exclude
     protected int seqNumber;
 
     public boolean isEmpty() {
@@ -50,7 +49,7 @@ public class TbSubscriptionsInfo {
     }
 
     protected TbSubscriptionsInfo copy(int seqNumber) {
-        return new TbSubscriptionsInfo(notifications, alarms, tsAllKeys, tsKeys, attrAllKeys, attrKeys, seqNumber);
+        return new TbSubscriptionsInfo(notifications, alarms, tsAllKeys, attrAllKeys, tsKeys, attrKeys, seqNumber);
     }
 
 }

--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbTimeSeriesSubscription.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbTimeSeriesSubscription.java
@@ -53,12 +53,8 @@ public class TbTimeSeriesSubscription extends TbSubscription<TelemetrySubscripti
     }
 
     @Override
-    public boolean equals(Object o) {
-        return super.equals(o);
+    protected boolean canEqual(final Object other) {
+        return other instanceof TbTimeSeriesSubscription;
     }
 
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
 }

--- a/application/src/main/java/org/thingsboard/server/service/ws/notification/sub/AbstractNotificationSubscription.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/notification/sub/AbstractNotificationSubscription.java
@@ -35,4 +35,9 @@ public abstract class AbstractNotificationSubscription<T> extends TbSubscription
         super(serviceId, sessionId, subscriptionId, tenantId, entityId, type, updateProcessor);
     }
 
+    @Override
+    protected boolean canEqual(final Object other) {
+        return other instanceof AbstractNotificationSubscription;
+    }
+
 }

--- a/application/src/main/java/org/thingsboard/server/service/ws/notification/sub/NotificationsCountSubscription.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/notification/sub/NotificationsCountSubscription.java
@@ -23,7 +23,6 @@ import org.thingsboard.server.service.subscription.TbSubscription;
 import org.thingsboard.server.service.subscription.TbSubscriptionType;
 import org.thingsboard.server.service.ws.notification.cmd.UnreadNotificationsCountUpdate;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 @Getter
@@ -33,6 +32,11 @@ public class NotificationsCountSubscription extends AbstractNotificationSubscrip
     public NotificationsCountSubscription(String serviceId, String sessionId, int subscriptionId, TenantId tenantId, EntityId entityId,
                                           BiConsumer<TbSubscription<NotificationsSubscriptionUpdate>, NotificationsSubscriptionUpdate> updateProcessor) {
         super(serviceId, sessionId, subscriptionId, tenantId, entityId, TbSubscriptionType.NOTIFICATIONS_COUNT, updateProcessor);
+    }
+
+    @Override
+    protected boolean canEqual(final Object other) {
+        return other instanceof NotificationsCountSubscription;
     }
 
     public UnreadNotificationsCountUpdate createUpdate() {

--- a/application/src/main/java/org/thingsboard/server/service/ws/notification/sub/NotificationsSubscription.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/notification/sub/NotificationsSubscription.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -46,6 +45,11 @@ public class NotificationsSubscription extends AbstractNotificationSubscription<
                                      int limit) {
         super(serviceId, sessionId, subscriptionId, tenantId, entityId, TbSubscriptionType.NOTIFICATIONS, updateProcessor);
         this.limit = limit;
+    }
+
+    @Override
+    protected boolean canEqual(final Object other) {
+        return other instanceof NotificationsSubscription;
     }
 
     public UnreadNotificationsUpdate createFullUpdate() {


### PR DESCRIPTION
## DefaultTbLocalSubscriptionService WS single lock refactored by tenantId; TbEntityLocalSubsInfo performance optimizations for remove subscription

based on thread dump:

```
"DefaultWebSocketService-0-25" - Thread t@5330
   java.lang.Thread.State: WAITING
	at java.base@17.0.11/jdk.internal.misc.Unsafe.park(Native Method)
	- waiting to lock <7385cf25> (a java.util.concurrent.locks.ReentrantLock$NonfairSync) owned by "DefaultWebSocketService-0-45" t@104496
	at java.base@17.0.11/java.util.concurrent.locks.LockSupport.park(LockSupport.java:211)
	at java.base@17.0.11/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:715)
	at java.base@17.0.11/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:938)
	at java.base@17.0.11/java.util.concurrent.locks.ReentrantLock$Sync.lock(ReentrantLock.java:153)
	at java.base@17.0.11/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:322)
	at org.thingsboard.server.service.subscription.DefaultTbLocalSubscriptionService.cancelAllSessionSubscriptions(DefaultTbLocalSubscriptionService.java:275)
	at org.thingsboard.server.service.ws.DefaultWebSocketService.cleanupSessionById(DefaultWebSocketService.java:827)
	at org.thingsboard.server.service.ws.DefaultWebSocketService.handleSessionEvent(DefaultWebSocketService.java:226)
	at jdk.internal.reflect.GeneratedMethodAccessor654.invoke(Unknown Source)
	at java.base@17.0.11/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@17.0.11/java.lang.reflect.Method.invoke(Method.java:568)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:351)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213)
	at jdk.proxy2/jdk.proxy2.$Proxy340.handleSessionEvent(Unknown Source)
	at org.thingsboard.server.controller.plugin.TbWebSocketHandler.processInWebSocketService(TbWebSocketHandler.java:328)
	at org.thingsboard.server.controller.plugin.TbWebSocketHandler.afterConnectionClosed(TbWebSocketHandler.java:315)
	at org.springframework.web.socket.handler.WebSocketHandlerDecorator.afterConnectionClosed(WebSocketHandlerDecorator.java:85)
	at org.springframework.web.socket.handler.LoggingWebSocketHandlerDecorator.afterConnectionClosed(LoggingWebSocketHandlerDecorator.java:72)
	at org.springframework.web.socket.handler.ExceptionWebSocketHandlerDecorator.afterConnectionClosed(ExceptionWebSocketHandlerDecorator.java:78)
	at org.springframework.web.socket.adapter.standard.StandardWebSocketHandlerAdapter.onClose(StandardWebSocketHandlerAdapter.java:144)
	at org.apache.tomcat.websocket.WsSession.fireEndpointOnClose(WsSession.java:714)
	at org.apache.tomcat.websocket.WsSession.doClose(WsSession.java:590)
	at org.apache.tomcat.websocket.WsSession.doClose(WsSession.java:556)
	at org.apache.tomcat.websocket.WsSession.close(WsSession.java:544)
	at org.springframework.web.socket.adapter.standard.StandardWebSocketSession.closeInternal(StandardWebSocketSession.java:235)
	at org.springframework.web.socket.adapter.AbstractWebSocketSession.close(AbstractWebSocketSession.java:144)
	at org.thingsboard.server.controller.plugin.TbWebSocketHandler.close(TbWebSocketHandler.java:554)
	at org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData.closeSession(TbWebSocketHandler.java:409)
	at org.thingsboard.server.controller.plugin.TbWebSocketHandler$SessionMetaData.sendPing(TbWebSocketHandler.java:397)
	at org.thingsboard.server.controller.plugin.TbWebSocketHandler.sendPing(TbWebSocketHandler.java:537)
	at org.thingsboard.server.service.ws.DefaultWebSocketService.lambda$sendPing$26(DefaultWebSocketService.java:923)
	at org.thingsboard.server.service.ws.DefaultWebSocketService$$Lambda$4375/0x00007f663dc94000.run(Unknown Source)
	at java.base@17.0.11/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1375)
	at java.base@17.0.11/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base@17.0.11/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base@17.0.11/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base@17.0.11/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base@17.0.11/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)

   Locked ownable synchronizers:
	- None


"ws-entity-sub-callback-58-thread-1" - Thread t@329
   java.lang.Thread.State: WAITING
	at java.base@17.0.11/jdk.internal.misc.Unsafe.park(Native Method)
	- waiting to lock <7385cf25> (a java.util.concurrent.locks.ReentrantLock$NonfairSync) owned by "DefaultWebSocketService-0-45" t@104496
	at java.base@17.0.11/java.util.concurrent.locks.LockSupport.park(LockSupport.java:211)
	at java.base@17.0.11/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:715)
	at java.base@17.0.11/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:938)
	at java.base@17.0.11/java.util.concurrent.locks.ReentrantLock$Sync.lock(ReentrantLock.java:153)
	at java.base@17.0.11/java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:322)
	at org.thingsboard.server.service.subscription.DefaultTbLocalSubscriptionService.addSubscription(DefaultTbLocalSubscriptionService.java:200)
	at jdk.internal.reflect.GeneratedMethodAccessor376.invoke(Unknown Source)
	at java.base@17.0.11/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@17.0.11/java.lang.reflect.Method.invoke(Method.java:568)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:351)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:213)
	at jdk.proxy2/jdk.proxy2.$Proxy413.addSubscription(Unknown Source)
	at org.thingsboard.server.service.subscription.TbAbstractDataSubCtx$$Lambda$4120/0x00007f663dbf9cc8.accept(Unknown Source)
	at java.base@17.0.11/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.thingsboard.server.service.subscription.TbAbstractDataSubCtx.createSubscriptions(TbAbstractDataSubCtx.java:158)
	at org.thingsboard.server.service.subscription.TbAbstractDataSubCtx.createLatestValuesSubscriptions(TbAbstractDataSubCtx.java:138)
	at org.thingsboard.server.service.subscription.DefaultTbEntityDataSubscriptionService$2.onSuccess(DefaultTbEntityDataSubscriptionService.java:691)
	at org.thingsboard.server.service.subscription.DefaultTbEntityDataSubscriptionService$2.onSuccess(DefaultTbEntityDataSubscriptionService.java:678)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1137)
	at java.base@17.0.11/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base@17.0.11/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base@17.0.11/java.lang.Thread.run(Thread.java:840)
```


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



