### PR TITLE
Fix Misleading DATABASE_TS_LATEST_TYPE Comment and Description

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -203,7 +203,7 @@ database:
   ts:
     type: "${DATABASE_TS_TYPE:sql}" # cassandra, sql, or timescale (for hybrid mode, DATABASE_TS_TYPE value should be cassandra, or timescale)
   ts_latest:
-    type: "${DATABASE_TS_LATEST_TYPE:sql}" # Left for backward compatibility with older versions of ThingsBoard that can be installed with only a Cassandra database
+    type: "${DATABASE_TS_LATEST_TYPE:sql}" # Left for backward compatibility with older versions of ThingsBoard that can be installed with only a Cassandra database.
 
 # Cassandra driver configuration parameters
 cassandra:

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -203,7 +203,7 @@ database:
   ts:
     type: "${DATABASE_TS_TYPE:sql}" # cassandra, sql, or timescale (for hybrid mode, DATABASE_TS_TYPE value should be cassandra, or timescale)
   ts_latest:
-    type: "${DATABASE_TS_LATEST_TYPE:sql}" # cassandra, sql, or timescale (for hybrid mode, DATABASE_TS_TYPE value should be cassandra, or timescale)
+    type: "${DATABASE_TS_LATEST_TYPE:sql}" # Left for backward compatibility with older versions of ThingsBoard that can be installed with only a Cassandra database
 
 # Cassandra driver configuration parameters
 cassandra:


### PR DESCRIPTION
## Pull Request description

This PR is related to [Issue 11410](https://github.com/thingsboard/thingsboard/issues/11410).

A comment related to `DATABASE_TS_LATEST_TYPE` in `application/src/main/resources/thingsboard.yml` is misleading, the same for the description in the [Core/Rule engine deployment parameters](https://thingsboard.io/docs/user-guide/install/config/#database-telemetry-parameters) page which uses the same comment; it suggests that `DATABASE_TS_LATEST_TYP`E needs to be set to `cassandra` when using PostgreSQL + Cassandra which is not true as answered in [Issue 11410](https://github.com/thingsboard/thingsboard/issues/11410). Hence, both the comment and the website need to be updated.
