### PR TITLE
Fixed the problem of getAlarmTypes method query failure in rest-client

### DIFF
--- a/rest-client/src/main/java/org/thingsboard/rest/client/RestClient.java
+++ b/rest-client/src/main/java/org/thingsboard/rest/client/RestClient.java
@@ -507,13 +507,16 @@ public class RestClient implements Closeable {
         return restTemplate.postForEntity(baseURL + "/api/alarm", alarm, Alarm.class).getBody();
     }
 
-    public List<EntitySubtype> getAlarmTypes(PageLink pageLink) {
+    public PageData<EntitySubtype> getAlarmTypes(PageLink pageLink) {
+        Map<String, String> params = new HashMap<>();
+        addPageLinkToParam(params, pageLink);
         return restTemplate.exchange(
                 baseURL + "/api/alarm/types?" + getUrlParams(pageLink),
                 HttpMethod.GET,
                 HttpEntity.EMPTY,
-                new ParameterizedTypeReference<List<EntitySubtype>>() {
-                }).getBody();
+                new ParameterizedTypeReference<PageData<EntitySubtype>>() {
+                },
+                params).getBody();
     }
 
     public AlarmComment saveAlarmComment(AlarmId alarmId, AlarmComment alarmComment) {


### PR DESCRIPTION
## Pull Request description

I introduced java REST Client into my project. When I called getAlarmTypes, I got an error. Then I debugged the rest client code and found that there were some problems. The parameters were not concatenated to the URL. Then I fixed this problem.



