### PR TITLE
lwm2m: fix bug  send From Client CollectedValue

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
@@ -189,7 +189,9 @@ public class LwM2MTestClient {
         locationParams = new LwM2MLocationParams();
         locationParams.getPos();
         initializer.setInstancesForObject(LOCATION, new LwM2mLocation(locationParams.getLatitude(), locationParams.getLongitude(), locationParams.getScaleFactor(), executor, OBJECT_INSTANCE_ID_0));
-        initializer.setInstancesForObject(TEMPERATURE_SENSOR, lwM2MTemperatureSensor = new LwM2mTemperatureSensor(executor, OBJECT_INSTANCE_ID_0), new LwM2mTemperatureSensor(executor, OBJECT_INSTANCE_ID_12));
+        LwM2mTemperatureSensor lwM2mTemperatureSensor0 = new LwM2mTemperatureSensor(executor, OBJECT_INSTANCE_ID_0);
+        LwM2mTemperatureSensor lwM2mTemperatureSensor12 = new LwM2mTemperatureSensor(executor, OBJECT_INSTANCE_ID_12);
+        initializer.setInstancesForObject(TEMPERATURE_SENSOR, lwM2mTemperatureSensor0, lwM2mTemperatureSensor12);
 
         List<LwM2mObjectEnabler> enablers = initializer.createAll();
 
@@ -314,6 +316,7 @@ public class LwM2MTestClient {
         clientDtlsCid = new HashMap<>();
         clientStates.add(ON_INIT);
         leshanClient = builder.build();
+        lwM2mTemperatureSensor12.setLeshanClient(leshanClient);
 
         LwM2mClientObserver observer = new LwM2mClientObserver() {
             @Override

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationReadTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationReadTest.java
@@ -16,19 +16,34 @@
 package org.thingsboard.server.transport.lwm2m.rpc.sql;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.leshan.core.ResponseCode;
+import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.node.TimestampedLwM2mNodes;
+import org.eclipse.leshan.server.registration.Registration;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.transport.lwm2m.rpc.AbstractRpcLwM2MIntegrationTest;
+import org.thingsboard.server.transport.lwm2m.server.uplink.DefaultLwM2mUplinkMsgHandler;
+
+import java.time.Instant;
+import java.util.Map;
 
 import static org.eclipse.leshan.core.LwM2mId.SERVER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.BINARY_APP_DATA_CONTAINER;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_0;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_1;
+import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.OBJECT_INSTANCE_ID_12;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_0;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_1;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_11;
@@ -41,8 +56,12 @@ import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_3_14;
 import static org.thingsboard.server.transport.lwm2m.Lwm2mTestHelper.RESOURCE_ID_NAME_3_9;
 
-
+@Slf4j
 public class RpcLwm2mIntegrationReadTest extends AbstractRpcLwM2MIntegrationTest {
+
+    @SpyBean
+    DefaultLwM2mUplinkMsgHandler defaultUplinkMsgHandlerTest;
+
 
     /**
      * Read {"id":"/3"}
@@ -57,7 +76,7 @@ public class RpcLwm2mIntegrationReadTest extends AbstractRpcLwM2MIntegrationTest
                     String expectedObjectId = pathIdVerToObjectId((String) expected);
                     LwM2mPath expectedPath = new LwM2mPath(expectedObjectId);
                     ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
-                     assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult.get("result").asText());
+                    assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult.get("result").asText());
                     String expectedObjectInstances = "LwM2mObject [id=" + expectedPath.getObjectId() + ", instances={0=LwM2mObjectInstance [id=0, resources=";
                     if (expectedPath.getObjectId() == 1) {
                         expectedObjectInstances = "LwM2mObject [id=1, instances={1=";
@@ -209,6 +228,60 @@ public class RpcLwm2mIntegrationReadTest extends AbstractRpcLwM2MIntegrationTest
         assertTrue(actualValues.contains(expected3_0_14));
         assertTrue(actualValues.contains(expected19_0_0));
         assertTrue(actualValues.contains(expected19_1_0));
+    }
+
+
+    /**
+     * /3303/0/5700
+     *  Read {"id":"/3303/0/5700"}
+     * Trigger a Send operation from the client with multiple values for the same resource as a payload
+     * acked "[{"bn":"/3303/12/5700","bt":1724".. 116 bytes]
+     * 2 values for the resource /3303/12/5700 should be stored with timestamps1 =  Instance.now(), timestamps2 =  Instance.now()
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testReadSingleResource_sendFromClient_CollectedValue() throws Exception {
+        TimestampedLwM2mNodes[] tsNodesHolder = new TimestampedLwM2mNodes[1];
+        doAnswer(inv -> {
+            tsNodesHolder[0] = inv.getArgument(1);
+            return null;
+        }).when(defaultUplinkMsgHandlerTest).onUpdateValueWithSendRequest(
+                Mockito.any(Registration.class),
+                Mockito.any(TimestampedLwM2mNodes.class)
+        );
+        int resourceId = 5700;
+        String expectedIdVer = objectIdVer_3303 + "/" + OBJECT_INSTANCE_ID_12 + "/" + resourceId;
+        String actualResult = sendRPCById(expectedIdVer);
+        verify(defaultUplinkMsgHandlerTest,  timeout(10000).times(1))
+                .onUpdateValueWithSendRequest(Mockito.any(Registration.class), Mockito.any(TimestampedLwM2mNodes.class));
+
+        ObjectNode rpcActualResult = JacksonUtil.fromString(actualResult, ObjectNode.class);
+        assertEquals(ResponseCode.CONTENT.getName(), rpcActualResult.get("result").asText());
+        String expected = "LwM2mSingleResource [id=" + resourceId + ", value=";
+        String actual = rpcActualResult.get("value").asText();
+        assertTrue(actual.contains(expected));
+        int indStart = actual.indexOf(expected) + expected.length();
+        int indEnd = actual.indexOf(",", indStart);
+        String valStr = actual.substring(indStart, indEnd);
+        double dd = Double.parseDouble(valStr);
+        long combined = Double.doubleToRawLongBits(dd);
+        int t0 = (int) (combined >> 32);
+        int t1 = (int) combined;
+        double[] expectedValues ={(double)t0/100, (double)t1/100};
+        int ind = 0;
+        LwM2mPath expectedPath = new LwM2mPath("/3303/12/5700");
+        for (Instant ts : tsNodesHolder[0].getTimestamps()) {
+            Map<LwM2mPath, LwM2mNode> nodesAt = tsNodesHolder[0].getNodesAt(ts);
+            for (var instant : nodesAt.entrySet()) {
+                LwM2mPath actualPath = instant.getKey();
+                LwM2mNode node = instant.getValue();
+                LwM2mResource lwM2mResource = (LwM2mResource) node;
+                assertEquals(expectedPath, actualPath);
+                assertEquals(expectedValues[ind], lwM2mResource.getValue());
+                ind++;
+            }
+        }
     }
 
     /**

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mServerListener.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mServerListener.java
@@ -137,8 +137,9 @@ public class LwM2mServerListener {
 
         @Override
         public void dataReceived(Registration registration, TimestampedLwM2mNodes data, SendRequest request) {
+            log.trace("Received Send request from [{}] containing value: [{}], coapRequest: [{}]", registration.getEndpoint(), data.toString(), request.getCoapRequest().toString());
             if (registration != null) {
-                service.onUpdateValueWithSendRequest(registration, request);
+                service.onUpdateValueWithSendRequest(registration, data);
             }
         }
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/LwM2mUplinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/LwM2mUplinkMsgHandler.java
@@ -15,10 +15,10 @@
  */
 package org.thingsboard.server.transport.lwm2m.server.uplink;
 
+import org.eclipse.leshan.core.node.TimestampedLwM2mNodes;
 import org.eclipse.leshan.core.node.codec.LwM2mValueConverter;
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.request.CreateRequest;
-import org.eclipse.leshan.core.request.SendRequest;
 import org.eclipse.leshan.core.request.WriteCompositeRequest;
 import org.eclipse.leshan.core.request.WriteRequest;
 import org.eclipse.leshan.core.response.ReadCompositeResponse;
@@ -50,7 +50,7 @@ public interface LwM2mUplinkMsgHandler {
     void onUpdateValueAfterReadCompositeResponse(Registration registration, ReadCompositeResponse response);
     void onErrorObservation(Registration registration, String errorMsg);
 
-    void onUpdateValueWithSendRequest(Registration registration, SendRequest sendRequest);
+    void onUpdateValueWithSendRequest(Registration registration, TimestampedLwM2mNodes data);
 
     void onDeviceProfileUpdate(TransportProtos.SessionInfoProto sessionInfo, DeviceProfile deviceProfile);
 


### PR DESCRIPTION
## Pull Request description
### Before:
 - When "Collected Value" with TimestampedLwM2mNodes is sent from the client - only the last node was stored  

### After:
 - When "Collected Value" with TimestampedLwM2mNodes is sent from the client - all node was stored  
 
## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



