### PR TITLE
Aws lambda node: added validation on init

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/aws/lambda/TbAwsLambdaNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/aws/lambda/TbAwsLambdaNode.java
@@ -35,6 +35,7 @@ import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.plugin.ComponentType;
 import org.thingsboard.server.common.msg.TbMsg;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
+import org.thingsboard.server.dao.exception.DataValidationException;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
@@ -65,8 +66,8 @@ public class TbAwsLambdaNode extends TbAbstractExternalNode {
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
         config = TbNodeUtils.convert(configuration, TbAwsLambdaNodeConfiguration.class);
         String errorPrefix = "'" + ctx.getSelf().getName() + "' node configuration is invalid: ";
-        validateFields(config, errorPrefix);
         try {
+            validateFields(config, errorPrefix);
             AWSCredentials awsCredentials = new BasicAWSCredentials(config.getAccessKey(), config.getSecretKey());
             client = AWSLambdaAsyncClientBuilder.standard()
                     .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
@@ -75,6 +76,8 @@ public class TbAwsLambdaNode extends TbAbstractExternalNode {
                             .withConnectionTimeout((int) TimeUnit.SECONDS.toMillis(config.getConnectionTimeout()))
                             .withRequestTimeout((int) TimeUnit.SECONDS.toMillis(config.getRequestTimeout())))
                     .build();
+        } catch (DataValidationException e) {
+            throw new TbNodeException(e, true);
         } catch (Exception e) {
             throw new TbNodeException(e);
         }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/aws/lambda/TbAwsLambdaNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/aws/lambda/TbAwsLambdaNode.java
@@ -39,6 +39,8 @@ import org.thingsboard.server.common.msg.TbMsgMetaData;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
+import static org.thingsboard.server.dao.service.ConstraintValidator.validateFields;
+
 @Slf4j
 @RuleNode(
         type = ComponentType.EXTERNAL,
@@ -62,7 +64,8 @@ public class TbAwsLambdaNode extends TbAbstractExternalNode {
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
         config = TbNodeUtils.convert(configuration, TbAwsLambdaNodeConfiguration.class);
-        validateConfig();
+        String errorPrefix = "'" + ctx.getSelf().getName() + "' node configuration is invalid: ";
+        validateFields(config, errorPrefix);
         try {
             AWSCredentials awsCredentials = new BasicAWSCredentials(config.getAccessKey(), config.getSecretKey());
             client = AWSLambdaAsyncClientBuilder.standard()
@@ -134,27 +137,6 @@ public class TbAwsLambdaNode extends TbAbstractExternalNode {
         metaData.putValue("error", t.getClass() + ": " + t.getMessage());
         metaData.putValue("requestId", invokeResult.getSdkResponseMetadata().getRequestId());
         return TbMsg.transformMsgMetadata(origMsg, metaData);
-    }
-
-    private void validateConfig() throws TbNodeException {
-        if (StringUtils.isBlank(config.getFunctionName())) {
-            throw new TbNodeException("Function name must be set!", true);
-        }
-        if (StringUtils.isBlank(config.getAccessKey())) {
-            throw new TbNodeException("Access Key must be set!", true);
-        }
-        if (StringUtils.isBlank(config.getSecretKey())) {
-            throw new TbNodeException("Secret Access Key must be set!", true);
-        }
-        if (StringUtils.isBlank(config.getRegion())) {
-            throw new TbNodeException("Region must be set!", true);
-        }
-        if (config.getConnectionTimeout() < 0) {
-            throw new TbNodeException("Min connection timeout is 0!", true);
-        }
-        if (config.getRequestTimeout() < 0) {
-            throw new TbNodeException("Min request timeout is 0!", true);
-        }
     }
 
     @Override

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/aws/lambda/TbAwsLambdaNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/aws/lambda/TbAwsLambdaNode.java
@@ -62,9 +62,7 @@ public class TbAwsLambdaNode extends TbAbstractExternalNode {
     @Override
     public void init(TbContext ctx, TbNodeConfiguration configuration) throws TbNodeException {
         config = TbNodeUtils.convert(configuration, TbAwsLambdaNodeConfiguration.class);
-        if (StringUtils.isBlank(config.getFunctionName())) {
-            throw new TbNodeException("Function name must be set!", true);
-        }
+        validateConfig();
         try {
             AWSCredentials awsCredentials = new BasicAWSCredentials(config.getAccessKey(), config.getSecretKey());
             client = AWSLambdaAsyncClientBuilder.standard()
@@ -136,6 +134,27 @@ public class TbAwsLambdaNode extends TbAbstractExternalNode {
         metaData.putValue("error", t.getClass() + ": " + t.getMessage());
         metaData.putValue("requestId", invokeResult.getSdkResponseMetadata().getRequestId());
         return TbMsg.transformMsgMetadata(origMsg, metaData);
+    }
+
+    private void validateConfig() throws TbNodeException {
+        if (StringUtils.isBlank(config.getFunctionName())) {
+            throw new TbNodeException("Function name must be set!", true);
+        }
+        if (StringUtils.isBlank(config.getAccessKey())) {
+            throw new TbNodeException("Access Key must be set!", true);
+        }
+        if (StringUtils.isBlank(config.getSecretKey())) {
+            throw new TbNodeException("Secret Access Key must be set!", true);
+        }
+        if (StringUtils.isBlank(config.getRegion())) {
+            throw new TbNodeException("Region must be set!", true);
+        }
+        if (config.getConnectionTimeout() < 0) {
+            throw new TbNodeException("Min connection timeout is 0!", true);
+        }
+        if (config.getRequestTimeout() < 0) {
+            throw new TbNodeException("Min request timeout is 0!", true);
+        }
     }
 
     @Override

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/aws/lambda/TbAwsLambdaNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/aws/lambda/TbAwsLambdaNodeConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.thingsboard.rule.engine.aws.lambda;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import org.thingsboard.rule.engine.api.NodeConfiguration;
 
@@ -23,12 +25,18 @@ public class TbAwsLambdaNodeConfiguration implements NodeConfiguration<TbAwsLamb
 
     public static final String DEFAULT_QUALIFIER = "$LATEST";
 
+    @NotBlank
     private String accessKey;
+    @NotBlank
     private String secretKey;
+    @NotBlank
     private String region;
+    @NotBlank
     private String functionName;
     private String qualifier;
+    @Min(0)
     private int connectionTimeout;
+    @Min(0)
     private int requestTimeout;
     private boolean tellFailureIfFuncThrowsExc;
 


### PR DESCRIPTION
## Pull Request description

Added validation for Aws lambda node on init.   

There are no conflicts with PE.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



