### PR TITLE
Image service: default image sub-type value added to requests

### DIFF
--- a/ui-ngx/src/app/core/http/image.service.ts
+++ b/ui-ngx/src/app/core/http/image.service.ts
@@ -87,8 +87,8 @@ export class ImageService {
       imageInfo, defaultHttpOptionsFromConfig(config));
   }
 
-  public getImages(pageLink: PageLink, imageSubType: ResourceSubType = ResourceSubType.IMAGE,
-                   includeSystemImages = false, config?: RequestConfig): Observable<PageData<ImageResourceInfo>> {
+  public getImages(pageLink: PageLink, includeSystemImages = false,
+                   imageSubType: ResourceSubType = ResourceSubType.IMAGE, config?: RequestConfig): Observable<PageData<ImageResourceInfo>> {
     return this.http.get<PageData<ImageResourceInfo>>(
       `${IMAGES_URL_PREFIX}${pageLink.toQuery()}&imageSubType=${imageSubType}&includeSystemImages=${includeSystemImages}`,
       defaultHttpOptionsFromConfig(config));

--- a/ui-ngx/src/app/core/http/image.service.ts
+++ b/ui-ngx/src/app/core/http/image.service.ts
@@ -21,11 +21,15 @@ import { defaultHttpOptionsFromConfig, defaultHttpUploadOptions, RequestConfig }
 import { Observable, of, ReplaySubject } from 'rxjs';
 import { PageData } from '@shared/models/page/page-data';
 import {
-  NO_IMAGE_DATA_URI,
+  ImageExportData,
   ImageResourceInfo,
-  imageResourceType,
   ImageResourceType,
-  IMAGES_URL_PREFIX, isImageResourceUrl, ImageExportData, removeTbImagePrefix, ResourceSubType
+  imageResourceType,
+  IMAGES_URL_PREFIX,
+  isImageResourceUrl,
+  NO_IMAGE_DATA_URI,
+  removeTbImagePrefix,
+  ResourceSubType
 } from '@shared/models/resource.models';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
@@ -46,7 +50,8 @@ export class ImageService {
   ) {
   }
 
-  public uploadImage(file: File, title: string, imageSubType: ResourceSubType, config?: RequestConfig): Observable<ImageResourceInfo> {
+  public uploadImage(file: File, title: string, imageSubType: ResourceSubType = ResourceSubType.IMAGE,
+                     config?: RequestConfig): Observable<ImageResourceInfo> {
     if (!config) {
       config = {};
     }
@@ -82,7 +87,7 @@ export class ImageService {
       imageInfo, defaultHttpOptionsFromConfig(config));
   }
 
-  public getImages(pageLink: PageLink, imageSubType: ResourceSubType,
+  public getImages(pageLink: PageLink, imageSubType: ResourceSubType = ResourceSubType.IMAGE,
                    includeSystemImages = false, config?: RequestConfig): Observable<PageData<ImageResourceInfo>> {
     return this.http.get<PageData<ImageResourceInfo>>(
       `${IMAGES_URL_PREFIX}${pageLink.toQuery()}&imageSubType=${imageSubType}&includeSystemImages=${includeSystemImages}`,

--- a/ui-ngx/src/app/shared/components/image/image-gallery.component.ts
+++ b/ui-ngx/src/app/shared/components/image/image-gallery.component.ts
@@ -205,7 +205,7 @@ export class ImageGalleryComponent extends PageComponent implements OnInit, OnDe
         property: 'createdTime',
         direction: Direction.DESC
       });
-      return this.imageService.getImages(pageLink, this.imageSubType, filter.includeSystemImages);
+      return this.imageService.getImages(pageLink, filter.includeSystemImages, this.imageSubType);
     };
   }
 

--- a/ui-ngx/src/app/shared/components/image/images-datasource.ts
+++ b/ui-ngx/src/app/shared/components/image/images-datasource.ts
@@ -84,7 +84,7 @@ export class ImagesDatasource implements DataSource<ImageResourceInfo> {
   }
 
   fetchEntities(pageLink: PageLink, imageSubType: ResourceSubType, includeSystemImages = false): Observable<PageData<ImageResourceInfo>> {
-    return this.imageService.getImages(pageLink, imageSubType, includeSystemImages);
+    return this.imageService.getImages(pageLink, includeSystemImages, imageSubType);
   }
 
   isAllSelected(): Observable<boolean> {


### PR DESCRIPTION
## Pull Request description

Default image sub-type value added, and the order of parameters in requests changed to keep the backward compatibility with older version

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




