### PR TITLE
Mqtt node: added validation for client id

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/TbMqttNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/TbMqttNode.java
@@ -152,7 +152,7 @@ public class TbMqttNode extends TbAbstractExternalNode {
                 this.mqttNodeConfiguration.getClientId() + "_" + ctx.getServiceId() :
                 this.mqttNodeConfiguration.getClientId();
         if (clientId.length() > 23) {
-            throw new TbNodeException("Client ID was too long '" + clientId + "'. " +
+            throw new TbNodeException("Client ID is too long '" + clientId + "'. " +
                     "The length of Client ID cannot be longer than 23, but current length is " + clientId.length() + ".", true);
         }
         return clientId;

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/mqtt/TbMqttNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/mqtt/TbMqttNodeTest.java
@@ -192,6 +192,42 @@ public class TbMqttNodeTest extends AbstractRuleNodeUpgradeTest {
     }
 
     @Test
+    public void givenClientIdIsTooLong_whenInit_thenThrowsException() {
+        String invalidClientId = "vhfrbeb38ygwfwrgfwefgterhytjytj";
+        mqttNodeConfig.setClientId(invalidClientId);
+
+        given(ctxMock.getTenantId()).willReturn(TENANT_ID);
+        given(ctxMock.getSelf()).willReturn(new RuleNode(RULE_NODE_ID));
+
+        assertThatThrownBy(() -> mqttNode.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(mqttNodeConfig))))
+                .isInstanceOf(TbNodeException.class)
+                .hasMessage("Client ID was too long '" + invalidClientId + "'. " +
+                        "The length of Client ID cannot be longer than 23, but current length is " + invalidClientId.length() + ".")
+                .extracting(e -> ((TbNodeException) e).isUnrecoverable())
+                .isEqualTo(true);
+    }
+
+    @Test
+    public void givenClientIdIsOkAndAppendClientIdSuffixIsTrue_whenInit_thenClientIdBecomesInvalidAndThrowsException() {
+        String validClientId = "fertjnhnjj4ge";
+        mqttNodeConfig.setClientId("fertjnhnjj4ge");
+        mqttNodeConfig.setAppendClientIdSuffix(true);
+
+        given(ctxMock.getTenantId()).willReturn(TENANT_ID);
+        given(ctxMock.getSelf()).willReturn(new RuleNode(RULE_NODE_ID));
+        String serviceId = "test-service";
+        given(ctxMock.getServiceId()).willReturn(serviceId);
+
+        String resultedClientId = validClientId + "_" + serviceId;
+        assertThatThrownBy(() -> mqttNode.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(mqttNodeConfig))))
+                .isInstanceOf(TbNodeException.class)
+                .hasMessage("Client ID was too long '" + resultedClientId + "'. " +
+                        "The length of Client ID cannot be longer than 23, but current length is " + resultedClientId.length() + ".")
+                .extracting(e -> ((TbNodeException) e).isUnrecoverable())
+                .isEqualTo(true);
+    }
+
+    @Test
     public void givenFailedByTimeoutConnectResult_whenInit_thenThrowsException() throws ExecutionException, InterruptedException, TimeoutException {
         mqttNodeConfig.setHost("localhost");
         mqttNodeConfig.setClientId("bfrbTESTmfkr23");

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/mqtt/TbMqttNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/mqtt/TbMqttNodeTest.java
@@ -201,7 +201,7 @@ public class TbMqttNodeTest extends AbstractRuleNodeUpgradeTest {
 
         assertThatThrownBy(() -> mqttNode.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(mqttNodeConfig))))
                 .isInstanceOf(TbNodeException.class)
-                .hasMessage("Client ID was too long '" + invalidClientId + "'. " +
+                .hasMessage("Client ID is too long '" + invalidClientId + "'. " +
                         "The length of Client ID cannot be longer than 23, but current length is " + invalidClientId.length() + ".")
                 .extracting(e -> ((TbNodeException) e).isUnrecoverable())
                 .isEqualTo(true);
@@ -221,7 +221,7 @@ public class TbMqttNodeTest extends AbstractRuleNodeUpgradeTest {
         String resultedClientId = validClientId + "_" + serviceId;
         assertThatThrownBy(() -> mqttNode.init(ctxMock, new TbNodeConfiguration(JacksonUtil.valueToTree(mqttNodeConfig))))
                 .isInstanceOf(TbNodeException.class)
-                .hasMessage("Client ID was too long '" + resultedClientId + "'. " +
+                .hasMessage("Client ID is too long '" + resultedClientId + "'. " +
                         "The length of Client ID cannot be longer than 23, but current length is " + resultedClientId.length() + ".")
                 .extracting(e -> ((TbNodeException) e).isUnrecoverable())
                 .isEqualTo(true);


### PR DESCRIPTION
## Pull Request description

Added validation for client id, since error occurs during initialization, when client id length is longer than 23. 
It happens because we use Mqtt version 3.1. According to the MQTT 3.1 specification, the client ID should be between 1 and 23 characters.

PE PR: https://github.com/thingsboard/thingsboard-pe/pull/2799

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



