### PR TITLE
Fix last activity not being reported when activity reporting period ends

### DIFF
--- a/common/queue/src/main/java/org/thingsboard/server/queue/scheduler/DefaultSchedulerComponent.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/scheduler/DefaultSchedulerComponent.java
@@ -31,13 +31,11 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class DefaultSchedulerComponent implements SchedulerComponent {
 
-    private static final String SCHEDULER_NAME = "queue-scheduler";
-
     private ScheduledExecutorService schedulerExecutor;
 
     @PostConstruct
     public void init() {
-        schedulerExecutor = Executors.newSingleThreadScheduledExecutor(ThingsBoardThreadFactory.forName(SCHEDULER_NAME));
+        schedulerExecutor = Executors.newSingleThreadScheduledExecutor(ThingsBoardThreadFactory.forName("queue-scheduler"));
     }
 
     @PreDestroy
@@ -66,8 +64,8 @@ public class DefaultSchedulerComponent implements SchedulerComponent {
     private void runSafely(Runnable command) {
         try {
             command.run();
-        } catch (Exception e) {
-            log.error("[{}] Unexpected error occurred while executing task! {}", SCHEDULER_NAME, Thread.currentThread(), e);
+        } catch (Throwable t) {
+            log.error("Unexpected error occurred while executing task!", t);
         }
     }
 

--- a/common/queue/src/main/java/org/thingsboard/server/queue/scheduler/DefaultSchedulerComponent.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/scheduler/DefaultSchedulerComponent.java
@@ -15,25 +15,29 @@
  */
 package org.thingsboard.server.queue.scheduler;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.thingsboard.common.util.ThingsBoardThreadFactory;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Component
 public class DefaultSchedulerComponent implements SchedulerComponent {
 
-    protected ScheduledExecutorService schedulerExecutor;
+    private static final String SCHEDULER_NAME = "queue-scheduler";
+
+    private ScheduledExecutorService schedulerExecutor;
 
     @PostConstruct
     public void init() {
-        this.schedulerExecutor = Executors.newSingleThreadScheduledExecutor(ThingsBoardThreadFactory.forName("queue-scheduler"));
+        schedulerExecutor = Executors.newSingleThreadScheduledExecutor(ThingsBoardThreadFactory.forName(SCHEDULER_NAME));
     }
 
     @PreDestroy
@@ -52,10 +56,19 @@ public class DefaultSchedulerComponent implements SchedulerComponent {
     }
 
     public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
-        return schedulerExecutor.scheduleAtFixedRate(command, initialDelay, period, unit);
+        return schedulerExecutor.scheduleAtFixedRate(() -> runSafely(command), initialDelay, period, unit);
     }
 
     public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-        return schedulerExecutor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+        return schedulerExecutor.scheduleWithFixedDelay(() -> runSafely(command), initialDelay, delay, unit);
     }
+
+    private void runSafely(Runnable command) {
+        try {
+            command.run();
+        } catch (Exception e) {
+            log.error("[{}] Unexpected error occurred while executing task! {}", SCHEDULER_NAME, Thread.currentThread(), e);
+        }
+    }
+
 }

--- a/common/queue/src/test/java/org/thingsboard/server/queue/scheduler/DefaultSchedulerComponentTest.java
+++ b/common/queue/src/test/java/org/thingsboard/server/queue/scheduler/DefaultSchedulerComponentTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.queue.scheduler;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultSchedulerComponentTest {
+
+    DefaultSchedulerComponent schedulerComponent;
+
+    @BeforeEach
+    void setup() {
+        schedulerComponent = new DefaultSchedulerComponent();
+        schedulerComponent.init();
+    }
+
+    @AfterEach
+    void cleanup() {
+        schedulerComponent.destroy();
+    }
+
+    @Test
+    @DisplayName("scheduleAtFixedRate() should continue periodic execution even if command throws exception")
+    void scheduleAtFixedRateShouldNotStopPeriodicExecutionWhenCommandThrowsException() {
+        // GIVEN
+        var wasExecutedAtLeastOnce = new AtomicBoolean(false);
+
+        Runnable exceptionThrowingCommand = () -> {
+            try {
+                throw new RuntimeException("Unexpected exception");
+            } finally {
+                wasExecutedAtLeastOnce.set(true);
+            }
+        };
+
+        // WHEN
+        ScheduledFuture<?> future = schedulerComponent.scheduleAtFixedRate(exceptionThrowingCommand, 0, 200, TimeUnit.MILLISECONDS);
+
+        // THEN
+        Awaitility.await().alias("Wait until command is executed at least once")
+                .atMost(5, TimeUnit.SECONDS)
+                .until(wasExecutedAtLeastOnce::get);
+
+        assertThat(future.isDone()).as("Periodic execution should not stop after unhandled exception is thrown by the command").isFalse();
+    }
+
+    @Test
+    @DisplayName("scheduleWithFixedDelay() should continue periodic execution even if command throws exception")
+    void scheduleWithFixedDelayShouldNotStopPeriodicExecutionWhenCommandThrowsException() {
+        // GIVEN
+        var wasExecutedAtLeastOnce = new AtomicBoolean(false);
+
+        Runnable exceptionThrowingCommand = () -> {
+            try {
+                throw new RuntimeException("Unexpected exception");
+            } finally {
+                wasExecutedAtLeastOnce.set(true);
+            }
+        };
+
+        // WHEN
+        ScheduledFuture<?> future = schedulerComponent.scheduleWithFixedDelay(exceptionThrowingCommand, 0, 200, TimeUnit.MILLISECONDS);
+
+        // THEN
+        Awaitility.await().alias("Wait until command is executed at least once")
+                .atMost(5, TimeUnit.SECONDS)
+                .until(wasExecutedAtLeastOnce::get);
+
+        assertThat(future.isDone()).as("Periodic execution should not stop after unhandled exception is thrown by the command").isFalse();
+    }
+
+}

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/activity/strategy/FirstAndLastEventActivityStrategy.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/activity/strategy/FirstAndLastEventActivityStrategy.java
@@ -16,7 +16,9 @@
 package org.thingsboard.server.common.transport.activity.strategy;
 
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
+@ToString
 @EqualsAndHashCode
 public final class FirstAndLastEventActivityStrategy implements ActivityStrategy {
 

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/activity/strategy/FirstEventActivityStrategy.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/activity/strategy/FirstEventActivityStrategy.java
@@ -16,7 +16,9 @@
 package org.thingsboard.server.common.transport.activity.strategy;
 
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
+@ToString
 @EqualsAndHashCode
 public final class FirstEventActivityStrategy implements ActivityStrategy {
 


### PR DESCRIPTION
When `onReportingPeriodEnd()` throws an exception it causes periodic task to stop all all further executions. Result of this was that activities were not reported at all.

[PE PR](https://github.com/thingsboard/thingsboard-pe/pull/2801)