### PR TITLE
Fixed issue with Edge Root Rule Chain cache for related edges

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/EdgeEventSourcingListener.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/EdgeEventSourcingListener.java
@@ -34,8 +34,10 @@ import org.thingsboard.server.common.data.alarm.AlarmComment;
 import org.thingsboard.server.common.data.alarm.EntityAlarm;
 import org.thingsboard.server.common.data.audit.ActionType;
 import org.thingsboard.server.common.data.domain.Domain;
+import org.thingsboard.server.common.data.edge.Edge;
 import org.thingsboard.server.common.data.edge.EdgeEventActionType;
 import org.thingsboard.server.common.data.edge.EdgeEventType;
+import org.thingsboard.server.common.data.id.RuleChainId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.relation.EntityRelation;
 import org.thingsboard.server.common.data.relation.RelationTypeGroup;
@@ -134,6 +136,15 @@ public class EdgeEventSourcingListener {
             return;
         }
         try {
+            if (event.getEntityId().getEntityType().equals(EntityType.RULE_CHAIN) && event.getEdgeId() != null && event.getActionType().equals(ActionType.ASSIGNED_TO_EDGE)) {
+                try {
+                    Edge edge = JacksonUtil.fromString(event.getBody(), Edge.class);
+                    if (edge != null && new RuleChainId(event.getEntityId().getId()).equals(edge.getRootRuleChainId())) {
+                        log.trace("skipping ASSIGNED_TO_EDGE event of RULE_CHAIN entity in case Edge Root Rule Chain: {}", event);
+                        return;
+                    }
+                } catch (Exception ignored) {}
+            }
             log.trace("[{}] ActionEntityEvent called: {}", event.getTenantId(), event);
             tbClusterService.sendNotificationMsgToEdge(event.getTenantId(), event.getEdgeId(), event.getEntityId(),
                     event.getBody(), null, EdgeUtils.getEdgeEventActionTypeByActionType(event.getActionType()),

--- a/application/src/main/java/org/thingsboard/server/service/edge/EdgeEventSourcingListener.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/EdgeEventSourcingListener.java
@@ -140,10 +140,12 @@ public class EdgeEventSourcingListener {
                 try {
                     Edge edge = JacksonUtil.fromString(event.getBody(), Edge.class);
                     if (edge != null && new RuleChainId(event.getEntityId().getId()).equals(edge.getRootRuleChainId())) {
-                        log.trace("skipping ASSIGNED_TO_EDGE event of RULE_CHAIN entity in case Edge Root Rule Chain: {}", event);
+                        log.trace("[{}] skipping ASSIGNED_TO_EDGE event of RULE_CHAIN entity in case Edge Root Rule Chain: {}", event.getTenantId(), event);
                         return;
                     }
-                } catch (Exception ignored) {}
+                } catch (Exception ignored) {
+                    return;
+                }
             }
             log.trace("[{}] ActionEntityEvent called: {}", event.getTenantId(), event);
             tbClusterService.sendNotificationMsgToEdge(event.getTenantId(), event.getEdgeId(), event.getEntityId(),

--- a/application/src/main/java/org/thingsboard/server/service/edge/RelatedEdgesSourcingListener.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/RelatedEdgesSourcingListener.java
@@ -55,6 +55,7 @@ public class RelatedEdgesSourcingListener {
     @TransactionalEventListener(fallbackExecution = true)
     public void handleEvent(ActionEntityEvent<?> event) {
         executorService.submit(() -> {
+            log.trace("[{}] ActionEntityEvent called: {}", event.getTenantId(), event);
             try {
                 switch (event.getActionType()) {
                     case ASSIGNED_TO_EDGE, UNASSIGNED_FROM_EDGE ->
@@ -69,6 +70,7 @@ public class RelatedEdgesSourcingListener {
     @TransactionalEventListener(fallbackExecution = true)
     public void handleEvent(DeleteEntityEvent<?> event) {
         executorService.submit(() -> {
+            log.trace("[{}] DeleteEntityEvent called: {}", event.getTenantId(), event);
             try {
                 relatedEdgesService.publishRelatedEdgeIdsEvictEvent(event.getTenantId(), event.getEntityId());
             } catch (Exception e) {

--- a/application/src/test/java/org/thingsboard/server/edge/AbstractEdgeTest.java
+++ b/application/src/test/java/org/thingsboard/server/edge/AbstractEdgeTest.java
@@ -103,6 +103,7 @@ import org.thingsboard.server.gen.edge.v1.UserUpdateMsg;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -123,6 +124,8 @@ abstract public class AbstractEdgeTest extends AbstractControllerTest {
 
     protected EdgeImitator edgeImitator;
     protected Edge edge;
+
+    private Random random = new Random();
 
     @Autowired
     protected EdgeEventService edgeEventService;
@@ -191,10 +194,7 @@ abstract public class AbstractEdgeTest extends AbstractControllerTest {
 
         Asset savedAsset = saveAsset("Edge Asset 1");
 
-        RuleChainId rootRuleChainId = getEdgeRootRuleChainId();
-        RuleChainMetaData rootRuleChainMetadata = doGet("/api/ruleChain/" + rootRuleChainId.getId().toString() + "/metadata", RuleChainMetaData.class);
-        rootRuleChainMetadata.getNodes().forEach(n -> n.setDebugMode(true));
-        doPost("/api/ruleChain/metadata", rootRuleChainMetadata, RuleChainMetaData.class);
+        updateRootRuleChainMetadata();
 
         edge = doPost("/api/edge", constructEdge("Test Edge", "test"), Edge.class);
 
@@ -205,6 +205,13 @@ abstract public class AbstractEdgeTest extends AbstractControllerTest {
 
         // wait until assign device and asset events are fully processed by edge notification service
         TimeUnit.MILLISECONDS.sleep(1000);
+    }
+
+    protected void updateRootRuleChainMetadata() throws Exception {
+        RuleChainId rootRuleChainId = getEdgeRootRuleChainId();
+        RuleChainMetaData rootRuleChainMetadata = doGet("/api/ruleChain/" + rootRuleChainId.getId().toString() + "/metadata", RuleChainMetaData.class);
+        rootRuleChainMetadata.getNodes().forEach(n -> n.setDebugMode(random.nextBoolean()));
+        doPost("/api/ruleChain/metadata", rootRuleChainMetadata, RuleChainMetaData.class);
     }
 
     protected void extendDeviceProfileData(DeviceProfile deviceProfile) {

--- a/application/src/test/java/org/thingsboard/server/edge/RuleChainEdgeTest.java
+++ b/application/src/test/java/org/thingsboard/server/edge/RuleChainEdgeTest.java
@@ -186,6 +186,21 @@ public class RuleChainEdgeTest extends AbstractEdgeTest {
     }
 
     @Test
+    public void testUpdateRootRuleChain() throws Exception {
+        RuleChainMetaData rootRuleChainMetadata = doGet("/api/ruleChain/" + edge.getRootRuleChainId().getId().toString() + "/metadata", RuleChainMetaData.class);
+
+        rootRuleChainMetadata.getNodes().forEach(n -> n.setDebugMode(true));
+        edgeImitator.expectMessageAmount(2);
+        doPost("/api/ruleChain/metadata", rootRuleChainMetadata, RuleChainMetaData.class);
+        Assert.assertTrue(edgeImitator.waitForMessages());
+
+        Optional<RuleChainUpdateMsg> ruleChainUpdateMsgOpt = edgeImitator.findMessageByType(RuleChainUpdateMsg.class);
+        Assert.assertTrue(ruleChainUpdateMsgOpt.isPresent());
+        Optional<RuleChainMetadataUpdateMsg> ruleChainMetadataUpdateMsgOpt = edgeImitator.findMessageByType(RuleChainMetadataUpdateMsg.class);
+        Assert.assertTrue(ruleChainMetadataUpdateMsgOpt.isPresent());
+    }
+
+    @Test
     public void testSetRootRuleChain() throws Exception {
         // create rule chain
         RuleChain ruleChain = new RuleChain();

--- a/application/src/test/java/org/thingsboard/server/edge/RuleChainEdgeTest.java
+++ b/application/src/test/java/org/thingsboard/server/edge/RuleChainEdgeTest.java
@@ -187,11 +187,8 @@ public class RuleChainEdgeTest extends AbstractEdgeTest {
 
     @Test
     public void testUpdateRootRuleChain() throws Exception {
-        RuleChainMetaData rootRuleChainMetadata = doGet("/api/ruleChain/" + edge.getRootRuleChainId().getId().toString() + "/metadata", RuleChainMetaData.class);
-
-        rootRuleChainMetadata.getNodes().forEach(n -> n.setDebugMode(true));
         edgeImitator.expectMessageAmount(2);
-        doPost("/api/ruleChain/metadata", rootRuleChainMetadata, RuleChainMetaData.class);
+        updateRootRuleChainMetadata();
         Assert.assertTrue(edgeImitator.waitForMessages());
 
         Optional<RuleChainUpdateMsg> ruleChainUpdateMsgOpt = edgeImitator.findMessageByType(RuleChainUpdateMsg.class);

--- a/dao/src/main/java/org/thingsboard/server/dao/edge/BaseRelatedEdgesService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/edge/BaseRelatedEdgesService.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.dao.edge;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,7 @@ import org.thingsboard.server.common.data.page.PageLink;
 import org.thingsboard.server.dao.entity.AbstractCachedEntityService;
 
 @Service
+@Slf4j
 public class BaseRelatedEdgesService extends AbstractCachedEntityService<RelatedEdgesCacheKey, RelatedEdgesCacheValue, RelatedEdgesEvictEvent> implements RelatedEdgesService {
 
     public static final int RELATED_EDGES_CACHE_ITEMS = 1000;
@@ -47,6 +49,7 @@ public class BaseRelatedEdgesService extends AbstractCachedEntityService<Related
 
     @Override
     public PageData<EdgeId> findEdgeIdsByEntityId(TenantId tenantId, EntityId entityId, PageLink pageLink) {
+        log.trace("Executing findEdgeIdsByEntityId, tenantId [{}], entityId [{}], pageLink [{}]", tenantId, entityId, pageLink);
         if (!pageLink.equals(FIRST_PAGE)) {
             return edgeService.findEdgeIdsByTenantIdAndEntityId(tenantId, entityId, pageLink);
         }
@@ -56,6 +59,7 @@ public class BaseRelatedEdgesService extends AbstractCachedEntityService<Related
 
     @Override
     public void publishRelatedEdgeIdsEvictEvent(TenantId tenantId, EntityId entityId) {
+        log.trace("Executing publishRelatedEdgeIdsEvictEvent, tenantId [{}], entityId [{}]", tenantId, entityId);
         publishEvictEvent(new RelatedEdgesEvictEvent(tenantId, entityId));
     }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
@@ -640,10 +640,8 @@ public class BaseRuleChainService extends AbstractEntityService implements RuleC
             log.warn("[{}] Failed to create ruleChain relation. Edge Id: [{}]", ruleChainId, edgeId);
             throw new RuntimeException(e);
         }
-        if (!ruleChainId.equals(edge.getRootRuleChainId())) {
-            eventPublisher.publishEvent(ActionEntityEvent.builder().tenantId(tenantId).edgeId(edgeId).entityId(ruleChainId)
-                    .actionType(ActionType.ASSIGNED_TO_EDGE).build());
-        }
+        eventPublisher.publishEvent(ActionEntityEvent.builder().tenantId(tenantId).edgeId(edgeId).entityId(ruleChainId)
+                .actionType(ActionType.ASSIGNED_TO_EDGE).body(JacksonUtil.toString(edge)).build());
         return ruleChain;
     }
 


### PR DESCRIPTION
## Pull Request description

This PR introduces fixes for caching for the related edge functionality within the root rule chain. Initially, an empty list is cached, but it was never updated due to the 'Assign to Edge' action events being ignored. Now, all assignment events are pushed, and filters are applied at subsequent levels.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



