### PR TITLE
Fixed next button for notify again dialog

### DIFF
--- a/ui-ngx/src/app/shared/components/entity/entity-list.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-list.component.ts
@@ -46,6 +46,7 @@ import { MatChipGrid } from '@angular/material/chips';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { SubscriptSizing } from '@angular/material/form-field';
 import { coerceBoolean } from '@shared/decorators/coercion';
+import { isArray } from 'lodash';
 
 @Component({
   selector: 'tb-entity-list',
@@ -196,8 +197,8 @@ export class EntityListComponent implements ControlValueAccessor, OnInit, AfterV
           this.entityListFormGroup.get('entities').setValue(this.entities);
           if (this.syncIdsWithDB && this.modelValue.length !== entities.length) {
             this.modelValue = entities.map(entity => entity.id.id);
+            this.propagateChange(this.modelValue);
           }
-          this.propagateChange(this.modelValue);
         }
       );
     } else {
@@ -209,7 +210,7 @@ export class EntityListComponent implements ControlValueAccessor, OnInit, AfterV
   }
 
   validate(): ValidationErrors | null {
-    return this.entityListFormGroup.valid ? null : {
+    return isArray(this.modelValue) && this.modelValue.length ? null : {
       entities: {valid: false}
     };
   }

--- a/ui-ngx/src/app/shared/components/entity/entity-list.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-list.component.ts
@@ -196,8 +196,8 @@ export class EntityListComponent implements ControlValueAccessor, OnInit, AfterV
           this.entityListFormGroup.get('entities').setValue(this.entities);
           if (this.syncIdsWithDB && this.modelValue.length !== entities.length) {
             this.modelValue = entities.map(entity => entity.id.id);
-            this.propagateChange(this.modelValue);
           }
+          this.propagateChange(this.modelValue);
         }
       );
     } else {

--- a/ui-ngx/src/app/shared/components/entity/entity-list.component.ts
+++ b/ui-ngx/src/app/shared/components/entity/entity-list.component.ts
@@ -210,7 +210,7 @@ export class EntityListComponent implements ControlValueAccessor, OnInit, AfterV
   }
 
   validate(): ValidationErrors | null {
-    return isArray(this.modelValue) && this.modelValue.length ? null : {
+    return (isArray(this.modelValue) && this.modelValue.length) || !this.required ? null : {
       entities: {valid: false}
     };
   }


### PR DESCRIPTION
## Pull Request description

Steps to reproduce:
- Go to the Notification page
- Open Sent category at the top
- Click the “Notify again” button
- Click the Next button at the dialog bottom right side

Actual result: Nothing happened when a user click Next button inside the Notify again dialog

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



