### PR TITLE
fixed concurrent modification in TbSubscriptionsInfo

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscriptionsInfo.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/TbSubscriptionsInfo.java
@@ -20,6 +20,7 @@ import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -48,7 +49,7 @@ public class TbSubscriptionsInfo {
     }
 
     protected TbSubscriptionsInfo copy(int seqNumber) {
-        return new TbSubscriptionsInfo(notifications, alarms, tsAllKeys, tsKeys, attrAllKeys, attrKeys, seqNumber);
+        return new TbSubscriptionsInfo(notifications, alarms, tsAllKeys, tsKeys != null ? new HashSet<>(tsKeys) : null, attrAllKeys, attrKeys != null ? new HashSet<>(attrKeys) : null, seqNumber);
     }
 
 }

--- a/application/src/test/java/org/thingsboard/server/service/subscription/DefaultTbLocalSubscriptionServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/subscription/DefaultTbLocalSubscriptionServiceTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright © 2016-2024 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.subscription;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.server.cache.limits.RateLimitService;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.limit.LimitedApi;
+import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
+import org.thingsboard.server.gen.transport.TransportProtos;
+import org.thingsboard.server.queue.discovery.PartitionService;
+import org.thingsboard.server.service.ws.WebSocketSessionRef;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DefaultTbLocalSubscriptionServiceTest {
+
+    ListAppender<ILoggingEvent> testLogAppender;
+    TbLocalSubscriptionService subscriptionService;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        Logger logger = (Logger) LoggerFactory.getLogger(DefaultTbLocalSubscriptionService.class);
+        testLogAppender = new ListAppender<>();
+        testLogAppender.start();
+        logger.addAppender(testLogAppender);
+
+        RateLimitService rateLimitService = mock();
+        when(rateLimitService.checkRateLimit(eq(LimitedApi.WS_SUBSCRIPTIONS), any(Object.class), nullable(String.class))).thenReturn(true);
+        PartitionService partitionService = mock();
+        when(partitionService.resolve(any(), any(), any())).thenReturn(TopicPartitionInfo.builder().build());
+        subscriptionService = new DefaultTbLocalSubscriptionService(mock(), mock(), mock(), partitionService, mock(), mock(), mock(), rateLimitService);
+        ReflectionTestUtils.setField(subscriptionService, "serviceId", "serviceId");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (testLogAppender != null) {
+            testLogAppender.stop();
+            Logger logger = (Logger) LoggerFactory.getLogger(DefaultTbLocalSubscriptionService.class);
+            logger.detachAppender(testLogAppender);
+        }
+    }
+
+    @Test
+    public void addSubscriptionConcurrentModificationTest() throws Exception {
+        ListeningExecutorService executorService = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(10));
+        TenantId tenantId = new TenantId(UUID.randomUUID());
+        DeviceId deviceId = new DeviceId(UUID.randomUUID());
+        WebSocketSessionRef sessionRef = mock();
+        ReflectionTestUtils.setField(subscriptionService, "subscriptionUpdateExecutor", executorService);
+
+        List<ListenableFuture<?>> futures = new ArrayList<>();
+
+        try {
+            subscriptionService.onCoreStartupMsg(TransportProtos.CoreStartupMsg.newBuilder().addAllPartitions(List.of(0)).getDefaultInstanceForType());
+            for (int i = 0; i < 50; i++) {
+                futures.add(executorService.submit(() -> subscriptionService.addSubscription(createSubscription(tenantId, deviceId), sessionRef)));
+            }
+            Futures.allAsList(futures).get();
+        } finally {
+            executorService.shutdownNow();
+        }
+
+        List<ILoggingEvent> logs = testLogAppender.list;
+        boolean exceptionLogged = logs.stream()
+                .filter(event -> event.getThrowableProxy() != null)
+                .map(event -> event.getThrowableProxy().getClassName())
+                .anyMatch(log -> log.equals("java.util.ConcurrentModificationException"));
+
+        assertFalse(exceptionLogged, "Detected ConcurrentModificationException!");
+    }
+
+    private TbSubscription<?> createSubscription(TenantId tenantId, EntityId entityId) {
+        Map<String, Long> keys = new HashMap<>();
+        for (int i = 0; i < 50; i++) {
+            keys.put(RandomStringUtils.randomAlphanumeric(5), 1L);
+        }
+        return TbAttributeSubscription.builder()
+                .tenantId(tenantId)
+                .entityId(entityId)
+                .subscriptionId(1)
+                .sessionId(RandomStringUtils.randomAlphanumeric(5))
+                .keyStates(keys)
+                .build();
+    }
+}


### PR DESCRIPTION
## Pull Request description

https://thingsboard-portal.atlassian.net/browse/PROD-4465

```
[e0a17c00-8e1c-11eb-8b41-4fe141e00a57][04a84750-1114-11ef-bef7-5131a0fcf1e6] Failed to push subscription event TbEntitySubEvent(tenantId=e0a17c00-8e1c-11eb-8b41-4fe141e00a57, entityId=04a84750-1114-11ef-bef7-5131a0fcf1e6, type=CREATED, info=TbSubscriptionsInfo(notifications=false, alarms=false, tsAllKeys=false, tsKeys=[kw_in, latitude, longitude], attrAllKeys=false, attrKeys=[unit_id], seqNumber=2387), seqNumber=2387) due to java.util.ConcurrentModificationException: null
at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1620)
at com.google.protobuf.AbstractMessageLite$Builder.addAllCheckingNulls(AbstractMessageLite.java:352)
at com.google.protobuf.AbstractMessageLite$Builder.addAll(AbstractMessageLite.java:414)
at org.thingsboard.server.gen.transport.TransportProtos$TbEntitySubEventProto$Builder.addAllTsKeys(TransportProtos.java)
at org.thingsboard.server.service.subscription.TbSubscriptionUtils.toSubEventProto(TbSubscriptionUtils.java:91)
at org.thingsboard.server.service.subscription.DefaultTbLocalSubscriptionService.pushToQueue(DefaultTbLocalSubscriptionService.java:533)
at org.thingsboard.server.service.subscription.DefaultTbLocalSubscriptionService.pushSubEventToManagerService(DefaultTbLocalSubscriptionService.java:528)
at org.thingsboard.server.service.subscription.DefaultTbLocalSubscriptionService.pushSubscriptionEvent(DefaultTbLocalSubscriptionService.java:512)
at org.thingsboard.server.service.subscription.DefaultTbLocalSubscriptionService.addSubscription(DefaultTbLocalSubscriptionService.java:238)
```
Before fix:
![image](https://github.com/user-attachments/assets/eb041142-9d10-4d68-a0ec-8ca9245ffa4a)

After fix:
![image](https://github.com/user-attachments/assets/524406e8-0622-4b6c-9f07-a8c56533ae6f)

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



