### PR TITLE
jackson.version 2.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
         <apache-httpclient.version>4.5.14</apache-httpclient.version>
         <apache-httpcore.version>4.4.16</apache-httpcore.version>
         <joda-time.version>2.12.7</joda-time.version>
-        <jackson.version>2.17.0</jackson.version>
-        <jackson-databind.version>2.17.0</jackson-databind.version>
+        <jackson.version>2.17.2</jackson.version>
+        <jackson-databind.version>2.17.2</jackson-databind.version>
         <fasterxml-classmate.version>1.7.0</fasterxml-classmate.version>
         <auth0-jwt.version>4.4.0</auth0-jwt.version>
         <json-schema-validator.version>2.2.14</json-schema-validator.version>


### PR DESCRIPTION
## Pull Request description

https://github.com/FasterXML/jackson-databind/issues/4500

```
mvn dependency:tree | grep fasterxml | grep jackson > dep_jackson.txt
```

```
[[1;34mINFO[m] +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:runtime
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |     +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |     \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
[[1;34mINFO[m] |     \- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:provided
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:provided
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |        |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |     \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:test
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |        |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.14.0:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |        \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:provided
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:provided
[[1;34mINFO[m] |  |        |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.14.0:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |        \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:compile
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:provided
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:provided
[[1;34mINFO[m] |  |        |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.14.0:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |        \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
[[1;34mINFO[m] |     |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
[[1;34mINFO[m] |     |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
[[1;34mINFO[m] |     |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |     |     +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.17.2:provided
[[1;34mINFO[m] |     |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.17.2:provided
[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:compile
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:compile
[[1;34mINFO[m] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:compile
[[1;34mINFO[m] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.17.2:compile
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.17.2:provided
[[1;34mINFO[m] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.17.2:provided
[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.17.2:provided
[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.17.2:provided

```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



