### PR TITLE
activity_Failed to send message to core

### DIFF
--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
@@ -1105,7 +1105,7 @@ public class DefaultTransportService extends TransportActivityManager implements
         try {
             tpi = partitionService.resolve(ServiceType.TB_CORE, tenantId, entityId);
         } catch (Exception e) {
-            log.trace("Failed to send message to core. Tenant with ID [{}], entityType [{}], entityId [{}], routingKey [{}], \nmsg [{}].\n Message delivery aborted.", tenantId, entityId.getEntityType(),  entityId.toString(), routingKey, msg, e);
+            log.warn("Failed to send message to core. Tenant with ID [{}], routingKey [{}], msg [{}]. Message delivery aborted.", tenantId, routingKey, msg, e);
             if (callback != null) {
                 callback.onError(e);
             }

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
@@ -1104,12 +1104,12 @@ public class DefaultTransportService extends TransportActivityManager implements
         TopicPartitionInfo tpi;
         try {
             tpi = partitionService.resolve(ServiceType.TB_CORE, tenantId, entityId);
-        } catch (TenantNotFoundException e) {
-            log.trace("Failed to send message to core. Tenant with ID [{}] not found in the database. Message delivery aborted.", tenantId, e);
-            tpi = TopicPartitionInfo.builder().topic("").build();
+        } catch (Exception e) {
+            log.trace("Failed to send message to core. Tenant with ID [{}], entityType [{}], entityId [{}], routingKey [{}], \nmsg [{}].\n Message delivery aborted.", tenantId, entityId.getEntityType(),  entityId.toString(), routingKey, msg, e);
             if (callback != null) {
                 callback.onError(e);
             }
+            return;
         }
         if (log.isTraceEnabled()) {
             log.trace("[{}][{}] Pushing to topic {} message {}", tenantId, entityId, tpi.getFullTopicName(), msg);

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
@@ -1106,7 +1106,7 @@ public class DefaultTransportService extends TransportActivityManager implements
             tpi = partitionService.resolve(ServiceType.TB_CORE, tenantId, entityId);
         } catch (TenantNotFoundException e) {
             log.trace("Failed to send message to core. Tenant with ID [{}] not found in the database. Message delivery aborted.", tenantId, e);
-            tpi = TopicPartitionInfo.builder().topic(e.getMessage()).build();
+            tpi = TopicPartitionInfo.builder().topic("").build();
             if (callback != null) {
                 callback.onError(e);
             }

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
@@ -45,6 +45,7 @@ import org.thingsboard.server.common.data.ResourceType;
 import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.Tenant;
 import org.thingsboard.server.common.data.device.data.PowerMode;
+import org.thingsboard.server.common.data.exception.TenantNotFoundException;
 import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.DeviceProfileId;
@@ -1100,16 +1101,19 @@ public class DefaultTransportService extends TransportActivityManager implements
     }
 
     private void sendToCore(TenantId tenantId, EntityId entityId, ToCoreMsg msg, UUID routingKey, TransportServiceCallback<Void> callback) {
-        TopicPartitionInfo tpi = partitionService.resolve(ServiceType.TB_CORE, tenantId, entityId);
-        if (log.isTraceEnabled()) {
-            log.trace("[{}][{}] Pushing to topic {} message {}", tenantId, entityId, tpi.getFullTopicName(), msg);
+        try {
+            TopicPartitionInfo tpi = partitionService.resolve(ServiceType.TB_CORE, tenantId, entityId);
+            if (log.isTraceEnabled()) {
+                log.trace("[{}][{}] Pushing to topic {} message {}", tenantId, entityId, tpi.getFullTopicName(), msg);
+            }
+            TransportTbQueueCallback transportTbQueueCallback = callback != null ?
+                    new TransportTbQueueCallback(callback) : null;
+            tbCoreProducerStats.incrementTotal();
+            StatsCallback wrappedCallback = new StatsCallback(transportTbQueueCallback, tbCoreProducerStats);
+            tbCoreMsgProducer.send(tpi, new TbProtoQueueMsg<>(routingKey, msg), wrappedCallback);
+        } catch (TenantNotFoundException e) {
+            log.trace("Failed to send message to core. Tenant with ID [{}] not found in the database. Message delivery aborted.", tenantId, e);
         }
-
-        TransportTbQueueCallback transportTbQueueCallback = callback != null ?
-                new TransportTbQueueCallback(callback) : null;
-        tbCoreProducerStats.incrementTotal();
-        StatsCallback wrappedCallback = new StatsCallback(transportTbQueueCallback, tbCoreProducerStats);
-        tbCoreMsgProducer.send(tpi, new TbProtoQueueMsg<>(routingKey, msg), wrappedCallback);
     }
 
     private void sendToRuleEngine(TenantId tenantId, DeviceId deviceId, CustomerId customerId, TransportProtos.SessionInfoProto sessionInfo, JsonObject json,


### PR DESCRIPTION
## Pull Request description

Before: 

```
2024-10-17 14:03:09,170 [main] INFO  o.e.californium.core.CoapServer - Starting server
2024-10-17 14:03:09,171 [main] INFO  o.e.c.core.network.CoapEndpoint - [LWM2M Client-coap://0.0.0.0:0] Started endpoint at coap://[0:0:0:0:0:0:0:0]:54693
2024-10-17 14:03:09,171 [main] INFO  o.e.l.c.e.DefaultEndpointsManager - New CoAP over UDP endpoint based on Californium library with very experimental support of OSCORE created, 
 for server coap://localhost:5685 at coap://[0:0:0:0:0:0:0:0]:54693.
2024-10-17 14:03:09,172 [main] INFO  o.eclipse.leshan.client.LeshanClient - Leshan client[endpoint:LwNoSec00000000_4] started.
2024-10-17 14:03:09,172 [main] INFO  o.t.s.t.l.s.c.LwM2mClientContextImpl - [LwNoSec00000000_4] initialized new client.
2024-10-17 14:03:09,172 [test-lwm2m-scheduled-62-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Trying to register to coap://localhost:5685 ...
2024-10-17 14:03:09,183 [LwM2M uplink-0-1] DEBUG o.t.s.t.l.s.u.DefaultLwM2mUplinkMsgHandler - [LwNoSec00000000_4] [{pbVlA24MoI] Client: create after Registration
2024-10-17 14:03:09,184 [test-lwm2m-scheduled-62-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Registered with location '/rd/pbVlA24MoI'.
2024-10-17 14:03:09,185 [test-lwm2m-scheduled-62-thread-1] INFO  o.e.l.c.e.DefaultRegistrationEngine - Next registration update to coap://localhost:5685 in 5s...
2024-10-17 14:03:11,038 [queue-scheduler-7-thread-1] ERROR o.t.s.c.t.a.AbstractActivityManager - Failed to report last activity event on reporting period end for key: [cda823ff-c52d-4dc6-86a7-6c52e8be0da9]. State: [AbstractActivityManager.ActivityStateWrapper(state=ActivityState(lastRecordedTime=1729162986110, metadata=nodeId: "nick-tuxedo"
sessionIdMSB: -3627609918415221306
sessionIdLSB: -8743901048168641111
tenantIdMSB: 6820916661251936751
tenantIdLSB: -5255659518403289610
deviceIdMSB: 6897882475196256751
deviceIdLSB: -5255659518403289610
deviceName: "LwPsk00000000_2"
deviceType: "profileForLwPsk00000000_2"
deviceProfileIdMSB: 6896465135988576751
deviceProfileIdLSB: -5255659518403289610
customerIdMSB: 1405474927960789426
customerIdLSB: -9187201950435737472
), lastReportedTime=0, strategy=org.thingsboard.server.common.transport.activity.strategy.LastEventActivityStrategy@4ad4898d)].
org.thingsboard.server.common.data.exception.TenantNotFoundException: Tenant with id 5ea8c390-8c77-11ef-b710-2583812bddf6 not found
	at org.thingsboard.server.service.queue.DefaultTenantRoutingInfoService.getRoutingInfo(DefaultTenantRoutingInfoService.java:45)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at org.thingsboard.server.queue.discovery.HashPartitionService.getRoutingInfo(HashPartitionService.java:563)
	at org.thingsboard.server.queue.discovery.HashPartitionService.isIsolated(HashPartitionService.java:552)
	at org.thingsboard.server.queue.discovery.HashPartitionService.getIsolatedOrSystemTenantId(HashPartitionService.java:567)
	at org.thingsboard.server.queue.discovery.HashPartitionService.getQueueKey(HashPartitionService.java:328)
	at org.thingsboard.server.queue.discovery.HashPartitionService.resolve(HashPartitionService.java:270)
	at org.thingsboard.server.queue.discovery.HashPartitionService.resolve(HashPartitionService.java:286)
	at org.thingsboard.server.common.transport.service.DefaultTransportService.sendToCore(DefaultTransportService.java:1105)
	at org.thingsboard.server.common.transport.service.DefaultTransportService.sendToDeviceActor(DefaultTransportService.java:1100)
	at org.thingsboard.server.common.transport.service.DefaultTransportService.process(DefaultTransportService.java:505)
	at org.thingsboard.server.common.transport.service.TransportActivityManager.reportActivity(TransportActivityManager.java:120)
	at org.thingsboard.server.common.transport.service.TransportActivityManager.reportActivity(TransportActivityManager.java:33)
	at org.thingsboard.server.common.transport.activity.AbstractActivityManager.reportLastEvent(AbstractActivityManager.java:158)
	at org.thingsboard.server.common.transport.activity.AbstractActivityManager.onReportingPeriodEnd(AbstractActivityManager.java:119)
	at org.thingsboard.server.queue.scheduler.DefaultSchedulerComponent.runSafely(DefaultSchedulerComponent.java:66)
	at org.thingsboard.server.queue.scheduler.DefaultSchedulerComponent.lambda$scheduleAtFixedRate$0(DefaultSchedulerComponent.java:57)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)

```

after:
```
2024-10-17 14:06:21,256 [main] INFO  o.e.californium.core.CoapServer - Starting server
2024-10-17 14:06:21,258 [main] INFO  o.e.c.core.network.CoapEndpoint - [LWM2M Client-coap://0.0.0.0:0] Started endpoint at coap://[0:0:0:0:0:0:0:0]:50887
2024-10-17 14:06:21,258 [main] INFO  o.e.l.c.e.DefaultEndpointsManager - New CoAP over UDP endpoint based on Californium library with very experimental support of OSCORE created, 
 for server coap://localhost:5685 at coap://[0:0:0:0:0:0:0:0]:50887.
2024-10-17 14:06:21,258 [main] INFO  o.eclipse.leshan.client.LeshanClient - Leshan client[endpoint:LwNoSec00000000_17] started.
2024-10-17 14:06:21,258 [main] INFO  o.t.s.t.l.s.c.LwM2mClientContextImpl - [LwNoSec00000000_17] initialized new client.
2024-10-17 14:06:21,258 [test-lwm2m-scheduled-62-thread-2] INFO  o.e.l.c.e.DefaultRegistrationEngine - Trying to register 
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



