### PR TITLE
Fix email sender address issue

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/mail/TbMailSender.java
+++ b/application/src/main/java/org/thingsboard/server/service/mail/TbMailSender.java
@@ -67,6 +67,9 @@ public class TbMailSender extends JavaMailSenderImpl {
         if (jsonConfig.has("password")) {
             setPassword(jsonConfig.get("password").asText());
         }
+        if (jsonConfig.has("mailFrom")) {
+            setUsername(jsonConfig.get("mailFrom").asText());
+        }
         setJavaMailProperties(createJavaMailProperties(jsonConfig));
     }
 


### PR DESCRIPTION
Fixes #9878

Update `TbMailSender` to correctly handle the `mailFrom` field in the email configuration.

* Checks the `mailFrom` field in the JSON configuration and set it as the sender address if present.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/thingsboard/thingsboard/issues/9878?shareId=dee656a3-8747-41a5-89e8-e6ef63196e62).