### PR TITLE
enhancement: add high contrast color mode styling support

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/chart/chart.models.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/chart/chart.models.ts
@@ -14,175 +14,192 @@
 /// limitations under the License.
 ///
 
-import { isNumber } from '@core/utils';
-import { TbColorScheme } from '@shared/models/color.models';
-import { LinearGradientObject } from 'zrender/lib/graphic/LinearGradient';
-import tinycolor from 'tinycolor2';
-import { ComponentStyle, Font, textStyle } from '@shared/models/widget-settings.models';
-import { LabelFormatterCallback, RadialGradientObject } from 'echarts';
-import { AnimationOptionMixin, LabelLayoutOption } from 'echarts/types/src/util/types';
-import { LabelLayoutOptionCallback } from 'echarts/types/dist/shared';
-import { BuiltinTextPosition } from 'zrender/src/core/types';
-import { WidgetContext } from '@home/models/widget-component.models';
+import { isNumber } from "@core/utils";
+import { TbColorScheme } from "@shared/models/color.models";
+import { LinearGradientObject } from "zrender/lib/graphic/LinearGradient";
+import tinycolor from "tinycolor2";
+import {
+  ComponentStyle,
+  Font,
+  textStyle,
+} from "@shared/models/widget-settings.models";
+import { LabelFormatterCallback, RadialGradientObject } from "echarts";
+import {
+  AnimationOptionMixin,
+  LabelLayoutOption,
+} from "echarts/types/src/util/types";
+import { LabelLayoutOptionCallback } from "echarts/types/dist/shared";
+import { BuiltinTextPosition } from "zrender/src/core/types";
+import { WidgetContext } from "@home/models/widget-component.models";
 
 export const chartColorScheme: TbColorScheme = {
-  'threshold.line': {
-    light: 'rgba(0, 0, 0, 0.76)',
-    dark: '#eee'
+  "threshold.line": {
+    light: "rgba(0, 0, 0, 0.76)",
+    dark: "#eee",
+    highContrast: "#FFEB3B",
   },
-  'threshold.label': {
-    light: 'rgba(0, 0, 0, 0.76)',
-    dark: '#eee'
+  "threshold.label": {
+    light: "rgba(0, 0, 0, 0.76)",
+    dark: "#eee",
+    highContrast: "#FFEB3B",
   },
-  'axis.line': {
-    light: 'rgba(0, 0, 0, 0.54)',
-    dark: '#B9B8CE'
+  "axis.line": {
+    light: "rgba(0, 0, 0, 0.54)",
+    dark: "#B9B8CE",
+    highContrast: "#FFD600",
   },
-  'axis.label': {
-    light: 'rgba(0, 0, 0, 0.54)',
-    dark: '#B9B8CE'
+  "axis.label": {
+    light: "rgba(0, 0, 0, 0.54)",
+    dark: "#B9B8CE",
+    highContrast: "#FFD600",
   },
-  'axis.ticks': {
-    light: 'rgba(0, 0, 0, 0.54)',
-    dark: '#B9B8CE'
+  "axis.ticks": {
+    light: "rgba(0, 0, 0, 0.54)",
+    dark: "#B9B8CE",
+    highContrast: "#FFD600",
   },
-  'axis.tickLabel': {
-    light: 'rgba(0, 0, 0, 0.54)',
-    dark: '#B9B8CE'
+  "axis.tickLabel": {
+    light: "rgba(0, 0, 0, 0.54)",
+    dark: "#B9B8CE",
+    highContrast: "#FFD600",
   },
-  'axis.splitLine': {
-    light: 'rgba(0, 0, 0, 0.12)',
-    dark: '#484753'
+  "axis.splitLine": {
+    light: "rgba(0, 0, 0, 0.12)",
+    dark: "#484753",
+    highContrast: "#FF5722",
   },
-  'series.label': {
-    light: 'rgba(0, 0, 0, 0.76)',
-    dark: '#eee'
-  }
+  "series.label": {
+    light: "rgba(0, 0, 0, 0.76)",
+    dark: "#eee",
+    highContrast: "#FFEB3B",
+  },
 };
 
 export enum ChartShape {
-  emptyCircle = 'emptyCircle',
-  circle = 'circle',
-  rect = 'rect',
-  roundRect = 'roundRect',
-  triangle = 'triangle',
-  diamond = 'diamond',
-  pin = 'pin',
-  arrow = 'arrow',
-  none = 'none'
+  emptyCircle = "emptyCircle",
+  circle = "circle",
+  rect = "rect",
+  roundRect = "roundRect",
+  triangle = "triangle",
+  diamond = "diamond",
+  pin = "pin",
+  arrow = "arrow",
+  none = "none",
 }
 
 export const chartShapes = Object.keys(ChartShape) as ChartShape[];
 
-export const chartShapeTranslations = new Map<ChartShape, string>(
-  [
-    [ChartShape.emptyCircle, 'widgets.chart.shape-empty-circle'],
-    [ChartShape.circle, 'widgets.chart.shape-circle'],
-    [ChartShape.rect, 'widgets.chart.shape-rect'],
-    [ChartShape.roundRect, 'widgets.chart.shape-round-rect'],
-    [ChartShape.triangle, 'widgets.chart.shape-triangle'],
-    [ChartShape.diamond, 'widgets.chart.shape-diamond'],
-    [ChartShape.pin, 'widgets.chart.shape-pin'],
-    [ChartShape.arrow, 'widgets.chart.shape-arrow'],
-    [ChartShape.none, 'widgets.chart.shape-none']
-  ]
-);
+export const chartShapeTranslations = new Map<ChartShape, string>([
+  [ChartShape.emptyCircle, "widgets.chart.shape-empty-circle"],
+  [ChartShape.circle, "widgets.chart.shape-circle"],
+  [ChartShape.rect, "widgets.chart.shape-rect"],
+  [ChartShape.roundRect, "widgets.chart.shape-round-rect"],
+  [ChartShape.triangle, "widgets.chart.shape-triangle"],
+  [ChartShape.diamond, "widgets.chart.shape-diamond"],
+  [ChartShape.pin, "widgets.chart.shape-pin"],
+  [ChartShape.arrow, "widgets.chart.shape-arrow"],
+  [ChartShape.none, "widgets.chart.shape-none"],
+]);
 
 export enum ChartLineType {
-  solid = 'solid',
-  dashed = 'dashed',
-  dotted = 'dotted'
+  solid = "solid",
+  dashed = "dashed",
+  dotted = "dotted",
 }
 
 export const chartLineTypes = Object.keys(ChartLineType) as ChartLineType[];
 
-export const chartLineTypeTranslations = new Map<ChartLineType, string>(
-  [
-    [ChartLineType.solid, 'widgets.chart.line-type-solid'],
-    [ChartLineType.dashed, 'widgets.chart.line-type-dashed'],
-    [ChartLineType.dotted, 'widgets.chart.line-type-dotted']
-  ]
-);
+export const chartLineTypeTranslations = new Map<ChartLineType, string>([
+  [ChartLineType.solid, "widgets.chart.line-type-solid"],
+  [ChartLineType.dashed, "widgets.chart.line-type-dashed"],
+  [ChartLineType.dotted, "widgets.chart.line-type-dotted"],
+]);
 
 export enum ChartAnimationEasing {
-  linear = 'linear',
-  quadraticIn = 'quadraticIn',
-  quadraticOut = 'quadraticOut',
-  quadraticInOut = 'quadraticInOut',
-  cubicIn = 'cubicIn',
-  cubicOut = 'cubicOut',
-  cubicInOut = 'cubicInOut',
-  quarticIn = 'quarticIn',
-  quarticOut = 'quarticOut',
-  quarticInOut = 'quarticInOut',
-  quinticIn = 'quinticIn',
-  quinticOut = 'quinticOut',
-  quinticInOut = 'quinticInOut',
-  sinusoidalIn = 'sinusoidalIn',
-  sinusoidalOut = 'sinusoidalOut',
-  sinusoidalInOut = 'sinusoidalInOut',
-  exponentialIn = 'exponentialIn',
-  exponentialOut = 'exponentialOut',
-  exponentialInOut = 'exponentialInOut',
-  circularIn = 'circularIn',
-  circularOut = 'circularOut',
-  circularInOut = 'circularInOut',
-  elasticIn = 'elasticIn',
-  elasticOut = 'elasticOut',
-  elasticInOut = 'elasticInOut',
-  backIn = 'backIn',
-  backOut = 'backOut',
-  backInOut = 'backInOut',
-  bounceIn = 'bounceIn',
-  bounceOut = 'bounceOut',
-  bounceInOut = 'bounceInOut'
+  linear = "linear",
+  quadraticIn = "quadraticIn",
+  quadraticOut = "quadraticOut",
+  quadraticInOut = "quadraticInOut",
+  cubicIn = "cubicIn",
+  cubicOut = "cubicOut",
+  cubicInOut = "cubicInOut",
+  quarticIn = "quarticIn",
+  quarticOut = "quarticOut",
+  quarticInOut = "quarticInOut",
+  quinticIn = "quinticIn",
+  quinticOut = "quinticOut",
+  quinticInOut = "quinticInOut",
+  sinusoidalIn = "sinusoidalIn",
+  sinusoidalOut = "sinusoidalOut",
+  sinusoidalInOut = "sinusoidalInOut",
+  exponentialIn = "exponentialIn",
+  exponentialOut = "exponentialOut",
+  exponentialInOut = "exponentialInOut",
+  circularIn = "circularIn",
+  circularOut = "circularOut",
+  circularInOut = "circularInOut",
+  elasticIn = "elasticIn",
+  elasticOut = "elasticOut",
+  elasticInOut = "elasticInOut",
+  backIn = "backIn",
+  backOut = "backOut",
+  backInOut = "backInOut",
+  bounceIn = "bounceIn",
+  bounceOut = "bounceOut",
+  bounceInOut = "bounceInOut",
 }
 
-export const chartAnimationEasings = Object.keys(ChartAnimationEasing) as ChartAnimationEasing[];
+export const chartAnimationEasings = Object.keys(
+  ChartAnimationEasing
+) as ChartAnimationEasing[];
 
 export enum ChartFillType {
-  none = 'none',
-  opacity = 'opacity',
-  gradient = 'gradient'
+  none = "none",
+  opacity = "opacity",
+  gradient = "gradient",
 }
 
 export const chartFillTypes = Object.keys(ChartFillType) as ChartFillType[];
 
-export const chartFillTypeTranslations = new Map<ChartFillType, string>(
-  [
-    [ChartFillType.none, 'widgets.chart.fill-type-none'],
-    [ChartFillType.opacity, 'widgets.chart.fill-type-opacity'],
-    [ChartFillType.gradient, 'widgets.chart.fill-type-gradient']
-  ]
-);
+export const chartFillTypeTranslations = new Map<ChartFillType, string>([
+  [ChartFillType.none, "widgets.chart.fill-type-none"],
+  [ChartFillType.opacity, "widgets.chart.fill-type-opacity"],
+  [ChartFillType.gradient, "widgets.chart.fill-type-gradient"],
+]);
 
 export enum ChartLabelPosition {
-  top = 'top',
-  bottom = 'bottom'
+  top = "top",
+  bottom = "bottom",
 }
 
-export const chartLabelPositions = Object.keys(ChartLabelPosition) as ChartLabelPosition[];
+export const chartLabelPositions = Object.keys(
+  ChartLabelPosition
+) as ChartLabelPosition[];
 
-export const chartLabelPositionTranslations = new Map<ChartLabelPosition, string>(
-  [
-    [ChartLabelPosition.top, 'widgets.chart.label-position-top'],
-    [ChartLabelPosition.bottom, 'widgets.chart.label-position-bottom']
-  ]
-);
+export const chartLabelPositionTranslations = new Map<
+  ChartLabelPosition,
+  string
+>([
+  [ChartLabelPosition.top, "widgets.chart.label-position-top"],
+  [ChartLabelPosition.bottom, "widgets.chart.label-position-bottom"],
+]);
 
 export enum PieChartLabelPosition {
-  inside = 'inside',
-  outside = 'outside'
+  inside = "inside",
+  outside = "outside",
 }
 
-export const pieChartLabelPositions = Object.keys(PieChartLabelPosition) as PieChartLabelPosition[];
+export const pieChartLabelPositions = Object.keys(
+  PieChartLabelPosition
+) as PieChartLabelPosition[];
 
-export const pieChartLabelPositionTranslations = new Map<PieChartLabelPosition, string>(
-  [
-    [PieChartLabelPosition.inside, 'widgets.chart.label-position-inside'],
-    [PieChartLabelPosition.outside, 'widgets.chart.label-position-outside']
-  ]
-);
+export const pieChartLabelPositionTranslations = new Map<
+  PieChartLabelPosition,
+  string
+>([
+  [PieChartLabelPosition.inside, "widgets.chart.label-position-inside"],
+  [PieChartLabelPosition.outside, "widgets.chart.label-position-outside"],
+]);
 
 export interface ChartAnimationSettings {
   animation: boolean;
@@ -203,7 +220,7 @@ export const chartAnimationDefaultSettings: ChartAnimationSettings = {
   animationDelay: 0,
   animationDurationUpdate: 300,
   animationEasingUpdate: ChartAnimationEasing.cubicOut,
-  animationDelayUpdate: 0
+  animationDelayUpdate: 0,
 };
 
 export interface ChartFillSettings {
@@ -221,14 +238,17 @@ export interface ChartBarSettings {
   borderRadius: number;
   barWidth?: number;
   showLabel: boolean;
-  labelPosition: ChartLabelPosition | PieChartLabelPosition | BuiltinTextPosition;
+  labelPosition:
+    | ChartLabelPosition
+    | PieChartLabelPosition
+    | BuiltinTextPosition;
   labelFont: Font;
   labelColor: string;
   enableLabelBackground: boolean;
   labelBackground: string;
   labelFormatter?: string | LabelFormatterCallback;
   labelLayout?: LabelLayoutOption | LabelLayoutOptionCallback;
-  additionalLabelOption?: {[key: string]: any};
+  additionalLabelOption?: { [key: string]: any };
   backgroundSettings: ChartFillSettings;
 }
 
@@ -239,46 +259,51 @@ export const chartBarDefaultSettings: ChartBarSettings = {
   showLabel: false,
   labelPosition: ChartLabelPosition.top,
   labelFont: {
-    family: 'Roboto',
+    family: "Roboto",
     size: 11,
-    sizeUnit: 'px',
-    style: 'normal',
-    weight: '400',
-    lineHeight: '1'
+    sizeUnit: "px",
+    style: "normal",
+    weight: "400",
+    lineHeight: "1",
   },
-  labelColor: chartColorScheme['series.label'].light,
+  labelColor: chartColorScheme["series.label"].light,
   enableLabelBackground: false,
-  labelBackground: 'rgba(255,255,255,0.56)',
+  labelBackground: "rgba(255,255,255,0.56)",
   backgroundSettings: {
     type: ChartFillType.none,
     opacity: 0.4,
     gradient: {
       start: 100,
-      end: 0
-    }
-  }
+      end: 0,
+    },
+  },
 };
 
 type ChartShapeOffsetFunction = (size: number) => number;
 
 const chartShapeOffsetFunctions = new Map<ChartShape, ChartShapeOffsetFunction>(
   [
-    [ChartShape.emptyCircle, size => size / 2 + 1],
-    [ChartShape.circle, size => size / 2],
-    [ChartShape.rect, size => size / 2],
-    [ChartShape.roundRect, size => size / 2],
-    [ChartShape.triangle, size => size / 2],
-    [ChartShape.diamond, size => size / 2],
-    [ChartShape.pin, size => size],
+    [ChartShape.emptyCircle, (size) => size / 2 + 1],
+    [ChartShape.circle, (size) => size / 2],
+    [ChartShape.rect, (size) => size / 2],
+    [ChartShape.roundRect, (size) => size / 2],
+    [ChartShape.triangle, (size) => size / 2],
+    [ChartShape.diamond, (size) => size / 2],
+    [ChartShape.pin, (size) => size],
     [ChartShape.arrow, () => 0],
     [ChartShape.none, () => 0],
   ]
 );
 
-export const measureSymbolOffset = (symbol: string, symbolSize: any): number => {
+export const measureSymbolOffset = (
+  symbol: string,
+  symbolSize: any
+): number => {
   if (isNumber(symbolSize)) {
     if (symbol) {
-      const offsetFunction = chartShapeOffsetFunctions.get(symbol as ChartShape);
+      const offsetFunction = chartShapeOffsetFunctions.get(
+        symbol as ChartShape
+      );
       if (offsetFunction) {
         return offsetFunction(symbolSize);
       } else {
@@ -290,46 +315,96 @@ export const measureSymbolOffset = (symbol: string, symbolSize: any): number => 
   }
 };
 
-export const createLinearOpacityGradient = (color: string, gradient: {start: number; end: number}): LinearGradientObject => ({
-  type: 'linear',
+export const createLinearOpacityGradient = (
+  color: string,
+  gradient: { start: number; end: number }
+): LinearGradientObject => ({
+  type: "linear",
   x: 0,
   y: 0,
   x2: 0,
   y2: 1,
-  colorStops: [{
-    offset: 0, color: tinycolor(color).setAlpha(gradient.start / 100).toRgbString() // color at 0%
-  }, {
-    offset: 1, color: tinycolor(color).setAlpha(gradient.end / 100).toRgbString() // color at 100%
-  }],
-  global: false
+  colorStops: [
+    {
+      offset: 0,
+      color: tinycolor(color)
+        .setAlpha(gradient.start / 100)
+        .toRgbString(), // color at 0%
+    },
+    {
+      offset: 1,
+      color: tinycolor(color)
+        .setAlpha(gradient.end / 100)
+        .toRgbString(), // color at 100%
+    },
+  ],
+  global: false,
 });
 
-export const createRadialOpacityGradient = (color: string, gradient: {start: number; end: number}): RadialGradientObject => ({
-  type: 'radial',
+export const createRadialOpacityGradient = (
+  color: string,
+  gradient: { start: number; end: number }
+): RadialGradientObject => ({
+  type: "radial",
   x: 0.5,
   y: 0.5,
   r: 0.5,
-  colorStops: [{
-    offset: 0, color: tinycolor(color).setAlpha(gradient.end / 100).toRgbString() // color at 0%
-  }, {
-    offset: 1, color: tinycolor(color).setAlpha(gradient.start / 100).toRgbString() // color at 100%
-  }],
-  global: false
+  colorStops: [
+    {
+      offset: 0,
+      color: tinycolor(color)
+        .setAlpha(gradient.end / 100)
+        .toRgbString(), // color at 0%
+    },
+    {
+      offset: 1,
+      color: tinycolor(color)
+        .setAlpha(gradient.start / 100)
+        .toRgbString(), // color at 100%
+    },
+  ],
+  global: false,
 });
 
-export const createChartTextStyle = (font: Font, color: string, darkMode: boolean, colorKey?: string, fill = false): ComponentStyle => {
+export const createChartTextStyle = (
+  font: Font,
+  color: string,
+  darkMode: boolean,
+  colorKey?: string,
+  fill = false,
+  highContrast: boolean = false
+): ComponentStyle => {
   const style = textStyle(font);
   delete style.lineHeight;
   style.fontSize = font.size;
   if (fill) {
-    style.fill = prepareChartThemeColor(color, darkMode, colorKey);
+    style.fill = prepareChartThemeColor(
+      color,
+      darkMode,
+      colorKey,
+      highContrast
+    );
   } else {
-    style.color = prepareChartThemeColor(color, darkMode, colorKey);
+    style.color = prepareChartThemeColor(
+      color,
+      darkMode,
+      colorKey,
+      highContrast
+    );
   }
   return style;
 };
 
-export const prepareChartThemeColor = (color: string, darkMode: boolean, colorKey?: string): string => {
+export const prepareChartThemeColor = (
+  color: string,
+  darkMode: boolean,
+  colorKey?: string,
+  highContrast: boolean = false
+): string => {
+  if (colorKey && highContrast) {
+    return chartColorScheme[colorKey].highContrast;
+  }
+
   if (darkMode) {
     let colorInstance = tinycolor(color);
     if (colorInstance.isDark()) {
@@ -337,7 +412,12 @@ export const prepareChartThemeColor = (color: string, darkMode: boolean, colorKe
         return chartColorScheme[colorKey].dark;
       } else {
         const rgb = colorInstance.toRgb();
-        colorInstance = tinycolor({r: 255 - rgb.r, g: 255 - rgb.g, b: 255 - rgb.b, a: rgb.a});
+        colorInstance = tinycolor({
+          r: 255 - rgb.r,
+          g: 255 - rgb.g,
+          b: 255 - rgb.b,
+          a: rgb.a,
+        });
         return colorInstance.toRgbString();
       }
     }
@@ -345,7 +425,10 @@ export const prepareChartThemeColor = (color: string, darkMode: boolean, colorKe
   return color;
 };
 
-export const toAnimationOption = (ctx: WidgetContext, settings: ChartAnimationSettings): AnimationOptionMixin => ({
+export const toAnimationOption = (
+  ctx: WidgetContext,
+  settings: ChartAnimationSettings
+): AnimationOptionMixin => ({
   animation: settings.animation,
   animationThreshold: settings.animationThreshold,
   animationDuration: settings.animationDuration,
@@ -353,5 +436,5 @@ export const toAnimationOption = (ctx: WidgetContext, settings: ChartAnimationSe
   animationDelay: settings.animationDelay,
   animationDurationUpdate: settings.animationDurationUpdate,
   animationEasingUpdate: settings.animationEasingUpdate,
-  animationDelayUpdate: settings.animationDelayUpdate
+  animationDelayUpdate: settings.animationDelayUpdate,
 });

--- a/ui-ngx/src/app/modules/home/components/widget/lib/chart/time-series-chart.models.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/chart/time-series-chart.models.ts
@@ -694,6 +694,7 @@ export const timeSeriesChartGridDefaultSettings: TimeSeriesChartGridSettings = {
 export interface TimeSeriesChartSettings extends TimeSeriesChartTooltipWidgetSettings, TimeSeriesChartComparisonSettings {
   thresholds: TimeSeriesChartThreshold[];
   darkMode: boolean;
+  highContrast: boolean;
   dataZoom: boolean;
   stack: boolean;
   grid: TimeSeriesChartGridSettings;
@@ -709,6 +710,7 @@ export interface TimeSeriesChartSettings extends TimeSeriesChartTooltipWidgetSet
 export const timeSeriesChartDefaultSettings: TimeSeriesChartSettings = {
   thresholds: [],
   darkMode: false,
+  highContrast: false,
   dataZoom: true,
   stack: false,
   grid: mergeDeep({} as TimeSeriesChartGridSettings,
@@ -1310,6 +1312,113 @@ export const updateDarkMode = (options: EChartsOption,
         const barSettings = item.dataKey.settings as ChartBarSettings;
         (item.barRenderContext.labelOption.rich.value as any).fill = prepareChartThemeColor(barSettings.labelColor,
           darkMode, 'series.label');
+      }
+    }
+  }
+  return options;
+};
+
+export const updateHighContrastMode = (
+  options: EChartsOption,
+  xAxisList: TimeSeriesChartXAxis[],
+  yAxisList: TimeSeriesChartYAxis[],
+  dataItems: TimeSeriesChartDataItem[],
+  highContrast: boolean
+): EChartsOption => {
+  options.highContrast = highContrast;
+  if (Array.isArray(options.yAxis)) {
+    for (let i = 0; i < options.yAxis.length; i++) {
+      const yAxis = options.yAxis[i];
+      const yAxisSettings = yAxisList[i].settings;
+      yAxis.nameTextStyle.color = prepareChartThemeColor(
+        yAxisSettings.labelColor,
+        highContrast,
+        "axis.label"
+      );
+      yAxis.axisLabel.color = prepareChartThemeColor(
+        yAxisSettings.tickLabelColor,
+        highContrast,
+        "axis.tickLabel"
+      );
+      yAxis.axisLine.lineStyle.color = prepareChartThemeColor(
+        yAxisSettings.lineColor,
+        highContrast,
+        "axis.line"
+      );
+      yAxis.axisTick.lineStyle.color = prepareChartThemeColor(
+        yAxisSettings.ticksColor,
+        highContrast,
+        "axis.ticks"
+      );
+      yAxis.splitLine.lineStyle.color = prepareChartThemeColor(
+        yAxisSettings.splitLinesColor,
+        highContrast,
+        "axis.splitLine"
+      );
+    }
+  }
+  if (Array.isArray(options.xAxis)) {
+    for (let i = 0; i < options.xAxis.length; i++) {
+      const xAxis = options.xAxis[i];
+      const xAxisSettings = xAxisList[i].settings;
+      xAxis.nameTextStyle.color = prepareChartThemeColor(
+        xAxisSettings.labelColor,
+        highContrast,
+        "axis.label"
+      );
+      xAxis.axisLabel.color = prepareChartThemeColor(
+        xAxisSettings.tickLabelColor,
+        highContrast,
+        "axis.tickLabel"
+      );
+      xAxis.axisLine.lineStyle.color = prepareChartThemeColor(
+        xAxisSettings.lineColor,
+        highContrast,
+        "axis.line"
+      );
+      xAxis.axisTick.lineStyle.color = prepareChartThemeColor(
+        xAxisSettings.ticksColor,
+        highContrast,
+        "axis.ticks"
+      );
+      xAxis.splitLine.lineStyle.color = prepareChartThemeColor(
+        xAxisSettings.splitLinesColor,
+        highContrast,
+        "axis.splitLine"
+      );
+    }
+  }
+  for (const item of dataItems) {
+    if (item.dataKey.settings.type === TimeSeriesChartSeriesType.line) {
+      const lineSettings = item.dataKey.settings as LineSeriesSettings;
+      if (item.option.label?.show) {
+        item.option.label.rich.value.color = prepareChartThemeColor(
+          lineSettings.pointLabelColor,
+          highContrast,
+          "series.label"
+        );
+      }
+      if (Array.isArray(options.series)) {
+        const series = options.series.find((s) => s.id === item.id);
+        if (series) {
+          if (series.label?.show) {
+            series.label.rich.value.color = prepareChartThemeColor(
+              lineSettings.pointLabelColor,
+              highContrast,
+              "series.label"
+            );
+          }
+        }
+      }
+    } else {
+      if (item.barRenderContext?.labelOption?.show) {
+        const barSettings = item.dataKey.settings as ChartBarSettings;
+        (item.barRenderContext.labelOption.rich.value as any).fill =
+          prepareChartThemeColor(
+            barSettings.labelColor,
+            highContrast,
+            "series.label"
+          );
       }
     }
   }

--- a/ui-ngx/src/app/modules/home/components/widget/lib/chart/time-series-chart.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/chart/time-series-chart.ts
@@ -149,6 +149,8 @@ export class TbTimeSeriesChart {
 
   private darkMode = false;
 
+  private highContrast = false;
+
   private darkModeObserver: MutationObserver;
 
   private topPointLabels = false;
@@ -184,6 +186,7 @@ export class TbTimeSeriesChart {
     const $dashboardPageElement = this.ctx.$containerParent.parents('.tb-dashboard-page');
     const dashboardPageElement = $dashboardPageElement.length ? $($dashboardPageElement[$dashboardPageElement.length-1]) : null;
     this.darkMode = this.settings.darkMode || dashboardPageElement?.hasClass('dark');
+    this.highContrast = this.settings.highContrast || dashboardPageElement?.hasClass('high-contrast');
     this.setupXAxes();
     this.setupYAxes();
     this.setupData();
@@ -375,8 +378,24 @@ export class TbTimeSeriesChart {
     }
   }
 
+  
+  public setHighContrast(highContrast: boolean): void {
+    if (this.highContrast !== highContrast) {
+      this.highContrast = highContrast;
+      if (this.timeSeriesChart) {
+        this.timeSeriesChartOptions = updateDarkMode(this.timeSeriesChartOptions,
+          this.xAxisList, this.yAxisList, this.dataItems, highContrast);
+        this.timeSeriesChart.setOption(this.timeSeriesChartOptions);
+      }
+    }
+  }
+
   public isDarkMode(): boolean {
     return this.darkMode;
+  }
+
+  public isHighContrast() : boolean {
+    return this.highContrast;
   }
 
   private setupData(): void {

--- a/ui-ngx/src/app/shared/models/color.models.ts
+++ b/ui-ngx/src/app/shared/models/color.models.ts
@@ -17,6 +17,7 @@
 export interface TbColor {
   light: string;
   dark: string;
+  highContrast: string;
 }
 
 export interface TbColorScheme {

--- a/ui-ngx/src/form.scss
+++ b/ui-ngx/src/form.scss
@@ -39,7 +39,7 @@
   }
 }
 
-.tb-default, .tb-dark {
+.tb-default, .tb-dark .tb-high-contrast {
   .tb-form-panel {
     box-shadow: 0 0 10px 6px rgba(11, 17, 51, 0.04);
     border-radius: 4px;

--- a/ui-ngx/src/styles.scss
+++ b/ui-ngx/src/styles.scss
@@ -427,7 +427,7 @@ pre.tb-highlight {
   }
 }
 
-.tb-default, .tb-dark {
+.tb-default, .tb-dark .tb-high-contrast {
 
   /*********************************
    * MATERIAL DESIGN CUSTOMIZATIONS

--- a/ui-ngx/src/theme.scss
+++ b/ui-ngx/src/theme.scss
@@ -147,6 +147,76 @@ $color: map_merge($color, (background: $tb-dark-theme-background));
 $tb-dark-theme: map_merge($tb-dark-theme, (color: $color));
 $tb-dark-theme: map_merge($tb-dark-theme, $color);
 
+// New Theme: High Contrast
+$tb-high-contrast-indigo: (
+  50: #ffffff,
+  100: #e8e8e8,
+  200: #c5c5c5,
+  300: #9f9f9f,
+  400: #7a7a7a,
+  500: #000000, 
+  600: #ffffff, 
+  700: #1a1a1a,
+  800: #0d0d0d,
+  900: #000000,
+  A100: #ffff00, 
+  A200: #00ff00, 
+  A400: #ff0000, 
+  A700: #00ffff, 
+  contrast: (
+    50: black,
+    100: black,
+    200: black,
+    300: white,
+    400: white,
+    500: white,
+    600: black,
+    700: white,
+    800: white,
+    900: white,
+    A100: black,
+    A200: white,
+    A400: white,
+    A700: white,
+  )
+);
+
+$tb-high-contrast-primary: mat.m2-define-palette($tb-high-contrast-indigo);
+$tb-high-contrast-accent: mat.m2-define-palette(mat.$m2-pink-palette);
+
+$tb-high-contrast-theme-background: (
+  status-bar: black,
+  app-bar:    #000000,
+  background: #ffffff,
+  hover:      #c5c5c5,
+  card:       #ffffff,
+  dialog:     #ffffff,
+  disabled-button: #c5c5c5,
+  raised-button: #7a7a7a,
+  focused-button: #c5c5c5,
+  selected-button: #000000,
+  selected-disabled-button: #7a7a7a,
+  disabled-button-toggle: #c5c5c5,
+  unselected-chip: #000000,
+  disabled-list-option: #c5c5c5,
+  tooltip: #ffffff,
+);
+
+$tb-high-contrast-theme: mat.m2-define-light-theme((
+  color: (
+    primary: $tb-high-contrast-primary,
+    accent: $tb-high-contrast-accent,
+  ),
+  typography: mat.m2-define-typography-config(
+    $button: mat.m2-define-typography-level(16px, 36px, 700, $letter-spacing: 0.05em)
+  ),
+  density: 0,
+));
+
+$color: map_get($tb-high-contrast-theme, color);
+$color: map_merge($color, (background: $tb-high-contrast-theme-background));
+$tb-high-contrast-theme: map_merge($tb-high-contrast-theme, (color: $color));
+
 @mixin mat-fab-toolbar-theme($theme) {
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);
@@ -266,3 +336,12 @@ $tb-dark-theme: map_merge($tb-dark-theme, $color);
 .tb-dark {
   @include mat.all-component-colors($tb-dark-theme);
 }
+
+.tb-high-contrast {
+  @include mat.all-component-themes($tb-high-contrast-theme);
+  @include mat-datetimepicker-theme($tb-high-contrast-theme);
+  @include tb-components-theme($tb-high-contrast-theme);
+  @include overwrites.theme-overwrites($tb-high-contrast-primary, $tb-high-contrast-theme);
+  @include mat.typography-hierarchy($tb-high-contrast-theme);
+}
+


### PR DESCRIPTION
### Add high contrast color mode support

**Description**
- The addressed issue
  - Added high contrast themes that helps in improve readability and usability of interfaces for users with visual disabilities, including color blindness and low vision. See [The Importance of High Contrast Mode in a Design System.
](https://pros.com/ascend/the-importance-of-high-contrast-mode-in-a-design-system/). 

- What you have reengineered
  - Add new high contrast color scheme inside the existing scss stylesheet. This color scheme support as one of the color theme in the future. 
  - Integrated the high contrast color scheme into specific components and chart libraries to ensure compatibility and uniform visual presentation.

- Reengineering strategy or approach used
  - Incremental approach, changes were introduced gradually by adding the high-contrast theme to the existing stylesheet and updating only the necessary components and charts to support the new theme. This allowed for testing and validation of functionality without disrupting the current system.

- Impact of changes
  - Enhanced accessibility, making the system more inclusive for users with visual impairments.
  - Improved system adaptability by introducing a flexible, reusable high-contrast theme framework.

![image](https://github.com/user-attachments/assets/4a04e09a-6b90-4d92-8e6c-1c947be0d82c)