### PR TITLE
Timewindow: fixed applying "disable custom interval" parameter

### DIFF
--- a/ui-ngx/src/app/shared/components/time/timewindow-config-dialog.component.ts
+++ b/ui-ngx/src/app/shared/components/time/timewindow-config-dialog.component.ts
@@ -340,6 +340,18 @@ export class TimewindowConfigDialogComponent extends PageComponent implements On
   update() {
     const timewindowFormValue = this.timewindowForm.getRawValue();
     this.timewindow = mergeDeep(this.timewindow, timewindowFormValue);
+    if (!this.timewindow.realtime.disableCustomInterval) {
+      delete this.timewindow.realtime.disableCustomInterval;
+    }
+    if (!this.timewindow.realtime.disableCustomGroupInterval) {
+      delete this.timewindow.realtime.disableCustomGroupInterval;
+    }
+    if (!this.timewindow.history.disableCustomInterval) {
+      delete this.timewindow.history.disableCustomInterval;
+    }
+    if (!this.timewindow.history.disableCustomGroupInterval) {
+      delete this.timewindow.history.disableCustomGroupInterval;
+    }
     if (!this.aggregation) {
       delete this.timewindow.aggregation;
     }

--- a/ui-ngx/src/app/shared/models/time/time.models.ts
+++ b/ui-ngx/src/app/shared/models/time/time.models.ts
@@ -331,6 +331,12 @@ export const initModelFromDefaultTimewindow = (value: Timewindow, quickIntervalO
       if (isDefinedAndNotNull(value.realtime.hideQuickInterval)) {
         model.realtime.hideQuickInterval = value.realtime.hideQuickInterval;
       }
+      if (isDefinedAndNotNull(value.realtime.disableCustomInterval)) {
+        model.realtime.disableCustomInterval = value.realtime.disableCustomInterval;
+      }
+      if (isDefinedAndNotNull(value.realtime.disableCustomGroupInterval)) {
+        model.realtime.disableCustomGroupInterval = value.realtime.disableCustomGroupInterval;
+      }
 
       if (isDefined(value.realtime.interval)) {
         model.realtime.interval = value.realtime.interval;
@@ -363,6 +369,12 @@ export const initModelFromDefaultTimewindow = (value: Timewindow, quickIntervalO
       }
       if (isDefinedAndNotNull(value.history.hideQuickInterval)) {
         model.history.hideQuickInterval = value.history.hideQuickInterval;
+      }
+      if (isDefinedAndNotNull(value.history.disableCustomInterval)) {
+        model.history.disableCustomInterval = value.history.disableCustomInterval;
+      }
+      if (isDefinedAndNotNull(value.history.disableCustomGroupInterval)) {
+        model.history.disableCustomGroupInterval = value.history.disableCustomGroupInterval;
       }
 
       if (isDefined(value.history.interval)) {
@@ -444,6 +456,8 @@ export const toHistoryTimewindow = (timewindow: Timewindow, startTimeMs: number,
       hideInterval: timewindow.history?.hideInterval || false,
       hideLastInterval: timewindow.history?.hideLastInterval || false,
       hideQuickInterval: timewindow.history?.hideQuickInterval || false,
+      disableCustomInterval: timewindow.history?.disableCustomInterval || false,
+      disableCustomGroupInterval: timewindow.history?.disableCustomGroupInterval || false,
     },
     aggregation: {
       type: aggType,

--- a/ui-ngx/src/app/shared/models/time/time.models.ts
+++ b/ui-ngx/src/app/shared/models/time/time.models.ts
@@ -331,10 +331,10 @@ export const initModelFromDefaultTimewindow = (value: Timewindow, quickIntervalO
       if (isDefinedAndNotNull(value.realtime.hideQuickInterval)) {
         model.realtime.hideQuickInterval = value.realtime.hideQuickInterval;
       }
-      if (isDefinedAndNotNull(value.realtime.disableCustomInterval)) {
+      if (value.realtime.disableCustomInterval) {
         model.realtime.disableCustomInterval = value.realtime.disableCustomInterval;
       }
-      if (isDefinedAndNotNull(value.realtime.disableCustomGroupInterval)) {
+      if (value.realtime.disableCustomGroupInterval) {
         model.realtime.disableCustomGroupInterval = value.realtime.disableCustomGroupInterval;
       }
 
@@ -370,10 +370,10 @@ export const initModelFromDefaultTimewindow = (value: Timewindow, quickIntervalO
       if (isDefinedAndNotNull(value.history.hideQuickInterval)) {
         model.history.hideQuickInterval = value.history.hideQuickInterval;
       }
-      if (isDefinedAndNotNull(value.history.disableCustomInterval)) {
+      if (value.history.disableCustomInterval) {
         model.history.disableCustomInterval = value.history.disableCustomInterval;
       }
-      if (isDefinedAndNotNull(value.history.disableCustomGroupInterval)) {
+      if (value.history.disableCustomGroupInterval) {
         model.history.disableCustomGroupInterval = value.history.disableCustomGroupInterval;
       }
 
@@ -441,7 +441,7 @@ export const toHistoryTimewindow = (timewindow: Timewindow, startTimeMs: number,
     aggType = AggregationType.AVG;
     limit = timeService.getMaxDatapointsLimit();
   }
-  return {
+  const historyTimewindow: Timewindow = {
     hideAggregation: timewindow.hideAggregation || false,
     hideAggInterval: timewindow.hideAggInterval || false,
     hideTimezone: timewindow.hideTimezone || false,
@@ -455,9 +455,7 @@ export const toHistoryTimewindow = (timewindow: Timewindow, startTimeMs: number,
       interval: timeService.boundIntervalToTimewindow(endTimeMs - startTimeMs, interval, AggregationType.AVG),
       hideInterval: timewindow.history?.hideInterval || false,
       hideLastInterval: timewindow.history?.hideLastInterval || false,
-      hideQuickInterval: timewindow.history?.hideQuickInterval || false,
-      disableCustomInterval: timewindow.history?.disableCustomInterval || false,
-      disableCustomGroupInterval: timewindow.history?.disableCustomGroupInterval || false,
+      hideQuickInterval: timewindow.history?.hideQuickInterval || false
     },
     aggregation: {
       type: aggType,
@@ -465,6 +463,13 @@ export const toHistoryTimewindow = (timewindow: Timewindow, startTimeMs: number,
     },
     timezone: timewindow.timezone
   };
+  if (timewindow.history?.disableCustomInterval) {
+    historyTimewindow.history.disableCustomInterval = timewindow.history.disableCustomInterval;
+  }
+  if (timewindow.history?.disableCustomGroupInterval) {
+    historyTimewindow.history.disableCustomGroupInterval = timewindow.history.disableCustomGroupInterval;
+  }
+  return historyTimewindow;
 };
 
 export const timewindowTypeChanged = (newTimewindow: Timewindow, oldTimewindow: Timewindow): boolean => {


### PR DESCRIPTION
## Pull Request description

Before:
The "Disable custom interval selection" parameter is not applied after saving the dashboard configuration; the custom interval is still available.

After:
Custom interval is not available for selection after when the option has been disabled.
![image](https://github.com/user-attachments/assets/531b9522-db04-4833-815a-5a0dd7797077)


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

