### PR TITLE
Refactoring SCADA symbols

### DIFF
--- a/application/src/main/data/json/system/scada_symbols/bottom-flow-meter.svg
+++ b/application/src/main/data/json/system/scada_symbols/bottom-flow-meter.svg
@@ -120,7 +120,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -134,6 +134,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -155,7 +164,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -169,6 +178,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/centrifugal-pump.svg
+++ b/application/src/main/data/json/system/scada_symbols/centrifugal-pump.svg
@@ -105,7 +105,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -119,6 +119,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -140,7 +149,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -154,6 +163,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/control-panel-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/control-panel-hp.svg
@@ -19,7 +19,7 @@
     },
     {
       "tag": "offButton",
-      "stateRenderFunction": "var offButtonChildren = element.children();\nif(ctx.values.value){\n  ctx.api.enable(element);\n  offButtonChildren[0].fill(ctx.properties.defaultButtonColor);\n} else {\n  ctx.api.disable(element);\n    offButtonChildren[0].fill(ctx.properties.activeButtonColor);\n}\n\noffButtonChildren[1].stroke(ctx.properties.borderButtonColor);\n\nif (!ctx.properties.label) {\n    element.transform({translateY: -60});\n}",
+      "stateRenderFunction": "var offButtonChildren = element.children();\nif(ctx.values.value){\n  ctx.api.enable(element);\n  offButtonChildren[0].fill(ctx.properties.defaultButtonColor);\n} else {\n  ctx.api.disable(element);\n    offButtonChildren[0].fill(ctx.properties.activeButtonColor);\n}\n\noffButtonChildren[1].stroke(ctx.properties.borderButtonColor);\n\nif (!ctx.properties.label) {\n    element.transform({translateY: -37});\n}",
       "actions": {
         "click": {
           "actionFunction": "ctx.api.disable(element);\nctx.api.callAction(event, 'offUpdateState', undefined, {\n  next: () => {\n     ctx.api.setValue('value', false);\n  },\n  error: () => {\n     ctx.api.enable(element);\n  }  \n});"
@@ -33,7 +33,7 @@
     },
     {
       "tag": "onButton",
-      "stateRenderFunction": "var onButtonChildren = element.children();\nif(ctx.values.value){\n    ctx.api.disable(element);\n    onButtonChildren[0].fill(ctx.properties.activeButtonColor);\n} else {\n    ctx.api.enable(element);\n    onButtonChildren[0].fill(ctx.properties.defaultButtonColor);\n}\nonButtonChildren[1].stroke(ctx.properties.borderButtonColor);\nif (!ctx.properties.label) {\n    element.transform({translateY: -60});\n}",
+      "stateRenderFunction": "var onButtonChildren = element.children();\nif(ctx.values.value){\n    ctx.api.disable(element);\n    onButtonChildren[0].fill(ctx.properties.activeButtonColor);\n} else {\n    ctx.api.enable(element);\n    onButtonChildren[0].fill(ctx.properties.defaultButtonColor);\n}\nonButtonChildren[1].stroke(ctx.properties.borderButtonColor);\nif (!ctx.properties.label) {\n    element.transform({translateY: -37});\n}",
       "actions": {
         "click": {
           "actionFunction": "ctx.api.disable(element);\nctx.api.callAction(event, 'onUpdateState', undefined, {\n  next: () => {\n     ctx.api.setValue('value', true);\n  },\n  error: () => {\n     ctx.api.enable(element);\n  }  \n});"
@@ -320,13 +320,13 @@
     }
   ]
 }]]></tb:metadata>
-<rect width="400" height="200" rx="8" fill="#dedede" tb:tag="background"/><rect x="1" y="1" width="398" height="198" rx="7" stroke="#000" stroke-opacity=".87" stroke-width="2"/><text x="198.7832" y="57.511719" fill="#000000" font-family="Roboto" font-size="56px" font-weight="400" text-anchor="middle" tb:tag="label" xml:space="preserve"><tspan dominant-baseline="middle">Heat pump</tspan></text><g transform="translate(-11 -36.996)" tb:tag="onButton">
-  <rect x="40" y="137" width="156" height="72" rx="9.8143" fill="#999" style="stroke-width:.95761"/>
-  <path d="m40.957 146.03c0-4.4589 3.9482-8.0734 8.8189-8.0734h136.45c4.8707 0 8.8189 3.6144 8.8189 8.0734v53.938c0 4.4589-3.9482 8.0743-8.8189 8.0743h-136.45c-4.8707 0-8.8189-3.6153-8.8189-8.0743z" shape-rendering="crispEdges" stroke="#999" stroke-width="1.9147"/>
-  <text x="118.48975" y="176.07759" fill="#000000" font-family="Roboto" font-size="34px" font-weight="500" text-anchor="middle" tb:tag="onLabel" xml:space="preserve"><tspan dominant-baseline="middle">On</tspan></text>
- </g><g transform="translate(-6,-36.996)" tb:tag="offButton">
-  <rect x="220" y="137" width="156" height="72" rx="9.8143" fill="#dedede" style="stroke-width:.95761"/>
-  <path d="m220.96 146.03c0-4.4589 3.9482-8.0734 8.8189-8.0734h136.45c4.8707 0 8.8189 3.6144 8.8189 8.0734v53.938c0 4.4589-3.9482 8.0743-8.8189 8.0743h-136.45c-4.8707 0-8.8189-3.6153-8.8189-8.0743z" shape-rendering="crispEdges" stroke="#999" stroke-width="1.9147"/>
-  <text x="296.72168" y="176.37642" fill="#000000" font-family="Roboto" font-size="34px" font-weight="500" text-anchor="middle" tb:tag="offLabel" xml:space="preserve"><tspan dominant-baseline="middle">Off</tspan></text>
+<rect width="400" height="200" rx="8" fill="#dedede" tb:tag="background"/><rect x="1" y="1" width="398" height="198" rx="7" stroke="#000" stroke-opacity=".87" stroke-width="2"/><text x="198.7832" y="57.511719" fill="#000000" font-family="Roboto" font-size="56px" font-weight="400" text-anchor="middle" tb:tag="label" xml:space="preserve"><tspan dominant-baseline="middle">Heat pump</tspan></text><g tb:tag="onButton">
+  <rect x="29" y="100" width="156" height="72" rx="9.8143" fill="#999" style="stroke-width:.95761"/>
+  <path d="m29.957 109.03c0-4.4589 3.9482-8.0734 8.8189-8.0734h136.45c4.8707 0 8.8189 3.6144 8.8189 8.0734v53.938c0 4.4589-3.9482 8.0743-8.8189 8.0743h-136.45c-4.8707 0-8.8189-3.6153-8.8189-8.0743z" shape-rendering="crispEdges" stroke="#999" stroke-width="1.9147"/>
+  <text x="107.44609" y="138.7375" fill="#000000" font-family="Roboto" font-size="34px" font-weight="500" text-anchor="middle" tb:tag="onLabel" xml:space="preserve"><tspan dominant-baseline="middle">On</tspan></text>
+ </g><g tb:tag="offButton">
+  <rect x="214" y="100" width="156" height="72" rx="9.8143" fill="#dedede" style="stroke-width:.95761"/>
+  <path d="m214.96 109.03c0-4.4589 3.9482-8.0734 8.8189-8.0734h136.45c4.8707 0 8.8189 3.6144 8.8189 8.0734v53.938c0 4.4589-3.9482 8.0743-8.8189 8.0743h-136.45c-4.8707 0-8.8189-3.6153-8.8189-8.0743z" shape-rendering="crispEdges" stroke="#999" stroke-width="1.9147"/>
+  <text x="290.68408" y="139.33516" fill="#000000" font-family="Roboto" font-size="34px" font-weight="500" text-anchor="middle" tb:tag="offLabel" xml:space="preserve"><tspan dominant-baseline="middle">Off</tspan></text>
  </g>
 </svg>

--- a/application/src/main/data/json/system/scada_symbols/cylindrical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/cylindrical-tank.svg
@@ -142,7 +142,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -151,16 +151,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -177,7 +186,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -186,16 +195,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/dynamic-horizontal-scale-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/dynamic-horizontal-scale-hp.svg
@@ -1,5 +1,4 @@
-<svg width="800" height="400" fill="none" version="1.1" viewBox="0 0 800 400" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="800" height="400" fill="none" version="1.1" viewBox="0 0 800 400"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Dynamic horizontal scale",
   "description": "Dynamic horizontal scale with current volume value and dynamically configurable warning and critical scale.",
   "searchTags": [
@@ -19,22 +18,12 @@
     },
     {
       "tag": "highCriticalScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar highCriticalValue = ctx.values.highCriticalState;\nif (showHighCriticalScale && highCriticalValue !== null) {\n    element.show();\n    var offset = calculateOffset(highCriticalValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(653-offset);\n    childrenElement[1].height(653-offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "highCriticalScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showHighCriticalState = ctx.properties.showHighCriticalScale;\nvar highCriticalScale = ctx.values.highCriticalState;\n\nif (showHighCriticalState && value !== null && highCriticalScale !== null) {\n    if (value >= highCriticalScale && value <= ctx.properties.maxValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar highCriticalState = ctx.values.highCriticalState;\nif (showHighCriticalScale && highCriticalState !== null) {\n    element.show();\n    var offset = calculateOffset(highCriticalState, minValue, maxValue);\n    element.width(653-offset);\n} else {\n    element.hide();\n}\n\nif (showHighCriticalScale && value !== null && highCriticalState !== null) {\n    if (value >= highCriticalState && value <= ctx.properties.maxValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
       "actions": null
     },
     {
       "tag": "highWarningScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\nvar highWarningValue = ctx.values.highWarningState;\nif (showHighWarningScale && highWarningValue !== null) {\n    element.show();\n    var offset = calculateOffset(highWarningValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(653-offset);\n    childrenElement[1].height(653-offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "highWarningScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\n\nif (showHighWarningScale && value !== null) {\n    var highWarningScale = ctx.values.highWarningState;\n    var highCriticalScale = ctx.values.highCriticalState;\n    if (!showHighCriticalScale) {\n        highCriticalScale = ctx.properties.maxValue;\n    }\n    \n    if (highWarningScale !== null && highCriticalScale !== null) {\n        if (value < highCriticalScale && value >= highWarningScale) {\n            element.fill(ctx.properties.activeWarningScaleColor);\n        } else {\n            element.fill(ctx.properties.defaultWarningScaleColor);\n        }\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\nvar highWarningState = ctx.values.highWarningState;\nvar highCriticalState = ctx.values.highCriticalState;\nif (showHighWarningScale && highWarningState !== null) {\n    element.show();\n    var offset = calculateOffset(highWarningState, minValue, maxValue);\n    element.width(653-offset);\n} else {\n    element.hide();\n}\n\nif (showHighWarningScale && value !== null) {\n    if (!showHighCriticalScale) {\n        highCriticalState = ctx.properties.maxValue;\n    }\n    \n    if (highWarningState !== null && highCriticalState !== null) {\n        if (value < highCriticalState && value >= highWarningState) {\n            element.fill(ctx.properties.activeWarningScaleColor);\n        } else {\n            element.fill(ctx.properties.defaultWarningScaleColor);\n        }\n    }\n}",
       "actions": null
     },
     {
@@ -44,22 +33,12 @@
     },
     {
       "tag": "lowCriticalScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowCriticalValue = ctx.values.lowCriticalState;\n\nif (showLowCriticalScale && lowCriticalValue !== null) {\n    element.show();\n    var offset = calculateOffset(lowCriticalValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(offset);\n    childrenElement[1].height(offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "lowCriticalScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\n\nif (showLowCriticalScale && value !== null) {\n    var lowCriticalScale = ctx.values.lowCriticalState;\n    if (value <= lowCriticalScale && value >= ctx.properties.minValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowCriticalValue = ctx.values.lowCriticalState;\n\nif (showLowCriticalScale && lowCriticalValue !== null) {\n    element.show();\n    var offset = calculateOffset(lowCriticalValue, minValue, maxValue);\n    element.width(offset);\n} else {\n    element.hide();\n}\n\nif (showLowCriticalScale && value !== null) {\n    var lowCriticalScale = ctx.values.lowCriticalState;\n    if (value <= lowCriticalScale && value >= ctx.properties.minValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
       "actions": null
     },
     {
       "tag": "lowWarningScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar lowWarningValue = ctx.values.lowWarningState;\nif (showLowWarningScale && lowWarningValue !== null) {\n    element.show();\n    var offset = calculateOffset(lowWarningValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(offset);\n    childrenElement[1].height(offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "lowWarningScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\n\nif (showLowWarningScale && value !== null) {\n    var lowCriticalScale = ctx.values.lowCriticalState;\n    var lowWarningScale = ctx.values.lowWarningState;\n    if (!showLowCriticalScale) {\n        lowCriticalScale = ctx.properties.minValue;\n    }\n    if (lowCriticalScale !== null && lowWarningScale !== null) {\n        if (value > lowCriticalScale && value <= lowWarningScale) {\n            element.fill(ctx.properties.activeWarningScaleColor);\n        } else {\n            element.fill(ctx.properties.defaultWarningScaleColor);\n        }\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowWarningState = ctx.values.lowWarningState;\nvar lowCriticalState = ctx.values.lowCriticalState;\nif (showLowWarningScale && lowWarningState !== null) {\n    element.show();\n    var offset = calculateOffset(lowWarningState, minValue, maxValue);\n    element.width(offset);\n} else {\n    element.hide();\n}\n\nif (showLowWarningScale && value !== null) {\n    if (!showLowCriticalScale) {\n        lowCriticalState = ctx.properties.minValue;\n    }\n    if (lowCriticalState !== null && lowWarningState !== null) {\n        if (value > lowCriticalState && value <= lowWarningState) {\n            element.fill(ctx.properties.activeWarningScaleColor);\n        } else {\n            element.fill(ctx.properties.defaultWarningScaleColor);\n        }\n    }\n}",
       "actions": null
     },
     {
@@ -84,7 +63,7 @@
     },
     {
       "tag": "target",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 640;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showTarget = ctx.properties.showTarget;\nvar targetValue = ctx.values.targetValue;\n\nif (showTarget && targetValue !== null) {\n    element.show();\n    var offset = calculateOffset(targetValue, minValue, maxValue);\n    element.transform({translateX: -(640 - (Math.min(Math.max(offset+17, 36), 640)))});\n} else {\n    element.hide();\n}\n\n",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showTarget = ctx.properties.showTarget;\nvar targetValue = ctx.values.targetValue;\n\nif (showTarget && targetValue !== null) {\n    element.show();\n    var offset = calculateOffset(targetValue, minValue, maxValue);\n    element.transform({translateX: Math.min(Math.max(offset-17, 0), 619)});\n} else {\n    element.hide();\n}",
       "actions": null
     },
     {
@@ -99,7 +78,12 @@
     },
     {
       "tag": "value",
-      "stateRenderFunction": "if (ctx.properties.value !== null) {\n    element.show();\n    ctx.api.font(element, ctx.properties.valueFont, ctx.properties.valueColor);\n    ctx.api.text(element, ctx.api.formatValue(ctx.values.value, ctx.properties.valueDecimals, null, ctx.properties.valueDecimals));\n} else {\n    element.hide();\n}",
+      "stateRenderFunction": "if (ctx.properties.value) {\n    element.show();\n    ctx.api.font(element, ctx.properties.valueFont, ctx.properties.valueColor);\n    ctx.api.text(element, ctx.api.formatValue(ctx.values.value, ctx.properties.valueDecimals, null, ctx.properties.valueDecimals));\n} else {\n    element.hide();\n}",
+      "actions": null
+    },
+    {
+      "tag": "valueArrowPosition",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateX: offset});\n}\n",
       "actions": null
     },
     {
@@ -108,8 +92,8 @@
       "actions": null
     },
     {
-      "tag": "valuePosition",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 638;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateX: -(638 - offset)});\n}\n",
+      "tag": "valueTextPositon",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateX: offset});\n}\n",
       "actions": null
     }
   ],
@@ -792,39 +776,20 @@
     }
   ]
 }]]></tb:metadata>
- <text x="409.16602" y="97.234375" fill="#000000" font-family="Roboto" font-size="56px" font-weight="400" text-anchor="middle" tb:tag="label" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">Outdoor</tspan></text>
- <text x="401.15625" y="345.75" fill="#000000" font-family="Roboto" font-size="40px" font-weight="400" text-anchor="middle" tb:tag="units" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">°C</tspan></text>
- <g transform="matrix(.98289 0 0 1 8.2492 -20)" fill="#666" font-family="Roboto" font-size="32px" font-weight="500" text-anchor="middle" style="display:none" tb:tag="minMaxValue">
-  <text x="100.02344" y="268" style="" tb:tag="maxValue" xml:space="preserve"><tspan dominant-baseline="middle">100</tspan></text>
-  <text x="715.07031" y="268" style="" tb:tag="minValue" xml:space="preserve"><tspan dominant-baseline="middle">0</tspan></text>
- </g>
- <g transform="translate(-350)" tb:tag="valuePosition">
-  <path d="m719 179 24-42h-48z" fill="#666" tb:tag="valuePointer"/>
-  <text x="718.7793" y="273.125" fill="#002878" font-family="Roboto" font-size="60px" font-weight="400" text-anchor="middle" tb:tag="value" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">26</tspan></text>
- </g>
- <g transform="matrix(.97855 0 0 1 9.5443 -16.995)" tb:tag="scale">
-  <rect transform="rotate(-90)" x="-242" y="72" width="42" height="653" fill="#c8dff7" style="stroke-width:.9497" tb:tag="scaleBackground"/>
-  <rect transform="rotate(-90)" x="-241.52" y="72.475" width="41.05" height="652.05" stroke="#000" stroke-opacity=".87" style="stroke-width:.95024"/>
-  <g tb:tag="lowWarningScale">
-   <rect transform="rotate(-90)" x="-242" y="72" width="42" height="153.12" fill="#ebebeb" style="stroke-width:.94905" tb:tag="lowWarningScaleBackground"/>
-   <rect transform="rotate(-90)" x="-241.53" y="72.475" width="41.051" height="152.17" stroke="#000" stroke-opacity=".87" style="stroke-width:.94948"/>
-  </g>
-  <g tb:tag="lowCriticalScale">
-   <rect transform="rotate(-90)" x="-242" y="72" width="42" height="81.062" fill="#666" style="stroke-width:.94905" tb:tag="lowCriticalScaleBackground"/>
-   <rect transform="rotate(-90)" x="-241.53" y="72.475" width="41.051" height="80.113" stroke="#000" stroke-opacity=".87" style="stroke-width:.94934"/>
-  </g>
-  <g transform="rotate(90,700.5,265.5)" tb:tag="highWarningScale">
-   <rect transform="scale(-1,1)" x="-677" y="241" width="42" height="153.12" fill="#ebebeb" style="stroke-width:.94905" tb:tag="highWarningScaleBackground"/>
-   <rect transform="scale(-1,1)" x="-676.53" y="241.47" width="41.051" height="152.17" stroke="#000" stroke-opacity=".87" style="stroke-width:.94948"/>
-  </g>
-  <g transform="rotate(90,700.5,265.5)" tb:tag="highCriticalScale">
-   <rect transform="scale(-1,1)" x="-677" y="241" width="42" height="81.062" fill="#666" style="stroke-width:.94905" tb:tag="highCriticalScaleBackground"/>
-   <rect transform="scale(-1,1)" x="-676.53" y="241.48" width="41.051" height="80.113" stroke="#000" stroke-opacity=".87" style="stroke-width:.94934"/>
-  </g>
- </g>
- <g transform="translate(-180)" tb:tag="target">
-  <rect transform="rotate(45)" x="627.89" y="-363.43" width="24" height="24" fill="#dedede" tb:tag="targetBackground"/>
-  <rect transform="rotate(45)" x="628.89" y="-362.43" width="22" height="22" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- </g>
- <path d="m269.06 0s-269.06 0-269.06 67v328.36c0 2.6512 7.1634 4.6404 16 4.6404h768c8.836 0 16-1.9892 16-4.6404v-328.36c0-67-264.28-67-264.28-67h-135.72zm268.28 81.2c-5.1546 0-9.3334 1.2536-9.3334 2.8v300.4c0 1.5464 4.1786 2.8 9.3334 2.8h58.666c5.1546 0 9.3334-1.2536 9.3334-2.8v-300.4c0-1.5464-4.1786-2.8-9.3334-2.8z" fill="#000" fill-opacity="0" style="stroke-width:.7303" tb:tag="clickArea"/>
+<text x="409.16602" y="97.234375" fill="#000000" font-family="Roboto" font-size="56px" font-weight="400" text-anchor="middle" tb:tag="label" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">Outdoor</tspan></text><text x="401.15625" y="345.75" fill="#000000" font-family="Roboto" font-size="40px" font-weight="400" text-anchor="middle" tb:tag="units" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">°C</tspan></text><g fill="#666" font-family="Roboto" font-size="32px" font-weight="500" text-anchor="middle" style="display: none;" tb:tag="minMaxValue">
+  <text x="88.070312" y="268" tb:tag="minValue" xml:space="preserve" style=""><tspan dominant-baseline="middle">0</tspan></text>
+  <text x="705.02344" y="268" tb:tag="maxValue" xml:space="preserve" style=""><tspan dominant-baseline="middle">100</tspan></text>
+ </g><g transform="translate(180)" tb:tag="valueArrowPosition">
+  <path d="m80 179 24-42h-48z" fill="#666" tb:tag="valuePointer"/>
+ </g><g transform="translate(180)" tb:tag="valueTextPositon">
+  <text x="79.779297" y="273.125" fill="#002878" font-family="Roboto" font-size="60px" font-weight="400" text-anchor="middle" tb:tag="value" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">26</tspan></text>
+ </g><g stroke="#000" tb:tag="scale">
+  <rect x="80.5" y="183.5" width="652" height="41" fill="#c8dff7" tb:tag="scaleBackground"/>
+  <rect x="80.5" y="183.5" width="164" height="41" fill="#ebebeb" tb:tag="lowWarningScale"/>
+  <rect x="80.5" y="183.5" width="81" height="41" fill="#666" tb:tag="lowCriticalScale"/>
+  <rect transform="scale(-1,1)" x="-732.5" y="183.5" width="164" height="41" fill="#ebebeb" tb:tag="highWarningScale"/>
+  <rect transform="scale(-1,1)" x="-732.5" y="183.5" width="81" height="41" fill="#666" tb:tag="highCriticalScale"/>
+ </g><g transform="translate(400)" style="display: none;" tb:tag="target">
+  <rect transform="rotate(45)" x="201.8" y="64.66" width="22" height="22" fill="#dedede" stroke="#000" stroke-width="2" tb:tag="targetBackground" style=""/>
+ </g><path d="m269.06 0s-269.06 0-269.06 67v328.36c0 2.6512 7.1634 4.6404 16 4.6404h768c8.836 0 16-1.9892 16-4.6404v-328.36c0-67-264.28-67-264.28-67h-135.72zm268.28 81.2c-5.1546 0-9.3334 1.2536-9.3334 2.8v300.4c0 1.5464 4.1786 2.8 9.3334 2.8h58.666c5.1546 0 9.3334-1.2536 9.3334-2.8v-300.4c0-1.5464-4.1786-2.8-9.3334-2.8z" fill="#000" fill-opacity="0" style="stroke-width:.7303" tb:tag="clickArea"/>
 </svg>

--- a/application/src/main/data/json/system/scada_symbols/dynamic-vertical-scale-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/dynamic-vertical-scale-hp.svg
@@ -1,5 +1,4 @@
-<svg width="400" height="800" fill="none" version="1.1" viewBox="0 0 400 800" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="400" height="800" fill="none" version="1.1" viewBox="0 0 400 800"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Dynamic vertical scale",
   "description": "Dynamic vertical scale with current volume value and dynamically configurable warning and critical scale.",
   "searchTags": [
@@ -19,22 +18,12 @@
     },
     {
       "tag": "highCriticalScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar highCriticalValue = ctx.values.highCriticalState;\nif (showHighCriticalScale && highCriticalValue !== null) {\n    element.show();\n    var offset = calculateOffset(highCriticalValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(653-offset);\n    childrenElement[1].height(653-offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "highCriticalScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showHighCriticalState = ctx.properties.showHighCriticalScale;\nvar highCriticalScale = ctx.values.highCriticalState;\n\nif (showHighCriticalState && value !== null && highCriticalScale !== null) {\n    if (value >= highCriticalScale && value <= ctx.properties.maxValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar highCriticalState = ctx.values.highCriticalState;\nif (showHighCriticalScale && highCriticalState !== null) {\n    element.show();\n    var offset = calculateOffset(highCriticalState, minValue, maxValue);\n    element.height(653-offset);\n} else {\n    element.hide();\n}\n\nif (showHighCriticalScale && value !== null && highCriticalState !== null) {\n    if (value >= highCriticalState && value <= ctx.properties.maxValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
       "actions": null
     },
     {
       "tag": "highWarningScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\nvar highWarningValue = ctx.values.highWarningState;\nif (showHighWarningScale && highWarningValue !== null) {\n    element.show();\n    var offset = calculateOffset(highWarningValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(653-offset);\n    childrenElement[1].height(653-offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "highWarningScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\n\nif (showHighWarningScale && value !== null) {\n    var highWarningScale = ctx.values.highWarningState;\n    var highCriticalScale = ctx.values.highCriticalState;\n    if (!showHighCriticalScale) {\n        highCriticalScale = ctx.properties.maxValue;\n    }\n    \n    if (highWarningScale !== null && highCriticalScale !== null) {\n        if (value < highCriticalScale && value >= highWarningScale) {\n            element.fill(ctx.properties.activeWarningScaleColor);\n        } else {\n            element.fill(ctx.properties.defaultWarningScaleColor);\n        }\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\nvar highWarningState = ctx.values.highWarningState;\nvar highCriticalState = ctx.values.highCriticalState;\nif (showHighWarningScale && highWarningState !== null) {\n    element.show();\n    var offset = calculateOffset(highWarningState, minValue, maxValue);\n    element.height(653-offset);\n} else {\n    element.hide();\n}\nif (showHighWarningScale && value !== null) {\n    if (!showHighCriticalScale) {\n        highCriticalState = ctx.properties.maxValue;\n    }\n    if (highWarningState !== null && highCriticalState !== null) {\n        if (value < highCriticalState && value >= highWarningState) {\n            element.fill(ctx.properties.activeWarningScaleColor);\n        } else {\n            element.fill(ctx.properties.defaultWarningScaleColor);\n        }\n    }\n}",
       "actions": null
     },
     {
@@ -44,22 +33,12 @@
     },
     {
       "tag": "lowCriticalScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowCriticalValue = ctx.values.lowCriticalState;\n\nif (showLowCriticalScale && lowCriticalValue !== null) {\n    element.show();\n    var offset = calculateOffset(lowCriticalValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(offset);\n    childrenElement[1].height(offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "lowCriticalScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\n\nif (showLowCriticalScale && value !== null) {\n    var lowCriticalScale = ctx.values.lowCriticalState;\n    if (value <= lowCriticalScale && value >= ctx.properties.minValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowCriticalValue = ctx.values.lowCriticalState;\n\nif (showLowCriticalScale && lowCriticalValue !== null) {\n    element.show();\n    var offset = calculateOffset(lowCriticalValue, minValue, maxValue);\n    element.height(offset);\n} else {\n    element.hide();\n}\nif (showLowCriticalScale && value !== null) {\n    var lowCriticalScale = ctx.values.lowCriticalState;\n    if (value <= lowCriticalScale && value >= ctx.properties.minValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
       "actions": null
     },
     {
       "tag": "lowWarningScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar lowWarningValue = ctx.values.lowWarningState;\nif (showLowWarningScale && lowWarningValue !== null) {\n    element.show();\n    var offset = calculateOffset(lowWarningValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(offset);\n    childrenElement[1].height(offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "lowWarningScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\n\nif (showLowWarningScale && value !== null) {\n    var lowCriticalScale = ctx.values.lowCriticalState;\n    var lowWarningScale = ctx.values.lowWarningState;\n    if (!showLowCriticalScale) {\n        lowCriticalScale = ctx.properties.minValue;\n    }\n    if (lowCriticalScale !== null && lowWarningScale !== null) {\n        if (value > lowCriticalScale && value <= lowWarningScale) {\n            element.fill(ctx.properties.activeWarningScaleColor);\n        } else {\n            element.fill(ctx.properties.defaultWarningScaleColor);\n        }\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowWarningState = ctx.values.lowWarningState;\nvar lowCriticalState = ctx.values.lowCriticalState;\nif (showLowWarningScale && lowWarningState !== null) {\n    element.show();\n    var offset = calculateOffset(lowWarningState, minValue, maxValue);\n    element.height(offset);\n} else {\n    element.hide();\n}\nif (showLowWarningScale && value !== null) {\n    if (!showLowCriticalScale) {\n        lowCriticalState = ctx.properties.minValue;\n    }\n    if (lowCriticalState !== null && lowWarningState !== null) {\n        if (value > lowCriticalState && value <= lowWarningState) {\n            element.fill(ctx.properties.activeWarningScaleColor);\n        } else {\n            element.fill(ctx.properties.defaultWarningScaleColor);\n        }\n    }\n}",
       "actions": null
     },
     {
@@ -84,7 +63,7 @@
     },
     {
       "tag": "target",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showTarget = ctx.properties.showTarget;\nvar targetValue = ctx.values.targetValue;\n\nif (showTarget && targetValue !== null) {\n    element.show();\n    var offset = calculateOffset(targetValue, minValue, maxValue);\n    element.transform({translateY: -(Math.min(Math.max(offset-17, 0), 617))});\n} else {\n    element.hide();\n}\n\n",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showTarget = ctx.properties.showTarget;\nvar targetValue = ctx.values.targetValue;\n\nif (showTarget && targetValue !== null) {\n    element.show();\n    var offset = calculateOffset(targetValue, minValue, maxValue);\n    element.transform({translateY: -Math.min(Math.max(offset-17, 0), 619)});\n} else {\n    element.hide();\n}",
       "actions": null
     },
     {
@@ -99,7 +78,12 @@
     },
     {
       "tag": "value",
-      "stateRenderFunction": "if (ctx.properties.value !== null) {\n    element.show();\n    ctx.api.font(element, ctx.properties.valueFont, ctx.properties.valueColor);\n    ctx.api.text(element, ctx.api.formatValue(ctx.values.value, ctx.properties.valueDecimals, null, ctx.properties.valueDecimals));\n} else {\n    element.hide();\n}",
+      "stateRenderFunction": "if (ctx.properties.value) {\n    element.show();\n    ctx.api.font(element, ctx.properties.valueFont, ctx.properties.valueColor);\n    ctx.api.text(element, ctx.api.formatValue(ctx.values.value, ctx.properties.valueDecimals, null, ctx.properties.valueDecimals));\n} else {\n    element.hide();\n}",
+      "actions": null
+    },
+    {
+      "tag": "valueArrowPosition",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateY: -offset});\n}\n",
       "actions": null
     },
     {
@@ -108,8 +92,8 @@
       "actions": null
     },
     {
-      "tag": "valuePosition",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateY: -offset});\n}\n",
+      "tag": "valueTextPositon",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateY: -offset});\n}\n",
       "actions": null
     }
   ],
@@ -792,39 +776,20 @@
     }
   ]
 }]]></tb:metadata>
- <text x="206.16602" y="43.234375" fill="#000000" font-family="Roboto" font-size="56px" font-weight="400" text-anchor="middle" tb:tag="label" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">Outdoor</tspan></text>
- <text x="195.21875" y="784.75" fill="#000000" font-family="Roboto" font-size="40px" font-weight="400" text-anchor="middle" tb:tag="units" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">°C</tspan></text>
- <g transform="matrix(1 0 0 .97781 0 13.842)" tb:tag="scale">
-  <rect x="176" y="83" width="42" height="652" fill="#c8dff7" tb:tag="scaleBackground"/>
-  <rect x="176.5" y="83.5" width="41" height="651" stroke="#000" stroke-opacity=".87"/>
-  <g tb:tag="lowWarningScale">
-   <rect transform="scale(1,-1)" x="176" y="-736.5" width="42" height="170" fill="#ebebeb" tb:tag="lowWarningScaleBackground"/>
-   <rect transform="scale(1,-1)" x="176.5" y="-736" width="41" height="169" stroke="#000" stroke-opacity=".87"/>
-  </g>
-  <g tb:tag="highWarningScale">
-   <rect x="176" y="83" width="42" height="170" fill="#ebebeb" tb:tag="highWarningScaleBackground"/>
-   <rect x="176.5" y="83.5" width="41" height="169" stroke="#000" stroke-opacity=".87"/>
-  </g>
-  <g tb:tag="lowCriticalScale">
-   <rect transform="scale(1,-1)" x="176" y="-736.5" width="42" height="90" fill="#666" tb:tag="lowCriticalScaleBackground"/>
-   <rect transform="scale(1,-1)" x="176.5" y="-736" width="41" height="89" stroke="#000" stroke-opacity=".87"/>
-  </g>
-  <g tb:tag="highCriticalScale">
-   <rect x="176" y="83" width="42" height="90" fill="#666" tb:tag="highCriticalScaleBackground"/>
-   <rect x="176.5" y="83.5" width="41" height="89" stroke="#000" stroke-opacity=".87"/>
-  </g>
- </g>
- <g transform="matrix(1 0 0 .97676 0 14.906)" fill="#666" font-family="Roboto" font-size="32px" font-weight="500" text-anchor="middle" style="display:none" tb:tag="minMaxValue">
-  <text x="260.02344" y="97" tb:tag="maxValue" xml:space="preserve"><tspan dominant-baseline="middle">100</tspan></text>
-  <text x="239.07031" y="727" tb:tag="minValue" xml:space="preserve"><tspan dominant-baseline="middle">0</tspan></text>
- </g>
- <g transform="translate(0,-350)" tb:tag="valuePosition">
-  <path d="m168 734-42-24v48z" fill="#666" tb:tag="valuePointer"/>
-  <text x="262.53329" y="738.125" fill="#002878" font-family="Roboto" font-size="60px" font-weight="400" text-anchor="middle" tb:tag="value" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">26</tspan></text>
- </g>
- <g transform="translate(0,-420)" tb:tag="target">
-  <rect transform="rotate(-45)" x="-379.7" y="634.25" width="24" height="24" fill="#dedede" tb:tag="targetBackground"/>
-  <rect transform="rotate(-45)" x="-378.7" y="635.25" width="22" height="22" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- </g>
- <path d="m134.53 0s-134.53 0-134.53 134v656.72c0 5.3024 3.5817 9.2808 8 9.2808h384c4.418 0 8-3.9784 8-9.2808v-656.72c0-134-132.14-134-132.14-134h-67.86zm134.14 162.4c-2.5773 0-4.6667 2.5072-4.6667 5.6v600.8c0 3.0928 2.0893 5.6 4.6667 5.6h29.333c2.5773 0 4.6667-2.5072 4.6667-5.6v-600.8c0-3.0928-2.0893-5.6-4.6667-5.6z" fill="#000" fill-opacity="0" style="stroke-width:.7303" tb:tag="clickArea"/>
+<text x="206.16602" y="43.234375" fill="#000000" font-family="Roboto" font-size="56px" font-weight="400" text-anchor="middle" tb:tag="label" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">Outdoor</tspan></text><text x="195.21875" y="784.75" fill="#000000" font-family="Roboto" font-size="40px" font-weight="400" text-anchor="middle" tb:tag="units" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">°C</tspan></text><g stroke="#000" tb:tag="scale">
+  <rect x="176.5" y="83" width="41" height="652" fill="#c8dff7" tb:tag="scaleBackground"/>
+  <rect transform="scale(1,-1)" x="176.5" y="-735" width="41" height="164" fill="#ebebeb" tb:tag="lowWarningScale"/>
+  <rect x="176.5" y="83.5" width="41" height="164" fill="#ebebeb" tb:tag="highWarningScale"/>
+  <rect transform="scale(1,-1)" x="176.5" y="-735" width="41" height="81" fill="#666" tb:tag="lowCriticalScale"/>
+  <rect x="176.5" y="83.5" width="41" height="81" fill="#666" tb:tag="highCriticalScale"/>
+ </g><g fill="#666" font-family="Roboto" font-size="32px" font-weight="500" style="display: none;" tb:tag="minMaxValue">
+  <text x="237.48438" y="97" tb:tag="maxValue" xml:space="preserve" style=""><tspan dominant-baseline="middle">100</tspan></text>
+  <text x="238.89062" y="727" tb:tag="minValue" xml:space="preserve" style=""><tspan dominant-baseline="middle">0</tspan></text>
+ </g><g transform="translate(0,-180)" tb:tag="valueArrowPosition">
+  <path d="m168 735-42-24v48z" fill="#666" tb:tag="valuePointer"/>
+ </g><g transform="translate(0,-180)" tb:tag="valueTextPositon">
+  <text x="223.60547" y="739.125" fill="#002878" font-family="Roboto" font-size="60px" font-weight="400" tb:tag="value" xml:space="preserve"><tspan dominant-baseline="middle">26</tspan></text>
+ </g><g transform="translate(0,-400)" style="display: none;" tb:tag="target">
+  <rect transform="rotate(-45)" x="-379.76" y="636.31" width="22" height="22" fill="#dedede" stroke="#000" stroke-width="2" tb:tag="targetBackground" style=""/>
+ </g><path d="m134.53 0s-134.53 0-134.53 134v656.72c0 5.3024 3.5817 9.2808 8 9.2808h384c4.418 0 8-3.9784 8-9.2808v-656.72c0-134-132.14-134-132.14-134h-67.86zm134.14 162.4c-2.5773 0-4.6667 2.5072-4.6667 5.6v600.8c0 3.0928 2.0893 5.6 4.6667 5.6h29.333c2.5773 0 4.6667-2.5072 4.6667-5.6v-600.8c0-3.0928-2.0893-5.6-4.6667-5.6z" fill="#000" fill-opacity="0" style="stroke-width:.7303" tb:tag="clickArea"/>
 </svg>

--- a/application/src/main/data/json/system/scada_symbols/elevated-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/elevated-tank.svg
@@ -138,7 +138,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -147,16 +147,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -173,7 +182,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -182,16 +191,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/filter-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/filter-hp.svg
@@ -1,5 +1,4 @@
-<svg width="200" height="400" fill="none" version="1.1" viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="200" height="400" fill="none" version="1.1" viewBox="0 0 200 400"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Filter",
   "description": "Filter",
   "searchTags": [
@@ -8,11 +7,6 @@
   "widgetSizeX": 1,
   "widgetSizeY": 2,
   "tags": [
-    {
-      "tag": "background",
-      "stateRenderFunction": "element.attr({fill: ctx.properties.runningColor});",
-      "actions": null
-    },
     {
       "tag": "clickArea",
       "stateRenderFunction": null,
@@ -44,16 +38,16 @@
   "behavior": [
     {
       "id": "warning",
-      "name": "{i18n:scada.symbol.warning-state}",
+      "name": "{i18n:scada.symbol.warning}",
       "hint": "{i18n:scada.symbol.warning-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.warning-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -62,33 +56,62 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
     },
     {
+      "id": "warningClick",
+      "name": "{i18n:scada.symbol.warning-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.warning-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
+    },
+    {
       "id": "critical",
-      "name": "{i18n:scada.symbol.critical-state}",
+      "name": "{i18n:scada.symbol.critical}",
       "hint": "{i18n:scada.symbol.critical-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.critical-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -97,20 +120,46 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
+    },
+    {
+      "id": "criticalClick",
+      "name": "{i18n:scada.symbol.critical-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.critical-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
     },
     {
       "id": "criticalAnimation",
@@ -148,46 +197,6 @@
       "defaultWidgetActionSettings": null
     },
     {
-      "id": "warningClick",
-      "name": "{i18n:scada.symbol.warning-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
-      "id": "criticalClick",
-      "name": "{i18n:scada.symbol.critical-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
       "id": "click",
       "name": "{i18n:scada.symbol.on-click}",
       "hint": "{i18n:scada.symbol.on-click-hint}",
@@ -211,12 +220,12 @@
   "properties": [
     {
       "id": "runningColor",
-      "name": "{i18n:scada.symbol.running-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#FFFFFF",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.running}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -227,12 +236,12 @@
     },
     {
       "id": "warningColor",
-      "name": "{i18n:scada.symbol.warning-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#FAA405",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.warning}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -243,11 +252,11 @@
     },
     {
       "id": "criticalColor",
-      "name": "{i18n:scada.symbol.critical-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#D12730",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.critical}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -259,16 +268,12 @@
     }
   ]
 }]]></tb:metadata>
- <path d="m18.383 177.21c-0.0635-1.09-0.5693-2.106-1.4002-2.815l-9.0297-7.696c-4.2584-3.63-6.8043-8.844-6.9791-14.436-0.65043-20.804-1.9643-74.241 0.29843-110.76 0.77895-12.572 2.4293-30.36 3.1494-37.9 0.19581-2.0502 1.9178-3.6002 3.9773-3.6002h183.2c2.059 0 3.781 1.5501 3.977 3.6002 0.72 7.5392 2.371 25.328 3.15 37.9 2.262 36.518 0.948 89.955 0.298 110.76-0.175 5.592-2.721 10.806-6.979 14.436l-9.03 7.696c-0.831 0.709-1.336 1.725-1.4 2.815l-8.57 147.01c-0.605 10.385-5.508 20.049-13.531 26.67-34.554 28.516-84.478 28.516-119.03 0-8.0233-6.621-12.926-16.285-13.532-26.67z" fill="#fff"/>
- <path d="m19.382 177.15c-0.0794-1.362-0.71139-2.633-1.7498-3.518l-9.0296-7.697c-4.0474-3.45-6.4624-8.4-6.6282-13.706-0.65056-20.807-1.9624-74.2 0.297-110.67 0.77777-12.553 2.4266-30.326 3.1467-37.866 0.1463-1.5318 1.4324-2.6953 2.9818-2.6953h183.2c1.549 0 2.835 1.1635 2.982 2.6953 0.71999 7.5402 2.369 25.314 3.146 37.866 2.26 36.465 0.94799 89.858 0.297 110.67-0.165 5.306-2.58 10.256-6.6279 13.706l-9.0289 7.697c-1.039 0.885-1.671 2.156-1.75 3.518l-8.5699 147.01c-0.589 10.108-5.361 19.513-13.17 25.958-34.184 28.21-83.573 28.21-117.76 0-7.8087-6.445-12.581-15.85-13.17-25.958z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- <path d="m67.264 0s-67.264 0-67.264 67v328.36c0 2.6512 1.7909 4.6404 4 4.6404h192c2.209 0 4-1.9892 4-4.6404v-328.36c0-67-66.07-67-66.07-67h-33.929zm67.07 81.2c-1.2887 0-2.3333 1.2536-2.3333 2.8v300.4c0 1.5464 1.0447 2.8 2.3333 2.8h14.666c1.2887 0 2.3333-1.2536 2.3333-2.8v-300.4c0-1.5464-1.0447-2.8-2.3333-2.8z" fill="#000" fill-opacity="0" style="stroke-width:1.4142" tb:tag="clickArea"/>
- <g transform="translate(0,316)" fill="#d12730" style="display:none" tb:tag="critical">
+<path d="m18.383 177.21c-0.0635-1.09-0.5693-2.106-1.4002-2.815l-9.0297-7.696c-4.2584-3.63-6.8043-8.844-6.9791-14.436-0.65043-20.804-1.9643-74.241 0.29843-110.76 0.77895-12.572 2.4293-30.36 3.1494-37.9 0.19581-2.0502 1.9178-3.6002 3.9773-3.6002h183.2c2.059 0 3.781 1.5501 3.977 3.6002 0.72 7.5392 2.371 25.328 3.15 37.9 2.262 36.518 0.948 89.955 0.298 110.76-0.175 5.592-2.721 10.806-6.979 14.436l-9.03 7.696c-0.831 0.709-1.336 1.725-1.4 2.815l-8.57 147.01c-0.605 10.385-5.508 20.049-13.531 26.67-34.554 28.516-84.478 28.516-119.03 0-8.0233-6.621-12.926-16.285-13.532-26.67z" fill="#fff"/><path d="m19.382 177.15c-0.0794-1.362-0.71139-2.633-1.7498-3.518l-9.0296-7.697c-4.0474-3.45-6.4624-8.4-6.6282-13.706-0.65056-20.807-1.9624-74.2 0.297-110.67 0.77777-12.553 2.4266-30.326 3.1467-37.866 0.1463-1.5318 1.4324-2.6953 2.9818-2.6953h183.2c1.549 0 2.835 1.1635 2.982 2.6953 0.71999 7.5402 2.369 25.314 3.146 37.866 2.26 36.465 0.94799 89.858 0.297 110.67-0.165 5.306-2.58 10.256-6.6279 13.706l-9.0289 7.697c-1.039 0.885-1.671 2.156-1.75 3.518l-8.5699 147.01c-0.589 10.108-5.361 19.513-13.17 25.958-34.184 28.21-83.573 28.21-117.76 0-7.8087-6.445-12.581-15.85-13.17-25.958z" stroke="#000" stroke-opacity=".87" stroke-width="2"/><path d="m67.264 0s-67.264 0-67.264 67v328.36c0 2.6512 1.7909 4.6404 4 4.6404h192c2.209 0 4-1.9892 4-4.6404v-328.36c0-67-66.07-67-66.07-67h-33.929zm67.07 81.2c-1.2887 0-2.3333 1.2536-2.3333 2.8v300.4c0 1.5464 1.0447 2.8 2.3333 2.8h14.666c1.2887 0 2.3333-1.2536 2.3333-2.8v-300.4c0-1.5464-1.0447-2.8-2.3333-2.8z" fill="#000" fill-opacity="0" style="stroke-width:1.4142" tb:tag="clickArea"/><g transform="translate(0,316)" fill="#d12730" style="display: none;" tb:tag="critical">
   <rect width="84" height="84" rx="4" fill="#fff" style=""/>
   <rect width="84" height="84" rx="4" style=""/>
   <rect x="2" y="2" width="80" height="80" rx="2" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>
   <path d="m44.559 27.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87" style=""/>
- </g>
- <g transform="translate(0,316)" fill="#faa405" style="display:none" tb:tag="warning">
+ </g><g transform="translate(0,316)" fill="#faa405" style="display: none;" tb:tag="warning">
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" fill="#fff" style=""/>
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" style=""/>
   <path d="m40.211 8.0498c0.7371-1.4741 2.8407-1.4741 3.5778-1e-5l35.528 71.056c0.6649 1.3298-0.3021 2.8944-1.7888 2.8944h-71.056c-1.4868 0-2.4538-1.5646-1.7889-2.8944z" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>

--- a/application/src/main/data/json/system/scada_symbols/heat-pump-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/heat-pump-hp.svg
@@ -1,9 +1,9 @@
-<svg width="800" height="600" fill="none" version="1.1" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="800" height="600" fill="none" version="1.1" viewBox="0 0 800 600"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Heat pump",
   "description": "Heat pump",
   "searchTags": [
-    "pump"
+    "pump",
+    "high performance"
   ],
   "widgetSizeX": 4,
   "widgetSizeY": 3,
@@ -181,16 +181,16 @@
     },
     {
       "id": "warning",
-      "name": "{i18n:scada.symbol.warning-state}",
+      "name": "{i18n:scada.symbol.warning}",
       "hint": "{i18n:scada.symbol.warning-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.warning-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -199,33 +199,62 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
     },
     {
+      "id": "warningClick",
+      "name": "{i18n:scada.symbol.warning-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.warning-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
+    },
+    {
       "id": "critical",
-      "name": "{i18n:scada.symbol.critical-state}",
+      "name": "{i18n:scada.symbol.critical}",
       "hint": "{i18n:scada.symbol.critical-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.critical-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -234,20 +263,46 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
+    },
+    {
+      "id": "criticalClick",
+      "name": "{i18n:scada.symbol.critical-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.critical-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
     },
     {
       "id": "criticalAnimation",
@@ -285,46 +340,6 @@
       "defaultWidgetActionSettings": null
     },
     {
-      "id": "warningClick",
-      "name": "{i18n:scada.symbol.warning-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
-      "id": "criticalClick",
-      "name": "{i18n:scada.symbol.critical-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
       "id": "click",
       "name": "{i18n:scada.symbol.on-click}",
       "hint": "{i18n:scada.symbol.on-click-hint}",
@@ -348,12 +363,12 @@
   "properties": [
     {
       "id": "runningColor",
-      "name": "{i18n:scada.symbol.running-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#FFFFFF",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.running}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -364,11 +379,11 @@
     },
     {
       "id": "stoppedColor",
-      "name": "{i18n:scada.symbol.stopped-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#666666",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.stopped}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -380,12 +395,12 @@
     },
     {
       "id": "warningColor",
-      "name": "{i18n:scada.symbol.warning-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#FAA405",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.warning}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -396,11 +411,11 @@
     },
     {
       "id": "criticalColor",
-      "name": "{i18n:scada.symbol.critical-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#D12730",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.critical}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -516,7 +531,7 @@
       "id": "units",
       "name": "{i18n:scada.symbol.value-units}",
       "type": "units",
-      "default": "&#176;C",
+      "default": "°C",
       "required": null,
       "subLabel": null,
       "divider": null,
@@ -546,7 +561,7 @@
     }
   ]
 }]]></tb:metadata>
- <g fill="#fff" tb:tag="background">
+<g fill="#fff" tb:tag="background">
   <rect x="250" y="571" width="300" height="29" rx="6.9964"/>
   <rect x="251" y="572" width="298" height="27" rx="5.9964" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
   <path d="m303 542h194l32 31h-258l32-31z"/>
@@ -572,31 +587,25 @@
    <path d="m722 284c0 99.411-80.589 180-180 180s-180-80.589-180-180 80.589-180 180-180 180 80.589 180 180zm-331.96 0c0 83.926 68.035 151.96 151.96 151.96s151.96-68.035 151.96-151.96-68.035-151.96-151.96-151.96-151.96 68.035-151.96 151.96z"/>
   </mask>
   <path d="m722 284c0 99.411-80.589 180-180 180s-180-80.589-180-180 80.589-180 180-180 180 80.589 180 180zm-331.96 0c0 83.926 68.035 151.96 151.96 151.96s151.96-68.035 151.96-151.96-68.035-151.96-151.96-151.96-151.96 68.035-151.96 151.96z" fill="#DEDEDE" mask="url(#path-29-inside-1_3215_7169)" stroke="#000" stroke-opacity=".87" stroke-width="4" tb:tag="circle-background"/>
- </g>
- <path d="m269.06 0s-269.06 0-269.06 100.5v492.54c0 3.9768 7.1636 6.9606 16 6.9606h768c8.836 0 16-2.9838 16-6.9606v-492.54c0-100.5-264.28-100.5-264.28-100.5h-135.72zm268.28 121.8c-5.1548 0-9.3332 1.8804-9.3332 4.2v450.6c0 2.3196 4.1788 4.2 9.3332 4.2h58.664c5.1548 0 9.3332-1.8804 9.3332-4.2v-450.6c0-2.3196-4.1788-4.2-9.3332-4.2z" fill="#000" fill-opacity="0" style="stroke-width:2.4495" tb:tag="clickArea"/>
- <g tb:tag="levelUpButton">
+ </g><path d="m269.06 0s-269.06 0-269.06 100.5v492.54c0 3.9768 7.1636 6.9606 16 6.9606h768c8.836 0 16-2.9838 16-6.9606v-492.54c0-100.5-264.28-100.5-264.28-100.5h-135.72zm268.28 121.8c-5.1548 0-9.3332 1.8804-9.3332 4.2v450.6c0 2.3196 4.1788 4.2 9.3332 4.2h58.664c5.1548 0 9.3332-1.8804 9.3332-4.2v-450.6c0-2.3196-4.1788-4.2-9.3332-4.2z" fill="#000" fill-opacity="0" style="stroke-width:2.4495" tb:tag="clickArea"/><g tb:tag="levelUpButton">
   <path d="m164 290.19c0 5.42-4.394 9.814-9.815 9.814h-68.371c-5.4203 0-9.8143-4.394-9.8143-9.814v-68.373c0-5.421 4.394-9.815 9.8143-9.815h68.371c5.421 0 9.815 4.394 9.815 9.815z"/>
   <path d="m163 290.19c0 4.868-3.947 8.814-8.815 8.814h-68.371c-4.868 0-8.8143-3.946-8.8143-8.814v-68.373c0-4.868 3.9463-8.815 8.8143-8.815h68.371c4.868 0 8.815 3.947 8.815 8.815z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
   <path d="m135.92 263.33c0.89 0 1.336-1.077 0.707-1.706l-15.921-15.921c-0.39-0.39-1.023-0.39-1.413 0l-15.921 15.921c-0.629 0.629-0.183 1.706 0.707 1.706z" fill="#000" fill-opacity=".87"/>
- </g>
- <g tb:tag="levelDownButton">
+ </g><g tb:tag="levelDownButton">
   <path d="m264.96 221.82c0-5.42-4.394-9.814-9.814-9.814h-69.327c-5.42 0-9.814 4.394-9.814 9.814v68.372c0 5.42 4.394 9.814 9.814 9.814h69.327c5.42 0 9.814-4.394 9.814-9.814z"/>
   <path d="m263.96 221.82c0-4.868-3.946-8.814-8.814-8.814h-69.327c-4.868 0-8.814 3.946-8.814 8.814v68.372c0 4.868 3.946 8.814 8.814 8.814h69.327c4.868 0 8.814-3.946 8.814-8.814z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
   <path d="m236.58 248.67c0.893 0 1.338 1.082 0.703 1.711l-16.101 15.927c-0.389 0.386-1.016 0.386-1.406 0l-16.1-15.927c-0.635-0.629-0.191-1.711 0.703-1.711z" fill="#000" fill-opacity=".87"/>
- </g>
- <g transform="translate(0,516)" fill="#d12730" style="display:none" tb:tag="critical">
+ </g><g transform="translate(0,516)" fill="#d12730" style="display: none;" tb:tag="critical">
   <rect width="84" height="84" rx="4" fill="#fff" style=""/>
   <rect width="84" height="84" rx="4" style=""/>
   <rect x="2" y="2" width="80" height="80" rx="2" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>
   <path d="m44.559 27.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87" style=""/>
- </g>
- <g transform="translate(0,516)" fill="#faa405" style="display:none" tb:tag="warning">
+ </g><g transform="translate(0,516)" fill="#faa405" style="display: none;" tb:tag="warning">
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" fill="#fff" style=""/>
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" style=""/>
   <path d="m40.211 8.0498c0.7371-1.4741 2.8407-1.4741 3.5778-1e-5l35.528 71.056c0.6649 1.3298-0.3021 2.8944-1.7888 2.8944h-71.056c-1.4868 0-2.4538-1.5646-1.7889-2.8944z" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>
   <path d="m44.559 37.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87" style=""/>
- </g>
- <defs>
+ </g><defs>
   <clipPath id="clip1_3215_7169">
    <rect x="362" y="104" width="360" height="360" rx="180" fill="#fff"/>
   </clipPath>

--- a/application/src/main/data/json/system/scada_symbols/heat-pump-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/heat-pump-hp.svg
@@ -57,7 +57,7 @@
     },
     {
       "tag": "value-box-background",
-      "stateRenderFunction": "if (ctx.values.running) {\n    var color = ctx.properties.valueBoxBackground;\n    element.attr({fill: color});\n}\n",
+      "stateRenderFunction": "if (ctx.values.running) {\n    var color = ctx.properties.valueBoxBackground;\n    element.attr({fill: color});\n} else {\n    var color = ctx.properties.stoppedColor;\n    element.attr({fill: color});\n}\n",
       "actions": null
     },
     {

--- a/application/src/main/data/json/system/scada_symbols/horizontal-inline-flow-meter.svg
+++ b/application/src/main/data/json/system/scada_symbols/horizontal-inline-flow-meter.svg
@@ -120,7 +120,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -134,6 +134,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -155,7 +164,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -169,6 +178,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/horizontal-tank-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/horizontal-tank-hp.svg
@@ -1,9 +1,9 @@
-<svg width="1e3" height="600" fill="none" version="1.1" viewBox="0 0 1e3 600" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="1e3" height="600" fill="none" version="1.1" viewBox="0 0 1e3 600"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Horizontal tank",
-  "description": "Horizontal tank",
+  "description": "Horizontal tank with level visualizations.",
   "searchTags": [
-    "horizontal tank"
+    "horizontal tank",
+    "high performance"
   ],
   "widgetSizeX": 5,
   "widgetSizeY": 3,
@@ -122,16 +122,16 @@
     },
     {
       "id": "warning",
-      "name": "{i18n:scada.symbol.warning-state}",
+      "name": "{i18n:scada.symbol.warning}",
       "hint": "{i18n:scada.symbol.warning-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.warning-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -140,33 +140,62 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
     },
     {
+      "id": "warningClick",
+      "name": "{i18n:scada.symbol.warning-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.warning-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
+    },
+    {
       "id": "critical",
-      "name": "{i18n:scada.symbol.critical-state}",
+      "name": "{i18n:scada.symbol.critical}",
       "hint": "{i18n:scada.symbol.critical-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.critical-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -175,20 +204,46 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
+    },
+    {
+      "id": "criticalClick",
+      "name": "{i18n:scada.symbol.critical-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.critical-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
     },
     {
       "id": "criticalAnimation",
@@ -224,46 +279,6 @@
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
-    },
-    {
-      "id": "warningClick",
-      "name": "{i18n:scada.symbol.warning-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
-      "id": "criticalClick",
-      "name": "{i18n:scada.symbol.critical-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
     },
     {
       "id": "click",
@@ -342,7 +357,7 @@
       "default": 10,
       "required": null,
       "subLabel": "{i18n:scada.symbol.intervals}",
-      "divider": true,
+      "divider": false,
       "fieldSuffix": null,
       "disableOnProperty": "scale",
       "rowClass": "",
@@ -375,7 +390,7 @@
     },
     {
       "id": "majorColor",
-      "name": "{i18n:scada.symbol.major-ticks-color}",
+      "name": "{i18n:scada.symbol.major-ticks}",
       "type": "color",
       "default": "#00000061",
       "required": null,
@@ -407,7 +422,7 @@
     },
     {
       "id": "minorColor",
-      "name": "{i18n:scada.symbol.minor-ticks-color}",
+      "name": "{i18n:scada.symbol.minor-ticks}",
       "type": "color",
       "default": "#0000001F",
       "required": null,
@@ -423,12 +438,12 @@
     },
     {
       "id": "warningColor",
-      "name": "{i18n:scada.symbol.warning-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#FAA405",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.warning}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -439,11 +454,11 @@
     },
     {
       "id": "criticalColor",
-      "name": "{i18n:scada.symbol.critical-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#D12730",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.critical}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -455,16 +470,12 @@
     }
   ]
 }]]></tb:metadata>
- <path d="m174 600c-174 0-174-151.63-174-239 4.9551e-6 -1.386 9.6938e-6 -2.741 1.4223e-5 -4.065 1.18e-8 -4e-3 -1.4223e-5 -113.93-1.4223e-5 -113.94 0-87.373-8.3346e-7 -243 174-243h653.5c173 0 172.5 156.06 172.5 243v118c0 86.939 0 239-172.5 239h-653.5z" fill="#EBEBEB" tb:tag="background"/>
- <path d="m174 599c-43.353 0-75.782-9.444-100.06-24.9-24.272-15.456-40.469-36.971-51.28-61.242-21.649-48.601-21.664-108.13-21.663-151.86l2e-5 -4.065-2e-5 -113.94c0-43.727 0.0143-104.26 21.666-153.86 10.814-24.774 27.013-46.788 51.286-62.616 24.274-15.828 56.7-25.52 100.05-25.52h653.5c43.097 0 75.302 9.7177 99.388 25.578 24.085 15.86 40.129 37.914 50.819 62.716 21.294 49.406 21.294 109.58 21.293 153.04v118.67c0 43.512-0.015 103.04-21.477 151.7-10.719 24.299-26.776 45.854-50.838 61.342-24.063 15.489-56.209 24.959-99.185 24.959h-653.5z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- <mask id="mask0_3610_178965" x="2" y="2" width="996" height="596" style="mask-type:alpha" maskUnits="userSpaceOnUse">
+<path d="m174 600c-174 0-174-151.63-174-239 4.9551e-6 -1.386 9.6938e-6 -2.741 1.4223e-5 -4.065 1.18e-8 -4e-3 -1.4223e-5 -113.93-1.4223e-5 -113.94 0-87.373-8.3346e-7 -243 174-243h653.5c173 0 172.5 156.06 172.5 243v118c0 86.939 0 239-172.5 239h-653.5z" fill="#EBEBEB" tb:tag="background"/><path d="m174 599c-43.353 0-75.782-9.444-100.06-24.9-24.272-15.456-40.469-36.971-51.28-61.242-21.649-48.601-21.664-108.13-21.663-151.86l2e-5 -4.065-2e-5 -113.94c0-43.727 0.0143-104.26 21.666-153.86 10.814-24.774 27.013-46.788 51.286-62.616 24.274-15.828 56.7-25.52 100.05-25.52h653.5c43.097 0 75.302 9.7177 99.388 25.578 24.085 15.86 40.129 37.914 50.819 62.716 21.294 49.406 21.294 109.58 21.293 153.04v118.67c0 43.512-0.015 103.04-21.477 151.7-10.719 24.299-26.776 45.854-50.838 61.342-24.063 15.489-56.209 24.959-99.185 24.959h-653.5z" stroke="#000" stroke-opacity=".87" stroke-width="2"/><mask id="mask0_3610_178965" x="2" y="2" width="996" height="596" style="mask-type:alpha" maskUnits="userSpaceOnUse">
   <path d="m175.3 598c-173.3 0-173.3-150.62-173.3-237.41 1e-5 -1.377 1e-5 -2.723 1e-5 -4.038 1e-5 -3e-3 -1e-5 -113.17-1e-5 -113.18 0-86.79 0-241.38 173.3-241.38h650.89c172.31 0 171.81 155.02 171.81 241.38v117.21c0 86.36 0 237.41-171.81 237.41h-650.89z" fill="#EBEBEB"/>
   <path d="m175.3 597c-43.18 0-75.478-9.381-99.655-24.734-24.175-15.352-40.305-36.723-51.073-60.831-21.561-48.274-21.576-107.4-21.576-150.84l2e-5 -4.038-2e-5 -113.18c0-43.436 0.01436-103.56 21.579-152.84 10.77-24.608 26.904-46.474 51.079-62.196 24.176-15.722 56.471-25.349 99.646-25.349h650.89c42.925 0 75 9.653 98.989 25.407 23.988 15.754 39.967 37.659 50.614 62.295 21.208 49.075 21.208 108.84 21.207 152.01v117.88c0 43.222-0.015 102.35-21.391 150.68-10.675 24.136-26.667 45.547-50.631 60.931-23.967 15.385-55.984 24.792-98.788 24.792h-650.89z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- </mask>
- <g mask="url(#mask0_3610_178965)">
+ </mask><g mask="url(#mask0_3610_178965)">
   <rect transform="scale(1,-1)" x="2" y="-596" width="996" height="419" fill="#c8dff7" tb:tag="fluid-background"/>
- </g>
- <g tb:tag="scale">
+ </g><g tb:tag="scale">
   <line x1="208" x2="240" y1="3.5" y2="3.5" stroke="#000" stroke-opacity=".38" stroke-width="3"/>
   <line x1="220" x2="240" y1="15.359" y2="15.359" stroke="#000" stroke-opacity=".12" stroke-width="3"/>
   <line x1="220" x2="240" y1="27.221" y2="27.221" stroke="#000" stroke-opacity=".12" stroke-width="3"/>
@@ -527,15 +538,12 @@
   <path d="m185.2 478.95v2.25h-11.437v-1.933l5.554-6.059c0.61-0.687 1.09-1.281 1.442-1.781 0.351-0.5 0.598-0.949 0.738-1.348 0.149-0.406 0.223-0.801 0.223-1.183 0-0.54-0.102-1.012-0.305-1.418-0.195-0.415-0.484-0.739-0.867-0.973-0.383-0.242-0.848-0.363-1.395-0.363-0.632 0-1.164 0.136-1.593 0.41-0.43 0.273-0.754 0.652-0.973 1.137-0.219 0.476-0.328 1.023-0.328 1.64h-2.824c0-0.992 0.226-1.898 0.679-2.719 0.453-0.828 1.11-1.484 1.969-1.968 0.86-0.493 1.895-0.739 3.106-0.739 1.14 0 2.109 0.192 2.906 0.575 0.797 0.382 1.402 0.925 1.816 1.628 0.422 0.704 0.633 1.536 0.633 2.497 0 0.531-0.086 1.058-0.258 1.582-0.172 0.523-0.418 1.046-0.738 1.57-0.313 0.516-0.684 1.035-1.113 1.558-0.43 0.516-0.903 1.04-1.418 1.571l-3.692 4.066zm13.575-7.711v2.789c0 1.336-0.133 2.477-0.399 3.422-0.258 0.938-0.633 1.699-1.125 2.285s-1.082 1.016-1.769 1.289c-0.68 0.274-1.442 0.411-2.286 0.411-0.671 0-1.296-0.086-1.875-0.258-0.57-0.172-1.086-0.442-1.546-0.809-0.461-0.367-0.856-0.84-1.184-1.418-0.32-0.586-0.57-1.285-0.75-2.097-0.172-0.813-0.258-1.754-0.258-2.825v-2.789c0-1.343 0.133-2.476 0.399-3.398 0.265-0.93 0.644-1.684 1.136-2.262 0.492-0.586 1.078-1.012 1.758-1.277 0.688-0.266 1.453-0.399 2.297-0.399 0.68 0 1.305 0.086 1.875 0.258 0.578 0.164 1.094 0.426 1.547 0.785 0.461 0.36 0.851 0.828 1.172 1.407 0.328 0.57 0.578 1.261 0.75 2.074 0.172 0.804 0.258 1.742 0.258 2.812zm-2.825 3.188v-3.61c0-0.679-0.039-1.277-0.117-1.793-0.078-0.523-0.195-0.964-0.351-1.324-0.149-0.367-0.336-0.664-0.563-0.89-0.226-0.235-0.484-0.403-0.773-0.504-0.289-0.11-0.614-0.164-0.973-0.164-0.438 0-0.828 0.086-1.172 0.257-0.344 0.164-0.633 0.43-0.867 0.797s-0.414 0.852-0.539 1.453c-0.117 0.594-0.176 1.317-0.176 2.168v3.61c0 0.687 0.039 1.293 0.117 1.816 0.078 0.524 0.196 0.973 0.352 1.348 0.156 0.367 0.344 0.672 0.562 0.914 0.227 0.234 0.485 0.406 0.774 0.516 0.297 0.109 0.621 0.164 0.972 0.164 0.446 0 0.84-0.086 1.184-0.258s0.633-0.446 0.867-0.821c0.235-0.382 0.41-0.878 0.528-1.488 0.117-0.609 0.175-1.34 0.175-2.191z" fill="#000" fill-opacity=".38"/>
   <path d="m181.47 521.48v17.121h-2.824v-13.77l-4.184 1.418v-2.332l6.668-2.437zm17.301 7.16v2.789c0 1.336-0.133 2.476-0.399 3.422-0.258 0.937-0.633 1.699-1.125 2.285s-1.082 1.015-1.769 1.289c-0.68 0.273-1.442 0.41-2.286 0.41-0.671 0-1.296-0.086-1.875-0.258-0.57-0.172-1.086-0.441-1.546-0.808-0.461-0.368-0.856-0.84-1.184-1.418-0.32-0.586-0.57-1.286-0.75-2.098-0.172-0.813-0.258-1.754-0.258-2.824v-2.789c0-1.344 0.133-2.477 0.399-3.399 0.265-0.929 0.644-1.683 1.136-2.261 0.492-0.586 1.078-1.012 1.758-1.278 0.688-0.265 1.453-0.398 2.297-0.398 0.68 0 1.305 0.086 1.875 0.258 0.578 0.164 1.094 0.425 1.547 0.785 0.461 0.359 0.851 0.828 1.172 1.406 0.328 0.57 0.578 1.262 0.75 2.074 0.172 0.805 0.258 1.742 0.258 2.813zm-2.825 3.187v-3.609c0-0.68-0.039-1.278-0.117-1.793-0.078-0.524-0.195-0.965-0.351-1.324-0.149-0.368-0.336-0.664-0.563-0.891-0.226-0.234-0.484-0.402-0.773-0.504-0.289-0.109-0.614-0.164-0.973-0.164-0.438 0-0.828 0.086-1.172 0.258-0.344 0.164-0.633 0.43-0.867 0.797s-0.414 0.851-0.539 1.453c-0.117 0.594-0.176 1.316-0.176 2.168v3.609c0 0.688 0.039 1.293 0.117 1.817 0.078 0.523 0.196 0.972 0.352 1.347 0.156 0.367 0.344 0.672 0.562 0.914 0.227 0.235 0.485 0.407 0.774 0.516 0.297 0.109 0.621 0.164 0.972 0.164 0.446 0 0.84-0.086 1.184-0.258s0.633-0.445 0.867-0.82c0.235-0.383 0.41-0.879 0.528-1.488 0.117-0.61 0.175-1.34 0.175-2.192z" fill="#000" fill-opacity=".38"/>
   <path d="m198.77 586.04v2.789c0 1.336-0.133 2.477-0.399 3.422-0.258 0.938-0.633 1.699-1.125 2.285s-1.082 1.016-1.769 1.289c-0.68 0.274-1.442 0.41-2.286 0.41-0.671 0-1.296-0.086-1.875-0.257-0.57-0.172-1.086-0.442-1.546-0.809-0.461-0.367-0.856-0.84-1.184-1.418-0.32-0.586-0.57-1.285-0.75-2.098-0.172-0.812-0.258-1.754-0.258-2.824v-2.789c0-1.344 0.133-2.477 0.399-3.398 0.265-0.93 0.644-1.684 1.136-2.262 0.492-0.586 1.078-1.012 1.758-1.277 0.688-0.266 1.453-0.399 2.297-0.399 0.68 0 1.305 0.086 1.875 0.258 0.578 0.164 1.094 0.426 1.547 0.785 0.461 0.359 0.851 0.828 1.172 1.406 0.328 0.571 0.578 1.262 0.75 2.075 0.172 0.804 0.258 1.742 0.258 2.812zm-2.825 3.188v-3.61c0-0.679-0.039-1.277-0.117-1.793-0.078-0.523-0.195-0.965-0.351-1.324-0.149-0.367-0.336-0.664-0.563-0.891-0.226-0.234-0.484-0.402-0.773-0.504-0.289-0.109-0.614-0.164-0.973-0.164-0.438 0-0.828 0.086-1.172 0.258-0.344 0.164-0.633 0.43-0.867 0.797s-0.414 0.852-0.539 1.453c-0.117 0.594-0.176 1.317-0.176 2.168v3.61c0 0.687 0.039 1.293 0.117 1.816s0.196 0.973 0.352 1.348c0.156 0.367 0.344 0.671 0.562 0.914 0.227 0.234 0.485 0.406 0.774 0.515 0.297 0.11 0.621 0.164 0.972 0.164 0.446 0 0.84-0.086 1.184-0.257 0.344-0.172 0.633-0.446 0.867-0.821 0.235-0.383 0.41-0.879 0.528-1.488 0.117-0.609 0.175-1.34 0.175-2.191z" fill="#000" fill-opacity=".38"/>
- </g>
- <path d="m336.32 0s-336.32 0-336.32 100.5v492.54c0 3.9768 8.9546 6.9606 20 6.9606h960c11.045 0 20-2.9838 20-6.9606v-492.54c0-100.5-330.35-100.5-330.35-100.5h-169.65zm335.35 121.8c-6.4433 0-11.667 1.8804-11.667 4.2v450.6c0 2.3196 5.2233 4.2 11.667 4.2h73.329c6.4433 0 11.667-1.8804 11.667-4.2v-450.6c0-2.3196-5.2233-4.2-11.667-4.2z" fill="#000" fill-opacity="0" style="stroke-width:.55902" tb:tag="clickArea"/>
- <g fill="#d12730" style="display:none" tb:tag="critical">
+ </g><path d="m336.32 0s-336.32 0-336.32 100.5v492.54c0 3.9768 8.9546 6.9606 20 6.9606h960c11.045 0 20-2.9838 20-6.9606v-492.54c0-100.5-330.35-100.5-330.35-100.5h-169.65zm335.35 121.8c-6.4433 0-11.667 1.8804-11.667 4.2v450.6c0 2.3196 5.2233 4.2 11.667 4.2h73.329c6.4433 0 11.667-1.8804 11.667-4.2v-450.6c0-2.3196-5.2233-4.2-11.667-4.2z" fill="#000" fill-opacity="0" style="stroke-width:.55902" tb:tag="clickArea"/><g fill="#d12730" style="display: none;" tb:tag="critical">
   <rect width="84" height="84" rx="4" fill="#fff" style=""/>
   <rect width="84" height="84" rx="4" style=""/>
   <rect x="2" y="2" width="80" height="80" rx="2" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>
   <path d="m44.559 27.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87" style=""/>
- </g>
- <g transform="translate(0,-4.9442)" fill="#faa405" style="display:none" tb:tag="warning">
+ </g><g transform="translate(0,-4.9442)" fill="#faa405" style="display: none;" tb:tag="warning">
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" fill="#fff" style=""/>
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" style=""/>
   <path d="m40.211 8.0498c0.7371-1.4741 2.8407-1.4741 3.5778-1e-5l35.528 71.056c0.6649 1.3298-0.3021 2.8944-1.7888 2.8944h-71.056c-1.4868 0-2.4538-1.5646-1.7889-2.8944z" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>

--- a/application/src/main/data/json/system/scada_symbols/horizontal-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/horizontal-tank.svg
@@ -142,7 +142,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -151,16 +151,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -177,7 +186,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -186,16 +195,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/horizontal-valve-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/horizontal-valve-hp.svg
@@ -1,9 +1,9 @@
-<svg width="200" height="200" fill="none" version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="200" height="200" fill="none" version="1.1" viewBox="0 0 200 200"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Horizontal valve",
   "description": "Horizontal valve with various states.",
   "searchTags": [
-    "valve"
+    "valve",
+    "high performance"
   ],
   "widgetSizeX": 1,
   "widgetSizeY": 1,
@@ -147,16 +147,16 @@
     },
     {
       "id": "warning",
-      "name": "{i18n:scada.symbol.warning-state}",
+      "name": "{i18n:scada.symbol.warning}",
       "hint": "{i18n:scada.symbol.warning-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.warning-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -165,33 +165,62 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
     },
     {
+      "id": "warningClick",
+      "name": "{i18n:scada.symbol.warning-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.warning-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
+    },
+    {
       "id": "critical",
-      "name": "{i18n:scada.symbol.critical-state}",
+      "name": "{i18n:scada.symbol.critical}",
       "hint": "{i18n:scada.symbol.critical-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.critical-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -200,20 +229,46 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
+    },
+    {
+      "id": "criticalClick",
+      "name": "{i18n:scada.symbol.critical-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.critical-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
     },
     {
       "id": "criticalAnimation",
@@ -249,57 +304,17 @@
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
-    },
-    {
-      "id": "warningClick",
-      "name": "{i18n:scada.symbol.warning-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
-      "id": "criticalClick",
-      "name": "{i18n:scada.symbol.critical-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
     }
   ],
   "properties": [
     {
       "id": "openedColor",
-      "name": "{i18n:scada.symbol.running-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#FFFFFF",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.opened}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -310,11 +325,11 @@
     },
     {
       "id": "closedColor",
-      "name": "{i18n:scada.symbol.closed-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#666666",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.closed-mode}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -326,12 +341,12 @@
     },
     {
       "id": "warningColor",
-      "name": "{i18n:scada.symbol.warning-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#FAA405",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.warning}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -342,12 +357,12 @@
     },
     {
       "id": "criticalColor",
-      "name": "{i18n:scada.symbol.critical-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#D12730",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.critical}",
+      "divider": false,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -358,23 +373,17 @@
     }
   ]
 }]]></tb:metadata>
- <path d="M100 100V47" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- <g fill="#fff" tb:tag="background">
+<path d="M100 100V47" stroke="#000" stroke-opacity=".87" stroke-width="2"/><g fill="#fff" tb:tag="background">
   <path d="m101 100-101-58v116l101-58z"/>
   <path d="m0.99999 156.27 97.992-56.273-97.992-56.273v112.55z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
   <path d="M99 100L200 42V158L99 100Z"/>
   <path d="M199 156.273L101.008 100L199 43.7274V156.273Z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- </g>
- <rect transform="rotate(-90 52 48)" x="52" y="48" width="48" height="96"/>
- <rect transform="rotate(-90 53 47)" x="53" y="47" width="46" height="94" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- <path d="m67.264 0s-67.264 0-67.264 33.5v164.18c0 1.3256 1.7909 2.3202 4 2.3202h192c2.209 0 4-0.99459 4-2.3202v-164.18c0-33.5-66.07-33.5-66.07-33.5h-33.929zm67.07 40.6c-1.2887 0-2.3333 0.6268-2.3333 1.4v150.2c0 0.7732 1.0447 1.4 2.3333 1.4h14.666c1.2887 0 2.3333-0.6268 2.3333-1.4v-150.2c0-0.7732-1.0447-1.4-2.3333-1.4z" fill="#000" fill-opacity="0" tb:tag="clickArea"/>
- <g transform="translate(0,116)" fill="#d12730" style="display:none" tb:tag="critical">
+ </g><rect transform="rotate(-90 52 48)" x="52" y="48" width="48" height="96"/><rect transform="rotate(-90 53 47)" x="53" y="47" width="46" height="94" stroke="#000" stroke-opacity=".87" stroke-width="2"/><path d="m67.264 0s-67.264 0-67.264 33.5v164.18c0 1.3256 1.7909 2.3202 4 2.3202h192c2.209 0 4-0.99459 4-2.3202v-164.18c0-33.5-66.07-33.5-66.07-33.5h-33.929zm67.07 40.6c-1.2887 0-2.3333 0.6268-2.3333 1.4v150.2c0 0.7732 1.0447 1.4 2.3333 1.4h14.666c1.2887 0 2.3333-0.6268 2.3333-1.4v-150.2c0-0.7732-1.0447-1.4-2.3333-1.4z" fill="#000" fill-opacity="0" tb:tag="clickArea"/><g transform="translate(0,116)" fill="#d12730" style="display: none;" tb:tag="critical">
   <rect width="84" height="84" rx="4" fill="#fff" style=""/>
   <rect width="84" height="84" rx="4" style=""/>
   <rect x="2" y="2" width="80" height="80" rx="2" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>
   <path d="m44.559 27.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87" style=""/>
- </g>
- <g transform="translate(0,116)" fill="#faa405" style="display:none" tb:tag="warning">
+ </g><g transform="translate(0,116)" fill="#faa405" style="display: none;" tb:tag="warning">
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" fill="#fff" style=""/>
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" style=""/>
   <path d="m40.211 8.0498c0.7371-1.4741 2.8407-1.4741 3.5778-1e-5l35.528 71.056c0.6649 1.3298-0.3021 2.8944-1.7888 2.8944h-71.056c-1.4868 0-2.4538-1.5646-1.7889-2.8944z" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>

--- a/application/src/main/data/json/system/scada_symbols/large-cylindrical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/large-cylindrical-tank.svg
@@ -142,7 +142,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -151,16 +151,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -177,7 +186,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -186,16 +195,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/large-stand-cylindrical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/large-stand-cylindrical-tank.svg
@@ -143,7 +143,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -152,16 +152,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -178,7 +187,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -187,16 +196,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/large-stand-vertical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/large-stand-vertical-tank.svg
@@ -143,7 +143,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -152,16 +152,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -178,7 +187,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -187,16 +196,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/large-vertical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/large-vertical-tank.svg
@@ -142,7 +142,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -151,16 +151,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -177,7 +186,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -186,16 +195,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/left-analog-water-level-meter.svg
+++ b/application/src/main/data/json/system/scada_symbols/left-analog-water-level-meter.svg
@@ -135,7 +135,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -144,16 +144,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -170,7 +179,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -179,16 +188,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/left-flow-meter.svg
+++ b/application/src/main/data/json/system/scada_symbols/left-flow-meter.svg
@@ -120,7 +120,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -134,6 +134,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -155,7 +164,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -169,6 +178,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/left-heat-pump.svg
+++ b/application/src/main/data/json/system/scada_symbols/left-heat-pump.svg
@@ -259,7 +259,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -268,16 +268,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -294,7 +303,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -303,16 +312,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/left-motor-pump.svg
+++ b/application/src/main/data/json/system/scada_symbols/left-motor-pump.svg
@@ -70,7 +70,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -84,6 +84,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -105,7 +114,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -119,6 +128,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/long-vertical-connector-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/long-vertical-connector-hp.svg
@@ -1,4 +1,4 @@
-<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="200" height="400" fill="none" version="1.1" viewBox="0 0 200 400" id="svg4" sodipodi:docname="long-vertical-connector.svg" inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"><tb:metadata xmlns=""><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="200" height="400" fill="none" version="1.1" viewBox="0 0 200 400"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Long vertical connector",
   "description": "Long vertical connector",
   "widgetSizeX": 1,
@@ -170,5 +170,5 @@
     }
   ]
 }]]></tb:metadata>
-<defs id="defs8"/><sodipodi:namedview id="namedview6" pagecolor="#505050" bordercolor="#eeeeee" borderopacity="1" inkscape:pageshadow="0" inkscape:pageopacity="0" inkscape:pagecheckerboard="0" showgrid="false" inkscape:zoom="2.2475" inkscape:cx="99.888765" inkscape:cy="200" inkscape:window-width="1920" inkscape:window-height="1136" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1" inkscape:current-layer="svg4"/><path d="M100 400L100 0" stroke="#1A1A1A" stroke-width="6" id="path4" tb:tag="line"/><path d="M100 171L129 229H71L100 171Z" fill="#1A1A1A" id="path2" tb:tag="arrow"/>
+<path d="m100 400v-400" stroke="#1A1A1A" stroke-width="6" tb:tag="line"/><path d="m100 171 29 58h-58l29-58z" fill="#1A1A1A" tb:tag="arrow"/>
 </svg>

--- a/application/src/main/data/json/system/scada_symbols/pool-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/pool-hp.svg
@@ -1,9 +1,9 @@
-<svg width="2400" height="800" fill="none" version="1.1" viewBox="0 0 2400 800" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="2400" height="800" fill="none" version="1.1" viewBox="0 0 2400 800"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Pool",
-  "description": "Pool",
+  "description": "Pool with level visualizations.",
   "searchTags": [
-    "pool"
+    "pool",
+    "high performance"
   ],
   "widgetSizeX": 12,
   "widgetSizeY": 4,
@@ -122,16 +122,16 @@
     },
     {
       "id": "warning",
-      "name": "{i18n:scada.symbol.warning-state}",
+      "name": "{i18n:scada.symbol.warning}",
       "hint": "{i18n:scada.symbol.warning-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.warning-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -140,33 +140,62 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
     },
     {
+      "id": "warningClick",
+      "name": "{i18n:scada.symbol.warning-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.warning-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
+    },
+    {
       "id": "critical",
-      "name": "{i18n:scada.symbol.critical-state}",
+      "name": "{i18n:scada.symbol.critical}",
       "hint": "{i18n:scada.symbol.critical-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.critical-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -175,20 +204,46 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
+    },
+    {
+      "id": "criticalClick",
+      "name": "{i18n:scada.symbol.critical-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.critical-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
     },
     {
       "id": "criticalAnimation",
@@ -224,46 +279,6 @@
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
-    },
-    {
-      "id": "warningClick",
-      "name": "{i18n:scada.symbol.warning-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
-      "id": "criticalClick",
-      "name": "{i18n:scada.symbol.critical-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
     },
     {
       "id": "click",
@@ -342,7 +357,7 @@
       "default": 10,
       "required": null,
       "subLabel": "{i18n:scada.symbol.intervals}",
-      "divider": true,
+      "divider": false,
       "fieldSuffix": null,
       "disableOnProperty": "scale",
       "rowClass": "",
@@ -375,7 +390,7 @@
     },
     {
       "id": "majorColor",
-      "name": "{i18n:scada.symbol.major-ticks-color}",
+      "name": "{i18n:scada.symbol.major-ticks}",
       "type": "color",
       "default": "#00000061",
       "required": null,
@@ -407,7 +422,7 @@
     },
     {
       "id": "minorColor",
-      "name": "{i18n:scada.symbol.minor-ticks-color}",
+      "name": "{i18n:scada.symbol.minor-ticks}",
       "type": "color",
       "default": "#0000001F",
       "required": null,
@@ -423,12 +438,12 @@
     },
     {
       "id": "warningColor",
-      "name": "{i18n:scada.symbol.warning-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#FAA405",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.warning}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -439,11 +454,11 @@
     },
     {
       "id": "criticalColor",
-      "name": "{i18n:scada.symbol.critical-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#D12730",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.critical}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -455,15 +470,11 @@
     }
   ]
 }]]></tb:metadata>
- <path d="m0 14.714c0-8.1263 6.5877-14.714 14.714-14.714h2370.6c8.12 0 14.71 6.5877 14.71 14.714v770.57c0 8.126-6.59 14.714-14.71 14.714h-2370.6c-8.1263 0-14.714-6.588-14.714-14.714v-770.57z" fill="#EBEBEB" tb:tag="background"/>
- <path d="m1 14.714c0-7.574 6.14-13.714 13.714-13.714h2370.6c7.57 0 13.71 6.14 13.71 13.714v770.57c0 7.574-6.14 13.714-13.71 13.714h-2370.6c-7.574 0-13.714-6.14-13.714-13.714v-770.57z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- <mask id="mask0_3600_177361" x="2" y="2" width="2396" height="796" style="mask-type:alpha" maskUnits="userSpaceOnUse">
+<path d="m0 14.714c0-8.1263 6.5877-14.714 14.714-14.714h2370.6c8.12 0 14.71 6.5877 14.71 14.714v770.57c0 8.126-6.59 14.714-14.71 14.714h-2370.6c-8.1263 0-14.714-6.588-14.714-14.714v-770.57z" fill="#EBEBEB" tb:tag="background"/><path d="m1 14.714c0-7.574 6.14-13.714 13.714-13.714h2370.6c7.57 0 13.71 6.14 13.71 13.714v770.57c0 7.574-6.14 13.714-13.71 13.714h-2370.6c-7.574 0-13.714-6.14-13.714-13.714v-770.57z" stroke="#000" stroke-opacity=".87" stroke-width="2"/><mask id="mask0_3600_177361" x="2" y="2" width="2396" height="796" style="mask-type:alpha" maskUnits="userSpaceOnUse">
   <path d="m2386 2c6.63 0 12 5.3726 12 12v772c0 6.627-5.37 12-12 12h-2372c-6.6274 0-12-5.373-12-12v-772c0-6.6274 5.3726-12 12-12h2372z" fill="#C8DFF7"/>
- </mask>
- <g mask="url(#mask0_3600_177361)">
+ </mask><g mask="url(#mask0_3600_177361)">
   <rect transform="scale(1,-1)" x="2" y="-798" width="2396" height="615" fill="#c8dff7" style="stroke-width:3.1235" tb:tag="fluid-background"/>
- </g>
- <g tb:tag="scale">
+ </g><g tb:tag="scale">
   <line x1="298" x2="330" y1="3.5" y2="3.5" stroke="#000" stroke-opacity=".38" stroke-width="3"/>
   <line x1="310" x2="330" y1="19.36" y2="19.36" stroke="#000" stroke-opacity=".12" stroke-width="3"/>
   <line x1="310" x2="330" y1="35.22" y2="35.22" stroke="#000" stroke-opacity=".12" stroke-width="3"/>
@@ -526,15 +537,12 @@
   <path d="m275.2 639.35v2.25h-11.437v-1.934l5.554-6.059c0.61-0.687 1.09-1.281 1.442-1.781 0.351-0.5 0.598-0.949 0.738-1.347 0.149-0.407 0.223-0.801 0.223-1.184 0-0.539-0.102-1.012-0.305-1.418-0.195-0.414-0.484-0.738-0.867-0.973-0.383-0.242-0.848-0.363-1.395-0.363-0.632 0-1.164 0.137-1.593 0.41-0.43 0.274-0.754 0.653-0.973 1.137-0.219 0.476-0.328 1.023-0.328 1.641h-2.824c0-0.993 0.226-1.899 0.679-2.719 0.453-0.828 1.11-1.485 1.969-1.969 0.86-0.492 1.895-0.738 3.106-0.738 1.14 0 2.109 0.191 2.906 0.574s1.402 0.926 1.816 1.629c0.422 0.703 0.633 1.535 0.633 2.496 0 0.531-0.086 1.059-0.258 1.582s-0.418 1.047-0.738 1.57c-0.313 0.516-0.684 1.035-1.113 1.559-0.43 0.516-0.903 1.039-1.418 1.57l-3.692 4.067zm13.575-7.711v2.789c0 1.336-0.133 2.476-0.399 3.422-0.258 0.937-0.633 1.699-1.125 2.285s-1.082 1.015-1.769 1.289c-0.68 0.273-1.442 0.41-2.286 0.41-0.671 0-1.296-0.086-1.875-0.258-0.57-0.172-1.086-0.441-1.546-0.808-0.461-0.368-0.856-0.84-1.184-1.418-0.32-0.586-0.57-1.286-0.75-2.098-0.172-0.813-0.258-1.754-0.258-2.824v-2.789c0-1.344 0.133-2.477 0.399-3.399 0.265-0.929 0.644-1.683 1.136-2.261 0.492-0.586 1.078-1.012 1.758-1.278 0.688-0.265 1.453-0.398 2.297-0.398 0.68 0 1.305 0.086 1.875 0.258 0.578 0.164 1.094 0.425 1.547 0.785 0.461 0.359 0.851 0.828 1.172 1.406 0.328 0.57 0.578 1.262 0.75 2.074 0.172 0.805 0.258 1.742 0.258 2.813zm-2.825 3.187v-3.609c0-0.68-0.039-1.278-0.117-1.793-0.078-0.524-0.195-0.965-0.351-1.324-0.149-0.368-0.336-0.664-0.563-0.891-0.226-0.234-0.484-0.402-0.773-0.504-0.289-0.109-0.614-0.164-0.973-0.164-0.438 0-0.828 0.086-1.172 0.258-0.344 0.164-0.633 0.43-0.867 0.797s-0.414 0.851-0.539 1.453c-0.117 0.594-0.176 1.316-0.176 2.168v3.609c0 0.688 0.039 1.293 0.117 1.817 0.078 0.523 0.196 0.972 0.352 1.347 0.156 0.367 0.344 0.672 0.562 0.914 0.227 0.235 0.485 0.407 0.774 0.516 0.297 0.109 0.621 0.164 0.972 0.164 0.446 0 0.84-0.086 1.184-0.258s0.633-0.445 0.867-0.82c0.235-0.383 0.41-0.879 0.528-1.488 0.117-0.61 0.175-1.34 0.175-2.192z" fill="#000" fill-opacity=".38"/>
   <path d="m271.47 702.18v17.121h-2.824v-13.77l-4.184 1.418v-2.332l6.668-2.437zm17.301 7.16v2.789c0 1.336-0.133 2.476-0.399 3.422-0.258 0.937-0.633 1.699-1.125 2.285s-1.082 1.016-1.769 1.289c-0.68 0.273-1.442 0.41-2.286 0.41-0.671 0-1.296-0.086-1.875-0.258-0.57-0.172-1.086-0.441-1.546-0.808-0.461-0.367-0.856-0.84-1.184-1.418-0.32-0.586-0.57-1.285-0.75-2.098-0.172-0.812-0.258-1.754-0.258-2.824v-2.789c0-1.344 0.133-2.477 0.399-3.399 0.265-0.929 0.644-1.683 1.136-2.261 0.492-0.586 1.078-1.012 1.758-1.278 0.688-0.265 1.453-0.398 2.297-0.398 0.68 0 1.305 0.086 1.875 0.258 0.578 0.164 1.094 0.426 1.547 0.785 0.461 0.359 0.851 0.828 1.172 1.406 0.328 0.57 0.578 1.262 0.75 2.074 0.172 0.805 0.258 1.743 0.258 2.813zm-2.825 3.187v-3.609c0-0.68-0.039-1.277-0.117-1.793-0.078-0.523-0.195-0.965-0.351-1.324-0.149-0.367-0.336-0.664-0.563-0.891-0.226-0.234-0.484-0.402-0.773-0.504-0.289-0.109-0.614-0.164-0.973-0.164-0.438 0-0.828 0.086-1.172 0.258-0.344 0.164-0.633 0.43-0.867 0.797s-0.414 0.851-0.539 1.453c-0.117 0.594-0.176 1.316-0.176 2.168v3.609c0 0.688 0.039 1.293 0.117 1.817 0.078 0.523 0.196 0.972 0.352 1.347 0.156 0.368 0.344 0.672 0.562 0.914 0.227 0.235 0.485 0.407 0.774 0.516 0.297 0.109 0.621 0.164 0.972 0.164 0.446 0 0.84-0.086 1.184-0.258s0.633-0.445 0.867-0.82c0.235-0.383 0.41-0.879 0.528-1.488 0.117-0.61 0.175-1.34 0.175-2.192z" fill="#000" fill-opacity=".38"/>
   <path d="m288.77 787.04v2.789c0 1.336-0.133 2.477-0.399 3.422-0.258 0.938-0.633 1.699-1.125 2.285s-1.082 1.016-1.769 1.289c-0.68 0.274-1.442 0.41-2.286 0.41-0.671 0-1.296-0.086-1.875-0.257-0.57-0.172-1.086-0.442-1.546-0.809-0.461-0.367-0.856-0.84-1.184-1.418-0.32-0.586-0.57-1.285-0.75-2.098-0.172-0.812-0.258-1.754-0.258-2.824v-2.789c0-1.344 0.133-2.477 0.399-3.398 0.265-0.93 0.644-1.684 1.136-2.262 0.492-0.586 1.078-1.012 1.758-1.277 0.688-0.266 1.453-0.399 2.297-0.399 0.68 0 1.305 0.086 1.875 0.258 0.578 0.164 1.094 0.426 1.547 0.785 0.461 0.359 0.851 0.828 1.172 1.406 0.328 0.571 0.578 1.262 0.75 2.075 0.172 0.804 0.258 1.742 0.258 2.812zm-2.825 3.188v-3.61c0-0.679-0.039-1.277-0.117-1.793-0.078-0.523-0.195-0.965-0.351-1.324-0.149-0.367-0.336-0.664-0.563-0.891-0.226-0.234-0.484-0.402-0.773-0.504-0.289-0.109-0.614-0.164-0.973-0.164-0.438 0-0.828 0.086-1.172 0.258-0.344 0.164-0.633 0.43-0.867 0.797s-0.414 0.852-0.539 1.453c-0.117 0.594-0.176 1.317-0.176 2.168v3.61c0 0.687 0.039 1.293 0.117 1.816s0.196 0.973 0.352 1.348c0.156 0.367 0.344 0.671 0.562 0.914 0.227 0.234 0.485 0.406 0.774 0.515 0.297 0.11 0.621 0.164 0.972 0.164 0.446 0 0.84-0.086 1.184-0.257 0.344-0.172 0.633-0.446 0.867-0.821 0.235-0.383 0.41-0.879 0.528-1.488 0.117-0.609 0.175-1.34 0.175-2.191z" fill="#000" fill-opacity=".38"/>
- </g>
- <path d="m807.17 0s-807.17 0-807.17 134v656.72c0 5.3024 21.491 9.2808 48 9.2808h2304c26.508 0 48-3.9784 48-9.2808v-656.72c0-134-792.84-134-792.84-134h-407.15zm804.84 162.4c-15.464 0-28 2.5072-28 5.6v600.8c0 3.0928 12.536 5.6 28 5.6h175.99c15.464 0 28-2.5072 28-5.6v-600.8c0-3.0928-12.536-5.6-28-5.6z" fill="#000" fill-opacity="0" style="stroke-width:6.9281" tb:tag="clickArea"/>
- <g fill="#d12730" style="display:none" tb:tag="critical">
+ </g><path d="m807.17 0s-807.17 0-807.17 134v656.72c0 5.3024 21.491 9.2808 48 9.2808h2304c26.508 0 48-3.9784 48-9.2808v-656.72c0-134-792.84-134-792.84-134h-407.15zm804.84 162.4c-15.464 0-28 2.5072-28 5.6v600.8c0 3.0928 12.536 5.6 28 5.6h175.99c15.464 0 28-2.5072 28-5.6v-600.8c0-3.0928-12.536-5.6-28-5.6z" fill="#000" fill-opacity="0" style="stroke-width:6.9281" tb:tag="clickArea"/><g fill="#d12730" style="display: none;" tb:tag="critical">
   <rect width="84" height="84" rx="4" fill="#fff" style=""/>
   <rect width="84" height="84" rx="4" style=""/>
   <rect x="2" y="2" width="80" height="80" rx="2" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>
   <path d="m44.559 27.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87" style=""/>
- </g>
- <g transform="translate(0 -4.9442)" fill="#faa405" style="display:none" tb:tag="warning">
+ </g><g transform="translate(0 -4.9442)" fill="#faa405" style="display: none;" tb:tag="warning">
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" fill="#fff" style=""/>
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" style=""/>
   <path d="m40.211 8.0498c0.7371-1.4741 2.8407-1.4741 3.5778-1e-5l35.528 71.056c0.6649 1.3298-0.3021 2.8944-1.7888 2.8944h-71.056c-1.4868 0-2.4538-1.5646-1.7889-2.8944z" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>

--- a/application/src/main/data/json/system/scada_symbols/pump-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/pump-hp.svg
@@ -3,7 +3,8 @@
   "description": "Centrifugal pump with configurable connectors and various states.",
   "searchTags": [
     "pump",
-    "centrifugal"
+    "centrifugal",
+    "high performance"
   ],
   "widgetSizeX": 2,
   "widgetSizeY": 2,
@@ -80,16 +81,16 @@
     },
     {
       "id": "warning",
-      "name": "{i18n:scada.symbol.warning-state}",
+      "name": "{i18n:scada.symbol.warning}",
       "hint": "{i18n:scada.symbol.warning-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.warning-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -98,33 +99,62 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
     },
     {
+      "id": "warningClick",
+      "name": "{i18n:scada.symbol.warning-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.warning-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
+    },
+    {
       "id": "critical",
-      "name": "{i18n:scada.symbol.critical-state}",
+      "name": "{i18n:scada.symbol.critical}",
       "hint": "{i18n:scada.symbol.critical-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.critical-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -133,20 +163,46 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
+    },
+    {
+      "id": "criticalClick",
+      "name": "{i18n:scada.symbol.critical-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.critical-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
     },
     {
       "id": "criticalAnimation",
@@ -184,46 +240,6 @@
       "defaultWidgetActionSettings": null
     },
     {
-      "id": "warningClick",
-      "name": "{i18n:scada.symbol.warning-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
-      "id": "criticalClick",
-      "name": "{i18n:scada.symbol.critical-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
       "id": "click",
       "name": "{i18n:scada.symbol.on-click}",
       "hint": "{i18n:scada.symbol.on-click-hint}",
@@ -247,12 +263,12 @@
   "properties": [
     {
       "id": "runningColor",
-      "name": "{i18n:scada.symbol.running-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#FFFFFF",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.running}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -263,11 +279,11 @@
     },
     {
       "id": "stoppedColor",
-      "name": "{i18n:scada.symbol.stopped-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#666666",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.stopped}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -279,12 +295,12 @@
     },
     {
       "id": "warningColor",
-      "name": "{i18n:scada.symbol.warning-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#FAA405",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.warning}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -295,11 +311,11 @@
     },
     {
       "id": "criticalColor",
-      "name": "{i18n:scada.symbol.critical-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#D12730",
       "required": null,
-      "subLabel": null,
+      "subLabel": "Critical",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,

--- a/application/src/main/data/json/system/scada_symbols/right-analog-water-level-meter.svg
+++ b/application/src/main/data/json/system/scada_symbols/right-analog-water-level-meter.svg
@@ -135,7 +135,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -144,16 +144,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -170,7 +179,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -179,16 +188,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/right-flow-meter.svg
+++ b/application/src/main/data/json/system/scada_symbols/right-flow-meter.svg
@@ -120,7 +120,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -134,6 +134,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -155,7 +164,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -169,6 +178,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/right-heat-pump.svg
+++ b/application/src/main/data/json/system/scada_symbols/right-heat-pump.svg
@@ -259,7 +259,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -268,16 +268,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -294,7 +303,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -303,16 +312,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/right-motor-pump.svg
+++ b/application/src/main/data/json/system/scada_symbols/right-motor-pump.svg
@@ -70,7 +70,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -84,6 +84,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -105,7 +114,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -119,6 +128,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/sand-filter-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/sand-filter-hp.svg
@@ -607,23 +607,35 @@
   <path d="m44.559 37.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87"/>
  </g>
  <g tb:tag="filterMode">
-  <rect x="75" y="410" width="208.86" height="96.012" rx="9.8143" fill="#999"/>
-  <path d="m76 419.81c0-4.868 3.9463-8.814 8.8143-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.383c0 4.868-3.946 8.815-8.814 8.815h-189.24c-4.868 0-8.8143-3.947-8.8143-8.815z" stroke="#999" stroke-width="2"/>
-  <text x="180.79984" y="460.00018" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Filter</tspan></text>
-  <path d="m75 539.7c0-5.42 4.394-9.814 9.8143-9.814h189.24c5.42 0 9.814 4.394 9.814 9.814v76.383c0 5.421-4.394 9.815-9.814 9.815h-189.24c-5.4203 0-9.8143-4.394-9.8143-9.815z" fill="#fff"/>
-  <path d="m76 539.7c0-4.868 3.9463-8.814 8.8143-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.383c0 4.868-3.946 8.815-8.814 8.815h-189.24c-4.868 0-8.8143-3.947-8.8143-8.815z" stroke="#999" stroke-width="2"/>
-  <text x="183.43652" y="579.61719" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Backwash</tspan></text>
-  <path d="m75 659.58c0-5.42 4.394-9.814 9.8143-9.814h189.24c5.42 0 9.814 4.394 9.814 9.814v76.384c0 5.42-4.394 9.814-9.814 9.814h-189.24c-5.4203 0-9.8143-4.394-9.8143-9.814z" fill="#fff"/>
-  <path d="m76 659.58c0-4.868 3.9463-8.814 8.8143-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.384c0 4.868-3.946 8.814-8.814 8.814h-189.24c-4.868 0-8.8143-3.946-8.8143-8.814z" stroke="#999" stroke-width="2"/>
-  <text x="181.64941" y="699.61719" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Rinse</tspan></text>
-  <path d="m315.69 419.81c0-5.42 4.394-9.814 9.814-9.814h189.24c5.42 0 9.815 4.394 9.815 9.814v76.383c0 5.421-4.395 9.815-9.815 9.815h-189.24c-5.42 0-9.814-4.394-9.814-9.814z" fill="#fff"/>
-  <path d="m316.69 419.81c0-4.868 3.946-8.814 8.814-8.814h189.24c4.868 0 8.815 3.946 8.815 8.814v76.383c0 4.869-3.947 8.815-8.815 8.815h-189.24c-4.868 0-8.814-3.946-8.814-8.814z" stroke="#999" stroke-width="2"/>
-  <text x="421.99316" y="459.75586" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Waste</tspan></text>
-  <path d="m315.69 539.7c0-5.42 4.394-9.814 9.815-9.814h189.24c5.42 0 9.814 4.394 9.814 9.814v76.383c0 5.421-4.394 9.815-9.814 9.815h-189.24c-5.421 0-9.815-4.394-9.815-9.815z" fill="#fff"/>
-  <path d="m316.69 539.7c0-4.868 3.947-8.814 8.815-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.383c0 4.868-3.946 8.815-8.814 8.815h-189.24c-4.868 0-8.815-3.947-8.815-8.815z" stroke="#999" stroke-width="2"/>
-  <text x="425.14062" y="579.61719" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Recirculate</tspan></text>
-  <path d="m315.69 659.58c0-5.42 4.394-9.814 9.815-9.814h189.24c5.42 0 9.814 4.394 9.814 9.814v76.383c0 5.42-4.394 9.814-9.814 9.814h-189.24c-5.421 0-9.815-4.394-9.815-9.814z" fill="#fff"/>
-  <path d="m316.69 659.58c0-4.868 3.947-8.814 8.815-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.383c0 4.868-3.946 8.814-8.814 8.814h-189.24c-4.868 0-8.815-3.946-8.815-8.814z" stroke="#999" stroke-width="2"/>
-  <text x="422.45215" y="699.61719" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Closed</tspan></text>
+  <g tb:tag="filter">
+   <rect x="75" y="410" width="208.86" height="96.012" rx="9.8143" fill="#999"/>
+   <path d="m76 419.81c0-4.868 3.9463-8.814 8.8143-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.383c0 4.868-3.946 8.815-8.814 8.815h-189.24c-4.868 0-8.8143-3.947-8.8143-8.815z" stroke="#999" stroke-width="2"/>
+   <text x="180.79984" y="460.00018" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Filter</tspan></text>
+  </g>
+  <g tb:tag="backwash">
+   <path d="m75 539.7c0-5.42 4.394-9.814 9.8143-9.814h189.24c5.42 0 9.814 4.394 9.814 9.814v76.383c0 5.421-4.394 9.815-9.814 9.815h-189.24c-5.4203 0-9.8143-4.394-9.8143-9.815z" fill="#fff"/>
+   <path d="m76 539.7c0-4.868 3.9463-8.814 8.8143-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.383c0 4.868-3.946 8.815-8.814 8.815h-189.24c-4.868 0-8.8143-3.947-8.8143-8.815z" stroke="#999" stroke-width="2"/>
+   <text x="183.43652" y="579.61719" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Backwash</tspan></text>
+  </g>
+  <g tb:tag="rinse">
+   <path d="m75 659.58c0-5.42 4.394-9.814 9.8143-9.814h189.24c5.42 0 9.814 4.394 9.814 9.814v76.384c0 5.42-4.394 9.814-9.814 9.814h-189.24c-5.4203 0-9.8143-4.394-9.8143-9.814z" fill="#fff"/>
+   <path d="m76 659.58c0-4.868 3.9463-8.814 8.8143-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.384c0 4.868-3.946 8.814-8.814 8.814h-189.24c-4.868 0-8.8143-3.946-8.8143-8.814z" stroke="#999" stroke-width="2"/>
+   <text x="181.64941" y="699.61719" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Rinse</tspan></text>
+  </g>
+  <g tb:tag="waste">
+   <path d="m315.69 419.81c0-5.42 4.394-9.814 9.814-9.814h189.24c5.42 0 9.815 4.394 9.815 9.814v76.383c0 5.421-4.395 9.815-9.815 9.815h-189.24c-5.42 0-9.814-4.394-9.814-9.814z" fill="#fff"/>
+   <path d="m316.69 419.81c0-4.868 3.946-8.814 8.814-8.814h189.24c4.868 0 8.815 3.946 8.815 8.814v76.383c0 4.869-3.947 8.815-8.815 8.815h-189.24c-4.868 0-8.814-3.946-8.814-8.814z" stroke="#999" stroke-width="2"/>
+   <text x="421.99316" y="459.75586" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Waste</tspan></text>
+  </g>
+  <g tb:tag="recirculate">
+   <path d="m315.69 539.7c0-5.42 4.394-9.814 9.815-9.814h189.24c5.42 0 9.814 4.394 9.814 9.814v76.383c0 5.421-4.394 9.815-9.814 9.815h-189.24c-5.421 0-9.815-4.394-9.815-9.815z" fill="#fff"/>
+   <path d="m316.69 539.7c0-4.868 3.947-8.814 8.815-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.383c0 4.868-3.946 8.815-8.814 8.815h-189.24c-4.868 0-8.815-3.947-8.815-8.815z" stroke="#999" stroke-width="2"/>
+   <text x="425.14062" y="579.61719" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Recirculate</tspan></text>
+  </g>
+  <g tb:tag="closed">
+   <path d="m315.69 659.58c0-5.42 4.394-9.814 9.815-9.814h189.24c5.42 0 9.814 4.394 9.814 9.814v76.383c0 5.42-4.394 9.814-9.814 9.814h-189.24c-5.421 0-9.815-4.394-9.815-9.814z" fill="#fff"/>
+   <path d="m316.69 659.58c0-4.868 3.947-8.814 8.815-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.383c0 4.868-3.946 8.814-8.814 8.814h-189.24c-4.868 0-8.815-3.946-8.815-8.814z" stroke="#999" stroke-width="2"/>
+   <text x="422.45215" y="699.61719" fill="#000000" font-family="Roboto" font-size="28px" font-weight="500" text-anchor="middle" xml:space="preserve"><tspan dominant-baseline="middle">Closed</tspan></text>
+  </g>
  </g>
 </svg>

--- a/application/src/main/data/json/system/scada_symbols/sand-filter-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/sand-filter-hp.svg
@@ -1,10 +1,10 @@
-<svg width="600" height="1e3" fill="none" version="1.1" viewBox="0 0 600 1e3" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="600" height="1e3" fill="none" version="1.1" viewBox="0 0 600 1e3"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Sand filter",
   "description": "Sand filter with configurable filtration mode option and various states.",
   "searchTags": [
     "filter",
-    "sand"
+    "sand",
+    "high performance"
   ],
   "widgetSizeX": 3,
   "widgetSizeY": 5,
@@ -154,16 +154,16 @@
     },
     {
       "id": "warning",
-      "name": "{i18n:scada.symbol.warning-state}",
+      "name": "{i18n:scada.symbol.warning}",
       "hint": "{i18n:scada.symbol.warning-state}",
-      "group": null,
+      "group": "{i18n:scada.symbol.warning-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -172,33 +172,62 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
     },
     {
+      "id": "warningClick",
+      "name": "{i18n:scada.symbol.warning-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.warning-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
+    },
+    {
       "id": "critical",
-      "name": "{i18n:scada.symbol.critical-state}",
+      "name": "{i18n:scada.symbol.critical}",
       "hint": "{i18n:scada.symbol.critical-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.critical-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -207,20 +236,46 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
+    },
+    {
+      "id": "criticalClick",
+      "name": "{i18n:scada.symbol.critical-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.critical-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
     },
     {
       "id": "criticalAnimation",
@@ -256,46 +311,6 @@
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
-    },
-    {
-      "id": "warningClick",
-      "name": "{i18n:scada.symbol.warning-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
-      "id": "criticalClick",
-      "name": "{i18n:scada.symbol.critical-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
     },
     {
       "id": "click",
@@ -417,12 +432,12 @@
     },
     {
       "id": "runningColor",
-      "name": "{i18n:scada.symbol.running-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#FFFFFF",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.running}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -433,11 +448,11 @@
     },
     {
       "id": "stoppedColor",
-      "name": "{i18n:scada.symbol.stopped-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#666666",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.stopped}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -449,12 +464,12 @@
     },
     {
       "id": "warningColor",
-      "name": "{i18n:scada.symbol.warning-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#FAA405",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.warning}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -465,11 +480,11 @@
     },
     {
       "id": "criticalColor",
-      "name": "{i18n:scada.symbol.critical-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#D12730",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.critical}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -577,7 +592,7 @@
     }
   ]
 }]]></tb:metadata>
- <g fill="#fff" tb:tag="background">
+<g fill="#fff" tb:tag="background">
   <path d="m137.58 946h324.84l53.581 24h-432l53.581-24z"/>
   <path d="m88.679 969 49.116-22h324.41l49.116 22h-422.64z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
   <path d="m0 388c0-99.411 80.588-180 180-180h240c99.411 0 180 80.589 180 180v412c0 81.738-66.262 148-148 148h-304c-81.738 0-148-66.262-148-148z"/>
@@ -592,21 +607,17 @@
   <path d="m428.98 272.03v-60.008c0-2.761-2.239-5-5-5h-41.554v-70.008h45.633c0.057 1e-3 0.142 2e-3 0.255 5e-3 0.227 5e-3 0.565 0.015 1.003 0.036 0.877 0.043 2.152 0.127 3.736 0.297 3.17 0.339 7.569 1.018 12.475 2.376 9.827 2.719 21.591 8.133 29.657 18.888 5.849 7.798 8.82 19.097 10.314 28.56 0.744 4.712 1.116 8.93 1.302 11.969 0.093 1.519 0.14 2.742 0.163 3.584 0.011 0.421 0.017 0.746 0.02 0.965 1e-3 0.11 2e-3 0.193 3e-3 0.248v56.087c0 2.762 2.238 5 5 5h107.01v70.009h-111.08c-0.046-1e-3 -0.116-2e-3 -0.21-4e-3 -0.187-4e-3 -0.467-0.013-0.831-0.03-0.73-0.034-1.797-0.103-3.136-0.242-2.68-0.277-6.443-0.832-10.761-1.943-8.647-2.223-19.463-6.659-28.296-15.492-7.797-7.797-11.745-19.07-13.731-28.501-0.989-4.701-1.484-8.908-1.732-11.939-0.123-1.515-0.185-2.735-0.216-3.573-0.015-0.419-0.023-0.743-0.027-0.96-2e-3 -0.109-3e-3 -0.191-3e-3 -0.246v-0.078z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
   <rect y="64" width="600" height="72"/>
   <rect x="1" y="65" width="598" height="70" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- </g>
- <path d="m201.79 0s-201.79 0-201.79 167.5v820.9c0 6.628 5.3726 11.601 12 11.601h576c6.6269 0 12-4.9729 12-11.601v-820.9c0-167.5-198.21-167.5-198.21-167.5h-101.79zm201.21 203c-3.866 0-7 3.134-7 7v751.01c0 3.866 3.134 7 7 7h43.999c3.866 0 7-3.134 7-7v-751.01c0-3.866-3.134-7-7-7z" fill="#000" fill-opacity="0" tb:tag="clickArea"/>
- <g fill="#d12730" style="display:none" tb:tag="critical">
-  <rect width="84" height="84" rx="4" fill="#fff"/>
-  <rect width="84" height="84" rx="4"/>
-  <rect x="2" y="2" width="80" height="80" rx="2" stroke="#000" stroke-opacity=".87" stroke-width="4"/>
-  <path d="m44.559 27.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87"/>
- </g>
- <g fill="#faa405" style="display:none" tb:tag="warning">
-  <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" fill="#fff"/>
-  <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z"/>
-  <path d="m40.211 8.0498c0.7371-1.4741 2.8407-1.4741 3.5778-1e-5l35.528 71.056c0.6649 1.3298-0.3021 2.8944-1.7888 2.8944h-71.056c-1.4868 0-2.4538-1.5646-1.7889-2.8944z" stroke="#000" stroke-opacity=".87" stroke-width="4"/>
-  <path d="m44.559 37.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87"/>
- </g>
- <g tb:tag="filterMode">
+ </g><path d="m201.79 0s-201.79 0-201.79 167.5v820.9c0 6.628 5.3726 11.601 12 11.601h576c6.6269 0 12-4.9729 12-11.601v-820.9c0-167.5-198.21-167.5-198.21-167.5h-101.79zm201.21 203c-3.866 0-7 3.134-7 7v751.01c0 3.866 3.134 7 7 7h43.999c3.866 0 7-3.134 7-7v-751.01c0-3.866-3.134-7-7-7z" fill="#000" fill-opacity="0" tb:tag="clickArea"/><g fill="#d12730" style="display: none;" tb:tag="critical">
+  <rect width="84" height="84" rx="4" fill="#fff" style=""/>
+  <rect width="84" height="84" rx="4" style=""/>
+  <rect x="2" y="2" width="80" height="80" rx="2" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>
+  <path d="m44.559 27.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87" style=""/>
+ </g><g fill="#faa405" style="display: none;" tb:tag="warning">
+  <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" fill="#fff" style=""/>
+  <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" style=""/>
+  <path d="m40.211 8.0498c0.7371-1.4741 2.8407-1.4741 3.5778-1e-5l35.528 71.056c0.6649 1.3298-0.3021 2.8944-1.7888 2.8944h-71.056c-1.4868 0-2.4538-1.5646-1.7889-2.8944z" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>
+  <path d="m44.559 37.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87" style=""/>
+ </g><g tb:tag="filterMode">
   <g tb:tag="filter">
    <rect x="75" y="410" width="208.86" height="96.012" rx="9.8143" fill="#999"/>
    <path d="m76 419.81c0-4.868 3.9463-8.814 8.8143-8.814h189.24c4.868 0 8.814 3.946 8.814 8.814v76.383c0 4.868-3.946 8.815-8.814 8.815h-189.24c-4.868 0-8.8143-3.947-8.8143-8.815z" stroke="#999" stroke-width="2"/>

--- a/application/src/main/data/json/system/scada_symbols/short-vertical-tank-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/short-vertical-tank-hp.svg
@@ -1,9 +1,9 @@
-<svg width="600" height="600" fill="none" version="1.1" viewBox="0 0 600 600" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="600" height="600" fill="none" version="1.1" viewBox="0 0 600 600"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Short vertical tank",
-  "description": "Short vertical tank",
+  "description": "Short vertical tank with level visualizations.",
   "searchTags": [
-    "short tank"
+    "short tank",
+    "high performance"
   ],
   "widgetSizeX": 3,
   "widgetSizeY": 3,
@@ -122,16 +122,16 @@
     },
     {
       "id": "warning",
-      "name": "{i18n:scada.symbol.warning-state}",
+      "name": "{i18n:scada.symbol.warning}",
       "hint": "{i18n:scada.symbol.warning-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.warning-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -140,33 +140,62 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
     },
     {
+      "id": "warningClick",
+      "name": "{i18n:scada.symbol.warning-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.warning-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
+    },
+    {
       "id": "critical",
-      "name": "{i18n:scada.symbol.critical-state}",
+      "name": "{i18n:scada.symbol.critical}",
       "hint": "{i18n:scada.symbol.critical-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.critical-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -175,20 +204,46 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
+    },
+    {
+      "id": "criticalClick",
+      "name": "{i18n:scada.symbol.critical-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.critical-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
     },
     {
       "id": "criticalAnimation",
@@ -224,46 +279,6 @@
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
-    },
-    {
-      "id": "warningClick",
-      "name": "{i18n:scada.symbol.warning-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
-      "id": "criticalClick",
-      "name": "{i18n:scada.symbol.critical-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
     },
     {
       "id": "click",
@@ -342,7 +357,7 @@
       "default": 10,
       "required": null,
       "subLabel": "{i18n:scada.symbol.intervals}",
-      "divider": true,
+      "divider": false,
       "fieldSuffix": null,
       "disableOnProperty": "scale",
       "rowClass": "",
@@ -375,7 +390,7 @@
     },
     {
       "id": "majorColor",
-      "name": "{i18n:scada.symbol.major-ticks-color}",
+      "name": "{i18n:scada.symbol.major-ticks}",
       "type": "color",
       "default": "#00000061",
       "required": null,
@@ -407,7 +422,7 @@
     },
     {
       "id": "minorColor",
-      "name": "{i18n:scada.symbol.minor-ticks-color}",
+      "name": "{i18n:scada.symbol.minor-ticks}",
       "type": "color",
       "default": "#0000001F",
       "required": null,
@@ -423,12 +438,12 @@
     },
     {
       "id": "warningColor",
-      "name": "{i18n:scada.symbol.warning-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#FAA405",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.warning}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -439,11 +454,11 @@
     },
     {
       "id": "criticalColor",
-      "name": "{i18n:scada.symbol.critical-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#D12730",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.critical}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -455,16 +470,12 @@
     }
   ]
 }]]></tb:metadata>
- <path d="m0 120s0-120 140-120c124.5-5.6458e-4 194.5 2.7873e-4 320 0 140-3.1093e-4 140 120 140 120v360s0 120-140 120h-320c-140 0-140-120-140-120v-360z" fill="#EBEBEB" tb:tag="background"/>
- <path d="m0.936 120h0.064l1e-5 -3e-3 5e-5 -0.014 4.3e-4 -0.061c5.1e-4 -0.054 0.00153-0.137 0.00361-0.247 0.00415-0.221 0.0125-0.551 0.02932-0.984 0.03365-0.865 0.10115-2.139 0.23656-3.764 0.27086-3.25 0.81325-7.901 1.8991-13.486 2.1725-11.173 6.5161-26.059 15.195-40.937 17.319-29.69 51.988-59.504 121.64-59.504 68.61-3.13e-4 120.67-2e-4 174.59-8e-5 43.92 1e-4 89.074 2e-4 145.41 8e-5 69.648-1.6e-4 104.32 29.814 121.64 59.504 8.679 14.878 13.022 29.764 15.195 40.937 1.086 5.585 1.628 10.236 1.899 13.486 0.135 1.625 0.203 2.899 0.237 3.764 6e-3 0.169 0.011 0.321 0.016 0.458 6e-3 0.215 0.01 0.391 0.013 0.526 2e-3 0.11 3e-3 0.193 4e-3 0.247v0.078h0.051-0.051v360h0.064-0.064v0.078c-1e-3 0.054-2e-3 0.137-4e-3 0.248-4e-3 0.22-0.013 0.55-0.029 0.983-0.034 0.865-0.102 2.139-0.237 3.764-0.271 3.251-0.813 7.902-1.899 13.486-2.173 11.173-6.516 26.06-15.195 40.937-17.319 29.69-51.988 59.504-121.64 59.504h-320c-69.648 0-104.32-29.814-121.64-59.504-8.6786-14.877-13.022-29.764-15.195-40.937-1.0859-5.584-1.6283-10.235-1.8991-13.486-0.13541-1.625-0.20291-2.899-0.23656-3.764-0.01682-0.433-0.02517-0.763-0.02932-0.983-0.00208-0.111-0.0031-0.194-0.00361-0.248l-4.3e-4 -0.061-5e-5 -0.014-1e-5 -3e-3h-0.064 0.064v-360h-0.064z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- <mask id="mask0_3610_179735" x="2" y="2" width="596" height="596" style="mask-type:alpha" maskUnits="userSpaceOnUse">
+<path d="m0 120s0-120 140-120c124.5-5.6458e-4 194.5 2.7873e-4 320 0 140-3.1093e-4 140 120 140 120v360s0 120-140 120h-320c-140 0-140-120-140-120v-360z" fill="#EBEBEB" tb:tag="background"/><path d="m0.936 120h0.064l1e-5 -3e-3 5e-5 -0.014 4.3e-4 -0.061c5.1e-4 -0.054 0.00153-0.137 0.00361-0.247 0.00415-0.221 0.0125-0.551 0.02932-0.984 0.03365-0.865 0.10115-2.139 0.23656-3.764 0.27086-3.25 0.81325-7.901 1.8991-13.486 2.1725-11.173 6.5161-26.059 15.195-40.937 17.319-29.69 51.988-59.504 121.64-59.504 68.61-3.13e-4 120.67-2e-4 174.59-8e-5 43.92 1e-4 89.074 2e-4 145.41 8e-5 69.648-1.6e-4 104.32 29.814 121.64 59.504 8.679 14.878 13.022 29.764 15.195 40.937 1.086 5.585 1.628 10.236 1.899 13.486 0.135 1.625 0.203 2.899 0.237 3.764 6e-3 0.169 0.011 0.321 0.016 0.458 6e-3 0.215 0.01 0.391 0.013 0.526 2e-3 0.11 3e-3 0.193 4e-3 0.247v0.078h0.051-0.051v360h0.064-0.064v0.078c-1e-3 0.054-2e-3 0.137-4e-3 0.248-4e-3 0.22-0.013 0.55-0.029 0.983-0.034 0.865-0.102 2.139-0.237 3.764-0.271 3.251-0.813 7.902-1.899 13.486-2.173 11.173-6.516 26.06-15.195 40.937-17.319 29.69-51.988 59.504-121.64 59.504h-320c-69.648 0-104.32-29.814-121.64-59.504-8.6786-14.877-13.022-29.764-15.195-40.937-1.0859-5.584-1.6283-10.235-1.8991-13.486-0.13541-1.625-0.20291-2.899-0.23656-3.764-0.01682-0.433-0.02517-0.763-0.02932-0.983-0.00208-0.111-0.0031-0.194-0.00361-0.248l-4.3e-4 -0.061-5e-5 -0.014-1e-5 -3e-3h-0.064 0.064v-360h-0.064z" stroke="#000" stroke-opacity=".87" stroke-width="2"/><mask id="mask0_3610_179735" x="2" y="2" width="596" height="596" style="mask-type:alpha" maskUnits="userSpaceOnUse">
   <path d="m2 121.2s0-119.2 139.07-119.2c123.67-5.6e-4 193.2 2.7e-4 317.87 0 139.07-3.1e-4 139.07 119.2 139.07 119.2v357.6s0 119.2-139.07 119.2h-317.87c-139.07 0-139.07-119.2-139.07-119.2v-357.6z" fill="#EBEBEB"/>
   <path d="m2.9398 121.2h0.06019l1e-5 -3e-3 5e-5 -0.014 4.3e-4 -0.06c5e-4 -0.054 0.00152-0.136 0.00358-0.246 0.00412-0.219 0.01242-0.547 0.02913-0.977 0.03341-0.859 0.10046-2.125 0.23496-3.739 0.26903-3.228 0.80778-7.848 1.8864-13.395 2.1579-11.098 6.4724-25.884 15.093-40.662 17.202-29.49 51.638-59.104 120.82-59.104 68.154-3.1e-4 119.87-2e-4 173.43-8e-5 43.627 1e-4 88.479 2e-4 144.44 8e-5 69.181-1.6e-4 103.62 29.614 120.82 59.104 8.62 14.778 12.935 29.564 15.092 40.662 1.079 5.547 1.618 10.167 1.887 13.395 0.134 1.614 0.201 2.88 0.235 3.739 0.017 0.43 0.025 0.758 0.029 0.977 2e-3 0.11 3e-3 0.192 4e-3 0.246v0.077h0.06-0.06v357.6h0.05-0.05v0.077c-1e-3 0.054-2e-3 0.137-4e-3 0.246-4e-3 0.219-0.012 0.547-0.029 0.977-0.034 0.859-0.101 2.125-0.235 3.739-0.269 3.228-0.808 7.848-1.887 13.395-2.157 11.098-6.472 25.885-15.092 40.662-17.203 29.49-51.639 59.104-120.82 59.104h-317.87c-69.181 0-103.62-29.614-120.82-59.104-8.6202-14.777-12.935-29.564-15.093-40.662-1.0786-5.547-1.6173-10.167-1.8864-13.395-0.1345-1.614-0.20155-2.88-0.23496-3.739-0.01671-0.43-0.02501-0.758-0.02913-0.977-0.00206-0.109-0.00308-0.192-0.00358-0.246l-4.3e-4 -0.06-5e-5 -0.014-1e-5 -3e-3h-0.05001 0.05001v-357.6h-0.06019z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- </mask>
- <g mask="url(#mask0_3610_179735)">
+ </mask><g mask="url(#mask0_3610_179735)">
   <rect transform="scale(1,-1)" x="2" y="-596" width="600" height="419" fill="#c8dff7" tb:tag="fluid-background"/>
- </g>
- <g tb:tag="scale">
+ </g><g tb:tag="scale">
   <line x1="168" x2="200" y1="2.5" y2="2.5" stroke="#000" stroke-opacity=".38" stroke-width="3"/>
   <line x1="180" x2="200" y1="14.381" y2="14.381" stroke="#000" stroke-opacity=".12" stroke-width="3"/>
   <line x1="180" x2="200" y1="26.26" y2="26.26" stroke="#000" stroke-opacity=".12" stroke-width="3"/>
@@ -527,15 +538,12 @@
   <path d="m145.2 478.55v2.25h-11.437v-1.934l5.554-6.058c0.61-0.688 1.09-1.282 1.442-1.782 0.351-0.5 0.598-0.949 0.738-1.347 0.149-0.407 0.223-0.801 0.223-1.184 0-0.539-0.102-1.012-0.305-1.418-0.195-0.414-0.484-0.738-0.867-0.973-0.383-0.242-0.848-0.363-1.395-0.363-0.632 0-1.164 0.137-1.593 0.41-0.43 0.274-0.754 0.653-0.973 1.137-0.219 0.477-0.328 1.023-0.328 1.641h-2.824c0-0.992 0.226-1.899 0.679-2.719 0.453-0.828 1.11-1.484 1.969-1.969 0.86-0.492 1.895-0.738 3.106-0.738 1.14 0 2.109 0.191 2.906 0.574s1.402 0.926 1.816 1.629c0.422 0.703 0.633 1.535 0.633 2.496 0 0.531-0.086 1.059-0.258 1.582-0.172 0.524-0.418 1.047-0.738 1.57-0.313 0.516-0.684 1.036-1.113 1.559-0.43 0.516-0.903 1.039-1.418 1.57l-3.692 4.067zm13.575-7.711v2.789c0 1.336-0.133 2.476-0.399 3.422-0.258 0.937-0.633 1.699-1.125 2.285s-1.082 1.016-1.769 1.289c-0.68 0.273-1.442 0.41-2.286 0.41-0.671 0-1.296-0.086-1.875-0.258-0.57-0.172-1.086-0.441-1.546-0.808-0.461-0.367-0.856-0.84-1.184-1.418-0.32-0.586-0.57-1.285-0.75-2.098-0.172-0.812-0.258-1.754-0.258-2.824v-2.789c0-1.344 0.133-2.477 0.399-3.399 0.265-0.929 0.644-1.683 1.136-2.261 0.492-0.586 1.078-1.012 1.758-1.278 0.688-0.265 1.453-0.398 2.297-0.398 0.68 0 1.305 0.086 1.875 0.258 0.578 0.164 1.094 0.426 1.547 0.785 0.461 0.359 0.851 0.828 1.172 1.406 0.328 0.57 0.578 1.262 0.75 2.074 0.172 0.805 0.258 1.743 0.258 2.813zm-2.825 3.187v-3.609c0-0.68-0.039-1.277-0.117-1.793-0.078-0.523-0.195-0.965-0.351-1.324-0.149-0.367-0.336-0.664-0.563-0.891-0.226-0.234-0.484-0.402-0.773-0.504-0.289-0.109-0.614-0.164-0.973-0.164-0.438 0-0.828 0.086-1.172 0.258-0.344 0.164-0.633 0.43-0.867 0.797s-0.414 0.851-0.539 1.453c-0.117 0.594-0.176 1.316-0.176 2.168v3.609c0 0.688 0.039 1.293 0.117 1.817 0.078 0.523 0.196 0.972 0.352 1.347 0.156 0.368 0.344 0.672 0.562 0.914 0.227 0.235 0.485 0.407 0.774 0.516 0.297 0.109 0.621 0.164 0.972 0.164 0.446 0 0.84-0.086 1.184-0.258s0.633-0.445 0.867-0.82c0.235-0.383 0.41-0.879 0.528-1.488 0.117-0.61 0.175-1.34 0.175-2.192z" fill="#000" fill-opacity=".38"/>
   <path d="m141.47 521.28v17.121h-2.824v-13.769l-4.184 1.418v-2.332l6.668-2.438zm17.301 7.16v2.79c0 1.335-0.133 2.476-0.399 3.421-0.258 0.938-0.633 1.7-1.125 2.286-0.492 0.585-1.082 1.015-1.769 1.289-0.68 0.273-1.442 0.41-2.286 0.41-0.671 0-1.296-0.086-1.875-0.258-0.57-0.172-1.086-0.441-1.546-0.809-0.461-0.367-0.856-0.839-1.184-1.418-0.32-0.586-0.57-1.285-0.75-2.097-0.172-0.813-0.258-1.754-0.258-2.824v-2.79c0-1.343 0.133-2.476 0.399-3.398 0.265-0.93 0.644-1.684 1.136-2.262 0.492-0.586 1.078-1.011 1.758-1.277 0.688-0.266 1.453-0.398 2.297-0.398 0.68 0 1.305 0.085 1.875 0.257 0.578 0.164 1.094 0.426 1.547 0.785 0.461 0.36 0.851 0.829 1.172 1.407 0.328 0.57 0.578 1.261 0.75 2.074 0.172 0.805 0.258 1.742 0.258 2.812zm-2.825 3.188v-3.609c0-0.68-0.039-1.278-0.117-1.793-0.078-0.524-0.195-0.965-0.351-1.325-0.149-0.367-0.336-0.664-0.563-0.89-0.226-0.235-0.484-0.403-0.773-0.504-0.289-0.11-0.614-0.164-0.973-0.164-0.438 0-0.828 0.086-1.172 0.258-0.344 0.164-0.633 0.429-0.867 0.796-0.234 0.368-0.414 0.852-0.539 1.454-0.117 0.593-0.176 1.316-0.176 2.168v3.609c0 0.687 0.039 1.293 0.117 1.816 0.078 0.524 0.196 0.973 0.352 1.348 0.156 0.367 0.344 0.672 0.562 0.914 0.227 0.234 0.485 0.406 0.774 0.516 0.297 0.109 0.621 0.164 0.972 0.164 0.446 0 0.84-0.086 1.184-0.258s0.633-0.445 0.867-0.82c0.235-0.383 0.41-0.879 0.528-1.489 0.117-0.609 0.175-1.339 0.175-2.191z" fill="#000" fill-opacity=".38"/>
   <path d="m158.77 586.04v2.789c0 1.336-0.133 2.477-0.399 3.422-0.258 0.938-0.633 1.699-1.125 2.285s-1.082 1.016-1.769 1.289c-0.68 0.274-1.442 0.41-2.286 0.41-0.671 0-1.296-0.086-1.875-0.257-0.57-0.172-1.086-0.442-1.546-0.809-0.461-0.367-0.856-0.84-1.184-1.418-0.32-0.586-0.57-1.285-0.75-2.098-0.172-0.812-0.258-1.754-0.258-2.824v-2.789c0-1.344 0.133-2.477 0.399-3.398 0.265-0.93 0.644-1.684 1.136-2.262 0.492-0.586 1.078-1.012 1.758-1.277 0.688-0.266 1.453-0.399 2.297-0.399 0.68 0 1.305 0.086 1.875 0.258 0.578 0.164 1.094 0.426 1.547 0.785 0.461 0.359 0.851 0.828 1.172 1.406 0.328 0.571 0.578 1.262 0.75 2.075 0.172 0.804 0.258 1.742 0.258 2.812zm-2.825 3.188v-3.61c0-0.679-0.039-1.277-0.117-1.793-0.078-0.523-0.195-0.965-0.351-1.324-0.149-0.367-0.336-0.664-0.563-0.891-0.226-0.234-0.484-0.402-0.773-0.504-0.289-0.109-0.614-0.164-0.973-0.164-0.438 0-0.828 0.086-1.172 0.258-0.344 0.164-0.633 0.43-0.867 0.797s-0.414 0.852-0.539 1.453c-0.117 0.594-0.176 1.317-0.176 2.168v3.61c0 0.687 0.039 1.293 0.117 1.816s0.196 0.973 0.352 1.348c0.156 0.367 0.344 0.671 0.562 0.914 0.227 0.234 0.485 0.406 0.774 0.515 0.297 0.11 0.621 0.164 0.972 0.164 0.446 0 0.84-0.086 1.184-0.257 0.344-0.172 0.633-0.446 0.867-0.821 0.235-0.383 0.41-0.879 0.528-1.488 0.117-0.609 0.175-1.34 0.175-2.191z" fill="#000" fill-opacity=".38"/>
- </g>
- <path d="m201.79 0s-201.79 0-201.79 100.5v492.54c0 3.9768 5.3727 6.9606 12 6.9606h576c6.627 0 12-2.9838 12-6.9606v-492.54c0-100.5-198.21-100.5-198.21-100.5h-101.79zm201.21 121.8c-3.866 0-7 1.8804-7 4.2v450.6c0 2.3196 3.134 4.2 7 4.2h43.998c3.866 0 7-1.8804 7-4.2v-450.6c0-2.3196-3.134-4.2-7-4.2z" fill="#000" fill-opacity="0" style="stroke-width:.43301" tb:tag="clickArea"/>
- <g fill="#d12730" style="display:none" tb:tag="critical">
+ </g><path d="m201.79 0s-201.79 0-201.79 100.5v492.54c0 3.9768 5.3727 6.9606 12 6.9606h576c6.627 0 12-2.9838 12-6.9606v-492.54c0-100.5-198.21-100.5-198.21-100.5h-101.79zm201.21 121.8c-3.866 0-7 1.8804-7 4.2v450.6c0 2.3196 3.134 4.2 7 4.2h43.998c3.866 0 7-1.8804 7-4.2v-450.6c0-2.3196-3.134-4.2-7-4.2z" fill="#000" fill-opacity="0" style="stroke-width:.43301" tb:tag="clickArea"/><g fill="#d12730" style="display: none;" tb:tag="critical">
   <rect width="84" height="84" rx="4" fill="#fff" style=""/>
   <rect width="84" height="84" rx="4" style=""/>
   <rect x="2" y="2" width="80" height="80" rx="2" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>
   <path d="m44.559 27.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87" style=""/>
- </g>
- <g transform="translate(0 -4.9442)" fill="#faa405" style="display:none" tb:tag="warning">
+ </g><g transform="translate(0 -4.9442)" fill="#faa405" style="display: none;" tb:tag="warning">
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" fill="#fff" style=""/>
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" style=""/>
   <path d="m40.211 8.0498c0.7371-1.4741 2.8407-1.4741 3.5778-1e-5l35.528 71.056c0.6649 1.3298-0.3021 2.8944-1.7888 2.8944h-71.056c-1.4868 0-2.4538-1.5646-1.7889-2.8944z" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>

--- a/application/src/main/data/json/system/scada_symbols/simple-horizontal-scale-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/simple-horizontal-scale-hp.svg
@@ -1,5 +1,4 @@
-<svg width="800" height="400" fill="none" version="1.1" viewBox="0 0 800 400" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="800" height="400" fill="none" version="1.1" viewBox="0 0 800 400"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Simple horizontal scale",
   "description": "Simple horizontal scale with current volume value and configurable warning and critical scale.",
   "searchTags": [
@@ -19,22 +18,12 @@
     },
     {
       "tag": "highCriticalScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 638;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighCriticalValue = ctx.properties.showHighCriticalScale;\nvar highCriticalValue = ctx.properties.highCriticalScale;\n\nif (showHighCriticalValue) {\n    element.show();\n    var offset = calculateOffset(highCriticalValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(638-offset);\n    childrenElement[1].height(638-offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "highCriticalScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showHighCriticalValue = ctx.properties.showHighCriticalScale;\n\nif (showHighCriticalValue && value !== null) {\n    var highCriticalScale = ctx.properties.highCriticalScale;\n    if (value >= highCriticalScale && value <= ctx.properties.maxValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar highCriticalValue = ctx.properties.highCriticalScale;\nvar value = ctx.values.value;\n\nif (showHighCriticalScale) {\n    element.show();\n    var offset = calculateOffset(highCriticalValue, minValue, maxValue);\n    element.width(653-offset);\n} else {\n    element.hide();\n}\n\nif (showHighCriticalScale && value !== null) {\n    var highCriticalScale = ctx.properties.highCriticalScale;\n    if (value >= highCriticalScale && value <= ctx.properties.maxValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
       "actions": null
     },
     {
       "tag": "highWarningScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 638;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\nvar highWarningValue = ctx.properties.highWarningScale;\nif (showHighWarningScale) {\n    element.show();\n    var offset = calculateOffset(highWarningValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(638-offset);\n    childrenElement[1].height(638-offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "highWarningScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\n\nif (showHighWarningScale && value !== null) {\n    var highCriticalScale = ctx.properties.highCriticalScale;\n    if (!showHighCriticalScale) {\n        highCriticalScale = ctx.properties.maxValue;\n    }\n    var highWarningScale = ctx.properties.highWarningScale;\n    if (value < highCriticalScale && value >= highWarningScale) {\n        element.fill(ctx.properties.activeWarningScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultWarningScaleColor);\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar highWarningValue = ctx.properties.highWarningScale;\nvar value = ctx.values.value;\n\nif (showHighWarningScale) {\n    element.show();\n    var offset = calculateOffset(highWarningValue, minValue, maxValue);\n    element.width(653-offset);\n} else {\n    element.hide();\n}\n\nif (showHighWarningScale && value !== null) {\n    var highCriticalScale = ctx.properties.highCriticalScale;\n    if (!showHighCriticalScale) {\n        highCriticalScale = ctx.properties.maxValue;\n    }\n    var highWarningScale = ctx.properties.highWarningScale;\n    if (value < highCriticalScale && value >= highWarningScale) {\n        element.fill(ctx.properties.activeWarningScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultWarningScaleColor);\n    }\n}",
       "actions": null
     },
     {
@@ -44,22 +33,12 @@
     },
     {
       "tag": "lowCriticalScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 638;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowCriticalValue = ctx.properties.lowCriticalScale;\nif (showLowCriticalScale) {\n    element.show();\n    var offset = calculateOffset(lowCriticalValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(offset);\n    childrenElement[1].height(offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "lowCriticalScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nif (showLowCriticalScale && value !== null) {\n    var lowCriticalScale = ctx.properties.lowCriticalScale;\n    if (value <= lowCriticalScale && value >= ctx.properties.minValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowCriticalScale = ctx.properties.lowCriticalScale;\n\nif (showLowCriticalScale) {\n    element.show();\n    var offset = calculateOffset(lowCriticalScale, minValue, maxValue);\n    var childrenElement = element.children();\n    element.width(offset);\n} else {\n    element.hide();\n}\n\nif (showLowCriticalScale && value !== null) {\n    if (value <= lowCriticalScale && value >= ctx.properties.minValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
       "actions": null
     },
     {
       "tag": "lowWarningScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 638;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar lowWarningValue = ctx.properties.lowWarningScale;\nif (showLowWarningScale) {\n    element.show();\n    var offset = calculateOffset(lowWarningValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(offset);\n    childrenElement[1].height(offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "lowWarningScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\n\nif (showLowWarningScale && value !== null) {\n    var lowCriticalScale = ctx.properties.lowCriticalScale;\n    if (!showLowCriticalScale) {\n        lowCriticalScale = ctx.properties.minValue;\n    }\n    var lowWarningScale = ctx.properties.lowWarningScale;\n    if (value > lowCriticalScale && value <= lowWarningScale) {\n        element.fill(ctx.properties.activeWarningScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultWarningScaleColor);\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowWarningScale = ctx.properties.lowWarningScale;\nif (showLowWarningScale) {\n    element.show();\n    var offset = calculateOffset(lowWarningScale, minValue, maxValue);\n    element.width(offset);\n} else {\n    element.hide();\n}\n\nif (showLowWarningScale && value !== null) {\n    var lowCriticalScale = ctx.properties.lowCriticalScale;\n    if (!showLowCriticalScale) {\n        lowCriticalScale = ctx.properties.minValue;\n    }\n    if (value > lowCriticalScale && value <= lowWarningScale) {\n        element.fill(ctx.properties.activeWarningScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultWarningScaleColor);\n    }\n}",
       "actions": null
     },
     {
@@ -84,7 +63,7 @@
     },
     {
       "tag": "target",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 640;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showTarget = ctx.properties.showTarget;\nvar targetValue = ctx.values.targetValue;\n\nif (showTarget && targetValue !== null) {\n    element.show();\n    var offset = calculateOffset(targetValue, minValue, maxValue);\n    element.transform({translateX: -(640 - (Math.min(Math.max(offset+12, 30), 635)))});\n} else {\n    element.hide();\n}\n\n",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showTarget = ctx.properties.showTarget;\nvar targetValue = ctx.values.targetValue;\n\nif (showTarget && targetValue !== null) {\n    element.show();\n    var offset = calculateOffset(targetValue, minValue, maxValue);\n    element.transform({translateX: Math.min(Math.max(offset-17, 0), 619)});\n} else {\n    element.hide();\n}\n\n",
       "actions": null
     },
     {
@@ -99,7 +78,12 @@
     },
     {
       "tag": "value",
-      "stateRenderFunction": "if (ctx.properties.value !== null) {\n    element.show();\n    ctx.api.font(element, ctx.properties.valueFont, ctx.properties.valueColor);\n    ctx.api.text(element, ctx.api.formatValue(ctx.values.value, ctx.properties.valueDecimals, null, ctx.properties.valueDecimals));\n} else {\n    element.hide();\n}",
+      "stateRenderFunction": "if (ctx.properties.value) {\n    element.show();\n    ctx.api.font(element, ctx.properties.valueFont, ctx.properties.valueColor);\n    ctx.api.text(element, ctx.api.formatValue(ctx.values.value, ctx.properties.valueDecimals, null, ctx.properties.valueDecimals));\n} else {\n    element.hide();\n}",
+      "actions": null
+    },
+    {
+      "tag": "valueArrowPosition",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateX: offset});\n}\n",
       "actions": null
     },
     {
@@ -108,8 +92,8 @@
       "actions": null
     },
     {
-      "tag": "valuePosition",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 638;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateX: -(638 - offset)});\n}\n",
+      "tag": "valueTextPositon",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateX: offset});\n}\n",
       "actions": null
     }
   ],
@@ -720,39 +704,20 @@
     }
   ]
 }]]></tb:metadata>
- <text x="409.16602" y="97.234375" fill="#000000" font-family="Roboto" font-size="56px" font-weight="400" text-anchor="middle" tb:tag="label" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">Outdoor</tspan></text>
- <text x="401.15625" y="345.75" fill="#000000" font-family="Roboto" font-size="40px" font-weight="400" text-anchor="middle" tb:tag="units" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">°C</tspan></text>
- <g transform="matrix(.98289 0 0 1 8.2492 -20)" fill="#666" font-family="Roboto" font-size="32px" font-weight="500" text-anchor="middle" style="display:none" tb:tag="minMaxValue">
-  <text x="100.02344" y="268" style="" tb:tag="maxValue" xml:space="preserve"><tspan dominant-baseline="middle">100</tspan></text>
-  <text x="715.07031" y="268" style="" tb:tag="minValue" xml:space="preserve"><tspan dominant-baseline="middle">0</tspan></text>
- </g>
- <g transform="translate(-350)" tb:tag="valuePosition">
-  <path d="m719 179 24-42h-48z" fill="#666" tb:tag="valuePointer"/>
-  <text x="718.7793" y="273.125" fill="#002878" font-family="Roboto" font-size="60px" font-weight="400" text-anchor="middle" tb:tag="value" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">26</tspan></text>
- </g>
- <g transform="matrix(.97855 0 0 1 9.5443 -16.995)" tb:tag="scale">
-  <rect transform="rotate(-90)" x="-242" y="72" width="42" height="653" fill="#c8dff7" style="stroke-width:.9497" tb:tag="scaleBackground"/>
-  <rect transform="rotate(-90)" x="-241.52" y="72.475" width="41.05" height="652.05" stroke="#000" stroke-opacity=".87" style="stroke-width:.95024"/>
-  <g tb:tag="lowWarningScale">
-   <rect transform="rotate(-90)" x="-242" y="72" width="42" height="153.12" fill="#ebebeb" style="stroke-width:.94905" tb:tag="lowWarningScaleBackground"/>
-   <rect transform="rotate(-90)" x="-241.53" y="72.475" width="41.051" height="152.17" stroke="#000" stroke-opacity=".87" style="stroke-width:.94948"/>
-  </g>
-  <g tb:tag="lowCriticalScale">
-   <rect transform="rotate(-90)" x="-242" y="72" width="42" height="81.062" fill="#666" style="stroke-width:.94905" tb:tag="lowCriticalScaleBackground"/>
-   <rect transform="rotate(-90)" x="-241.53" y="72.475" width="41.051" height="80.113" stroke="#000" stroke-opacity=".87" style="stroke-width:.94934"/>
-  </g>
-  <g transform="rotate(90,700.5,265.5)" tb:tag="highWarningScale">
-   <rect transform="scale(-1,1)" x="-677" y="241" width="42" height="153.12" fill="#ebebeb" style="stroke-width:.94905" tb:tag="highWarningScaleBackground"/>
-   <rect transform="scale(-1,1)" x="-676.53" y="241.47" width="41.051" height="152.17" stroke="#000" stroke-opacity=".87" style="stroke-width:.94948"/>
-  </g>
-  <g transform="rotate(90,700.5,265.5)" tb:tag="highCriticalScale">
-   <rect transform="scale(-1,1)" x="-677" y="241" width="42" height="81.062" fill="#666" style="stroke-width:.94905" tb:tag="highCriticalScaleBackground"/>
-   <rect transform="scale(-1,1)" x="-676.53" y="241.48" width="41.051" height="80.113" stroke="#000" stroke-opacity=".87" style="stroke-width:.94934"/>
-  </g>
- </g>
- <g transform="translate(-180)" tb:tag="target">
-  <rect transform="rotate(45)" x="627.89" y="-363.43" width="24" height="24" fill="#dedede" tb:tag="targetBackground"/>
-  <rect transform="rotate(45)" x="628.89" y="-362.43" width="22" height="22" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- </g>
- <path d="m269.06 0s-269.06 0-269.06 67v328.36c0 2.6512 7.1634 4.6404 16 4.6404h768c8.836 0 16-1.9892 16-4.6404v-328.36c0-67-264.28-67-264.28-67h-135.72zm268.28 81.2c-5.1546 0-9.3334 1.2536-9.3334 2.8v300.4c0 1.5464 4.1786 2.8 9.3334 2.8h58.666c5.1546 0 9.3334-1.2536 9.3334-2.8v-300.4c0-1.5464-4.1786-2.8-9.3334-2.8z" fill="#000" fill-opacity="0" style="stroke-width:.7303" tb:tag="clickArea"/>
+<text x="409.16602" y="97.234375" fill="#000000" font-family="Roboto" font-size="56px" font-weight="400" text-anchor="middle" tb:tag="label" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">Outdoor</tspan></text><text x="401.15625" y="345.75" fill="#000000" font-family="Roboto" font-size="40px" font-weight="400" text-anchor="middle" tb:tag="units" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">°C</tspan></text><g fill="#666" font-family="Roboto" font-size="32px" font-weight="500" text-anchor="middle" style="display: none;" tb:tag="minMaxValue">
+  <text x="88.070312" y="268" tb:tag="minValue" xml:space="preserve" style=""><tspan dominant-baseline="middle">0</tspan></text>
+  <text x="705.02344" y="268" tb:tag="maxValue" xml:space="preserve" style=""><tspan dominant-baseline="middle">100</tspan></text>
+ </g><g transform="translate(180)" tb:tag="valueArrowPosition">
+  <path d="m80 179 24-42h-48z" fill="#666" tb:tag="valuePointer"/>
+ </g><g transform="translate(180)" tb:tag="valueTextPositon">
+  <text x="79.779297" y="273.125" fill="#002878" font-family="Roboto" font-size="60px" font-weight="400" text-anchor="middle" tb:tag="value" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">26</tspan></text>
+ </g><g stroke="#000" tb:tag="scale">
+  <rect x="80.5" y="183.5" width="652" height="41" fill="#c8dff7" tb:tag="scaleBackground"/>
+  <rect x="80.5" y="183.5" width="164" height="41" fill="#ebebeb" tb:tag="lowWarningScale"/>
+  <rect x="80.5" y="183.5" width="81" height="41" fill="#666" tb:tag="lowCriticalScale"/>
+  <rect transform="scale(-1,1)" x="-732.5" y="183.5" width="164" height="41" fill="#ebebeb" tb:tag="highWarningScale"/>
+  <rect transform="scale(-1,1)" x="-732.5" y="183.5" width="81" height="41" fill="#666" tb:tag="highCriticalScale"/>
+ </g><g transform="translate(400)" style="display: none;" tb:tag="target">
+  <rect transform="rotate(45)" x="201.8" y="64.66" width="22" height="22" fill="#dedede" stroke="#000" stroke-width="2" tb:tag="targetBackground" style=""/>
+ </g><path d="m269.06 0s-269.06 0-269.06 67v328.36c0 2.6512 7.1634 4.6404 16 4.6404h768c8.836 0 16-1.9892 16-4.6404v-328.36c0-67-264.28-67-264.28-67h-135.72zm268.28 81.2c-5.1546 0-9.3334 1.2536-9.3334 2.8v300.4c0 1.5464 4.1786 2.8 9.3334 2.8h58.666c5.1546 0 9.3334-1.2536 9.3334-2.8v-300.4c0-1.5464-4.1786-2.8-9.3334-2.8z" fill="#000" fill-opacity="0" style="stroke-width:.7303" tb:tag="clickArea"/>
 </svg>

--- a/application/src/main/data/json/system/scada_symbols/simple-vertical-scale-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/simple-vertical-scale-hp.svg
@@ -1,5 +1,4 @@
-<svg width="400" height="800" fill="none" version="1.1" viewBox="0 0 400 800" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="400" height="800" fill="none" version="1.1" viewBox="0 0 400 800"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Simple vertical scale",
   "description": "Simple vertical scale with current volume value and configurable warning and critical scale.",
   "searchTags": [
@@ -19,22 +18,12 @@
     },
     {
       "tag": "highCriticalScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighCriticalValue = ctx.properties.showHighCriticalScale;\nvar highCriticalValue = ctx.properties.highCriticalScale;\n\nif (showHighCriticalValue) {\n    element.show();\n    var offset = calculateOffset(highCriticalValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(653-offset);\n    childrenElement[1].height(653-offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "highCriticalScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showHighCriticalValue = ctx.properties.showHighCriticalScale;\n\nif (showHighCriticalValue && value !== null) {\n    var highCriticalScale = ctx.properties.highCriticalScale;\n    if (value >= highCriticalScale && value <= ctx.properties.maxValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar highCriticalScale = ctx.properties.highCriticalScale;\n\nif (showHighCriticalScale) {\n    element.show();\n    var offset = calculateOffset(highCriticalScale, minValue, maxValue);\n    element.height(653-offset);\n} else {\n    element.hide();\n}\n\nif (showHighCriticalScale && value !== null) {\n    var highCriticalScale = ctx.properties.highCriticalScale;\n    if (value >= highCriticalScale && value <= ctx.properties.maxValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
       "actions": null
     },
     {
       "tag": "highWarningScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\nvar highWarningValue = ctx.properties.highWarningScale;\nif (showHighWarningScale) {\n    element.show();\n    var offset = calculateOffset(highWarningValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(653-offset);\n    childrenElement[1].height(653-offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "highWarningScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\n\nif (showHighWarningScale && value !== null) {\n    var highCriticalScale = ctx.properties.highCriticalScale;\n    if (!showHighCriticalScale) {\n        highCriticalScale = ctx.properties.maxValue;\n    }\n    var highWarningScale = ctx.properties.highWarningScale;\n    if (value < highCriticalScale && value >= highWarningScale) {\n        element.fill(ctx.properties.activeWarningScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultWarningScaleColor);\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showHighWarningScale = ctx.properties.showHighWarningScale;\nvar showHighCriticalScale = ctx.properties.showHighCriticalScale;\nvar highWarningValue = ctx.properties.highWarningScale;\nif (showHighWarningScale) {\n    element.show();\n    var offset = calculateOffset(highWarningValue, minValue, maxValue);\n    element.height(653-offset);\n} else {\n    element.hide();\n}\nif (showHighWarningScale && value !== null) {\n    var highCriticalScale = ctx.properties.highCriticalScale;\n    if (!showHighCriticalScale) {\n        highCriticalScale = ctx.properties.maxValue;\n    }\n    var highWarningScale = ctx.properties.highWarningScale;\n    if (value < highCriticalScale && value >= highWarningScale) {\n        element.fill(ctx.properties.activeWarningScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultWarningScaleColor);\n    }\n}",
       "actions": null
     },
     {
@@ -44,22 +33,12 @@
     },
     {
       "tag": "lowCriticalScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowCriticalValue = ctx.properties.lowCriticalScale;\nif (showLowCriticalScale) {\n    element.show();\n    var offset = calculateOffset(lowCriticalValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(offset);\n    childrenElement[1].height(offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "lowCriticalScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nif (showLowCriticalScale && value !== null) {\n    var lowCriticalScale = ctx.properties.lowCriticalScale;\n    if (value <= lowCriticalScale && value >= ctx.properties.minValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowCriticalScale = ctx.properties.lowCriticalScale;\nif (showLowCriticalScale) {\n    element.show();\n    var offset = calculateOffset(lowCriticalScale, minValue, maxValue);\n    element.height(offset);\n} else {\n    element.hide();\n}\n\nif (showLowCriticalScale && value !== null) {\n    if (value <= lowCriticalScale && value >= ctx.properties.minValue) {\n        element.fill(ctx.properties.activeCriticalScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultCriticalScaleColor)\n    }\n}",
       "actions": null
     },
     {
       "tag": "lowWarningScale",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar lowWarningValue = ctx.properties.lowWarningScale;\nif (showLowWarningScale) {\n    element.show();\n    var offset = calculateOffset(lowWarningValue, minValue, maxValue);\n    var childrenElement = element.children();\n    childrenElement[0].height(offset);\n    childrenElement[1].height(offset-1);\n} else {\n    element.hide();\n}",
-      "actions": null
-    },
-    {
-      "tag": "lowWarningScaleBackground",
-      "stateRenderFunction": "var value = ctx.values.value;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\n\nif (showLowWarningScale && value !== null) {\n    var lowCriticalScale = ctx.properties.lowCriticalScale;\n    if (!showLowCriticalScale) {\n        lowCriticalScale = ctx.properties.minValue;\n    }\n    var lowWarningScale = ctx.properties.lowWarningScale;\n    if (value > lowCriticalScale && value <= lowWarningScale) {\n        element.fill(ctx.properties.activeWarningScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultWarningScaleColor);\n    }\n}",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar value = ctx.values.value;\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showLowWarningScale = ctx.properties.showLowWarningScale;\nvar showLowCriticalScale = ctx.properties.showLowCriticalScale;\nvar lowWarningScale = ctx.properties.lowWarningScale;\nif (showLowWarningScale) {\n    element.show();\n    var offset = calculateOffset(lowWarningScale, minValue, maxValue);\n    element.height(offset);\n} else {\n    element.hide();\n}\n\nif (showLowWarningScale && value !== null) {\n    var lowCriticalScale = ctx.properties.lowCriticalScale;\n    if (!showLowCriticalScale) {\n        lowCriticalScale = ctx.properties.minValue;\n    }\n    if (value > lowCriticalScale && value <= lowWarningScale) {\n        element.fill(ctx.properties.activeWarningScaleColor);\n    } else {\n        element.fill(ctx.properties.defaultWarningScaleColor);\n    }\n}",
       "actions": null
     },
     {
@@ -84,7 +63,7 @@
     },
     {
       "tag": "target",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showTarget = ctx.properties.showTarget;\nvar targetValue = ctx.values.targetValue;\n\nif (showTarget && targetValue !== null) {\n    element.show();\n    var offset = calculateOffset(targetValue, minValue, maxValue);\n    element.transform({translateY: -(Math.min(Math.max(offset-17, 0), 617))});\n} else {\n    element.hide();\n}\n\n",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar showTarget = ctx.properties.showTarget;\nvar targetValue = ctx.values.targetValue;\n\nif (showTarget && targetValue !== null) {\n    element.show();\n    var offset = calculateOffset(targetValue, minValue, maxValue);\n    element.transform({translateY: -Math.min(Math.max(offset-17, 0), 619)});\n} else {\n    element.hide();\n}",
       "actions": null
     },
     {
@@ -99,7 +78,12 @@
     },
     {
       "tag": "value",
-      "stateRenderFunction": "if (ctx.properties.value !== null) {\n    element.show();\n    ctx.api.font(element, ctx.properties.valueFont, ctx.properties.valueColor);\n    ctx.api.text(element, ctx.api.formatValue(ctx.values.value, ctx.properties.valueDecimals, null, ctx.properties.valueDecimals));\n} else {\n    element.hide();\n}",
+      "stateRenderFunction": "if (ctx.properties.value) {\n    element.show();\n    ctx.api.font(element, ctx.properties.valueFont, ctx.properties.valueColor);\n    ctx.api.text(element, ctx.api.formatValue(ctx.values.value, ctx.properties.valueDecimals, null, ctx.properties.valueDecimals));\n} else {\n    element.hide();\n}",
+      "actions": null
+    },
+    {
+      "tag": "valueArrowPosition",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateY: -offset});\n}\n",
       "actions": null
     },
     {
@@ -108,8 +92,8 @@
       "actions": null
     },
     {
-      "tag": "valuePosition",
-      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateY: -offset});\n}\n",
+      "tag": "valueTextPositon",
+      "stateRenderFunction": "function calculateOffset(value, minValue, maxValue) {\n    var clampedValue = Math.max(minValue, Math.min(value, maxValue));\n    var normalizedValue = (clampedValue - minValue) / (maxValue - minValue);\n    var offset = normalizedValue * 653;\n    return offset;\n}\n\nvar minValue = ctx.properties.minValue;\nvar maxValue = ctx.properties.maxValue;\nvar value = ctx.values.value;\n\nif (value !== null) {\n    var offset = calculateOffset(value, minValue, maxValue);\n    element.transform({translateY: -offset});\n}\n",
       "actions": null
     }
   ],
@@ -720,39 +704,20 @@
     }
   ]
 }]]></tb:metadata>
- <text x="206.16602" y="43.234375" fill="#000000" font-family="Roboto" font-size="56px" font-weight="400" text-anchor="middle" tb:tag="label" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">Outdoor</tspan></text>
- <text x="195.21875" y="786.75" fill="#000000" font-family="Roboto" font-size="40px" font-weight="400" text-anchor="middle" tb:tag="units" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">°C</tspan></text>
- <g transform="matrix(1 0 0 .97781 0 13.842)" tb:tag="scale">
-  <rect x="176" y="83" width="42" height="652" fill="#c8dff7" tb:tag="scaleBackground"/>
-  <rect x="176.5" y="83.5" width="41" height="651" stroke="#000" stroke-opacity=".87"/>
-  <g tb:tag="lowWarningScale">
-   <rect transform="scale(1,-1)" x="176" y="-736.5" width="42" height="170" fill="#ebebeb" tb:tag="lowWarningScaleBackground"/>
-   <rect transform="scale(1,-1)" x="176.5" y="-736" width="41" height="169" stroke="#000" stroke-opacity=".87"/>
-  </g>
-  <g tb:tag="highWarningScale">
-   <rect x="176" y="83" width="42" height="170" fill="#ebebeb" tb:tag="highWarningScaleBackground"/>
-   <rect x="176.5" y="83.5" width="41" height="169" stroke="#000" stroke-opacity=".87"/>
-  </g>
-  <g tb:tag="lowCriticalScale">
-   <rect transform="scale(1,-1)" x="176" y="-736.5" width="42" height="90" fill="#666" tb:tag="lowCriticalScaleBackground"/>
-   <rect transform="scale(1,-1)" x="176.5" y="-736" width="41" height="89" stroke="#000" stroke-opacity=".87"/>
-  </g>
-  <g tb:tag="highCriticalScale">
-   <rect x="176" y="83" width="42" height="90" fill="#666" tb:tag="highCriticalScaleBackground"/>
-   <rect x="176.5" y="83.5" width="41" height="89" stroke="#000" stroke-opacity=".87"/>
-  </g>
- </g>
- <g transform="matrix(1 0 0 .97676 0 14.906)" fill="#666" font-family="Roboto" font-size="32px" font-weight="500" text-anchor="middle" tb:tag="minMaxValue">
-  <text x="260.02344" y="97" tb:tag="maxValue" xml:space="preserve"><tspan dominant-baseline="middle">100</tspan></text>
-  <text x="239.07031" y="727" tb:tag="minValue" xml:space="preserve"><tspan dominant-baseline="middle">0</tspan></text>
- </g>
- <g transform="translate(0,-350)" tb:tag="valuePosition">
-  <path d="m168 734-42-24v48z" fill="#666" tb:tag="valuePointer"/>
-  <text x="262.53329" y="738.125" fill="#002878" font-family="Roboto" font-size="60px" font-weight="400" text-anchor="middle" tb:tag="value" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">26</tspan></text>
- </g>
- <g transform="translate(0,-420)" tb:tag="target">
-  <rect transform="rotate(-45)" x="-379.7" y="634.25" width="24" height="24" fill="#dedede" tb:tag="targetBackground"/>
-  <rect transform="rotate(-45)" x="-378.7" y="635.25" width="22" height="22" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- </g>
- <path d="m134.53 0s-134.53 0-134.53 134v656.72c0 5.3024 3.5817 9.2808 8 9.2808h384c4.418 0 8-3.9784 8-9.2808v-656.72c0-134-132.14-134-132.14-134h-67.86zm134.14 162.4c-2.5773 0-4.6667 2.5072-4.6667 5.6v600.8c0 3.0928 2.0893 5.6 4.6667 5.6h29.333c2.5773 0 4.6667-2.5072 4.6667-5.6v-600.8c0-3.0928-2.0893-5.6-4.6667-5.6z" fill="#000" fill-opacity="0" style="stroke-width:.7303" tb:tag="clickArea"/>
+<text x="206.16602" y="43.234375" fill="#000000" font-family="Roboto" font-size="56px" font-weight="400" text-anchor="middle" tb:tag="label" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">Outdoor</tspan></text><text x="195.21875" y="786.75" fill="#000000" font-family="Roboto" font-size="40px" font-weight="400" text-anchor="middle" tb:tag="units" xml:space="preserve"><tspan transform="translate(0,-144)" dominant-baseline="middle">°C</tspan></text><g stroke="#000" tb:tag="scale">
+  <rect x="176.5" y="83" width="41" height="652" fill="#c8dff7" tb:tag="scaleBackground"/>
+  <rect transform="scale(1,-1)" x="176.5" y="-735" width="41" height="164" fill="#ebebeb" tb:tag="lowWarningScale"/>
+  <rect x="176.5" y="83.5" width="41" height="164" fill="#ebebeb" tb:tag="highWarningScale"/>
+  <rect transform="scale(1,-1)" x="176.5" y="-735" width="41" height="81" fill="#666" tb:tag="lowCriticalScale"/>
+  <rect x="176.5" y="83.5" width="41" height="81" fill="#666" tb:tag="highCriticalScale"/>
+ </g><g fill="#666" font-family="Roboto" font-size="32px" font-weight="500" style="display: none;" tb:tag="minMaxValue">
+  <text x="237.48438" y="97" tb:tag="maxValue" xml:space="preserve" style=""><tspan dominant-baseline="middle">100</tspan></text>
+  <text x="238.89062" y="727" tb:tag="minValue" xml:space="preserve" style=""><tspan dominant-baseline="middle">0</tspan></text>
+ </g><g transform="translate(0,-180)" tb:tag="valueArrowPosition">
+  <path d="m168 735-42-24v48z" fill="#666" tb:tag="valuePointer"/>
+ </g><g transform="translate(0,-180)" tb:tag="valueTextPositon">
+  <text x="223.60547" y="739.125" fill="#002878" font-family="Roboto" font-size="60px" font-weight="400" tb:tag="value" xml:space="preserve"><tspan dominant-baseline="middle">26</tspan></text>
+ </g><g transform="translate(0,-400)" style="display: none;" tb:tag="target">
+  <rect transform="rotate(-45)" x="-379.76" y="636.31" width="22" height="22" fill="#dedede" stroke="#000" stroke-width="2" tb:tag="targetBackground" style=""/>
+ </g><path d="m134.53 0s-134.53 0-134.53 134v656.72c0 5.3024 3.5817 9.2808 8 9.2808h384c4.418 0 8-3.9784 8-9.2808v-656.72c0-134-132.14-134-132.14-134h-67.86zm134.14 162.4c-2.5773 0-4.6667 2.5072-4.6667 5.6v600.8c0 3.0928 2.0893 5.6 4.6667 5.6h29.333c2.5773 0 4.6667-2.5072 4.6667-5.6v-600.8c0-3.0928-2.0893-5.6-4.6667-5.6z" fill="#000" fill-opacity="0" style="stroke-width:.7303" tb:tag="clickArea"/>
 </svg>

--- a/application/src/main/data/json/system/scada_symbols/small-cylindrical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/small-cylindrical-tank.svg
@@ -143,7 +143,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -152,16 +152,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -178,7 +187,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -187,16 +196,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/small-left-motor-pump.svg
+++ b/application/src/main/data/json/system/scada_symbols/small-left-motor-pump.svg
@@ -70,7 +70,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -84,6 +84,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -105,7 +114,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -119,6 +128,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/small-right-motor-pump.svg
+++ b/application/src/main/data/json/system/scada_symbols/small-right-motor-pump.svg
@@ -70,7 +70,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -84,6 +84,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -105,7 +114,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -119,6 +128,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/small-spherical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/small-spherical-tank.svg
@@ -143,7 +143,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -152,16 +152,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -178,7 +187,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -187,16 +196,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/spherical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/spherical-tank.svg
@@ -143,7 +143,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -152,16 +152,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -178,7 +187,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -187,16 +196,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/stand-cylindrical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/stand-cylindrical-tank.svg
@@ -143,7 +143,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -152,16 +152,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -178,7 +187,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -187,16 +196,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/stand-horizontal-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/stand-horizontal-tank.svg
@@ -143,7 +143,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -152,16 +152,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -178,7 +187,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -187,16 +196,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/stand-vertical-short-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/stand-vertical-short-tank.svg
@@ -144,7 +144,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -153,16 +153,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -179,7 +188,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -188,16 +197,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/stand-vertical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/stand-vertical-tank.svg
@@ -143,7 +143,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -152,16 +152,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -178,7 +187,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -187,16 +196,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/top-flow-meter.svg
+++ b/application/src/main/data/json/system/scada_symbols/top-flow-meter.svg
@@ -120,7 +120,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -134,6 +134,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -155,7 +164,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -169,6 +178,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/vertical-inline-flow-meter.svg
+++ b/application/src/main/data/json/system/scada_symbols/vertical-inline-flow-meter.svg
@@ -120,7 +120,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -134,6 +134,15 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",
@@ -155,7 +164,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -169,6 +178,12 @@
         },
         "getTimeSeries": {
           "key": "state"
+        },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
         },
         "dataToValue": {
           "type": "NONE",

--- a/application/src/main/data/json/system/scada_symbols/vertical-short-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/vertical-short-tank.svg
@@ -143,7 +143,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -152,16 +152,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -178,7 +187,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -187,16 +196,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/vertical-tank-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/vertical-tank-hp.svg
@@ -1,8 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="600" height="1e3" fill="none" version="1.1" viewBox="0 0 600 1e3"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Vertical tank",
-  "description": "Vertical tank",
+  "description": "Vertical tank with level visualizations.",
   "searchTags": [
-    "vertical tank"
+    "vertical tank",
+    "high performance"
   ],
   "widgetSizeX": 3,
   "widgetSizeY": 5,
@@ -121,16 +122,16 @@
     },
     {
       "id": "warning",
-      "name": "{i18n:scada.symbol.warning-state}",
+      "name": "{i18n:scada.symbol.warning}",
       "hint": "{i18n:scada.symbol.warning-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.warning-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -139,33 +140,62 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
     },
     {
+      "id": "warningClick",
+      "name": "{i18n:scada.symbol.warning-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.warning-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
+    },
+    {
       "id": "critical",
-      "name": "{i18n:scada.symbol.critical-state}",
+      "name": "{i18n:scada.symbol.critical}",
       "hint": "{i18n:scada.symbol.critical-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.critical-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -174,20 +204,46 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
+    },
+    {
+      "id": "criticalClick",
+      "name": "{i18n:scada.symbol.critical-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.critical-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
     },
     {
       "id": "criticalAnimation",
@@ -223,46 +279,6 @@
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
-    },
-    {
-      "id": "warningClick",
-      "name": "{i18n:scada.symbol.warning-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
-      "id": "criticalClick",
-      "name": "{i18n:scada.symbol.critical-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
     },
     {
       "id": "click",
@@ -341,7 +357,7 @@
       "default": 10,
       "required": null,
       "subLabel": "{i18n:scada.symbol.intervals}",
-      "divider": true,
+      "divider": false,
       "fieldSuffix": null,
       "disableOnProperty": "scale",
       "rowClass": "",
@@ -374,7 +390,7 @@
     },
     {
       "id": "majorColor",
-      "name": "{i18n:scada.symbol.major-ticks-color}",
+      "name": "{i18n:scada.symbol.major-ticks}",
       "type": "color",
       "default": "#00000061",
       "required": null,
@@ -406,7 +422,7 @@
     },
     {
       "id": "minorColor",
-      "name": "{i18n:scada.symbol.minor-ticks-color}",
+      "name": "{i18n:scada.symbol.minor-ticks}",
       "type": "color",
       "default": "#0000001F",
       "required": null,
@@ -422,12 +438,12 @@
     },
     {
       "id": "warningColor",
-      "name": "{i18n:scada.symbol.warning-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#FAA405",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.warning}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -438,11 +454,11 @@
     },
     {
       "id": "criticalColor",
-      "name": "{i18n:scada.symbol.critical-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#D12730",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.critical}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,

--- a/application/src/main/data/json/system/scada_symbols/vertical-tank.svg
+++ b/application/src/main/data/json/system/scada_symbols/vertical-tank.svg
@@ -142,7 +142,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -151,16 +151,25 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
@@ -177,7 +186,7 @@
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -186,16 +195,22 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,

--- a/application/src/main/data/json/system/scada_symbols/vertical-valve-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/vertical-valve-hp.svg
@@ -1,9 +1,9 @@
-<svg width="200" height="200" fill="none" version="1.1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg">
- <tb:metadata><![CDATA[{
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:tb="https://thingsboard.io/svg" width="200" height="200" fill="none" version="1.1" viewBox="0 0 200 200"><tb:metadata xmlns=""><![CDATA[{
   "title": "HP Vertical valve",
   "description": "Vertical valve with various states.",
   "searchTags": [
-    "valve"
+    "valve",
+    "high performance"
   ],
   "widgetSizeX": 1,
   "widgetSizeY": 1,
@@ -147,16 +147,16 @@
     },
     {
       "id": "warning",
-      "name": "{i18n:scada.symbol.warning-state}",
+      "name": "{i18n:scada.symbol.warning}",
       "hint": "{i18n:scada.symbol.warning-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.warning-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.warning}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -165,33 +165,62 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "MAJOR",
+            "MINOR",
+            "WARNING",
+            "INDETERMINATE"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
     },
     {
+      "id": "warningClick",
+      "name": "{i18n:scada.symbol.warning-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.warning-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
+    },
+    {
       "id": "critical",
-      "name": "{i18n:scada.symbol.critical-state}",
+      "name": "{i18n:scada.symbol.critical}",
       "hint": "{i18n:scada.symbol.critical-state-hint}",
-      "group": null,
+      "group": "{i18n:scada.symbol.critical-state}",
       "type": "value",
       "valueType": "BOOLEAN",
       "trueLabel": null,
       "falseLabel": null,
       "stateLabel": "{i18n:scada.symbol.critical}",
       "defaultGetValueSettings": {
-        "action": "DO_NOTHING",
+        "action": "GET_ALARM_STATUS",
         "defaultValue": false,
         "executeRpc": {
           "method": "getState",
@@ -200,20 +229,46 @@
           "persistentPollingInterval": 1000
         },
         "getAttribute": {
-          "key": "state",
-          "scope": null
+          "scope": null,
+          "key": "state"
         },
         "getTimeSeries": {
           "key": "state"
         },
+        "getAlarmStatus": {
+          "severityList": [
+            "CRITICAL"
+          ],
+          "typeList": null
+        },
         "dataToValue": {
           "type": "NONE",
-          "compareToValue": true,
-          "dataToValueFunction": "/* Should return boolean value */\nreturn data;"
+          "dataToValueFunction": "/* Should return boolean value */\nreturn data;",
+          "compareToValue": true
         }
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
+    },
+    {
+      "id": "criticalClick",
+      "name": "{i18n:scada.symbol.critical-click}",
+      "hint": "{i18n:scada.symbol.on-click-hint}",
+      "group": "{i18n:scada.symbol.critical-state}",
+      "type": "widgetAction",
+      "valueType": "BOOLEAN",
+      "trueLabel": null,
+      "falseLabel": null,
+      "stateLabel": null,
+      "defaultGetValueSettings": null,
+      "defaultSetValueSettings": null,
+      "defaultWidgetActionSettings": {
+        "type": "doNothing",
+        "targetDashboardStateId": null,
+        "openRightLayout": false,
+        "setEntityId": false,
+        "stateEntityParamName": null
+      }
     },
     {
       "id": "criticalAnimation",
@@ -249,57 +304,17 @@
       },
       "defaultSetValueSettings": null,
       "defaultWidgetActionSettings": null
-    },
-    {
-      "id": "warningClick",
-      "name": "{i18n:scada.symbol.warning-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
-    },
-    {
-      "id": "criticalClick",
-      "name": "{i18n:scada.symbol.critical-click}",
-      "hint": "{i18n:scada.symbol.on-click-hint}",
-      "group": null,
-      "type": "widgetAction",
-      "valueType": "BOOLEAN",
-      "trueLabel": null,
-      "falseLabel": null,
-      "stateLabel": null,
-      "defaultGetValueSettings": null,
-      "defaultSetValueSettings": null,
-      "defaultWidgetActionSettings": {
-        "type": "doNothing",
-        "targetDashboardStateId": null,
-        "openRightLayout": false,
-        "setEntityId": false,
-        "stateEntityParamName": null
-      }
     }
   ],
   "properties": [
     {
       "id": "openedColor",
-      "name": "{i18n:scada.symbol.opened-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#FFFFFF",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.opened}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -310,11 +325,11 @@
     },
     {
       "id": "closedColor",
-      "name": "{i18n:scada.symbol.closed-color}",
+      "name": "{i18n:scada.symbol.colors}",
       "type": "color",
       "default": "#666666",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.closed-mode}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -326,12 +341,12 @@
     },
     {
       "id": "warningColor",
-      "name": "{i18n:scada.symbol.warning-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#FAA405",
       "required": null,
-      "subLabel": null,
-      "divider": null,
+      "subLabel": "{i18n:scada.symbol.warning}",
+      "divider": true,
       "fieldSuffix": null,
       "disableOnProperty": null,
       "rowClass": "",
@@ -342,11 +357,11 @@
     },
     {
       "id": "criticalColor",
-      "name": "{i18n:scada.symbol.critical-color}",
+      "name": "{i18n:scada.symbol.alarm-colors}",
       "type": "color",
       "default": "#D12730",
       "required": null,
-      "subLabel": null,
+      "subLabel": "{i18n:scada.symbol.critical}",
       "divider": null,
       "fieldSuffix": null,
       "disableOnProperty": null,
@@ -358,23 +373,17 @@
     }
   ]
 }]]></tb:metadata>
- <path d="m100 100h51.83" stroke="#000" stroke-opacity=".87" stroke-width="1.9797"/>
- <g fill="#fff" tb:tag="background">
+<path d="m100 100h51.83" stroke="#000" stroke-opacity=".87" stroke-width="1.9797"/><g fill="#fff" tb:tag="background">
   <path d="m100 101 58-101h-116z" fill="#fff"/>
   <path d="m43.727 0.99999 56.273 97.992 56.273-97.992z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
   <path d="M100 99L158 200H42L100 99Z" fill="#fff"/>
   <path d="M43.7274 199L100 101.008L156.273 199H43.7274Z" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- </g>
- <rect x="151.83" y="52.185" width="48.169" height="96.338"/>
- <rect x="152.8" y="53.185" width="46.169" height="94.338" stroke="#000" stroke-opacity=".87" stroke-width="2"/>
- <path d="m67.648-1e-4s-67.264 0-67.264 33.5v164.18c0 1.3256 1.7909 2.3202 4 2.3202h192c2.209 0 4-0.99459 4-2.3202v-164.18c0-33.5-66.07-33.5-66.07-33.5h-33.929zm67.07 40.6c-1.2887 0-2.3333 0.6268-2.3333 1.4v150.2c0 0.7732 1.0447 1.4 2.3333 1.4h14.666c1.2887 0 2.3333-0.6268 2.3333-1.4v-150.2c0-0.7732-1.0447-1.4-2.3333-1.4z" fill="#000" fill-opacity="0" tb:tag="clickArea"/>
- <g transform="translate(0,116)" fill="#d12730" style="display:none" tb:tag="critical">
+ </g><rect x="151.83" y="52.185" width="48.169" height="96.338"/><rect x="152.8" y="53.185" width="46.169" height="94.338" stroke="#000" stroke-opacity=".87" stroke-width="2"/><path d="m67.648-1e-4s-67.264 0-67.264 33.5v164.18c0 1.3256 1.7909 2.3202 4 2.3202h192c2.209 0 4-0.99459 4-2.3202v-164.18c0-33.5-66.07-33.5-66.07-33.5h-33.929zm67.07 40.6c-1.2887 0-2.3333 0.6268-2.3333 1.4v150.2c0 0.7732 1.0447 1.4 2.3333 1.4h14.666c1.2887 0 2.3333-0.6268 2.3333-1.4v-150.2c0-0.7732-1.0447-1.4-2.3333-1.4z" fill="#000" fill-opacity="0" tb:tag="clickArea"/><g transform="translate(0,116)" fill="#d12730" style="display: none;" tb:tag="critical">
   <rect width="84" height="84" rx="4" fill="#fff" style=""/>
   <rect width="84" height="84" rx="4" style=""/>
   <rect x="2" y="2" width="80" height="80" rx="2" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>
   <path d="m44.559 27.562-0.4688 20.059h-4.0234l-0.4883-20.059zm-5.1172 26.211c0-0.7161 0.2344-1.3151 0.7031-1.7968 0.4818-0.4948 1.1459-0.7422 1.9922-0.7422 0.8334 0 1.4909 0.2474 1.9727 0.7422 0.4817 0.4817 0.7226 1.0807 0.7226 1.7968 0 0.6901-0.2409 1.2826-0.7226 1.7774-0.4818 0.4818-1.1393 0.7226-1.9727 0.7226-0.8463 0-1.5104-0.2408-1.9922-0.7226-0.4687-0.4948-0.7031-1.0873-0.7031-1.7774z" fill="#000" fill-opacity=".87" style=""/>
- </g>
- <g transform="translate(0,116)" fill="#faa405" style="display:none" tb:tag="warning">
+ </g><g transform="translate(0,116)" fill="#faa405" style="display: none;" tb:tag="warning">
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" fill="#fff" style=""/>
   <path d="m38.422 7.1554c1.4741-2.9482 5.6813-2.9482 7.1554 0l35.528 71.056c1.3298 2.6596-0.6042 5.7889-3.5777 5.7889h-71.056c-2.9735 0-4.9075-3.1292-3.5777-5.7889z" style=""/>
   <path d="m40.211 8.0498c0.7371-1.4741 2.8407-1.4741 3.5778-1e-5l35.528 71.056c0.6649 1.3298-0.3021 2.8944-1.7888 2.8944h-71.056c-1.4868 0-2.4538-1.5646-1.7889-2.8944z" stroke="#000" stroke-opacity=".87" stroke-width="4" style=""/>

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -7358,6 +7358,7 @@
             "get-dashboard-state": "Get dashboard state",
             "add-time-series": "Add time series",
             "execute-rpc-text": "Execute RPC method '{{methodName}}'",
+            "get-time-series-text": "Use time series '{{key}}'",
             "get-attribute-text": "Use attribute '{{key}}'",
             "get-alarm-status-text": "Use alarm status",
             "get-dashboard-state-text": "Use dashboard state",

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -3162,7 +3162,7 @@
             "critical": "Critical",
             "critical-click": "Critical click",
             "critical-state-hint": "Indicates whether component is in critical state.",
-            "critical-state-animation": "Critical state animation",
+            "critical-state-animation": "Alarm state animation",
             "critical-state-animation-hint": "Whether to enable blinking animation when component is in critical state.",
             "animation": "Animation",
             "broken": "Broken",
@@ -3187,6 +3187,7 @@
             "top-right-connector": "Top right connector",
             "running-color": "Running color",
             "stopped-color": "Stopped color",
+            "stopped": "Stopped",
             "warning-color": "Warning color",
             "critical-color": "Critical color",
             "opened": "Opened",
@@ -3286,7 +3287,9 @@
             "low-critical-state": "Low Critical state",
             "show-low-critical-scale": "Show Low Critical state",
             "low-critical-scale": "Low Critical state",
-            "low-critical-state-hint": "Double value indicates a low critical range up to the min value scale."
+            "low-critical-state-hint": "Double value indicates a low critical range up to the min value scale.",
+            "colors": "Colors",
+            "alarm-colors": "Alarm colors"
         }
     },
     "item": {


### PR DESCRIPTION
## Pull Request description

Refactoring scale symbols.
Fixed HP Sand filter.
Add deleted translate.
Refactoring warning and critical alarm state use 'Get alarm status' by default.

Change translate 'Critical state animation' -> 'Alarm state animation'


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




