### PR TITLE
Revert "Fix email sender address issue"

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/mail/TbMailSender.java
+++ b/application/src/main/java/org/thingsboard/server/service/mail/TbMailSender.java
@@ -67,9 +67,6 @@ public class TbMailSender extends JavaMailSenderImpl {
         if (jsonConfig.has("password")) {
             setPassword(jsonConfig.get("password").asText());
         }
-        if (jsonConfig.has("mailFrom")) {
-            setUsername(jsonConfig.get("mailFrom").asText());
-        }
         setJavaMailProperties(createJavaMailProperties(jsonConfig));
     }
 


### PR DESCRIPTION
The `mailFrom` is used for construction of the `MimeMessage`. See

```
    private void sendMail(JavaMailSenderImpl mailSender,
                          String mailFrom, String email,
                          String subject, String message,
                          long timeout) throws ThingsboardException {
        try {
            MimeMessage mimeMsg = mailSender.createMimeMessage();
            MimeMessageHelper helper = new MimeMessageHelper(mimeMsg, UTF_8);
            helper.setFrom(mailFrom);
            helper.setTo(email);
            helper.setSubject(subject);
            helper.setText(message, true);
            sendMailWithTimeout(mailSender, helper.getMimeMessage(), timeout);
        } catch (Exception e) {
            throw handleException(e);
        }
    }
```

and

```
    private void sendMail(TenantId tenantId, String email,
                          String subject, String message) throws ThingsboardException {
        JsonNode jsonConfig = getConfig(tenantId, "mail");
        TbMailSender mailSender = new TbMailSender(ctx, tenantId, jsonConfig);
        String mailFrom = getStringValue(jsonConfig, "mailFrom");
        sendMail(mailSender, mailFrom, email, subject, message, getTimeout(jsonConfig));
    }
```