### PR TITLE
Timewindow: fix applying default grouping interval

### DIFF
--- a/ui-ngx/src/app/shared/components/time/timewindow-config-dialog.component.html
+++ b/ui-ngx/src/app/shared/components/time/timewindow-config-dialog.component.html
@@ -68,7 +68,7 @@
                             timewindowForm.get('realtime.realtimeType').value === realtimeTypes.LAST_INTERVAL">
             <button *ngIf="!(timewindowForm.get('realtime.hideLastInterval').value ||
                             timewindowForm.get('realtime.hideInterval').value)"
-                    matSuffix mat-icon-button type="button" class="tb-mat-24"
+                    matSuffix mat-icon-button type="button"
                     (click)="configureRealtimeLastIntervalOptions($event)">
               <mat-icon>edit</mat-icon>
             </button>
@@ -95,7 +95,7 @@
                           timewindowForm.get('realtime.realtimeType').value === realtimeTypes.INTERVAL">
           <button *ngIf="!(timewindowForm.get('realtime.hideQuickInterval').value ||
                             timewindowForm.get('realtime.hideInterval').value)"
-                  matSuffix mat-icon-button type="button" class="tb-mat-24"
+                  matSuffix mat-icon-button type="button"
                   (click)="configureRealtimeQuickIntervalOptions($event)">
             <mat-icon>edit</mat-icon>
           </button>
@@ -137,7 +137,7 @@
                           timewindowForm.get('history.historyType').value === historyTypes.LAST_INTERVAL">
             <button *ngIf="!(timewindowForm.get('history.hideLastInterval').value ||
                             timewindowForm.get('history.hideInterval').value)"
-                    matSuffix mat-icon-button type="button" class="tb-mat-24"
+                    matSuffix mat-icon-button type="button"
                     (click)="configureHistoryLastIntervalOptions($event)">
               <mat-icon>edit</mat-icon>
             </button>
@@ -177,7 +177,7 @@
                         timewindowForm.get('history.historyType').value === historyTypes.INTERVAL">
             <button *ngIf="!(timewindowForm.get('history.hideQuickInterval').value ||
                             timewindowForm.get('history.hideInterval').value)"
-                    matSuffix mat-icon-button type="button" class="tb-mat-24"
+                    matSuffix mat-icon-button type="button"
                     (click)="configureHistoryQuickIntervalOptions($event)">
               <mat-icon>edit</mat-icon>
             </button>
@@ -199,7 +199,7 @@
                                         formControlName="type"
                                         [allowedAggregationTypes]="timewindowForm.get('allowedAggTypes').value">
               <button *ngIf="!timewindowForm.get('hideAggregation').value"
-                      matSuffix mat-icon-button type="button" class="tb-mat-24"
+                      matSuffix mat-icon-button type="button"
                       (click)="openAggregationOptionsConfig($event)">
                 <mat-icon>edit</mat-icon>
               </button>

--- a/ui-ngx/src/app/shared/components/time/timewindow-config-dialog.component.ts
+++ b/ui-ngx/src/app/shared/components/time/timewindow-config-dialog.component.ts
@@ -245,9 +245,9 @@ export class TimewindowConfigDialogComponent extends PageComponent implements On
           this.timewindowForm.get('realtime.advancedParams.lastAggIntervalsConfig').value;
         if (lastAggIntervalsConfig?.hasOwnProperty(timewindowMs) &&
           lastAggIntervalsConfig[timewindowMs].defaultAggInterval) {
-          this.timewindowForm.get('realtime.interval').patchValue(
+          setTimeout(() => this.timewindowForm.get('realtime.interval').patchValue(
             lastAggIntervalsConfig[timewindowMs].defaultAggInterval, {emitEvent: false}
-          );
+          ));
         }
       });
       this.timewindowForm.get('realtime.quickInterval').valueChanges.pipe(
@@ -257,9 +257,9 @@ export class TimewindowConfigDialogComponent extends PageComponent implements On
           this.timewindowForm.get('realtime.advancedParams.quickAggIntervalsConfig').value;
         if (quickAggIntervalsConfig?.hasOwnProperty(quickInterval) &&
           quickAggIntervalsConfig[quickInterval].defaultAggInterval) {
-          this.timewindowForm.get('realtime.interval').patchValue(
+          setTimeout(() => this.timewindowForm.get('realtime.interval').patchValue(
             quickAggIntervalsConfig[quickInterval].defaultAggInterval, {emitEvent: false}
-          );
+          ));
         }
       });
       this.timewindowForm.get('history.timewindowMs').valueChanges.pipe(
@@ -269,9 +269,9 @@ export class TimewindowConfigDialogComponent extends PageComponent implements On
           this.timewindowForm.get('history.advancedParams.lastAggIntervalsConfig').value;
         if (lastAggIntervalsConfig?.hasOwnProperty(timewindowMs) &&
           lastAggIntervalsConfig[timewindowMs].defaultAggInterval) {
-          this.timewindowForm.get('history.interval').patchValue(
+          setTimeout(() => this.timewindowForm.get('history.interval').patchValue(
             lastAggIntervalsConfig[timewindowMs].defaultAggInterval, {emitEvent: false}
-          );
+          ));
         }
       });
       this.timewindowForm.get('history.quickInterval').valueChanges.pipe(
@@ -281,9 +281,9 @@ export class TimewindowConfigDialogComponent extends PageComponent implements On
           this.timewindowForm.get('history.advancedParams.quickAggIntervalsConfig').value;
         if (quickAggIntervalsConfig?.hasOwnProperty(quickInterval) &&
           quickAggIntervalsConfig[quickInterval].defaultAggInterval) {
-          this.timewindowForm.get('history.interval').patchValue(
+          setTimeout(() => this.timewindowForm.get('history.interval').patchValue(
             quickAggIntervalsConfig[quickInterval].defaultAggInterval, {emitEvent: false}
-          );
+          ));
         }
       });
 

--- a/ui-ngx/src/app/shared/components/time/timewindow-panel.component.ts
+++ b/ui-ngx/src/app/shared/components/time/timewindow-panel.component.ts
@@ -308,9 +308,9 @@ export class TimewindowPanelComponent extends PageComponent implements OnInit, O
       ).subscribe((timewindowMs: number) => {
         if (this.realtimeAdvancedParams?.lastAggIntervalsConfig?.hasOwnProperty(timewindowMs) &&
           this.realtimeAdvancedParams.lastAggIntervalsConfig[timewindowMs].defaultAggInterval) {
-          this.timewindowForm.get('realtime.interval').patchValue(
+          setTimeout(() => this.timewindowForm.get('realtime.interval').patchValue(
             this.realtimeAdvancedParams.lastAggIntervalsConfig[timewindowMs].defaultAggInterval, {emitEvent: false}
-          );
+          ));
         }
       });
       this.timewindowForm.get('realtime.quickInterval').valueChanges.pipe(
@@ -318,9 +318,9 @@ export class TimewindowPanelComponent extends PageComponent implements OnInit, O
       ).subscribe((quickInterval: number) => {
         if (this.realtimeAdvancedParams?.quickAggIntervalsConfig?.hasOwnProperty(quickInterval) &&
           this.realtimeAdvancedParams.quickAggIntervalsConfig[quickInterval].defaultAggInterval) {
-          this.timewindowForm.get('realtime.interval').patchValue(
+          setTimeout(() => this.timewindowForm.get('realtime.interval').patchValue(
             this.realtimeAdvancedParams.quickAggIntervalsConfig[quickInterval].defaultAggInterval, {emitEvent: false}
-          );
+          ));
         }
       });
       this.timewindowForm.get('history.timewindowMs').valueChanges.pipe(
@@ -328,9 +328,9 @@ export class TimewindowPanelComponent extends PageComponent implements OnInit, O
       ).subscribe((timewindowMs: number) => {
         if (this.historyAdvancedParams?.lastAggIntervalsConfig?.hasOwnProperty(timewindowMs) &&
           this.historyAdvancedParams.lastAggIntervalsConfig[timewindowMs].defaultAggInterval) {
-          this.timewindowForm.get('history.interval').patchValue(
+          setTimeout(() => this.timewindowForm.get('history.interval').patchValue(
             this.historyAdvancedParams.lastAggIntervalsConfig[timewindowMs].defaultAggInterval, {emitEvent: false}
-          );
+          ));
         }
       });
       this.timewindowForm.get('history.quickInterval').valueChanges.pipe(
@@ -338,9 +338,9 @@ export class TimewindowPanelComponent extends PageComponent implements OnInit, O
       ).subscribe((quickInterval: number) => {
         if (this.historyAdvancedParams?.quickAggIntervalsConfig?.hasOwnProperty(quickInterval) &&
           this.historyAdvancedParams.quickAggIntervalsConfig[quickInterval].defaultAggInterval) {
-          this.timewindowForm.get('history.interval').patchValue(
+          setTimeout(() => this.timewindowForm.get('history.interval').patchValue(
             this.historyAdvancedParams.quickAggIntervalsConfig[quickInterval].defaultAggInterval, {emitEvent: false}
-          );
+          ));
         }
       });
 


### PR DESCRIPTION
## Pull Request description

Before:
The default grouping interval is applied only if it fits the min/max bounds for the time interval selected before. 

After:
The default grouping interval is applied after time interval selection.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




