### PR TITLE
Fix RPC Rule Node not producing any Success or Failure out message

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/rpc/DefaultTbRuleEngineRpcService.java
+++ b/application/src/main/java/org/thingsboard/server/service/rpc/DefaultTbRuleEngineRpcService.java
@@ -115,8 +115,9 @@ public class DefaultTbRuleEngineRpcService implements TbRuleEngineDeviceRpcServi
         ToDeviceRpcRequest request = new ToDeviceRpcRequest(src.getRequestUUID(), src.getTenantId(), src.getDeviceId(),
                 src.isOneway(), src.getExpirationTime(), new ToDeviceRpcRequestBody(src.getMethod(), src.getBody()), src.isPersisted(), src.getRetries(), src.getAdditionalInfo());
         forwardRpcRequestToDeviceActor(request, response -> {
-            if (src.isRestApiCall()) {
-                sendRpcResponseToTbCore(src.getOriginServiceId(), response);
+            String originServiceId = src.getOriginServiceId();
+            if (src.isRestApiCall() && originServiceId != null) {
+                sendRpcResponseToTbCore(originServiceId, response);
             }
             consumer.accept(RuleEngineDeviceRpcResponse.builder()
                     .deviceId(src.getDeviceId())


### PR DESCRIPTION
## Pull Request description

The RPC Rule Node does not produce any Success or Failure message in the output if we try to send RPC using generator node.

https://thingsboard-portal.atlassian.net/browse/PROD-5464

```
var msg = {
   "method": "getCurrentTime",
   "params": {}
};
var metadata = { oneway: true };
var msgType = "RPC_CALL_FROM_SERVER_TO_DEVICE";

return { msg: msg, metadata: metadata, msgType: msgType };
```

![image](https://github.com/user-attachments/assets/9d260edb-c615-4d95-8780-62831e0ab101)

```
java.lang.NullPointerException
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1693)
	at org.thingsboard.server.queue.discovery.TopicService.getNotificationsTopic(TopicService.java:65)
	at org.thingsboard.server.service.queue.DefaultTbClusterService.pushNotificationToCore(DefaultTbClusterService.java:242)
	at org.thingsboard.server.service.rpc.DefaultTbRuleEngineRpcService.sendRpcResponseToTbCore(DefaultTbRuleEngineRpcService.java:204)
	at org.thingsboard.server.service.rpc.DefaultTbRuleEngineRpcService.lambda$sendRpcRequestToDevice$0(DefaultTbRuleEngineRpcService.java:134)
	at org.thingsboard.server.service.rpc.DefaultTbRuleEngineRpcService.lambda$processRpcResponseFromDevice$1(DefaultTbRuleEngineRpcService.java:166)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



