### PR TITLE
Fix errors in Docker images related to nonexistent home directory

### DIFF
--- a/msa/edqs/docker/Dockerfile
+++ b/msa/edqs/docker/Dockerfile
@@ -26,6 +26,7 @@ RUN chmod a+x /tmp/*.sh \
     chown -R ${pkg.user}:${pkg.user} /tmp && \
     chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 CMD ["start-tb-edqs.sh"]

--- a/msa/monitoring/docker/Dockerfile
+++ b/msa/monitoring/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN chmod a+x /tmp/*.sh \
     (systemctl --no-reload disable --now ${pkg.name}.service > /dev/null 2>&1 || :) && \
     chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 CMD ["start-tb-monitoring.sh"]

--- a/msa/tb-node/docker/Dockerfile
+++ b/msa/tb-node/docker/Dockerfile
@@ -26,6 +26,7 @@ RUN chmod a+x /tmp/*.sh \
     chown -R ${pkg.user}:${pkg.user} /tmp && \
     chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 CMD ["start-tb-node.sh"]

--- a/msa/tb/docker-cassandra/Dockerfile
+++ b/msa/tb/docker-cassandra/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update \
     && chown -R ${pkg.user}:${pkg.user} /var/log/${pkg.name} \
     && chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 EXPOSE 9090

--- a/msa/tb/docker-postgres/Dockerfile
+++ b/msa/tb/docker-postgres/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update \
     && chown -R ${pkg.user}:${pkg.user} /var/log/${pkg.name} \
     && chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 EXPOSE 9090

--- a/msa/transport/coap/docker/Dockerfile
+++ b/msa/transport/coap/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN chmod a+x /tmp/*.sh \
     (systemctl --no-reload disable --now ${pkg.name}.service > /dev/null 2>&1 || :) && \
     chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 CMD ["start-tb-coap-transport.sh"]

--- a/msa/transport/http/docker/Dockerfile
+++ b/msa/transport/http/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN chmod a+x /tmp/*.sh \
     (systemctl --no-reload disable --now ${pkg.name}.service > /dev/null 2>&1 || :) && \
     chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 CMD ["start-tb-http-transport.sh"]

--- a/msa/transport/lwm2m/docker/Dockerfile
+++ b/msa/transport/lwm2m/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN chmod a+x /tmp/*.sh \
     (systemctl --no-reload disable --now ${pkg.name}.service > /dev/null 2>&1 || :) && \
     chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 CMD ["start-tb-lwm2m-transport.sh"]

--- a/msa/transport/mqtt/docker/Dockerfile
+++ b/msa/transport/mqtt/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN chmod a+x /tmp/*.sh \
     (systemctl --no-reload disable --now ${pkg.name}.service > /dev/null 2>&1 || :) && \
     chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 CMD ["start-tb-mqtt-transport.sh"]

--- a/msa/transport/snmp/docker/Dockerfile
+++ b/msa/transport/snmp/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN chmod a+x /tmp/*.sh \
     (systemctl --no-reload disable --now ${pkg.name}.service > /dev/null 2>&1 || :) && \
     chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 CMD ["start-tb-snmp-transport.sh"]

--- a/msa/vc-executor-docker/docker/Dockerfile
+++ b/msa/vc-executor-docker/docker/Dockerfile
@@ -32,6 +32,7 @@ RUN mkdir -p /home/thingsboard/.config/jgit \
     (systemctl --no-reload disable --now ${pkg.name}.service > /dev/null 2>&1 || :) && \
     chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar
 
+RUN usermod -d /home/${pkg.user} ${pkg.user}
 USER ${pkg.user}
 
 CMD ["start-tb-vc-executor.sh"]


### PR DESCRIPTION
## Pull Request description

When `thingsboard` user is added as a part of service installation (`thingsboard.deb`) on any Docker image, home directory is not properly configured and set as placeholder `/nonexistent`. This produces some warnings (e.g. JGit config dir creation), and in - some cases - critical startup errors (e.g. RocksDB init).
Examples:
<details>
  <summary>JGit</summary>
   <pre>
2025-03-10 14:18:04,041 [JGit-FileStoreAttributeWriter-2] ERROR org.eclipse.jgit.util.FS - Cannot save config file 'FileBasedConfig[/nonexistent/.config/jgit/config]'
java.io.IOException: Creating directories for /nonexistent/.config/jgit failed
 at org.eclipse.jgit.util.FileUtils.mkdirs(FileUtils.java:421)
 at org.eclipse.jgit.internal.storage.file.LockFile.lock(LockFile.java:144)
 at org.eclipse.jgit.storage.file.FileBasedConfig.save(FileBasedConfig.java:201)
 at org.eclipse.jgit.util.FS$FileStoreAttributes.saveToConfig(FS.java:776)
 at org.eclipse.jgit.util.FS$FileStoreAttributes.lambda$5(FS.java:458)
 at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
 at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
 at java.base/java.lang.Thread.run(Thread.java:840)
   </pre>
</details>
<details>
  <summary>RocksDB</summary>
   <pre>
Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
2025-03-10 12:30:37,712 [main] ERROR o.s.boot.SpringApplication - Application run failed
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'defaultTbCalculatedFieldConsumerService' defined in URL [jar:nested:/usr/share/thingsboard/bin/thingsboard.jar/!BOOT-INF/classes/!/org/thingsboard/server/service/queue/DefaultTbCalculatedFieldConsumerService.class]: Unsatisfied dependency expressed through constructor parameter 10: Error creating bean with name 'rocksDBCalculatedFieldStateService' defined in URL [jar:nested:/usr/share/thingsboard/bin/thingsboard.jar/!BOOT-INF/classes/!/org/thingsboard/server/service/cf/ctx/state/RocksDBCalculatedFieldStateService.class]: Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'cfRocksDb': Invocation of init method failed
<...>org.springframework.boot.loader.launch.PropertiesLauncher.main(PropertiesLauncher.java:580)
Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'rocksDBCalculatedFieldStateService' defined in URL [jar:nested:/usr/share/thingsboard/bin/thingsboard.jar/!BOOT-INF/classes/!/org/thingsboard/server/service/cf/ctx/state/RocksDBCalculatedFieldStateService.class]: Unsatisfied dependency expressed through constructor parameter 0: Error creating bean with name 'cfRocksDb': Invocation of init method failed
<...>
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'cfRocksDb': Invocation of init method failed
<...>
Caused by: java.nio.file.AccessDeniedException: /nonexistent
<...>
   </pre>  
</details>

This issue currently only affects `tb-postgres`, `tb-node` and `tb-vc-executor` images - but I have also added fixes for other images that install `thingsboard.deb` to ensure future features won't be potentially affected by this.

I have tested basic functionality for Docker images with these fixes (login, transport message send).

Tests:
<details>
  <summary>before</summary>
   <pre>
$ docker ps --format "table {{.Image}}" | grep "thingsboard/tb"
thingsboard/tb-http-transport:3.9.1
thingsboard/tb-mqtt-transport:3.9.1
thingsboard/tb-lwm2m-transport:3.9.1
thingsboard/tb-coap-transport:3.9.1
thingsboard/tb-vc-executor:3.9.1
thingsboard/tb-snmp-transport:3.9.1
thingsboard/tb-node:3.9.1
thingsboard/tb-js-executor:3.9.1
thingsboard/tb-web-ui:3.9.1
   </pre>
   <pre>
$ for container in $(docker ps -q); do docker exec -it $container sh -c "getent passwd thingsboard"; done
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/nonexistent:/usr/sbin/nologin
   </pre>
</details>
<details>
  <summary>after</summary>
   <pre>
$ docker ps --format "table {{.Image}}" | grep "thingsboard/tb"
thingsboard/tb-mqtt-transport:4.0.0-SNAPSHOT
thingsboard/tb-http-transport:4.0.0-SNAPSHOT
thingsboard/tb-lwm2m-transport:4.0.0-SNAPSHOT
thingsboard/tb-snmp-transport:4.0.0-SNAPSHOT
thingsboard/tb-vc-executor:4.0.0-SNAPSHOT
thingsboard/tb-coap-transport:4.0.0-SNAPSHOT
thingsboard/tb-node:4.0.0-SNAPSHOT
thingsboard/tb-js-executor:4.0.0-SNAPSHOT
thingsboard/tb-web-ui:4.0.0-SNAPSHOT
   </pre>
   <pre>
$ for container in $(docker ps -q); do docker exec -it $container sh -c "getent passwd thingsboard"; done
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
thingsboard:x:799:799:Thingsboard application,,,:/home/thingsboard:/usr/sbin/nologin
   </pre>
</details>

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



