### PR TITLE
MQTT client exponential reconnect strategy

### DIFF
--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttClientImpl.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttClientImpl.java
@@ -80,6 +80,8 @@ final class MqttClientImpl implements MqttClient {
 
     private final MqttHandler defaultHandler;
 
+    private final ReconnectStrategy reconnectStrategy;
+
     private EventLoopGroup eventLoop;
 
     private volatile Channel channel;
@@ -110,6 +112,7 @@ final class MqttClientImpl implements MqttClient {
         this.clientConfig = clientConfig;
         this.defaultHandler = defaultHandler;
         this.handlerExecutor = handlerExecutor;
+        this.reconnectStrategy = new ReconnectStrategyExponential(getClientConfig().getReconnectDelay());
     }
 
     /**
@@ -191,7 +194,7 @@ final class MqttClientImpl implements MqttClient {
             if (reconnect) {
                 this.reconnect = true;
             }
-            eventLoop.schedule((Runnable) () -> connect(host, port, reconnect), clientConfig.getReconnectDelay(), TimeUnit.SECONDS);
+            eventLoop.schedule((Runnable) () -> connect(host, port, reconnect), reconnectStrategy.getNextReconnectDelay(), TimeUnit.SECONDS);
         }
     }
 

--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttClientImpl.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/MqttClientImpl.java
@@ -194,7 +194,10 @@ final class MqttClientImpl implements MqttClient {
             if (reconnect) {
                 this.reconnect = true;
             }
-            eventLoop.schedule((Runnable) () -> connect(host, port, reconnect), reconnectStrategy.getNextReconnectDelay(), TimeUnit.SECONDS);
+
+            final long nextReconnectDelay = reconnectStrategy.getNextReconnectDelay();
+            log.info("[{}] Scheduling reconnect in [{}] sec", channel != null ? channel.id() : "UNKNOWN", nextReconnectDelay);
+            eventLoop.schedule((Runnable) () -> connect(host, port, reconnect), nextReconnectDelay, TimeUnit.SECONDS);
         }
     }
 

--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/ReconnectStrategy.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/ReconnectStrategy.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright © 2016-2025 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt;
+
+@FunctionalInterface
+public interface ReconnectStrategy {
+    long getNextReconnectDelay();
+}

--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/ReconnectStrategyExponential.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/ReconnectStrategyExponential.java
@@ -18,37 +18,61 @@ package org.thingsboard.mqtt;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 @Getter
 @Slf4j
 public class ReconnectStrategyExponential implements ReconnectStrategy {
 
-    public static final int DEFAULT_RECONNECT_INTERVAL = 10;
-    final long reconnectIntervalMinSeconds;
-    final long reconnectIntervalMaxSeconds = 30;
-    long lastDisconnectNanoTime = 0; //isotonic time
-    int retryCount = 0;
+    public static final int DEFAULT_RECONNECT_INTERVAL_SEC = 10;
+    public static final int MAX_RECONNECT_INTERVAL_SEC = 60;
+    public static final int EXP_MAX = 8;
+    public static final long JITTER_MAX = 1;
+    private final long reconnectIntervalMinSeconds;
+    private final long reconnectIntervalMaxSeconds;
+    private long lastDisconnectNanoTime = 0; //isotonic time
+    private long retryCount = 0;
 
-    public ReconnectStrategyExponential(long reconnectIntervalMin) {
-        this.reconnectIntervalMinSeconds = calculateIntervalMin(reconnectIntervalMin);
+    public ReconnectStrategyExponential(long reconnectIntervalMinSeconds) {
+        this.reconnectIntervalMaxSeconds = calculateIntervalMax(reconnectIntervalMinSeconds);
+        this.reconnectIntervalMinSeconds = calculateIntervalMin(reconnectIntervalMinSeconds);
     }
 
-    private long calculateIntervalMin(long reconnectIntervalMin) {
-        return Math.min((reconnectIntervalMin > 0 ? reconnectIntervalMin : DEFAULT_RECONNECT_INTERVAL), this.reconnectIntervalMaxSeconds);
+    long calculateIntervalMax(long reconnectIntervalMinSeconds) {
+        return reconnectIntervalMinSeconds > MAX_RECONNECT_INTERVAL_SEC ? reconnectIntervalMinSeconds : MAX_RECONNECT_INTERVAL_SEC;
+    }
+
+    long calculateIntervalMin(long reconnectIntervalMinSeconds) {
+        return Math.min((reconnectIntervalMinSeconds > 0 ? reconnectIntervalMinSeconds : DEFAULT_RECONNECT_INTERVAL_SEC), this.reconnectIntervalMaxSeconds);
     }
 
     @Override
     synchronized public long getNextReconnectDelay() {
         final long currentNanoTime = getNanoTime();
-        final long lastDisconnectIntervalNanos = currentNanoTime - lastDisconnectNanoTime;
+        final long coolDownSpentNanos = currentNanoTime - lastDisconnectNanoTime;
         lastDisconnectNanoTime = currentNanoTime;
-        if (TimeUnit.NANOSECONDS.toSeconds(lastDisconnectIntervalNanos) > reconnectIntervalMaxSeconds + reconnectIntervalMinSeconds) {
-            log.debug("Reset retry counter");
+        if (isCooledDown(coolDownSpentNanos)) {
             retryCount = 0;
             return reconnectIntervalMinSeconds;
         }
-        return Math.min(reconnectIntervalMaxSeconds, reconnectIntervalMinSeconds + (1L << retryCount++));
+        return calculateNextReconnectDelay() + calculateJitter();
+    }
+
+    long calculateJitter() {
+        return ThreadLocalRandom.current().nextInt() >= 0 ? JITTER_MAX : 0;
+    }
+
+    long calculateNextReconnectDelay() {
+        return Math.min(reconnectIntervalMaxSeconds, reconnectIntervalMinSeconds + calculateExp(retryCount++));
+    }
+
+    long calculateExp(long e) {
+        return 1L << Math.min(e, EXP_MAX);
+    }
+
+    boolean isCooledDown(long coolDownSpentNanos) {
+        return TimeUnit.NANOSECONDS.toSeconds(coolDownSpentNanos) > reconnectIntervalMaxSeconds + reconnectIntervalMinSeconds;
     }
 
     long getNanoTime() {

--- a/netty-mqtt/src/main/java/org/thingsboard/mqtt/ReconnectStrategyExponential.java
+++ b/netty-mqtt/src/main/java/org/thingsboard/mqtt/ReconnectStrategyExponential.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright © 2016-2025 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.TimeUnit;
+
+@Getter
+@Slf4j
+public class ReconnectStrategyExponential implements ReconnectStrategy {
+
+    public static final int DEFAULT_RECONNECT_INTERVAL = 10;
+    final long reconnectIntervalMinSeconds;
+    final long reconnectIntervalMaxSeconds = 30;
+    long lastDisconnectNanoTime = 0; //isotonic time
+    int retryCount = 0;
+
+    public ReconnectStrategyExponential(long reconnectIntervalMin) {
+        this.reconnectIntervalMinSeconds = calculateIntervalMin(reconnectIntervalMin);
+    }
+
+    private long calculateIntervalMin(long reconnectIntervalMin) {
+        return Math.min((reconnectIntervalMin > 0 ? reconnectIntervalMin : DEFAULT_RECONNECT_INTERVAL), this.reconnectIntervalMaxSeconds);
+    }
+
+    @Override
+    synchronized public long getNextReconnectDelay() {
+        final long currentNanoTime = getNanoTime();
+        final long lastDisconnectIntervalNanos = currentNanoTime - lastDisconnectNanoTime;
+        lastDisconnectNanoTime = currentNanoTime;
+        if (TimeUnit.NANOSECONDS.toSeconds(lastDisconnectIntervalNanos) > reconnectIntervalMaxSeconds + reconnectIntervalMinSeconds) {
+            log.debug("Reset retry counter");
+            retryCount = 0;
+            return reconnectIntervalMinSeconds;
+        }
+        return Math.min(reconnectIntervalMaxSeconds, reconnectIntervalMinSeconds + (1L << retryCount++));
+    }
+
+    long getNanoTime() {
+        return System.nanoTime();
+    }
+
+}

--- a/netty-mqtt/src/test/java/org/thingsboard/mqtt/ReconnectStrategyExponentialTest.java
+++ b/netty-mqtt/src/test/java/org/thingsboard/mqtt/ReconnectStrategyExponentialTest.java
@@ -16,28 +16,80 @@
 package org.thingsboard.mqtt;
 
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.thingsboard.mqtt.ReconnectStrategyExponential.EXP_MAX;
+import static org.thingsboard.mqtt.ReconnectStrategyExponential.JITTER_MAX;
 
 @Slf4j
 class ReconnectStrategyExponentialTest {
 
-    @Test
-    public void exponentialReconnect() {
-        ReconnectStrategyExponential strategy = Mockito.spy(new ReconnectStrategyExponential(1));
-        for (int i = 0; i < 10; i++) {
-            log.info("Disconnect [{}] Delay [{}]", i, strategy.getNextReconnectDelay());
-        }
+    @Execution(ExecutionMode.SAME_THREAD) // just for convenient log reading
+    @ParameterizedTest
+    @ValueSource(ints = {1, 0, 60})
+    public void exponentialReconnectDelayTest(final int reconnectIntervalMinSeconds) {
+        final ReconnectStrategyExponential strategy = Mockito.spy(new ReconnectStrategyExponential(reconnectIntervalMinSeconds));
+        log.info("=== Reconnect delay test for ReconnectStrategyExponential({}) : calculated min [{}] max [{}] ===", reconnectIntervalMinSeconds, strategy.getReconnectIntervalMinSeconds(), strategy.getReconnectIntervalMaxSeconds());
+        final AtomicLong nanoTime = new AtomicLong(System.nanoTime());
+        willAnswer((x) -> nanoTime.get()).given(strategy).getNanoTime();
+        final LinkedBlockingDeque<Long> jittersCaptured = new LinkedBlockingDeque<>();
+        final LinkedBlockingDeque<Long> expCaptured = new LinkedBlockingDeque<>();
 
-        final long coolDownPeriod = strategy.getReconnectIntervalMinSeconds() + strategy.getReconnectIntervalMaxSeconds() + 1;
+        willAnswer(captureResult(jittersCaptured)).given(strategy).calculateJitter();
+        willAnswer(captureResult(expCaptured)).given(strategy).calculateExp(anyLong());
 
-        BDDMockito.willAnswer((x) -> System.nanoTime() + TimeUnit.SECONDS.toNanos(coolDownPeriod)).given(strategy).getNanoTime();
-        log.info("After cooldown period [{}] seconds later...", coolDownPeriod);
-        for (int i = 0; i < 10; i++) {
-            log.info("Disconnect [{}] Delay [{}]", i, strategy.getNextReconnectDelay());
+        for (int phase = 0; phase < 3; phase++) {
+            log.info("== Phase {} ==", phase);
+            long previousDelay = 0;
+            for (int i = 0; i < EXP_MAX + 4; i++) {
+                final long nextReconnectDelay = strategy.getNextReconnectDelay();
+                nanoTime.addAndGet(TimeUnit.SECONDS.toNanos(nextReconnectDelay));
+                log.info("Retry [{}] Delay [{}] : min [{}] exp [{}] jitter [{}]", strategy.getRetryCount(), nextReconnectDelay, strategy.getReconnectIntervalMinSeconds(), expCaptured.peekLast(), jittersCaptured.peekLast());
+                assertThat(previousDelay).satisfiesAnyOf(
+                        v -> assertThat(v).isLessThanOrEqualTo(nextReconnectDelay),
+                        v -> assertThat(v).isCloseTo(nextReconnectDelay, offset(JITTER_MAX)) // Adjust tolerance as needed
+                );
+                previousDelay = nextReconnectDelay;
+            }
+            log.info("Jitters captured: {}", drainAll(jittersCaptured));
+            log.info("Exponents captured: {}", drainAll(expCaptured));
+            assertThat(previousDelay).isCloseTo(strategy.getReconnectIntervalMaxSeconds(), offset(JITTER_MAX));
+
+            final long coolDownPeriodSec = strategy.getReconnectIntervalMinSeconds() + strategy.getReconnectIntervalMaxSeconds() + 1;
+            log.info("Cooling down for [{}] seconds ...", coolDownPeriodSec);
+            nanoTime.addAndGet(TimeUnit.SECONDS.toNanos(coolDownPeriodSec));
+            assertThat(strategy.isCooledDown(TimeUnit.SECONDS.toNanos(coolDownPeriodSec))).as("cooled down").isTrue();
         }
     }
+
+    private Answer<Long> captureResult(Collection<Long> collection) {
+        return invocation -> {
+            long result = (long) invocation.callRealMethod();
+            collection.add(result);
+            return result;
+        };
+    }
+
+    private Collection<Long> drainAll(BlockingQueue<Long> jittersCaptured) {
+        Collection<Long> elements = new ArrayList<>();
+        jittersCaptured.drainTo(elements);
+        return elements;
+    }
+
 }

--- a/netty-mqtt/src/test/java/org/thingsboard/mqtt/ReconnectStrategyExponentialTest.java
+++ b/netty-mqtt/src/test/java/org/thingsboard/mqtt/ReconnectStrategyExponentialTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright © 2016-2025 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.mqtt;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+class ReconnectStrategyExponentialTest {
+
+    @Test
+    public void exponentialReconnect() {
+        ReconnectStrategyExponential strategy = Mockito.spy(new ReconnectStrategyExponential(1));
+        for (int i = 0; i < 10; i++) {
+            log.info("Disconnect [{}] Delay [{}]", i, strategy.getNextReconnectDelay());
+        }
+
+        final long coolDownPeriod = strategy.getReconnectIntervalMinSeconds() + strategy.getReconnectIntervalMaxSeconds() + 1;
+
+        BDDMockito.willAnswer((x) -> System.nanoTime() + TimeUnit.SECONDS.toNanos(coolDownPeriod)).given(strategy).getNanoTime();
+        log.info("After cooldown period [{}] seconds later...", coolDownPeriod);
+        for (int i = 0; i < 10; i++) {
+            log.info("Disconnect [{}] Delay [{}]", i, strategy.getNextReconnectDelay());
+        }
+    }
+}


### PR DESCRIPTION
## MQTT client reconnect strategy exponential

Addressing the issue with frequent reconnect for broken integrations (mqtt client)
![image](https://github.com/user-attachments/assets/9d171930-1405-4f94-ba6b-6c31fccd5fc3)

Parametrized tests output 
![image](https://github.com/user-attachments/assets/29ce40ac-e0fc-4e0a-b977-d0946e4d3e88)

```
2025-03-20 10:57:01,753 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - === Reconnect delay test for ReconnectStrategyExponential(1) : calculated min [1] max [60] ===
2025-03-20 10:57:01,757 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - == Phase 0 ==
2025-03-20 10:57:01,759 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [0] Delay [1] : min [1] exp [null] jitter [null]
2025-03-20 10:57:01,787 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [1] Delay [3] : min [1] exp [1] jitter [1]
2025-03-20 10:57:01,788 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [2] Delay [4] : min [1] exp [2] jitter [1]
2025-03-20 10:57:01,789 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [3] Delay [6] : min [1] exp [4] jitter [1]
2025-03-20 10:57:01,790 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [4] Delay [9] : min [1] exp [8] jitter [0]
2025-03-20 10:57:01,790 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [5] Delay [17] : min [1] exp [16] jitter [0]
2025-03-20 10:57:01,791 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [6] Delay [33] : min [1] exp [32] jitter [0]
2025-03-20 10:57:01,792 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [7] Delay [61] : min [1] exp [64] jitter [1]
2025-03-20 10:57:01,792 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [8] Delay [60] : min [1] exp [128] jitter [0]
2025-03-20 10:57:01,795 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [9] Delay [61] : min [1] exp [256] jitter [1]
2025-03-20 10:57:01,796 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [10] Delay [60] : min [1] exp [256] jitter [0]
2025-03-20 10:57:01,797 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [11] Delay [60] : min [1] exp [256] jitter [0]
2025-03-20 10:57:01,797 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Jitters captured: [1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0]
2025-03-20 10:57:01,797 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Exponents captured: [1, 2, 4, 8, 16, 32, 64, 128, 256, 256, 256]
2025-03-20 10:57:01,797 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Cooling down for [62] seconds ...
2025-03-20 10:57:01,798 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - == Phase 1 ==
2025-03-20 10:57:01,798 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [0] Delay [1] : min [1] exp [null] jitter [null]
2025-03-20 10:57:01,799 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [1] Delay [3] : min [1] exp [1] jitter [1]
2025-03-20 10:57:01,800 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [2] Delay [4] : min [1] exp [2] jitter [1]
2025-03-20 10:57:01,800 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [3] Delay [5] : min [1] exp [4] jitter [0]
2025-03-20 10:57:01,801 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [4] Delay [10] : min [1] exp [8] jitter [1]
2025-03-20 10:57:01,801 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [5] Delay [17] : min [1] exp [16] jitter [0]
2025-03-20 10:57:01,802 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [6] Delay [34] : min [1] exp [32] jitter [1]
2025-03-20 10:57:01,803 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [7] Delay [60] : min [1] exp [64] jitter [0]
2025-03-20 10:57:01,803 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [8] Delay [61] : min [1] exp [128] jitter [1]
2025-03-20 10:57:01,804 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [9] Delay [60] : min [1] exp [256] jitter [0]
2025-03-20 10:57:01,804 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [10] Delay [61] : min [1] exp [256] jitter [1]
2025-03-20 10:57:01,805 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [11] Delay [61] : min [1] exp [256] jitter [1]
2025-03-20 10:57:01,805 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Jitters captured: [1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1]
2025-03-20 10:57:01,805 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Exponents captured: [1, 2, 4, 8, 16, 32, 64, 128, 256, 256, 256]
2025-03-20 10:57:01,805 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Cooling down for [62] seconds ...
2025-03-20 10:57:01,805 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - == Phase 2 ==
2025-03-20 10:57:01,805 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [0] Delay [1] : min [1] exp [null] jitter [null]
2025-03-20 10:57:01,806 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [1] Delay [3] : min [1] exp [1] jitter [1]
2025-03-20 10:57:01,806 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [2] Delay [3] : min [1] exp [2] jitter [0]
2025-03-20 10:57:01,809 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [3] Delay [6] : min [1] exp [4] jitter [1]
2025-03-20 10:57:01,810 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [4] Delay [9] : min [1] exp [8] jitter [0]
2025-03-20 10:57:01,810 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [5] Delay [17] : min [1] exp [16] jitter [0]
2025-03-20 10:57:01,811 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [6] Delay [34] : min [1] exp [32] jitter [1]
2025-03-20 10:57:01,811 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [7] Delay [61] : min [1] exp [64] jitter [1]
2025-03-20 10:57:01,812 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [8] Delay [60] : min [1] exp [128] jitter [0]
2025-03-20 10:57:01,812 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [9] Delay [60] : min [1] exp [256] jitter [0]
2025-03-20 10:57:01,813 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [10] Delay [61] : min [1] exp [256] jitter [1]
2025-03-20 10:57:01,813 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [11] Delay [60] : min [1] exp [256] jitter [0]
2025-03-20 10:57:01,813 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Jitters captured: [1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]
2025-03-20 10:57:01,813 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Exponents captured: [1, 2, 4, 8, 16, 32, 64, 128, 256, 256, 256]
2025-03-20 10:57:01,813 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Cooling down for [62] seconds ...
2025-03-20 10:57:01,822 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - === Reconnect delay test for ReconnectStrategyExponential(0) : calculated min [10] max [60] ===
2025-03-20 10:57:01,822 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - == Phase 0 ==
2025-03-20 10:57:01,823 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [0] Delay [10] : min [10] exp [null] jitter [null]
2025-03-20 10:57:01,823 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [1] Delay [12] : min [10] exp [1] jitter [1]
2025-03-20 10:57:01,824 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [2] Delay [13] : min [10] exp [2] jitter [1]
2025-03-20 10:57:01,824 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [3] Delay [14] : min [10] exp [4] jitter [0]
2025-03-20 10:57:01,824 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [4] Delay [19] : min [10] exp [8] jitter [1]
2025-03-20 10:57:01,825 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [5] Delay [27] : min [10] exp [16] jitter [1]
2025-03-20 10:57:01,825 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [6] Delay [42] : min [10] exp [32] jitter [0]
2025-03-20 10:57:01,826 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [7] Delay [60] : min [10] exp [64] jitter [0]
2025-03-20 10:57:01,826 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [8] Delay [60] : min [10] exp [128] jitter [0]
2025-03-20 10:57:01,826 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [9] Delay [60] : min [10] exp [256] jitter [0]
2025-03-20 10:57:01,827 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [10] Delay [60] : min [10] exp [256] jitter [0]
2025-03-20 10:57:01,827 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [11] Delay [60] : min [10] exp [256] jitter [0]
2025-03-20 10:57:01,827 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Jitters captured: [1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0]
2025-03-20 10:57:01,827 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Exponents captured: [1, 2, 4, 8, 16, 32, 64, 128, 256, 256, 256]
2025-03-20 10:57:01,827 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Cooling down for [71] seconds ...
2025-03-20 10:57:01,827 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - == Phase 1 ==
2025-03-20 10:57:01,827 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [0] Delay [10] : min [10] exp [null] jitter [null]
2025-03-20 10:57:01,828 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [1] Delay [11] : min [10] exp [1] jitter [0]
2025-03-20 10:57:01,828 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [2] Delay [13] : min [10] exp [2] jitter [1]
2025-03-20 10:57:01,828 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [3] Delay [15] : min [10] exp [4] jitter [1]
2025-03-20 10:57:01,829 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [4] Delay [19] : min [10] exp [8] jitter [1]
2025-03-20 10:57:01,829 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [5] Delay [27] : min [10] exp [16] jitter [1]
2025-03-20 10:57:01,829 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [6] Delay [42] : min [10] exp [32] jitter [0]
2025-03-20 10:57:01,830 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [7] Delay [61] : min [10] exp [64] jitter [1]
2025-03-20 10:57:01,830 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [8] Delay [61] : min [10] exp [128] jitter [1]
2025-03-20 10:57:01,830 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [9] Delay [60] : min [10] exp [256] jitter [0]
2025-03-20 10:57:01,831 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [10] Delay [60] : min [10] exp [256] jitter [0]
2025-03-20 10:57:01,831 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [11] Delay [60] : min [10] exp [256] jitter [0]
2025-03-20 10:57:01,831 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Jitters captured: [0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0]
2025-03-20 10:57:01,831 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Exponents captured: [1, 2, 4, 8, 16, 32, 64, 128, 256, 256, 256]
2025-03-20 10:57:01,831 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Cooling down for [71] seconds ...
2025-03-20 10:57:01,831 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - == Phase 2 ==
2025-03-20 10:57:01,831 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [0] Delay [10] : min [10] exp [null] jitter [null]
2025-03-20 10:57:01,832 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [1] Delay [11] : min [10] exp [1] jitter [0]
2025-03-20 10:57:01,832 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [2] Delay [12] : min [10] exp [2] jitter [0]
2025-03-20 10:57:01,832 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [3] Delay [14] : min [10] exp [4] jitter [0]
2025-03-20 10:57:01,833 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [4] Delay [19] : min [10] exp [8] jitter [1]
2025-03-20 10:57:01,833 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [5] Delay [26] : min [10] exp [16] jitter [0]
2025-03-20 10:57:01,835 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [6] Delay [42] : min [10] exp [32] jitter [0]
2025-03-20 10:57:01,836 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [7] Delay [61] : min [10] exp [64] jitter [1]
2025-03-20 10:57:01,836 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [8] Delay [61] : min [10] exp [128] jitter [1]
2025-03-20 10:57:01,836 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [9] Delay [61] : min [10] exp [256] jitter [1]
2025-03-20 10:57:01,836 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [10] Delay [61] : min [10] exp [256] jitter [1]
2025-03-20 10:57:01,837 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [11] Delay [60] : min [10] exp [256] jitter [0]
2025-03-20 10:57:01,837 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Jitters captured: [0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 0]
2025-03-20 10:57:01,837 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Exponents captured: [1, 2, 4, 8, 16, 32, 64, 128, 256, 256, 256]
2025-03-20 10:57:01,837 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Cooling down for [71] seconds ...
2025-03-20 10:57:01,839 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - === Reconnect delay test for ReconnectStrategyExponential(60) : calculated min [60] max [60] ===
2025-03-20 10:57:01,839 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - == Phase 0 ==
2025-03-20 10:57:01,839 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [0] Delay [60] : min [60] exp [null] jitter [null]
2025-03-20 10:57:01,840 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [1] Delay [60] : min [60] exp [1] jitter [0]
2025-03-20 10:57:01,840 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [2] Delay [60] : min [60] exp [2] jitter [0]
2025-03-20 10:57:01,840 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [3] Delay [60] : min [60] exp [4] jitter [0]
2025-03-20 10:57:01,841 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [4] Delay [61] : min [60] exp [8] jitter [1]
2025-03-20 10:57:01,841 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [5] Delay [61] : min [60] exp [16] jitter [1]
2025-03-20 10:57:01,841 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [6] Delay [61] : min [60] exp [32] jitter [1]
2025-03-20 10:57:01,842 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [7] Delay [61] : min [60] exp [64] jitter [1]
2025-03-20 10:57:01,842 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [8] Delay [60] : min [60] exp [128] jitter [0]
2025-03-20 10:57:01,842 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [9] Delay [60] : min [60] exp [256] jitter [0]
2025-03-20 10:57:01,842 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [10] Delay [60] : min [60] exp [256] jitter [0]
2025-03-20 10:57:01,843 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [11] Delay [61] : min [60] exp [256] jitter [1]
2025-03-20 10:57:01,843 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Jitters captured: [0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 1]
2025-03-20 10:57:01,843 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Exponents captured: [1, 2, 4, 8, 16, 32, 64, 128, 256, 256, 256]
2025-03-20 10:57:01,843 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Cooling down for [121] seconds ...
2025-03-20 10:57:01,843 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - == Phase 1 ==
2025-03-20 10:57:01,843 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [0] Delay [60] : min [60] exp [null] jitter [null]
2025-03-20 10:57:01,843 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [1] Delay [61] : min [60] exp [1] jitter [1]
2025-03-20 10:57:01,844 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [2] Delay [60] : min [60] exp [2] jitter [0]
2025-03-20 10:57:01,844 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [3] Delay [61] : min [60] exp [4] jitter [1]
2025-03-20 10:57:01,844 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [4] Delay [60] : min [60] exp [8] jitter [0]
2025-03-20 10:57:01,844 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [5] Delay [61] : min [60] exp [16] jitter [1]
2025-03-20 10:57:01,845 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [6] Delay [61] : min [60] exp [32] jitter [1]
2025-03-20 10:57:01,845 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [7] Delay [60] : min [60] exp [64] jitter [0]
2025-03-20 10:57:01,845 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [8] Delay [61] : min [60] exp [128] jitter [1]
2025-03-20 10:57:01,845 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [9] Delay [60] : min [60] exp [256] jitter [0]
2025-03-20 10:57:01,846 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [10] Delay [61] : min [60] exp [256] jitter [1]
2025-03-20 10:57:01,846 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [11] Delay [61] : min [60] exp [256] jitter [1]
2025-03-20 10:57:01,846 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Jitters captured: [1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1]
2025-03-20 10:57:01,846 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Exponents captured: [1, 2, 4, 8, 16, 32, 64, 128, 256, 256, 256]
2025-03-20 10:57:01,846 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Cooling down for [121] seconds ...
2025-03-20 10:57:01,846 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - == Phase 2 ==
2025-03-20 10:57:01,847 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [0] Delay [60] : min [60] exp [null] jitter [null]
2025-03-20 10:57:01,847 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [1] Delay [61] : min [60] exp [1] jitter [1]
2025-03-20 10:57:01,847 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [2] Delay [60] : min [60] exp [2] jitter [0]
2025-03-20 10:57:01,847 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [3] Delay [60] : min [60] exp [4] jitter [0]
2025-03-20 10:57:01,847 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [4] Delay [60] : min [60] exp [8] jitter [0]
2025-03-20 10:57:01,848 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [5] Delay [61] : min [60] exp [16] jitter [1]
2025-03-20 10:57:01,848 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [6] Delay [61] : min [60] exp [32] jitter [1]
2025-03-20 10:57:01,848 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [7] Delay [60] : min [60] exp [64] jitter [0]
2025-03-20 10:57:01,848 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [8] Delay [60] : min [60] exp [128] jitter [0]
2025-03-20 10:57:01,848 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [9] Delay [61] : min [60] exp [256] jitter [1]
2025-03-20 10:57:01,848 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [10] Delay [61] : min [60] exp [256] jitter [1]
2025-03-20 10:57:01,849 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Retry [11] Delay [60] : min [60] exp [256] jitter [0]
2025-03-20 10:57:01,849 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Jitters captured: [1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0]
2025-03-20 10:57:01,849 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Exponents captured: [1, 2, 4, 8, 16, 32, 64, 128, 256, 256, 256]
2025-03-20 10:57:01,849 [ForkJoinPool-1-worker-1] INFO  o.t.m.ReconnectStrategyExponentialTest - Cooling down for [121] seconds ...
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



