### PR TITLE
Backward compatibility for header icon button action

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/action/manage-widget-actions-dialog.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/action/manage-widget-actions-dialog.component.html
@@ -33,6 +33,7 @@
       [callbacks]="data.callbacks"
       [widgetType] = "data.widgetType"
       [actionSources]="actionSources"
+      [defaultIconColor]="data.defaultIconColor"
       [additionalWidgetActionTypes]="data.additionalWidgetActionTypes"
       formControlName="actions">
     </tb-manage-widget-actions>

--- a/ui-ngx/src/app/modules/home/components/widget/action/manage-widget-actions-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/action/manage-widget-actions-dialog.component.ts
@@ -32,6 +32,7 @@ export interface ManageWidgetActionsDialogData {
   actionsData: WidgetActionsData;
   callbacks: WidgetActionCallbacks;
   widgetType: widgetType;
+  defaultIconColor?: string;
   additionalWidgetActionTypes?: WidgetActionType[];
 }
 

--- a/ui-ngx/src/app/modules/home/components/widget/action/manage-widget-actions.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/action/manage-widget-actions.component.ts
@@ -73,6 +73,8 @@ export class ManageWidgetActionsComponent extends PageComponent implements OnIni
 
   @Input() widgetType: widgetType;
 
+  @Input() defaultIconColor: string;
+
   @Input() callbacks: WidgetActionCallbacks;
 
   @Input() actionSources: {[actionSourceId: string]: WidgetActionSource};
@@ -239,6 +241,7 @@ export class ManageWidgetActionsComponent extends PageComponent implements OnIni
         actionsData,
         action: deepClone(action),
         widgetType: this.widgetType,
+        defaultIconColor: this.defaultIconColor,
         additionalWidgetActionTypes: this.additionalWidgetActionTypes
       }
     }).afterClosed().subscribe(

--- a/ui-ngx/src/app/modules/home/components/widget/action/widget-action-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/action/widget-action-dialog.component.ts
@@ -61,6 +61,7 @@ export interface WidgetActionDialogData {
   actionsData: WidgetActionsData;
   action?: WidgetActionDescriptorInfo;
   widgetType: widgetType;
+  defaultIconColor?: string;
   additionalWidgetActionTypes?: WidgetActionType[];
 }
 
@@ -77,6 +78,8 @@ export class WidgetActionDialogComponent extends DialogComponent<WidgetActionDia
 
   isAdd: boolean;
   action: WidgetActionDescriptorInfo;
+
+  defaultIconColor: string;
 
   customActionEditorCompleter = CustomActionEditorCompleter;
 
@@ -106,6 +109,7 @@ export class WidgetActionDialogComponent extends DialogComponent<WidgetActionDia
               private destroyRef: DestroyRef) {
     super(store, router, dialogRef);
     this.isAdd = data.isAdd;
+    this.defaultIconColor = data.defaultIconColor;
     if (this.isAdd) {
       this.action = {
         id: this.utils.guid(),
@@ -130,7 +134,7 @@ export class WidgetActionDialogComponent extends DialogComponent<WidgetActionDia
       buttonType: [{ value: this.action.buttonType ?? WidgetHeaderActionButtonType.icon, disabled: true}, []],
       showIcon: [{ value: this.action.showIcon ?? true, disabled: true}, []],
       icon: [this.action.icon, Validators.required],
-      buttonColor: [{ value: this.action.buttonColor ?? 'rgba(0, 0, 0, 0.87)', disabled: true}, []],
+      buttonColor: [{ value: this.action.buttonColor ?? this.defaultIconColor, disabled: true}, []],
       buttonFillColor: [{ value: this.action.buttonFillColor ?? '#3F52DD', disabled: true}, []],
       buttonBorderColor: [{ value: this.action.buttonBorderColor ?? '#3F52DD', disabled: true}, []],
       customButtonStyle: [{ value: this.action.customButtonStyle ?? {}, disabled: true}, []],

--- a/ui-ngx/src/app/modules/home/components/widget/config/basic/common/widget-actions-panel.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/config/basic/common/widget-actions-panel.component.ts
@@ -123,6 +123,7 @@ export class WidgetActionsPanelComponent implements ControlValueAccessor, OnInit
         callbacks: this.widgetConfigComponent.widgetConfigCallbacks,
         actionsData,
         widgetType: this.widgetConfigComponent.widgetType,
+        defaultIconColor: this.widgetConfigComponent.widgetSettings.get('color').value,
         additionalWidgetActionTypes: this.widgetConfigComponent.modelValue.typeParameters.additionalWidgetActionTypes
       }
     }).afterClosed().subscribe(

--- a/ui-ngx/src/app/modules/home/components/widget/widget-config.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-config.component.html
@@ -163,6 +163,7 @@
         <tb-manage-widget-actions
           [callbacks]="widgetConfigCallbacks"
           [widgetType] = "modelValue.widgetType"
+          [defaultIconColor]="widgetSettings.get('color').value"
           [actionSources]="modelValue.actionSources"
           [additionalWidgetActionTypes]="modelValue.typeParameters.additionalWidgetActionTypes"
           formControlName="actions">

--- a/ui-ngx/src/app/modules/home/components/widget/widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget.component.ts
@@ -365,7 +365,7 @@ export class WidgetComponent extends PageComponent implements OnInit, OnChanges,
 
   headerButtonStyle(buttonType: WidgetHeaderActionButtonType = WidgetHeaderActionButtonType.icon,
                     customButtonStyle:{[key: string]: string},
-                    buttonColor: string = 'rgba(0,0,0,0.87)',
+                    buttonColor: string = this.widget.config.color,
                     backgroundColor: string,
                     borderColor: string) {
     const buttonStyle = {};


### PR DESCRIPTION
## Pull Request description

Backward compatibility for header icon button action

Get default color from widget card settings text color property as default color for header button color.

![image](https://github.com/user-attachments/assets/f2dd71db-f083-4c52-b0b3-e6b399862755)
![image](https://github.com/user-attachments/assets/6bd8b756-9299-4416-ba71-de8d0841ac87)


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



