### PR TITLE
Fixed default action header button color

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/action/widget-action-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/action/widget-action-dialog.component.ts
@@ -192,6 +192,11 @@ export class WidgetActionDialogComponent extends DialogComponent<WidgetActionDia
 
   widgetHeaderButtonValidators() {
     const buttonType = this.widgetActionFormGroup.get('buttonType').value;
+    if (buttonType !== WidgetHeaderActionButtonType.icon) {
+      this.widgetActionFormGroup.get('buttonColor').patchValue('#ffffff', {emitEvent: false});
+    } else {
+      this.widgetActionFormGroup.get('buttonColor').patchValue(this.defaultIconColor, {emitEvent: false});
+    }
     this.widgetActionFormGroup.get('showIcon').disable({emitEvent: false});
     this.widgetActionFormGroup.get('buttonFillColor').disable({emitEvent: false});
     this.widgetActionFormGroup.get('buttonBorderColor').disable({emitEvent: false});

--- a/ui-ngx/src/app/modules/home/components/widget/action/widget-action-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/action/widget-action-dialog.component.ts
@@ -135,8 +135,8 @@ export class WidgetActionDialogComponent extends DialogComponent<WidgetActionDia
       showIcon: [{ value: this.action.showIcon ?? true, disabled: true}, []],
       icon: [this.action.icon, Validators.required],
       buttonColor: [{ value: this.action.buttonColor ?? this.defaultIconColor, disabled: true}, []],
-      buttonFillColor: [{ value: this.action.buttonFillColor ?? '#3F52DD', disabled: true}, []],
-      buttonBorderColor: [{ value: this.action.buttonBorderColor ?? '#3F52DD', disabled: true}, []],
+      buttonFillColor: [{ value: this.action.buttonFillColor ?? '#305680', disabled: true}, []],
+      buttonBorderColor: [{ value: this.action.buttonBorderColor ?? '#0000001F', disabled: true}, []],
       customButtonStyle: [{ value: this.action.customButtonStyle ?? {}, disabled: true}, []],
       useShowWidgetActionFunction: [this.action.useShowWidgetActionFunction],
       showWidgetActionFunction: [this.action.showWidgetActionFunction || 'return true;'],
@@ -146,7 +146,7 @@ export class WidgetActionDialogComponent extends DialogComponent<WidgetActionDia
     if (this.widgetActionFormGroup.get('actionSourceId').value === 'headerButton') {
       this.widgetActionFormGroup.get('buttonType').enable({emitEvent: false});
       this.widgetActionFormGroup.get('buttonColor').enable({emitEvent: false});
-      this.widgetHeaderButtonValidators();
+      this.widgetHeaderButtonValidators(true);
     }
     this.widgetActionFormGroup.get('actionSourceId').valueChanges.pipe(
       takeUntilDestroyed(this.destroyRef)
@@ -162,7 +162,7 @@ export class WidgetActionDialogComponent extends DialogComponent<WidgetActionDia
       if (value === 'headerButton') {
         this.widgetActionFormGroup.get('buttonType').enable({emitEvent: false});
         this.widgetActionFormGroup.get('buttonColor').enable({emitEvent: false});
-        this.widgetHeaderButtonValidators();
+        this.widgetHeaderButtonValidators(true);
       } else {
         this.widgetActionFormGroup.get('buttonType').disable({emitEvent: false});
         this.widgetActionFormGroup.get('showIcon').disable({emitEvent: false});
@@ -190,12 +190,16 @@ export class WidgetActionDialogComponent extends DialogComponent<WidgetActionDia
     });
   }
 
-  widgetHeaderButtonValidators() {
+  private widgetHeaderButtonValidators(ignoreUpdatedButtonColor = false) {
     const buttonType = this.widgetActionFormGroup.get('buttonType').value;
-    if (buttonType !== WidgetHeaderActionButtonType.icon) {
-      this.widgetActionFormGroup.get('buttonColor').patchValue('#ffffff', {emitEvent: false});
-    } else {
-      this.widgetActionFormGroup.get('buttonColor').patchValue(this.defaultIconColor, {emitEvent: false});
+    if (!ignoreUpdatedButtonColor) {
+      if ([WidgetHeaderActionButtonType.raised, WidgetHeaderActionButtonType.flat, WidgetHeaderActionButtonType.miniFab].includes(buttonType)) {
+        this.widgetActionFormGroup.get('buttonColor').patchValue('#ffffff', {emitEvent: false});
+      } else if ([WidgetHeaderActionButtonType.stroked].includes(buttonType)) {
+        this.widgetActionFormGroup.get('buttonColor').patchValue('#305680', {emitEvent: false});
+      } else {
+        this.widgetActionFormGroup.get('buttonColor').patchValue(this.defaultIconColor, {emitEvent: false});
+      }
     }
     this.widgetActionFormGroup.get('showIcon').disable({emitEvent: false});
     this.widgetActionFormGroup.get('buttonFillColor').disable({emitEvent: false});


### PR DESCRIPTION
## Pull Request description

The default color for buttons and FAB is white. The default color for icon is 'text color' from widget settings.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




