### PR TITLE
DeviceProfile alarm - Profile state alarm schedule dynamic attributeSource null

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/profile/ProfileState.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/profile/ProfileState.java
@@ -80,7 +80,7 @@ class ProfileState {
                     addEntityKeysFromAlarmConditionSpec(alarmRule);
                     AlarmSchedule schedule = alarmRule.getSchedule();
                     if (schedule != null) {
-                        addScheduleDynamicValues(schedule);
+                        addScheduleDynamicValues(schedule, entityKeys);
                     }
                 }));
                 if (alarm.getClearRule() != null) {
@@ -96,9 +96,9 @@ class ProfileState {
         }
     }
 
-    private void addScheduleDynamicValues(AlarmSchedule schedule) {
+    void addScheduleDynamicValues(AlarmSchedule schedule, final Set<AlarmConditionFilterKey> entityKeys) {
         DynamicValue<String> dynamicValue = schedule.getDynamicValue();
-        if (dynamicValue != null) {
+        if (dynamicValue != null && dynamicValue.getSourceAttribute() != null) {
             entityKeys.add(
                     new AlarmConditionFilterKey(AlarmConditionKeyType.ATTRIBUTE,
                             dynamicValue.getSourceAttribute())
@@ -137,13 +137,14 @@ class ProfileState {
 
     }
 
-    private void addDynamicValuesRecursively(KeyFilterPredicate predicate, Set<AlarmConditionFilterKey> entityKeys, Set<AlarmConditionFilterKey> ruleKeys) {
+    void addDynamicValuesRecursively(KeyFilterPredicate predicate, Set<AlarmConditionFilterKey> entityKeys, Set<AlarmConditionFilterKey> ruleKeys) {
         switch (predicate.getType()) {
             case STRING:
             case NUMERIC:
             case BOOLEAN:
                 DynamicValue value = ((SimpleKeyFilterPredicate) predicate).getValue().getDynamicValue();
-                if (value != null && (value.getSourceType() == DynamicValueSourceType.CURRENT_TENANT ||
+                if (value != null && value.getSourceAttribute() != null && (
+                        value.getSourceType() == DynamicValueSourceType.CURRENT_TENANT ||
                         value.getSourceType() == DynamicValueSourceType.CURRENT_CUSTOMER ||
                         value.getSourceType() == DynamicValueSourceType.CURRENT_DEVICE)) {
                     AlarmConditionFilterKey entityKey = new AlarmConditionFilterKey(AlarmConditionKeyType.ATTRIBUTE, value.getSourceAttribute());

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/profile/ProfileStateTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/profile/ProfileStateTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright © 2016-2025 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.rule.engine.profile;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.thingsboard.server.common.data.device.profile.AlarmConditionFilterKey;
+import org.thingsboard.server.common.data.device.profile.AlarmConditionKeyType;
+import org.thingsboard.server.common.data.device.profile.SpecificTimeSchedule;
+import org.thingsboard.server.common.data.query.ComplexFilterPredicate;
+import org.thingsboard.server.common.data.query.DynamicValue;
+import org.thingsboard.server.common.data.query.DynamicValueSourceType;
+import org.thingsboard.server.common.data.query.FilterPredicateType;
+import org.thingsboard.server.common.data.query.SimpleKeyFilterPredicate;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willCallRealMethod;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ProfileStateTest {
+
+    ProfileState profileState;
+    Set<AlarmConditionFilterKey> entityKeys = new HashSet<>();
+    Set<AlarmConditionFilterKey> ruleKeys = new HashSet<>();
+
+    @BeforeEach
+    void setUp() {
+        profileState = mock(ProfileState.class);
+    }
+
+    @ParameterizedTest()
+    @EnumSource(DynamicValueSourceType.class)
+    @NullSource
+    void addScheduleDynamicValuesSourceAttribute(DynamicValueSourceType sourceType) {
+        willCallRealMethod().given(profileState).addScheduleDynamicValues(any(), any());
+        final DynamicValue<String> dynamicValue = new DynamicValue<>(sourceType, "myKey");
+        SpecificTimeSchedule schedule = new SpecificTimeSchedule();
+        schedule.setDynamicValue(dynamicValue);
+
+        Assertions.assertThat(entityKeys.isEmpty()).isTrue();
+        Assertions.assertThat(schedule.getDynamicValue().getSourceAttribute()).isNotNull();
+
+        profileState.addScheduleDynamicValues(schedule, entityKeys);
+
+        Assertions.assertThat(entityKeys).isEqualTo(Set.of(
+                new AlarmConditionFilterKey(AlarmConditionKeyType.ATTRIBUTE, "myKey")));
+    }
+
+    @ParameterizedTest()
+    @EnumSource(DynamicValueSourceType.class)
+    @NullSource
+    void addScheduleDynamicValuesSourceAttributeIsNull(DynamicValueSourceType sourceType) {
+        willCallRealMethod().given(profileState).addScheduleDynamicValues(any(), any());
+        DynamicValue<String> dynamicValue = new DynamicValue<>(sourceType, null);
+        SpecificTimeSchedule schedule = new SpecificTimeSchedule();
+        schedule.setDynamicValue(dynamicValue);
+
+        Assertions.assertThat(entityKeys.isEmpty()).isTrue();
+        Assertions.assertThat(schedule.getDynamicValue().getSourceAttribute()).isNull();
+
+        profileState.addScheduleDynamicValues(schedule, entityKeys);
+
+        Assertions.assertThat(entityKeys.isEmpty()).isTrue();
+    }
+
+    @ParameterizedTest()
+    @EnumSource(value = FilterPredicateType.class,  names = {"COMPLEX"})
+    void addDynamicValuesRecursivelySourceAttributeComplexKeyFilter(FilterPredicateType predicateType) {
+        willCallRealMethod().given(profileState).addDynamicValuesRecursively(any(), any(), any());
+        ComplexFilterPredicate predicate = mock(ComplexFilterPredicate.class, RETURNS_DEEP_STUBS);
+        willReturn(predicateType).given(predicate).getType();
+        profileState.addDynamicValuesRecursively(predicate, entityKeys, ruleKeys);
+        Assertions.assertThat(entityKeys.isEmpty()).isTrue();
+        Assertions.assertThat(ruleKeys.isEmpty()).isTrue();
+    }
+
+    @ParameterizedTest()
+    @EnumSource(value = FilterPredicateType.class,  names = {"STRING", "NUMERIC", "BOOLEAN"})
+    void addDynamicValuesRecursivelySourceAttributeIsNull(FilterPredicateType predicateType) {
+        willCallRealMethod().given(profileState).addDynamicValuesRecursively(any(), any(), any());
+        SimpleKeyFilterPredicate<String> predicate = mock(SimpleKeyFilterPredicate.class, RETURNS_DEEP_STUBS);
+        willReturn(predicateType).given(predicate).getType();
+        when(predicate.getValue().getDynamicValue().getSourceType()).thenReturn(DynamicValueSourceType.CURRENT_DEVICE);
+        when(predicate.getValue().getDynamicValue().getSourceAttribute()).thenReturn(null);
+        profileState.addDynamicValuesRecursively(predicate, entityKeys, ruleKeys);
+        Assertions.assertThat(entityKeys.isEmpty()).isTrue();
+        Assertions.assertThat(ruleKeys.isEmpty()).isTrue();
+    }
+
+    @ParameterizedTest()
+    @EnumSource(value = FilterPredicateType.class,  names = {"STRING", "NUMERIC", "BOOLEAN"})
+    void addDynamicValuesRecursivelySourceAttributeAdded(FilterPredicateType predicateType) {
+        willCallRealMethod().given(profileState).addDynamicValuesRecursively(any(), any(), any());
+        SimpleKeyFilterPredicate<String> predicate = mock(SimpleKeyFilterPredicate.class, RETURNS_DEEP_STUBS);
+        willReturn(predicateType).given(predicate).getType();
+        when(predicate.getValue().getDynamicValue().getSourceType()).thenReturn(DynamicValueSourceType.CURRENT_DEVICE);
+        when(predicate.getValue().getDynamicValue().getSourceAttribute()).thenReturn("myKey");
+        profileState.addDynamicValuesRecursively(predicate, entityKeys, ruleKeys);
+        Assertions.assertThat(entityKeys).isEqualTo(Set.of(
+                new AlarmConditionFilterKey(AlarmConditionKeyType.ATTRIBUTE, "myKey")));
+        Assertions.assertThat(ruleKeys).isEqualTo(Set.of(
+                new AlarmConditionFilterKey(AlarmConditionKeyType.ATTRIBUTE, "myKey")));
+    }
+
+}


### PR DESCRIPTION
## Pull Request description

Skip null keys at ProfileState to tolerate the issue:

DeviceProfileNode is 'Failed to process' when alarm rules /createRules/INDETERMINATE/schedule/ dynamicValue / sourceAttribute is null 

```
.getSourceAttribute() != null
```

![image](https://github.com/user-attachments/assets/420b469c-04d0-411a-ae64-f7fb8dfe0470)

Debug events with failures for DeviceProfile rule node
![image](https://github.com/user-attachments/assets/b3ae431b-cc80-4c80-ad82-f1c23fd2266c)

The failure event stack trace

```
org.thingsboard.server.dao.exception.IncorrectParameterException: Incorrect attribute key null
	at org.thingsboard.server.dao.service.Validator.validateString(Validator.java:107)
	at org.thingsboard.server.dao.attributes.CachedAttributesService.lambda$find$3(CachedAttributesService.java:159)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.thingsboard.server.dao.attributes.CachedAttributesService.find(CachedAttributesService.java:159)
	at org.thingsboard.rule.engine.profile.DeviceState.addEntityKeysToSnapshot(DeviceState.java:401)
	at org.thingsboard.rule.engine.profile.DeviceState.fetchLatestValues(DeviceState.java:350)
	at org.thingsboard.rule.engine.profile.DeviceState.process(DeviceState.java:163)
	at org.thingsboard.rule.engine.profile.TbDeviceProfileNode.onMsg(TbDeviceProfileNode.java:153)
	at org.thingsboard.server.actors.ruleChain.RuleNodeActorMessageProcessor.onRuleChainToRuleNodeMsg(RuleNodeActorMessageProcessor.java:173)
	at org.thingsboard.server.actors.ruleChain.RuleNodeActor.onRuleChainToRuleNodeMsg(RuleNodeActor.java:117)
	at org.thingsboard.server.actors.ruleChain.RuleNodeActor.doProcess(RuleNodeActor.java:76)
	at org.thingsboard.server.actors.service.ContextAwareActor.process(ContextAwareActor.java:56)
	at org.thingsboard.server.actors.TbActorMailbox.processMailbox(TbActorMailbox.java:172)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1395)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

Workaround 

To workaround the issue it is enough to fill the sourceAttribute like non-existed_key 
![image](https://github.com/user-attachments/assets/1d8ddf94-6c68-41c1-ad58-6cb0799a7465)

Affected version 3.9.1

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



