### PR TITLE
Fixed early updatePosition call to prevent CDK overlay crash in matSuffix context

### DIFF
--- a/ui-ngx/src/app/shared/components/popover.component.ts
+++ b/ui-ngx/src/app/shared/components/popover.component.ts
@@ -472,7 +472,9 @@ export class TbPopoverComponent<T = any> implements OnDestroy, OnInit {
 
   set tbOverlayStyle(value: { [klass: string]: any }) {
     this._tbOverlayStyle = value;
-    this.cdr.detectChanges();
+    if (this.popover) {
+      this.cdr.detectChanges();
+    }
   }
 
   get tbOverlayStyle(): { [klass: string]: any } {


### PR DESCRIPTION
## 📝 Pull Request Description

Fixes a crash when using `tb-help-popup` inside `matSuffix`.

The issue occurred due to Angular CDK attempting to access the overlay pane's style before it was fully rendered, leading to the following error:

```
ERROR TypeError: Cannot read properties of undefined (reading 'style')
    at FlexibleConnectedPositionStrategy._resetOverlayElementStyles
```

---

## ❌ Before  
https://github.com/user-attachments/assets/cc13de6d-5594-44b2-b566-741e67fcbfb8

---

## ✅ After  
https://github.com/user-attachments/assets/9aabf126-946c-462d-a71c-9630167e7c65

---

## 🐞 Problem

When `tb-help-popup` is used inside `matSuffix`, the projected element may not be fully rendered at the time overlay positioning is calculated.  
This causes the CDK positioning strategy to fail when it attempts to access or update style properties on an overlay element that doesn't yet exist in the DOM.

⚠️ The issue **always occurs on the second opening**, when the overlay is destroyed and re-created. At this point, `tbOverlayStyle` is updated while the view is already initialized, and `ChangeDetectorRef` is not automatically triggered to reflect the change.

---

## ✅ Solution

To ensure correct styling behavior and safe DOM access, `ChangeDetectorRef.detectChanges()` is now conditionally called inside the `tbOverlayStyle` setter when the popover has already been initialized.

This guarantees that any style updates (like `opacity`, `maxWidth`, etc.) are applied after the component is fully rendered, without needing to defer logic or manipulate visibility.

---

## 📌 Summary

This change improves the reliability of `tb-help-popup` in `matSuffix` and other projection scenarios by ensuring style updates are applied at the right time in the component lifecycle.


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



