### PR TITLE
lwm2m_fix_bug_object19_For_Ota

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/AbstractOtaLwM2MIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/ota/AbstractOtaLwM2MIntegrationTest.java
@@ -120,7 +120,7 @@ public abstract class AbstractOtaLwM2MIntegrationTest extends AbstractLwM2MInteg
 
     public static final String CLIENT_LWM2M_SETTINGS_19 =
             "     {\n" +
-                    "    \"useObject19ForOta\": true,\n" +
+                    "    \"useObject19ForOtaInfo\": true,\n" +
                     "    \"edrxCycle\": null,\n" +
                     "    \"powerMode\": \"DRX\",\n" +
                     "    \"fwUpdateResource\": null,\n" +

--- a/ui-ngx/src/app/modules/home/components/profile/device/lwm2m/lwm2m-device-profile-transport-configuration.component.html
+++ b/ui-ngx/src/app/modules/home/components/profile/device/lwm2m/lwm2m-device-profile-transport-configuration.component.html
@@ -53,7 +53,7 @@
         <section formGroupName="clientLwM2mSettings">
           <fieldset class="fields-group">
             <legend class="group-title" translate>device-profile.lwm2m.ota-update</legend>
-            <mat-checkbox formControlName="useObject19ForOta">
+            <mat-checkbox formControlName="useObject19ForOtaInfo">
               <span tb-hint-tooltip-icon="{{ 'device-profile.lwm2m.use-object-19-for-ota-update-hint' | translate }}">
                 {{ 'device-profile.lwm2m.use-object-19-for-ota-update' | translate }}
               </span>

--- a/ui-ngx/src/app/modules/home/components/profile/device/lwm2m/lwm2m-device-profile-transport-configuration.component.ts
+++ b/ui-ngx/src/app/modules/home/components/profile/device/lwm2m/lwm2m-device-profile-transport-configuration.component.ts
@@ -104,7 +104,7 @@ export class Lwm2mDeviceProfileTransportConfigurationComponent implements Contro
       bootstrap: [[]],
       clientLwM2mSettings: this.fb.group({
         clientOnlyObserveAfterConnect: [1, []],
-        useObject19ForOta: [false],
+        useObject19ForOtaInfo: [false],
         fwUpdateStrategy: [1, []],
         swUpdateStrategy: [1, []],
         fwUpdateResource: [{value: '', disabled: true}, []],
@@ -263,7 +263,7 @@ export class Lwm2mDeviceProfileTransportConfigurationComponent implements Contro
         bootstrapServerUpdateEnable: this.configurationValue.bootstrapServerUpdateEnable || false,
         clientLwM2mSettings: {
           clientOnlyObserveAfterConnect: this.configurationValue.clientLwM2mSettings.clientOnlyObserveAfterConnect,
-          useObject19ForOta: this.configurationValue.clientLwM2mSettings.useObject19ForOta ?? false,
+          useObject19ForOtaInfo: this.configurationValue.clientLwM2mSettings.useObject19ForOtaInfo ?? false,
           fwUpdateStrategy: this.configurationValue.clientLwM2mSettings.fwUpdateStrategy || 1,
           swUpdateStrategy: this.configurationValue.clientLwM2mSettings.swUpdateStrategy || 1,
           fwUpdateResource: this.configurationValue.clientLwM2mSettings.fwUpdateResource || '',

--- a/ui-ngx/src/app/modules/home/components/profile/device/lwm2m/lwm2m-profile-config.models.ts
+++ b/ui-ngx/src/app/modules/home/components/profile/device/lwm2m/lwm2m-profile-config.models.ts
@@ -169,7 +169,7 @@ export interface Lwm2mProfileConfigModels {
 
 export interface ClientLwM2mSettings {
   clientOnlyObserveAfterConnect: number;
-  useObject19ForOta?: boolean;
+  useObject19ForOtaInfo?: boolean;
   fwUpdateStrategy: number;
   swUpdateStrategy: number;
   fwUpdateResource?: string;


### PR DESCRIPTION
## Pull Request description

`fix bug in the front: useObject19ForOta to useObject19ForOtaInfo`

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)
