### PR TITLE
Add support for `ENTITY_VIEW` and `EDGE` entity types in customer attributes node

### DIFF
--- a/common/dao-api/src/main/java/org/thingsboard/server/dao/entityview/EntityViewService.java
+++ b/common/dao-api/src/main/java/org/thingsboard/server/dao/entityview/EntityViewService.java
@@ -52,6 +52,8 @@ public interface EntityViewService extends EntityDaoService {
 
     EntityView findEntityViewById(TenantId tenantId, EntityViewId entityViewId, boolean putInCache);
 
+    ListenableFuture<EntityView> findEntityViewByIdAsync(TenantId tenantId, EntityViewId entityViewId);
+
     EntityView findEntityViewByTenantIdAndName(TenantId tenantId, String name);
 
     ListenableFuture<EntityView> findEntityViewByTenantIdAndNameAsync(TenantId tenantId, String name);
@@ -74,8 +76,6 @@ public interface EntityViewService extends EntityDaoService {
 
     ListenableFuture<List<EntityView>> findEntityViewsByQuery(TenantId tenantId, EntityViewSearchQuery query);
 
-    ListenableFuture<EntityView> findEntityViewByIdAsync(TenantId tenantId, EntityViewId entityViewId);
-
     ListenableFuture<List<EntityView>> findEntityViewsByTenantIdAndEntityIdAsync(TenantId tenantId, EntityId entityId);
 
     List<EntityView> findEntityViewsByTenantIdAndEntityId(TenantId tenantId, EntityId entityId);
@@ -95,4 +95,5 @@ public interface EntityViewService extends EntityDaoService {
     PageData<EntityView> findEntityViewsByTenantIdAndEdgeId(TenantId tenantId, EdgeId edgeId, PageLink pageLink);
 
     PageData<EntityView> findEntityViewsByTenantIdAndEdgeIdAndType(TenantId tenantId, EdgeId edgeId, String type, PageLink pageLink);
+
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbAbstractGetEntityDataNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbAbstractGetEntityDataNode.java
@@ -58,15 +58,9 @@ public abstract class TbAbstractGetEntityDataNode<T extends EntityId> extends Tb
     protected void processDataAndTell(TbContext ctx, TbMsg msg, T entityId, ObjectNode msgDataAsJsonNode) {
         DataToFetch dataToFetch = config.getDataToFetch();
         switch (dataToFetch) {
-            case ATTRIBUTES:
-                processAttributesKvEntryData(ctx, msg, entityId, msgDataAsJsonNode);
-                break;
-            case LATEST_TELEMETRY:
-                processTsKvEntryData(ctx, msg, entityId, msgDataAsJsonNode);
-                break;
-            case FIELDS:
-                processFieldsData(ctx, msg, entityId, msgDataAsJsonNode, true);
-                break;
+            case ATTRIBUTES -> processAttributesKvEntryData(ctx, msg, entityId, msgDataAsJsonNode);
+            case LATEST_TELEMETRY -> processTsKvEntryData(ctx, msg, entityId, msgDataAsJsonNode);
+            case FIELDS -> processFieldsData(ctx, msg, entityId, msgDataAsJsonNode, true);
         }
     }
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbAbstractNodeWithFetchTo.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbAbstractNodeWithFetchTo.java
@@ -17,8 +17,7 @@ package org.thingsboard.rule.engine.metadata;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.util.concurrent.AsyncFunction;
-import com.google.common.util.concurrent.Futures;
+import com.google.common.base.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.rule.engine.api.TbContext;
@@ -54,12 +53,12 @@ public abstract class TbAbstractNodeWithFetchTo<C extends TbAbstractFetchToNodeC
 
     protected abstract C loadNodeConfiguration(TbNodeConfiguration configuration) throws TbNodeException;
 
-    protected <I extends EntityId> AsyncFunction<I, I> checkIfEntityIsPresentOrThrow(String message) {
+    protected <I extends EntityId> Function<I, I> checkIfEntityIsPresentOrThrow(String message) {
         return id -> {
             if (id == null || id.isNullUid()) {
-                return Futures.immediateFailedFuture(new NoSuchElementException(message));
+                throw new NoSuchElementException(message);
             }
-            return Futures.immediateFuture(id);
+            return id;
         };
     }
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbGetCustomerAttributeNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbGetCustomerAttributeNode.java
@@ -18,6 +18,7 @@ package org.thingsboard.rule.engine.metadata;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import lombok.extern.slf4j.Slf4j;
 import org.thingsboard.rule.engine.api.RuleNode;
 import org.thingsboard.rule.engine.api.TbContext;
@@ -56,9 +57,9 @@ public class TbGetCustomerAttributeNode extends TbAbstractGetEntityDataNode<Cust
 
     @Override
     protected ListenableFuture<CustomerId> findEntityAsync(TbContext ctx, EntityId originator) {
-        return Futures.transformAsync(EntitiesCustomerIdAsyncLoader.findEntityIdAsync(ctx, originator),
+        return Futures.transform(EntitiesCustomerIdAsyncLoader.findEntityCustomerIdAsync(ctx, originator),
                 checkIfEntityIsPresentOrThrow(String.format(CUSTOMER_NOT_FOUND_MESSAGE, originator.getId(), originator.getEntityType().getNormalName())),
-                ctx.getDbCallbackExecutor()
+                MoreExecutors.directExecutor()
         );
     }
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbGetDeviceAttrNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbGetDeviceAttrNode.java
@@ -54,7 +54,7 @@ public class TbGetDeviceAttrNode extends TbAbstractGetAttributesNode<TbGetDevice
 
     @Override
     protected ListenableFuture<DeviceId> findEntityIdAsync(TbContext ctx, TbMsg msg) {
-        return Futures.transformAsync(
+        return Futures.transform(
                 EntitiesRelatedDeviceIdAsyncLoader.findDeviceAsync(ctx, msg.getOriginator(), config.getDeviceRelationsQuery()),
                 checkIfEntityIsPresentOrThrow(RELATED_DEVICE_NOT_FOUND_MESSAGE),
                 ctx.getDbCallbackExecutor());

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbGetRelatedAttributeNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbGetRelatedAttributeNode.java
@@ -58,7 +58,7 @@ public class TbGetRelatedAttributeNode extends TbAbstractGetEntityDataNode<Entit
     @Override
     public ListenableFuture<EntityId> findEntityAsync(TbContext ctx, EntityId originator) {
         var relatedAttrConfig = (TbGetRelatedDataNodeConfiguration) config;
-        return Futures.transformAsync(
+        return Futures.transform(
                 EntitiesRelatedEntityIdAsyncLoader.findEntityAsync(ctx, originator, relatedAttrConfig.getRelationsQuery()),
                 checkIfEntityIsPresentOrThrow(RELATED_ENTITY_NOT_FOUND_MESSAGE),
                 ctx.getDbCallbackExecutor());

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/transform/TbChangeOriginatorNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/transform/TbChangeOriginatorNode.java
@@ -80,7 +80,7 @@ public class TbChangeOriginatorNode extends TbAbstractTransformNode<TbChangeOrig
     private ListenableFuture<? extends EntityId> getNewOriginator(TbContext ctx, TbMsg msg) {
         switch (config.getOriginatorSource()) {
             case CUSTOMER:
-                return EntitiesCustomerIdAsyncLoader.findEntityIdAsync(ctx, msg.getOriginator());
+                return EntitiesCustomerIdAsyncLoader.findEntityCustomerIdAsync(ctx, msg.getOriginator());
             case TENANT:
                 return Futures.immediateFuture(ctx.getTenantId());
             case RELATED:

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/TestDbCallbackExecutor.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/TestDbCallbackExecutor.java
@@ -28,7 +28,7 @@ public class TestDbCallbackExecutor implements ListeningExecutor {
         try {
             return Futures.immediateFuture(task.call());
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            return Futures.immediateFailedFuture(e);
         }
     }
 


### PR DESCRIPTION
Previously, "customer attributes" node did not support entity views and edges as originator even though they can be owned by customers.