### PR TITLE
KafkaEdgeGrpcSession - improvements for stability during rollout restart of force restart of tb-core services

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/KafkaEdgeGrpcSession.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/KafkaEdgeGrpcSession.java
@@ -72,31 +72,36 @@ public class KafkaEdgeGrpcSession extends EdgeGrpcSession {
     }
 
     private void processMsgs(List<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> msgs, TbQueueConsumer<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> consumer) {
-        log.trace("[{}][{}] starting processing edge events", tenantId, sessionId);
-        if (isConnected() && !isSyncInProgress() && !isHighPriorityProcessing) {
-            List<EdgeEvent> edgeEvents = new ArrayList<>();
-            for (TbProtoQueueMsg<ToEdgeEventNotificationMsg> msg : msgs) {
-                EdgeEvent edgeEvent = ProtoUtils.fromProto(msg.getValue().getEdgeEventMsg());
-                edgeEvents.add(edgeEvent);
+        log.trace("[{}][{}][{}] starting processing edge events", tenantId, sessionId, edge.getId());
+        if (!isConnected()) {
+            log.debug("[{}][{}][{}] edge is not connected. Skipping iteration", tenantId, sessionId, edge.getId());
+            return;
+        }
+        if (isSyncInProgress() || isHighPriorityProcessing) {
+            log.debug("[{}][{}][{}] edge sync is not completed or high priority processing in progress, sync in progress = {}, high priority in progress = {}. Skipping iteration",
+                    tenantId, sessionId, edge.getId(), isSyncInProgress(), isHighPriorityProcessing);
+            return;
+        }
+        List<EdgeEvent> edgeEvents = new ArrayList<>();
+        for (TbProtoQueueMsg<ToEdgeEventNotificationMsg> msg : msgs) {
+            EdgeEvent edgeEvent = ProtoUtils.fromProto(msg.getValue().getEdgeEventMsg());
+            edgeEvents.add(edgeEvent);
+        }
+        List<DownlinkMsg> downlinkMsgsPack = convertToDownlinkMsgsPack(edgeEvents);
+        try {
+            boolean isInterrupted = sendDownlinkMsgsPack(downlinkMsgsPack).get();
+            if (isInterrupted) {
+                log.debug("[{}][{}][{}] Send downlink messages task was interrupted", tenantId, edge.getId(), sessionId);
+            } else {
+                consumer.commit();
             }
-            List<DownlinkMsg> downlinkMsgsPack = convertToDownlinkMsgsPack(edgeEvents);
-            try {
-                boolean isInterrupted = sendDownlinkMsgsPack(downlinkMsgsPack).get();
-                if (isInterrupted) {
-                    log.debug("[{}][{}][{}] Send downlink messages task was interrupted", tenantId, edge.getId(), sessionId);
-                } else {
-                    consumer.commit();
-                }
-            } catch (Exception e) {
-                log.error("[{}] Failed to process all downlink messages", sessionId, e);
-            }
-        } else {
-            try {
-                Thread.sleep(ctx.getEdgeEventStorageSettings().getNoRecordsSleepInterval());
-            } catch (InterruptedException interruptedException) {
-                log.trace("Failed to wait until the server has capacity to handle new requests", interruptedException);
-            }
-            log.trace("[{}][{}] edge is not connected or sync is not completed. Skipping iteration", tenantId, sessionId);
+        } catch (Exception e) {
+            log.error("[{}][{}] Failed to process all downlink messages", sessionId, edge.getId(), e);
+        }
+        try {
+            Thread.sleep(ctx.getEdgeEventStorageSettings().getNoRecordsSleepInterval());
+        } catch (InterruptedException interruptedException) {
+            log.trace("[{}][{}][{}] Failed to wait until the server has capacity to handle new requests", tenantId, sessionId, edge.getId(), interruptedException);
         }
     }
 
@@ -108,17 +113,22 @@ public class KafkaEdgeGrpcSession extends EdgeGrpcSession {
     @Override
     public ListenableFuture<Boolean> processEdgeEvents() {
         if (consumer == null) {
-            this.consumerExecutor = Executors.newSingleThreadExecutor(ThingsBoardThreadFactory.forName("edge-event-consumer"));
-            this.consumer = QueueConsumerManager.<TbProtoQueueMsg<ToEdgeEventNotificationMsg>>builder()
-                    .name("TB Edge events")
-                    .msgPackProcessor(this::processMsgs)
-                    .pollInterval(ctx.getEdgeEventStorageSettings().getNoRecordsSleepInterval())
-                    .consumerCreator(() -> tbCoreQueueFactory.createEdgeEventMsgConsumer(tenantId, edge.getId()))
-                    .consumerExecutor(consumerExecutor)
-                    .threadPrefix("edge-events")
-                    .build();
-            consumer.subscribe();
-            consumer.launch();
+            try {
+                this.consumerExecutor = Executors.newSingleThreadExecutor(ThingsBoardThreadFactory.forName("edge-event-consumer"));
+                this.consumer = QueueConsumerManager.<TbProtoQueueMsg<ToEdgeEventNotificationMsg>>builder()
+                        .name("TB Edge events [" + edge.getId() + "]")
+                        .msgPackProcessor(this::processMsgs)
+                        .pollInterval(ctx.getEdgeEventStorageSettings().getNoRecordsSleepInterval())
+                        .consumerCreator(() -> tbCoreQueueFactory.createEdgeEventMsgConsumer(tenantId, edge.getId()))
+                        .consumerExecutor(consumerExecutor)
+                        .threadPrefix("edge-events-" + edge.getId())
+                        .build();
+                consumer.subscribe();
+                consumer.launch();
+            } catch (Exception e) {
+                destroy();
+                log.warn("[{}][{}] Failed to start edge event consumer", sessionId, edge.getId(), e);
+            }
         }
         return Futures.immediateFuture(Boolean.FALSE);
     }
@@ -132,8 +142,16 @@ public class KafkaEdgeGrpcSession extends EdgeGrpcSession {
 
     @Override
     public void destroy() {
-        consumer.stop();
-        consumerExecutor.shutdown();
+        try {
+            if (consumer != null) {
+                consumer.stop();
+            }
+        } finally {
+            consumer = null;
+        }
+        if (consumerExecutor != null) {
+            consumerExecutor.shutdown();
+        }
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessor.java
@@ -164,7 +164,7 @@ public abstract class BaseEdgeProcessor implements EdgeProcessor {
                 futures.add(saveEdgeEvent(edge.getTenantId(), edge.getId(), type, actionType, entityId, body, false));
             }
         } else {
-            futures = processActionForAllEdgesByTenantId(tenantId, type, actionType, entityId, null, sourceEdgeId);
+            futures = processActionForAllEdgesByTenantId(tenantId, type, actionType, entityId, body, sourceEdgeId);
         }
         return Futures.transform(Futures.allAsList(futures), voids -> null, dbCallbackExecutorService);
     }


### PR DESCRIPTION
## Pull Request description

During the restart of tb-core, there was an issue where the edge consumer did not start correctly, leading to an incorrect state. Consequently, while the consumer is running on one tb-core instance, the edge is connected to another instance and is not receiving any messages.

This pull request includes fixes to ensure the correct state for the consumer (set it to null). Additionally, it introduces a check to stop the consumer if the edge is not connected to the current tb-core instance.
## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



