### PR TITLE
Fix wrong tooltip percentage value on doughnut latest-chart widget

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/chart/latest-chart.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/chart/latest-chart.ts
@@ -261,6 +261,12 @@ export abstract class TbLatestChart<S extends LatestChartSettings> {
     }
   }
 
+  private latestChartTooltipFormatter(params: CallbackDataParams): null | HTMLElement {
+    if (params.seriesType == 'pie' && this.dataItems.length != this.latestChartOption.series[0].data.length)
+      params.percent = undefined;
+    return latestChartTooltipFormatter(this.renderer, this.settings, params, this.units, this.total, this.dataItems);
+  }
+
   private drawChart() {
     echartsModule.init();
     this.renderer.setStyle(this.chartElement, 'letterSpacing', 'normal');
@@ -275,7 +281,7 @@ export abstract class TbLatestChart<S extends LatestChartSettings> {
         confine: true,
         formatter: (params: CallbackDataParams) =>
           this.settings.showTooltip
-            ? latestChartTooltipFormatter(this.renderer, this.settings, params, this.units, this.total, this.dataItems)
+            ? this.latestChartTooltipFormatter(params)
             : undefined,
         padding: [4, 8],
         backgroundColor: this.settings.tooltipBackgroundColor,


### PR DESCRIPTION
## Pull Request description

This PR fixes wrong doughnut chart tooltip value when percentage mode is selected. The wron value is due to 'fake' series data with 1% value added to doughnut echart just to insert a little space between doughnut segments.
The fix remove the percentage value computed by echart (that includes fake data) before triggering the tooltip formatter function in order to compute percentage as value / total ratio

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



