### PR TITLE
Fix queue prefix usage

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edqs/KafkaEdqsSyncService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edqs/KafkaEdqsSyncService.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.service.edqs;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Service;
 import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
+import org.thingsboard.server.queue.discovery.TopicService;
 import org.thingsboard.server.queue.edqs.EdqsConfig;
 import org.thingsboard.server.queue.kafka.TbKafkaAdmin;
 import org.thingsboard.server.queue.kafka.TbKafkaSettings;
@@ -32,11 +33,11 @@ public class KafkaEdqsSyncService extends EdqsSyncService {
 
     private final boolean syncNeeded;
 
-    public KafkaEdqsSyncService(TbKafkaSettings kafkaSettings, EdqsConfig edqsConfig) {
+    public KafkaEdqsSyncService(TbKafkaSettings kafkaSettings, TopicService topicService, EdqsConfig edqsConfig) {
         TbKafkaAdmin kafkaAdmin = new TbKafkaAdmin(kafkaSettings, Collections.emptyMap());
         this.syncNeeded = kafkaAdmin.areAllTopicsEmpty(IntStream.range(0, edqsConfig.getPartitions())
                 .mapToObj(partition -> TopicPartitionInfo.builder()
-                        .topic(edqsConfig.getEventsTopic())
+                        .topic(topicService.buildTopicName(edqsConfig.getEventsTopic()))
                         .partition(partition)
                         .build().getFullTopicName())
                 .collect(Collectors.toSet()));

--- a/common/edqs/src/main/java/org/thingsboard/server/edqs/state/KafkaEdqsStateService.java
+++ b/common/edqs/src/main/java/org/thingsboard/server/edqs/state/KafkaEdqsStateService.java
@@ -36,6 +36,7 @@ import org.thingsboard.server.queue.common.consumer.QueueConsumerManager;
 import org.thingsboard.server.queue.common.state.KafkaQueueStateService;
 import org.thingsboard.server.queue.common.state.QueueStateService;
 import org.thingsboard.server.queue.discovery.QueueKey;
+import org.thingsboard.server.queue.discovery.TopicService;
 import org.thingsboard.server.queue.edqs.EdqsConfig;
 import org.thingsboard.server.queue.edqs.KafkaEdqsComponent;
 import org.thingsboard.server.queue.edqs.KafkaEdqsQueueFactory;
@@ -59,6 +60,7 @@ public class KafkaEdqsStateService implements EdqsStateService {
     private final EdqsConfig config;
     private final EdqsPartitionService partitionService;
     private final KafkaEdqsQueueFactory queueFactory;
+    private final TopicService topicService;
     @Autowired
     @Lazy
     private EdqsProcessor edqsProcessor;
@@ -78,7 +80,7 @@ public class KafkaEdqsStateService implements EdqsStateService {
         TbKafkaAdmin queueAdmin = queueFactory.getEdqsQueueAdmin();
         stateConsumer = PartitionedQueueConsumerManager.<TbProtoQueueMsg<ToEdqsMsg>>create()
                 .queueKey(new QueueKey(ServiceType.EDQS, config.getStateTopic()))
-                .topic(config.getStateTopic())
+                .topic(topicService.buildTopicName(config.getStateTopic()))
                 .pollInterval(config.getPollInterval())
                 .msgPackProcessor((msgs, consumer, config) -> {
                     for (TbProtoQueueMsg<ToEdqsMsg> queueMsg : msgs) {
@@ -176,7 +178,7 @@ public class KafkaEdqsStateService implements EdqsStateService {
         if (queueStateService.getPartitions().isEmpty()) {
             Set<TopicPartitionInfo> allPartitions = IntStream.range(0, config.getPartitions())
                     .mapToObj(partition -> TopicPartitionInfo.builder()
-                            .topic(config.getEventsTopic())
+                            .topic(topicService.buildTopicName(config.getEventsTopic()))
                             .partition(partition)
                             .build())
                     .collect(Collectors.toSet());

--- a/common/queue/src/main/java/org/thingsboard/server/queue/discovery/HashPartitionService.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/discovery/HashPartitionService.java
@@ -156,7 +156,7 @@ public class HashPartitionService implements PartitionService {
 
     @Override
     public String getTopic(QueueKey queueKey) {
-        return partitionTopicsMap.get(queueKey);
+        return topicService.buildTopicName(partitionTopicsMap.get(queueKey));
     }
 
     private void doInitRuleEnginePartitions() {

--- a/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaAdmin.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaAdmin.java
@@ -136,6 +136,9 @@ public class TbKafkaAdmin implements TbQueueAdmin, TbEdgeQueueAdmin {
     }
 
     public CreateTopicsResult createTopic(NewTopic topic) {
+        if (!topic.name().startsWith("test.")) { // FIXME: remove me
+            log.error("Creating topic without configured prefix: {}", topic.name(), new RuntimeException("stacktrace"));
+        }
         return settings.getAdminClient().createTopics(Collections.singletonList(topic));
     }
 

--- a/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/ContainerTestSuite.java
+++ b/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/ContainerTestSuite.java
@@ -130,6 +130,7 @@ public class ContainerTestSuite {
 
             Map<String, String> queueEnv = new HashMap<>();
             queueEnv.put("TB_QUEUE_TYPE", QUEUE_TYPE);
+            queueEnv.put("TB_QUEUE_PREFIX", "test");
             switch (QUEUE_TYPE) {
                 case "kafka":
                     composeFiles.add(new File(targetDir + "docker-compose.kafka.yml"));


### PR DESCRIPTION
## Pull Request description

Put your PR description here instead of this sentence.   

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



