### PR TITLE
TimescaleDB Compression in ThingsBoard

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -389,6 +389,12 @@ sql:
     # Specify Interval size for new data chunks storage.
     chunk_time_interval: "${SQL_TIMESCALE_CHUNK_TIME_INTERVAL:604800000}"
     batch_threads: "${SQL_TIMESCALE_BATCH_THREADS:3}" # batch thread count has to be a prime number like 3 or 5 to gain perfect hash distribution
+    # Enable/disable compression for timeseries data
+    compression_enabled: "${SQL_TIMESCALE_COMPRESSION_ENABLED:true}"
+    # Compression schedule interval in milliseconds (default: 7 days)
+    compression_schedule_interval: "${SQL_TIMESCALE_COMPRESSION_SCHEDULE_INTERVAL:604800000}"
+    # Compression policy for timeseries data (default: 30 days)
+    compression_policy_days: "${SQL_TIMESCALE_COMPRESSION_POLICY_DAYS:30}"
   ttl:
     ts:
       # Enable/disable TTL (Time To Live) for timeseries records


### PR DESCRIPTION
## Pull Request description

# TimescaleDB Compression in ThingsBoard

## Overview

This document describes the implementation of TimescaleDB compression for timeseries data in ThingsBoard. TimescaleDB compression is a feature that significantly reduces the storage footprint of timeseries data while maintaining query performance.

## What is TimescaleDB Compression?

TimescaleDB compression is a native compression feature provided by TimescaleDB that automatically compresses older chunks of data in a hypertable. This compression:

- Reduces disk space usage by up to 95%
- Maintains query performance on compressed data
- Operates automatically based on configured policies
- Compresses data that is older than a specified time interval

## Implementation in ThingsBoard

ThingsBoard has implemented TimescaleDB compression for the `ts_kv` table, which stores all timeseries data. The implementation includes:

1. Creating a hypertable for the `ts_kv` table with a configurable chunk time interval
2. Enabling compression on the hypertable
3. Setting up a compression policy with configurable parameters:
   - Age threshold for when data should be compressed (in days)
   - Schedule interval for how often the compression job should run

## Configuration Parameters

The following configuration parameters are available in `thingsboard.yml`:

```yaml
sql:
  timescale:
    # Specify Interval size for new data chunks storage (in milliseconds)
    chunk_time_interval: "${SQL_TIMESCALE_CHUNK_TIME_INTERVAL:604800000}"  # Default: 7 days
    batch_threads: "${SQL_TIMESCALE_BATCH_THREADS:3}"  # Batch thread count (should be a prime number)
    # Enable/disable compression for timeseries data
    compression_enabled: "${SQL_TIMESCALE_COMPRESSION_ENABLED:true}"
    # Compression schedule interval in milliseconds
    compression_schedule_interval: "${SQL_TIMESCALE_COMPRESSION_SCHEDULE_INTERVAL:604800000}"  # Default: 7 days
    # Compression policy for timeseries data (in days)
    compression_policy_days: "${SQL_TIMESCALE_COMPRESSION_POLICY_DAYS:30}"  # Default: 30 days
```

### Parameter Details

- **chunk_time_interval**: Defines the size of chunks in the hypertable. Smaller chunks can improve query performance but may increase overhead.
- **batch_threads**: Number of threads used for batch operations.
- **compression_enabled**: Enables or disables the compression feature.
- **compression_schedule_interval**: How often the compression job runs (in milliseconds).
- **compression_policy_days**: Age threshold for data to be compressed (in days).

## How It Works

When ThingsBoard starts with TimescaleDB as the database type for timeseries data, the following process occurs:

1. The `TimescaleTsDatabaseSchemaService` creates the database schema and converts the `ts_kv` table to a hypertable.
2. If compression is enabled, it:
   - Enables compression on the hypertable with `ALTER TABLE ts_kv SET (timescaledb.compress = true);`
   - Sets up a compression policy to compress data older than the specified number of days
   - Configures how often the compression job should run

The compression job runs automatically according to the schedule interval, compressing data that is older than the policy threshold.

## Benefits

Using TimescaleDB compression in ThingsBoard provides several benefits:

1. **Reduced Storage Costs**: Significantly reduces the amount of disk space required for storing timeseries data.
2. **Improved Performance**: Can improve query performance by reducing I/O operations.
3. **Automatic Management**: Once configured, compression runs automatically without manual intervention.
4. **Configurable Policies**: Allows fine-tuning of when data is compressed and how often compression jobs run.

## Monitoring

You can monitor the compression status and effectiveness using TimescaleDB's built-in functions:

```sql
-- Check compression status
SELECT * FROM timescaledb_information.compression_settings;

-- Check compression stats
SELECT * FROM hypertable_compression_stats('ts_kv');
```

## Conclusion

TimescaleDB compression provides an efficient way to manage the storage of timeseries data in ThingsBoard. By compressing older data, it reduces storage costs while maintaining query performance, making it an ideal solution for IoT applications that generate large volumes of timeseries data.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



