### PR TITLE
Docker file improvements

### DIFF
--- a/msa/tb-node/docker/Dockerfile
+++ b/msa/tb-node/docker/Dockerfile
@@ -16,12 +16,14 @@
 
 FROM thingsboard/openjdk17:bookworm-slim
 
-COPY start-tb-node.sh ${pkg.name}.deb /tmp/
+COPY logback.xml start-tb-node.sh ${pkg.name}.deb /tmp/
 
 RUN chmod a+x /tmp/*.sh \
     && mv /tmp/start-tb-node.sh /usr/bin && \
     (yes | dpkg -i /tmp/${pkg.name}.deb) && \
     rm /tmp/${pkg.name}.deb && \
+    mv /tmp/logback.xml ${pkg.installFolder}/conf && \
+    chown -R ${pkg.user}:${pkg.user} ${pkg.installFolder}/conf/logback.xml && \
     (systemctl --no-reload disable --now ${pkg.name}.service > /dev/null 2>&1 || :) && \
     chown -R ${pkg.user}:${pkg.user} /tmp && \
     chmod 555 ${pkg.installFolder}/bin/${pkg.name}.jar

--- a/msa/tb-node/docker/logback.xml
+++ b/msa/tb-node/docker/logback.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright © 2016-2025 The Thingsboard Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE configuration>
+<configuration scan="true" scanPeriod="10 seconds">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.thingsboard.server" level="INFO" />
+    <logger name="com.google.common.util.concurrent.AggregateFuture" level="OFF" />
+    <logger name="org.apache.kafka.common.utils.AppInfoParser" level="WARN"/>
+    <logger name="org.apache.kafka.clients" level="WARN"/>
+    <logger name="com.microsoft.azure.servicebus.primitives.CoreMessageReceiver" level="OFF" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/msa/tb-node/docker/start-tb-node.sh
+++ b/msa/tb-node/docker/start-tb-node.sh
@@ -15,14 +15,21 @@
 # limitations under the License.
 #
 
-CONF_FOLDER="/config"
 jarfile=${pkg.installFolder}/bin/${pkg.name}.jar
 configfile=${pkg.name}.conf
 run_user=${pkg.user}
 
-source "${CONF_FOLDER}/${configfile}"
+CONF_FOLDER="/config"
+if [ -d "${CONF_FOLDER}" ]; then
+  LOGGING_CONFIG="${CONF_FOLDER}/logback.xml"
+  source "${CONF_FOLDER}/${configfile}"
+  export LOADER_PATH=${CONF_FOLDER},${LOADER_PATH}
+else
+  CONF_FOLDER="/usr/share/${pkg.name}/conf"
+  LOGGING_CONFIG="/usr/share/${pkg.name}/conf/logback.xml"
+  source "${CONF_FOLDER}/${configfile}"
+fi
 
-export LOADER_PATH=/config,${LOADER_PATH}
 
 cd ${pkg.installFolder}/bin
 
@@ -38,7 +45,6 @@ if [ "$INSTALL_TB" == "true" ]; then
 
     exec java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardInstallApplication \
                         -Dinstall.load_demo=${loadDemo} \
-                        -Dspring.jpa.hibernate.ddl-auto=none \
                         -Dinstall.upgrade=false \
                         -Dlogging.config=/usr/share/thingsboard/bin/install/logback.xml \
                         org.springframework.boot.loader.launch.PropertiesLauncher
@@ -51,7 +57,6 @@ elif [ "$UPGRADE_TB" == "true" ]; then
     fromVersion="${FROM_VERSION// }"
 
     exec java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardInstallApplication \
-                    -Dspring.jpa.hibernate.ddl-auto=none \
                     -Dinstall.upgrade=true \
                     -Dinstall.upgrade.from_version=${fromVersion} \
                     -Dlogging.config=/usr/share/thingsboard/bin/install/logback.xml \
@@ -62,8 +67,7 @@ else
     echo "Starting '${project.name}' ..."
 
     exec java -cp ${jarfile} $JAVA_OPTS -Dloader.main=org.thingsboard.server.ThingsboardServerApplication \
-                        -Dspring.jpa.hibernate.ddl-auto=none \
-                        -Dlogging.config=/config/logback.xml \
+                        -Dlogging.config=${LOGGING_CONFIG} \
                         org.springframework.boot.loader.launch.PropertiesLauncher
 
 fi


### PR DESCRIPTION
Docker file improvements to support installation **without mounting the configuration folder**. The idea is to simplify the installation instruction and avoid using the 'tb-posgres':

Contains correct built-in logback.xml to avoid spamming to file system.

Example of usage:

```
services:
  postgres:
    restart: always
    image: "postgres:16"
    ports:
      - "5432"
    environment:
      POSTGRES_DB: thingsboard
      POSTGRES_PASSWORD: postgres
    volumes:
      - postgres-data:/var/lib/postgresql/data
  thingsboard-ce:
    restart: always
    image: "thingsboard/tb-node:4.0.1"
    ports:
      - "8080:8080"
      - "7070"
      - "1883"
      - "5683-5688:5683-5688/udp"
    logging:
      driver: "json-file"
      options:
        max-size: "100m"
        max-file: "10"
    environment:
      TB_SERVICE_ID: tb-ce-node
      EDGES_ENABLED: "true"
      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/thingsboard
    depends_on:
      - postgres

volumes:
  postgres-data:
    name: tb-ce-postgres-data
```

To install the DB, first launch the command:

```
docker compose run --rm -e INSTALL_TB=true -e LOAD_DEMO=true thingsboard-ce
```

Then, simply launch the app:

```
docker compose up -d && docker compose logs -f
```
