### PR TITLE
Make last day selection default in Range (Time window History)

### DIFF
--- a/ui-ngx/src/app/shared/components/time/timewindow-panel.component.ts
+++ b/ui-ngx/src/app/shared/components/time/timewindow-panel.component.ts
@@ -294,7 +294,8 @@ export class TimewindowPanelComponent extends PageComponent implements OnInit, O
           disabled: hideAggInterval
         }],
         fixedTimewindow: [{
-          value: isDefined(history?.fixedTimewindow) ? history.fixedTimewindow : null,
+          value: isDefined(history?.fixedTimewindow) && this.timewindow.selectedTab === TimewindowType.HISTORY
+            && history.historyType === HistoryWindowType.FIXED ? history.fixedTimewindow : null,
           disabled: history.hideInterval || history.hideFixedInterval
         }],
         quickInterval: [{


### PR DESCRIPTION
## Pull Request description

The range previously selected by the user is not applied if the range option is not selected in the time window initially (another last/relative option selected)

History | Last option is selected
![image](https://github.com/user-attachments/assets/3ddf70a2-9d3c-469d-9dcb-1b91eed0f318)

Before:
After switching to the Range option, the dates range selected earlier in time will be applied
![image](https://github.com/user-attachments/assets/36e1ca6b-0c5f-4886-a9b7-2f3416b05f83)

After: 
After selecting the Range option, the last day interval will be applied
![image](https://github.com/user-attachments/assets/0e91dfa0-1e99-40fa-b4a1-1725e29ad8e4)


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




