### PR TITLE
EDQS - fixed relations query in case multiple previous path are present

### DIFF
--- a/common/edqs/src/main/java/org/thingsboard/server/edqs/query/processor/AbstractRelationQueryProcessor.java
+++ b/common/edqs/src/main/java/org/thingsboard/server/edqs/query/processor/AbstractRelationQueryProcessor.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.edqs.query.processor;
 
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 import org.thingsboard.server.common.data.permission.QueryContext;
 import org.thingsboard.server.common.data.query.EntityFilter;
@@ -106,7 +107,7 @@ public abstract class AbstractRelationQueryProcessor<T extends EntityFilter> ext
 
     private Set<EntityData<?>> getEntitiesSet(RelationsRepo relations) {
         Set<EntityData<?>> result = new HashSet<>();
-        Set<UUID> processed = new HashSet<>();
+        Set<RelationSearchTask> processed = new HashSet<>();
         Queue<RelationSearchTask> tasks = new LinkedList<>();
         int maxLvl = getMaxLevel() == 0 ? MAXIMUM_QUERY_LEVEL : Math.max(1, getMaxLevel());
         for (UUID uuid : getRootEntities()) {
@@ -114,7 +115,7 @@ public abstract class AbstractRelationQueryProcessor<T extends EntityFilter> ext
         }
         while (!tasks.isEmpty()) {
             RelationSearchTask task = tasks.poll();
-            if (processed.add(task.entityId)) {
+            if (processed.add(task)) {
                 var entityLvl = task.lvl + 1;
                 Set<RelationInfo> entities = EntitySearchDirection.FROM.equals(getDirection()) ? relations.getFrom(task.entityId) : relations.getTo(task.entityId);
                 if (isFetchLastLevelOnly() && entities.isEmpty() && task.previous != null && check(task.previous)) {
@@ -157,6 +158,7 @@ public abstract class AbstractRelationQueryProcessor<T extends EntityFilter> ext
     protected abstract boolean check(RelationInfo relationInfo);
 
     @RequiredArgsConstructor
+    @EqualsAndHashCode
     private static class RelationSearchTask {
         private final UUID entityId;
         private final int lvl;


### PR DESCRIPTION
## Pull Request description

🐞 Major Issue with EDQS Relations Query
There is a critical problem with how the EDQS relations query handles filtering when multiple previous paths are present and relations are filtered by name and entity type.

**Problem:**
The query currently filters results using **only one of the possible previous paths**, ignoring the rest. As a result, it fails to return the correct set of entities.

**Impact:**
This leads to an **incorrect number of related entities** being returned, which breaks expected functionality when working with complex relation graphs involving multiple paths.

**Expected:**
All valid previous paths should be considered when filtering by relation name and entity type, ensuring the returned set of entities is complete and accurate.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



