### PR TITLE
downgrade logback as the least compatible version with Spring Boot 3.2.12 is logback 1.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <jjwt.version>0.12.5</jjwt.version>
         <slf4j.version>2.0.17</slf4j.version>
         <log4j.version>2.24.3</log4j.version>
-        <logback.version>1.5.18</logback.version>
+        <logback.version>1.5.6</logback.version>
         <rat.version>0.10</rat.version> <!-- unused -->
         <cassandra.version>4.17.0</cassandra.version>
         <metrics.version>4.2.25</metrics.version>


### PR DESCRIPTION
downgrade logback as the least compatible version with Spring Boot 3.2.12 is logback 1.5.6