### PR TITLE
Patch for material autocoplete hasBackdrop

### DIFF
--- a/ui-ngx/patches/@angular+material+18.2.14.patch
+++ b/ui-ngx/patches/@angular+material+18.2.14.patch
@@ -1,0 +1,61 @@
+diff --git a/node_modules/@angular/material/autocomplete/index.d.ts b/node_modules/@angular/material/autocomplete/index.d.ts
+index 1ebc198..f572ea2 100755
+--- a/node_modules/@angular/material/autocomplete/index.d.ts
++++ b/node_modules/@angular/material/autocomplete/index.d.ts
+@@ -220,6 +220,10 @@ export declare interface MatAutocompleteDefaultOptions {
+     requireSelection?: boolean;
+     /** Class or list of classes to be applied to the autocomplete's overlay panel. */
+     overlayPanelClass?: string | string[];
++
++    backdropClass?: string;
++
++    hasBackdrop?: boolean;
+     /** Wheter icon indicators should be hidden for single-selection. */
+     hideSingleSelectionIndicator?: boolean;
+ }
+diff --git a/node_modules/@angular/material/esm2022/autocomplete/autocomplete-trigger.mjs b/node_modules/@angular/material/esm2022/autocomplete/autocomplete-trigger.mjs
+index 193f5e4..833446a 100755
+--- a/node_modules/@angular/material/esm2022/autocomplete/autocomplete-trigger.mjs
++++ b/node_modules/@angular/material/esm2022/autocomplete/autocomplete-trigger.mjs
+@@ -670,6 +670,8 @@ export class MatAutocompleteTrigger {
+             scrollStrategy: this._scrollStrategy(),
+             width: this._getPanelWidth(),
+             direction: this._dir ?? undefined,
++            hasBackdrop: this._defaults?.hasBackdrop,
++            backdropClass: this._defaults?.backdropClass,
+             panelClass: this._defaults?.overlayPanelClass,
+         });
+     }
+diff --git a/node_modules/@angular/material/esm2022/autocomplete/autocomplete.mjs b/node_modules/@angular/material/esm2022/autocomplete/autocomplete.mjs
+index 3d919a4..5fd6b4d 100755
+--- a/node_modules/@angular/material/esm2022/autocomplete/autocomplete.mjs
++++ b/node_modules/@angular/material/esm2022/autocomplete/autocomplete.mjs
+@@ -41,6 +41,7 @@ export function MAT_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY() {
+         autoSelectActiveOption: false,
+         hideSingleSelectionIndicator: false,
+         requireSelection: false,
++        hasBackdrop: false,
+     };
+ }
+ /** Autocomplete component. */
+diff --git a/node_modules/@angular/material/fesm2022/autocomplete.mjs b/node_modules/@angular/material/fesm2022/autocomplete.mjs
+index e3d0253..36cd6d7 100755
+--- a/node_modules/@angular/material/fesm2022/autocomplete.mjs
++++ b/node_modules/@angular/material/fesm2022/autocomplete.mjs
+@@ -65,6 +65,7 @@ function MAT_AUTOCOMPLETE_DEFAULT_OPTIONS_FACTORY() {
+         autoSelectActiveOption: false,
+         hideSingleSelectionIndicator: false,
+         requireSelection: false,
++        hasBackdrop: false,
+     };
+ }
+ /** Autocomplete component. */
+@@ -926,6 +927,8 @@ class MatAutocompleteTrigger {
+             scrollStrategy: this._scrollStrategy(),
+             width: this._getPanelWidth(),
+             direction: this._dir ?? undefined,
++            hasBackdrop: this._defaults?.hasBackdrop,
++            backdropClass: this._defaults?.backdropClass,
+             panelClass: this._defaults?.overlayPanelClass,
+         });
+     }

--- a/ui-ngx/src/app/shared/shared.module.ts
+++ b/ui-ngx/src/app/shared/shared.module.ts
@@ -276,6 +276,8 @@ export function MarkedOptionsFactory(markedOptionsService: MarkedOptionsService)
     {
       provide: MAT_AUTOCOMPLETE_DEFAULT_OPTIONS,
       useValue: {
+        hasBackdrop: true,
+        backdropClass: 'cdk-overlay-transparent-backdrop',
         hideSingleSelectionIndicator: true
       }
     },


### PR DESCRIPTION
## Pull Request description

Make by default hasBackdrop option for mat-autocomplete to true.

Before fix:
![image](https://github.com/user-attachments/assets/425f7141-8523-40ef-824b-4a812a4f88a8)
After fix:
![image](https://github.com/user-attachments/assets/7f64721a-daf9-4f9c-91fb-0b22f1185d8f)
Not scrolling while mat-autocomplete option is opened (behavior as mat-select).

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




