### PR TITLE
Added missing fields for RPC message in cluster mode

### DIFF
--- a/common/proto/src/main/java/org/thingsboard/server/common/util/ProtoUtils.java
+++ b/common/proto/src/main/java/org/thingsboard/server/common/util/ProtoUtils.java
@@ -522,7 +522,7 @@ public class ProtoUtils {
     }
 
     private static TransportProtos.ToDeviceRpcRequestActorMsgProto toProto(ToDeviceRpcRequestActorMsg msg) {
-        TransportProtos.ToDeviceRpcRequestMsg proto = TransportProtos.ToDeviceRpcRequestMsg.newBuilder()
+        TransportProtos.ToDeviceRpcRequestMsg.Builder builder = TransportProtos.ToDeviceRpcRequestMsg.newBuilder()
                 .setMethodName(msg.getMsg().getBody().getMethod())
                 .setParams(msg.getMsg().getBody().getParams())
                 .setExpirationTime(msg.getMsg().getExpirationTime())
@@ -530,7 +530,11 @@ public class ProtoUtils {
                 .setRequestIdLSB(msg.getMsg().getId().getLeastSignificantBits())
                 .setOneway(msg.getMsg().isOneway())
                 .setPersisted(msg.getMsg().isPersisted())
-                .build();
+                .setAdditionalInfo(msg.getMsg().getAdditionalInfo());
+        if (msg.getMsg().getRetries() != null) {
+            builder.setRetries(msg.getMsg().getRetries());
+        }
+        TransportProtos.ToDeviceRpcRequestMsg proto = builder.build();
 
         return TransportProtos.ToDeviceRpcRequestActorMsgProto.newBuilder()
                 .setTenantIdMSB(msg.getTenantId().getId().getMostSignificantBits())
@@ -551,7 +555,7 @@ public class ProtoUtils {
                 toDeviceRpcRequestMsg.getOneway(),
                 toDeviceRpcRequestMsg.getExpirationTime(),
                 new ToDeviceRpcRequestBody(toDeviceRpcRequestMsg.getMethodName(), toDeviceRpcRequestMsg.getParams()),
-                toDeviceRpcRequestMsg.getPersisted(), 0, "");
+                toDeviceRpcRequestMsg.getPersisted(), toDeviceRpcRequestMsg.hasRetries() ? toDeviceRpcRequestMsg.getRetries() : null, toDeviceRpcRequestMsg.getAdditionalInfo());
         return new ToDeviceRpcRequestActorMsg(proto.getServiceId(), toDeviceRpcRequest);
     }
 

--- a/common/proto/src/main/proto/queue.proto
+++ b/common/proto/src/main/proto/queue.proto
@@ -696,6 +696,8 @@ message ToDeviceRpcRequestMsg {
   int64 requestIdLSB = 6;
   bool oneway = 7;
   bool persisted = 8;
+  optional int32 retries = 9;
+  string additionalInfo = 10;
 }
 
 message ToDeviceRpcResponseMsg {


### PR DESCRIPTION
## Pull Request description

In cluster mode, the internal RPC notification message sent between core nodes was missing two required fields: 'additionalInfo' and 'retries'.

The 'additionalInfo' field is necessary for post-processing logic during the handling of RPC status messages (e.g., RPC_QUEUED, RPC_SENT, RPC_SUCCESSFUL, RPC_EXPIRED), and its absence resulted in null values in those messages, breaking functionality in use cases that depend on this data.

The 'retries' field is used for internal retry logic. Its omission led to a default value of 0 being applied during inter-node communication, which contradicted user expectations regarding the configured number of retry attempts for the RPC.

This fix ensures that both 'additionalInfo' and 'retries' are correctly populated when routing RPC requests between core nodes in clustered deployments.

## Explanation of the fix:

In cluster mode, the `retries` field was missing from the internode RPC notification message. As a result, it was explicitly set to 0 on the receiving node.

This caused the following logic to always treat it as 0:

```java
Integer maxRpcRetries = toDeviceRpcRequest.getRetries();
maxRpcRetries = maxRpcRetries == null ?
        systemContext.getMaxRpcRetries() : Math.min(maxRpcRetries, systemContext.getMaxRpcRetries());
```

Because retries was never null, the system default was never applied — leading to no retries being performed, even if they were expected in the original request.

In cluster mode, the `additionalInfo` field was defaulted to an empty string. However, during RPC persistence, the following code converts empty strings to null:

```java
rpc.setAdditionalInfo(JacksonUtil.toJsonNode(request.getAdditionalInfo()));
```

```java
public static JsonNode toJsonNode(String value, ObjectMapper mapper) {
    if (value == null || value.isEmpty()) {
        return null;
    }
    try {
        return mapper.readTree(value);
    } catch (IOException e) {
        throw new IllegalArgumentException(e);
    }
}
```

Which effectively meant that additionalInfo was always null in RPC status updates, even if it had a value in the original request — breaking use cases that rely on this field.

## PE

This PR doesn't have conflicts with PE version.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).