### PR TITLE
lwm2m_fix_bug_Fix incorrect ObjectId version resolution in telemetry send without observe

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/LwM2MTestClient.java
@@ -144,7 +144,7 @@ public class LwM2MTestClient {
     public void init(Security security, Security securityBs, int port, boolean isRpc,
                      LwM2mUplinkMsgHandler defaultLwM2mUplinkMsgHandler,
                      LwM2mClientContext clientContext, Integer cIdLength, boolean queueMode,
-                     boolean supportFormatOnly_SenMLJSON_SenMLCBOR) throws InvalidDDFFileException, IOException {
+                     boolean supportFormatOnly_SenMLJSON_SenMLCBOR, Integer value3_0_9) throws InvalidDDFFileException, IOException {
         Assert.assertNull("client already initialized", leshanClient);
         this.defaultLwM2mUplinkMsgHandlerTest = defaultLwM2mUplinkMsgHandler;
         this.clientContext = clientContext;
@@ -197,7 +197,7 @@ public class LwM2MTestClient {
             initializer.setInstancesForObject(SERVER, lwm2mServer);
         }
 
-        initializer.setInstancesForObject(DEVICE, lwM2MDevice = new SimpleLwM2MDevice(executor));
+        initializer.setInstancesForObject(DEVICE, lwM2MDevice = new SimpleLwM2MDevice(executor, value3_0_9));
         initializer.setInstancesForObject(FIRMWARE, fwLwM2MDevice = new FwLwM2MDevice());
         initializer.setInstancesForObject(SOFTWARE_MANAGEMENT, swLwM2MDevice = new SwLwM2MDevice());
         initializer.setClassForObject(ACCESS_CONTROL, DummyInstanceEnabler.class);

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/SimpleLwM2MDevice.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/SimpleLwM2MDevice.java
@@ -85,18 +85,22 @@ public class SimpleLwM2MDevice extends BaseInstanceEnabler implements Destroyabl
      */
     private static Map<Integer, Long> errorCode =
             Map.of(0, 0L);    // 0-32
+    private Integer value3_0_9;
 
     public SimpleLwM2MDevice() {
     }
 
-    public SimpleLwM2MDevice(ScheduledExecutorService executorService) {
+    public SimpleLwM2MDevice(ScheduledExecutorService executorService, Integer value3_0_9) {
+        this.value3_0_9 = value3_0_9;
         try {
-            executorService.scheduleWithFixedDelay(() -> {
-                        fireResourceChange(9);
-                        fireResourceChange(20);
-                    }
-                    , 1, 1, TimeUnit.SECONDS); // 2 sec
+            if ( this.value3_0_9 == null) {
+                executorService.scheduleWithFixedDelay(() -> {
+                            fireResourceChange(9);
+                            fireResourceChange(20);
+                        }
+                        , 1, 1, TimeUnit.SECONDS); // 2 sec
 //                    , 1800000, 1800000, TimeUnit.MILLISECONDS); // 30 MIN
+            }
         } catch (Throwable e) {
             log.error("[{}]Throwable", e.toString());
             e.printStackTrace();
@@ -211,8 +215,14 @@ public class SimpleLwM2MDevice extends BaseInstanceEnabler implements Destroyabl
     }
 
     private int getBatteryLevel() {
-        int valBattery = randomIterator.nextInt();
-        log.trace("Send from client [3/0/9] val: [{}]", valBattery);
+        int valBattery;
+        if (this.value3_0_9 == null) {
+            valBattery = randomIterator.nextInt();
+            log.trace("Send from client [3/0/9] val: [{}]", valBattery);
+        } else {
+            valBattery = this.value3_0_9;
+            log.warn("Send from client [3/0/9] constant value: [{}]", valBattery);
+        }
         return valBattery;
     }
 

--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationDataReceivedFromClientTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/rpc/sql/RpcLwm2mIntegrationDataReceivedFromClientTest.java
@@ -1,0 +1,16 @@
+package org.thingsboard.server.transport.lwm2m.rpc.sql;
+
+import org.junit.Test;
+import org.thingsboard.server.common.data.device.credentials.lwm2m.LwM2MDeviceCredentials;
+import org.thingsboard.server.transport.lwm2m.security.AbstractSecurityLwM2MIntegrationTest;
+
+public class RpcLwm2mIntegrationDataReceivedFromClientTest extends AbstractSecurityLwM2MIntegrationTest {
+
+    @Test
+    public void testWithNoSecConnectLwm2mSuccessAndObserveTelemetry() throws Exception {
+        String clientEndpoint = CLIENT_ENDPOINT_NO_SEC;
+        LwM2MDeviceCredentials clientCredentials = getDeviceCredentialsNoSec(createNoSecClientCredentials(clientEndpoint));
+        super.testConnectionWithoutObserveWithDataReceivedSingleTelemetry(SECURITY_NO_SEC, clientCredentials, clientEndpoint, false);
+    }
+
+}

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/DefaultLwM2mUplinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/DefaultLwM2mUplinkMsgHandler.java
@@ -383,7 +383,7 @@ public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService impl
                 LwM2mPath path = instant.getKey();
                 LwM2mNode node = instant.getValue();
                 LwM2mClient lwM2MClient = clientContext.getClientByEndpoint(registration.getEndpoint());
-                ObjectModel objectModelVersion = lwM2MClient.getObjectModel(path.toString(), modelProvider);
+                ObjectModel objectModelVersion = lwM2MClient.getObjectModel(convertObjectIdToVersionedId(path.toString(), lwM2MClient), modelProvider);
                 if (objectModelVersion != null) {
                     ResourceUpdateResult updateResource = new ResourceUpdateResult(lwM2MClient);
                     if (node instanceof LwM2mObject) {


### PR DESCRIPTION
## Pull Request description

https://thingsboard-portal.atlassian.net/browse/PROD-6472

https://thingsboard-portal.atlassian.net/browse/PROD-6508

Test case:
Path: "/3/0/9"
Value: 44 (constant), Count: 10
Data is sent from client to telemetry without observe.

Problem:
Before the fix, the version in ObjectId was always set to 1.0, regardless of the actual client model. This was caused by incorrect logic in version resolution.

Fix:
In method

```
onUpdateValueWithSendRequest(Registration registration, TimestampedLwM2mNodes data)
```

he version is now correctly resolved using

```
convertObjectIdToVersionedId(path.toString(), lwM2MClient)

```

which ensures the ObjectId version is derived from the actual LwM2M client model.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
 
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



