### PR TITLE
RPM packaging support for java-17-openjdk-headless

### DIFF
--- a/packaging/java/build.gradle
+++ b/packaging/java/build.gradle
@@ -92,7 +92,7 @@ buildRpm {
     archiveVersion = projectVersion.replace('-', '')
     archiveFileName = "${pkgName}.rpm"
 
-    requires("java-17")
+    requires("(java-17 or java-17-headless or jre-17 or jre-17-headless)") // .or() notation does work in RPM plugin
 
     from("${buildDir}/conf") {
         include "${pkgName}.conf"


### PR DESCRIPTION
## Pull Request description

RPM packaging: requires .or("java-17-openjdk").or("java-17-openjdk-headless") based on yum list available for AlmaLinux 8; Rocky Linux 8; Oracle Linux 8; RHEL Universal Base Image 8; Fedora 41

The problem to address:

```bash
rpm -Uvh /tmp/thingsboard.rpm
# error: Failed dependencies:
#       java-17 is needed by thingsboard-0:4.1.0~RC-1.noarch
```

Why headless does not work? The headless distro has different aliases with full jdk

```bash
 docker run -it --rm --name rpmtest almalinux:8 bash

dnf install java-17-openjdk-headless -y
 rpm -q --provides java-17-openjdk-headless-1:17.0.16.0.8-2.el8.aarch64
config(java-17-openjdk-headless) = 1:17.0.16.0.8-2.el8
java-17-headless = 1:17.0.16.0.8-2.el8
java-17-openjdk-headless = 1:17.0.16.0.8-2.el8
java-17-openjdk-headless(aarch-64) = 1:17.0.16.0.8-2.el8
jre-17-headless = 1:17.0.16.0.8-2.el8
jre-17-openjdk-headless = 1:17.0.16.0.8-2.el8
libsyslookup.so()(64bit)

dnf install java-17-openjdk -y
 rpm -q --provides java-17-openjdk-1:17.0.16.0.8-2.el8.aarch64
bundled(freetype) = 2.13.3
bundled(giflib) = 5.2.2
bundled(harfbuzz) = 10.4.0
bundled(lcms2) = 2.17.0
bundled(libjpeg) = 6b
bundled(libpng) = 1.6.47
bundled(zlib) = 1.3.1
java-17 = 1:17.0.16.0.8-2.el8
java-17-openjdk = 1:17.0.16.0.8-2.el8
java-17-openjdk(aarch-64) = 1:17.0.16.0.8-2.el8
jre-17 = 1:17.0.16.0.8-2.el8
jre-17-openjdk = 1:17.0.16.0.8-2.el8
```


The list available fetched from common distributions:

```
# AlmaLinux 8
docker run -it --rm almalinux:8 bash -c "yum makecache && yum list available 'java-17*'"

# Rocky Linux 8
docker run -it --rm rockylinux:8 bash -c "yum makecache && yum list available 'java-17*'"

# Oracle Linux 8
docker run -it --rm oraclelinux:8 bash -c "yum makecache && yum list available 'java-17*'"

# Fedora (41) – Fedora’s yum is a symlink to dnf under the hood
docker run -it --rm fedora:41 bash -c "yum makecache && yum list available 'java-17*'"

# RHEL Universal Base Image 8 (no login required)
docker run -it --rm registry.access.redhat.com/ubi8/ubi bash -c "yum makecache && yum list available 'java-17*'"
```

The output :

```
% docker run -it --rm almalinux:8 bash -c "yum makecache && yum list available 'java-17*'"

AlmaLinux 8 - BaseOS                                                                                                                                                                              18 MB/s |  23 MB     00:01    
AlmaLinux 8 - AppStream                                                                                                                                                                           15 MB/s |  18 MB     00:01    
AlmaLinux 8 - Extras                                                                                                                                                                              21 kB/s |  12 kB     00:00    
Metadata cache created.
Available Packages
java-17-openjdk.aarch64                                                                                             1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-demo.aarch64                                                                                        1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-devel.aarch64                                                                                       1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-headless.aarch64                                                                                    1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-javadoc.aarch64                                                                                     1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-javadoc-zip.aarch64                                                                                 1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-jmods.aarch64                                                                                       1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-src.aarch64                                                                                         1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-static-libs.aarch64                                                                                 1:17.0.16.0.8-2.el8                                                                                 appstream

docker run -it --rm rockylinux:8 bash -c "yum makecache && yum list available 'java-17*'"

Rocky Linux 8 - AppStream                                                                                                                                                                         12 MB/s |  17 MB     00:01    
Rocky Linux 8 - BaseOS                                                                                                                                                                            15 MB/s |  22 MB     00:01    
Rocky Linux 8 - Extras                                                                                                                                                                           2.5 MB/s | 942 kB     00:00    
Metadata cache created.
Available Packages
java-17-openjdk.aarch64                                                                                             1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-demo.aarch64                                                                                        1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-devel.aarch64                                                                                       1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-headless.aarch64                                                                                    1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-javadoc.aarch64                                                                                     1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-javadoc-zip.aarch64                                                                                 1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-jmods.aarch64                                                                                       1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-src.aarch64                                                                                         1:17.0.16.0.8-2.el8                                                                                 appstream
java-17-openjdk-static-libs.aarch64                                                                                 1:17.0.16.0.8-2.el8                                                                                 appstream

docker run -it --rm oraclelinux:8 bash -c "yum makecache && yum list available 'java-17*'"

Oracle Linux 8 BaseOS Latest (aarch64)                                                                                                                                                            30 MB/s | 137 MB     00:04    
Oracle Linux 8 Application Stream (aarch64)                                                                                                                                                       32 MB/s |  64 MB     00:01    
Last metadata expiration check: 0:00:08 ago on Mon Jul 21 15:09:09 2025.
Metadata cache created.
Last metadata expiration check: 0:00:11 ago on Mon Jul 21 15:09:09 2025.
Available Packages
java-17-openjdk.aarch64                                                                                         1:17.0.16.0.8-2.0.1.el8                                                                             ol8_appstream
java-17-openjdk.src                                                                                             1:17.0.16.0.8-2.0.1.el8                                                                             ol8_appstream
java-17-openjdk-demo.aarch64                                                                                    1:17.0.16.0.8-2.0.1.el8                                                                             ol8_appstream
java-17-openjdk-devel.aarch64                                                                                   1:17.0.16.0.8-2.0.1.el8                                                                             ol8_appstream
java-17-openjdk-headless.aarch64                                                                                1:17.0.16.0.8-2.0.1.el8                                                                             ol8_appstream
java-17-openjdk-javadoc.aarch64                                                                                 1:17.0.16.0.8-2.0.1.el8                                                                             ol8_appstream
java-17-openjdk-javadoc-zip.aarch64                                                                             1:17.0.16.0.8-2.0.1.el8                                                                             ol8_appstream
java-17-openjdk-jmods.aarch64                                                                                   1:17.0.16.0.8-2.0.1.el8                                                                             ol8_appstream
java-17-openjdk-src.aarch64                                                                                     1:17.0.16.0.8-2.0.1.el8                                                                             ol8_appstream
java-17-openjdk-static-libs.aarch64                                                                             1:17.0.16.0.8-2.0.1.el8                                                                             ol8_appstream

docker run -it --rm fedora:41 bash -c "yum makecache && yum list available 'java-17*'"

Updating and loading repositories:
 Fedora 41 openh264 (From Cisco) - aarch64                                                                                                                                               100% |   8.6 KiB/s |   5.8 KiB |  00m01s
 Fedora 41 - aarch64                                                                                                                                                                     100% |  21.1 MiB/s |  34.2 MiB |  00m02s
 Fedora 41 - aarch64 - Updates                                                                                                                                                           100% |   8.9 MiB/s |  10.2 MiB |  00m01s
Repositories loaded.
Metadata cache created.
Updating and loading repositories:
Repositories loaded.
Available packages
java-17-openjdk.aarch64                                1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-demo.aarch64                           1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-demo-fastdebug.aarch64                 1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-demo-slowdebug.aarch64                 1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-devel.aarch64                          1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-devel-fastdebug.aarch64                1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-devel-slowdebug.aarch64                1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-fastdebug.aarch64                      1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-headless.aarch64                       1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-headless-fastdebug.aarch64             1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-headless-slowdebug.aarch64             1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-javadoc.aarch64                        1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-javadoc-zip.aarch64                    1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-jmods.aarch64                          1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-jmods-fastdebug.aarch64                1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-jmods-slowdebug.aarch64                1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-portable.aarch64                       1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-devel.aarch64                 1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-devel-fastdebug.aarch64       1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-devel-slowdebug.aarch64       1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-docs.aarch64                  1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-fastdebug.aarch64             1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-misc.aarch64                  1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-slowdebug.aarch64             1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-sources.aarch64               1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-static-libs.aarch64           1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-static-libs-fastdebug.aarch64 1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-static-libs-slowdebug.aarch64 1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-portable-unstripped.aarch64            1:17.0.15.0.6-1.fc40 updates
java-17-openjdk-slowdebug.aarch64                      1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-src.aarch64                            1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-src-fastdebug.aarch64                  1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-src-slowdebug.aarch64                  1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-static-libs.aarch64                    1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-static-libs-fastdebug.aarch64          1:17.0.15.0.6-1.fc41 updates
java-17-openjdk-static-libs-slowdebug.aarch64          1:17.0.15.0.6-1.fc41 updates

docker run -it --rm registry.access.redhat.com/ubi8/ubi bash -c "yum makecache && yum list available 'java-17*'"

Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Red Hat Universal Base Image 8 (RPMs) - BaseOS                                                                                                                                                   2.4 MB/s | 593 kB     00:00    
Red Hat Universal Base Image 8 (RPMs) - AppStream                                                                                                                                                 16 MB/s | 3.1 MB     00:00    
Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder                                                                                                                                        1.1 MB/s | 122 kB     00:00    
Metadata cache created.
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.

Available Packages
java-17-openjdk.aarch64                                                                                      1:17.0.16.0.8-2.el8                                                                             ubi-8-appstream-rpms
java-17-openjdk-devel.aarch64                                                                                1:17.0.16.0.8-2.el8                                                                             ubi-8-appstream-rpms
java-17-openjdk-headless.aarch64                                                                             1:17.0.16.0.8-2.el8                                                                             ubi-8-appstream-rpms
java-17-openjdk-jmods.aarch64                                                                                1:17.0.16.0.8-2.el8                                                                             ubi-8-appstream-rpms

```

## Manual test

with headless

```bash
mvn clean install -DskipTests
docker run -it --rm --name rpmtest almalinux:8 bash
docker cp ./application/target/thingsboard.rpm rpmtest:/tmp/
# Successfully copied 323MB to rpmtest:/tmp/
# Follow instruction https://thingsboard.io/docs/user-guide/install/rhel/
dnf install java-17-openjdk-headless -y
java -version
# openjdk version "17.0.16" 2025-07-15 LTS
# OpenJDK Runtime Environment (Red_Hat-17.0.16.0.8-1) (build 17.0.16+8-LTS)
# OpenJDK 64-Bit Server VM (Red_Hat-17.0.16.0.8-1) (build 17.0.16+8-LTS, mixed mode, sharing)
ls -lah /tmp/thingsboard.rpm
# -rw-r--r-- 1 502 games 308M Jul 22 20:10 /tmp/thingsboard.rpm
 rpm -Uvh /tmp/thingsboard.rpm
# Verifying...                          ################################# [100%]
# Preparing...                          ################################# [100%]
# Updating / installing...
#   1:thingsboard-0:4.1.0~RC-1         ################################# [100%]
```

with jdk

```bash
docker run -it --rm --name rpmtest almalinux:8 bash
docker cp ./application/target/thingsboard.rpm rpmtest:/tmp/

dnf install java-17-openjdk -y
 ls -lah /tmp/thingsboard.rpm
-rw-r--r-- 1 502 games 308M Jul 22 21:26 /tmp/thingsboard.rpm
 rpm -Uvh /tmp/thingsboard.rpm
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:thingsboard-0:4.1.0~RC-1   
```

with no java installed

```bash
docker run -it --rm --name rpmtest almalinux:8 bash
docker cp ./application/target/thingsboard.rpm rpmtest:/tmp/

 ls -lah /tmp/thingsboard.rpm
-rw-r--r-- 1 502 games 308M Jul 22 21:26 /tmp/thingsboard.rpm

 rpm -Uvh /tmp/thingsboard.rpm
error: Failed dependencies:
        (java-17 or java-17-headless or jre-17 or jre-17-headless) is needed by thingsboard-0:4.1.0~RC-1.noarch
[root@2117bc5b9d30 /]# 

```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



