### PR TITLE
Change Stat Metrics to have static names

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/queue/TbRuleEngineConsumerStats.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/TbRuleEngineConsumerStats.java
@@ -45,6 +45,7 @@ public class TbRuleEngineConsumerStats {
     public static final String SUCCESSFUL_ITERATIONS = "successfulIterations";
     public static final String FAILED_ITERATIONS = "failedIterations";
     public static final String TENANT_ID_TAG = "tenantId";
+    public static final String QUEUE_ID_TAG = "queue";
 
     private final StatsFactory statsFactory;
 
@@ -72,16 +73,16 @@ public class TbRuleEngineConsumerStats {
         this.tenantId = queueKey.getTenantId();
         this.statsFactory = statsFactory;
 
-        String statsKey = StatsType.RULE_ENGINE.getName() + "." + queueName;
+        String statsKey = StatsType.RULE_ENGINE.getName();
         String tenant = tenantId == null || tenantId.isSysTenantId() ? "system" : tenantId.toString();
-        this.totalMsgCounter = statsFactory.createStatsCounter(statsKey, TOTAL_MSGS, TENANT_ID_TAG, tenant);
-        this.successMsgCounter = statsFactory.createStatsCounter(statsKey, SUCCESSFUL_MSGS, TENANT_ID_TAG, tenant);
-        this.timeoutMsgCounter = statsFactory.createStatsCounter(statsKey, TIMEOUT_MSGS, TENANT_ID_TAG, tenant);
-        this.failedMsgCounter = statsFactory.createStatsCounter(statsKey, FAILED_MSGS, TENANT_ID_TAG, tenant);
-        this.tmpTimeoutMsgCounter = statsFactory.createStatsCounter(statsKey, TMP_TIMEOUT, TENANT_ID_TAG, tenant);
-        this.tmpFailedMsgCounter = statsFactory.createStatsCounter(statsKey, TMP_FAILED, TENANT_ID_TAG, tenant);
-        this.successIterationsCounter = statsFactory.createStatsCounter(statsKey, SUCCESSFUL_ITERATIONS, TENANT_ID_TAG, tenant);
-        this.failedIterationsCounter = statsFactory.createStatsCounter(statsKey, FAILED_ITERATIONS, TENANT_ID_TAG, tenant);
+        this.totalMsgCounter = statsFactory.createStatsCounter(statsKey, TOTAL_MSGS, QUEUE_ID_TAG, queueName, TENANT_ID_TAG, tenant);
+        this.successMsgCounter = statsFactory.createStatsCounter(statsKey, SUCCESSFUL_MSGS, QUEUE_ID_TAG, queueName, TENANT_ID_TAG, tenant);
+        this.timeoutMsgCounter = statsFactory.createStatsCounter(statsKey, TIMEOUT_MSGS, QUEUE_ID_TAG, queueName, TENANT_ID_TAG, tenant);
+        this.failedMsgCounter = statsFactory.createStatsCounter(statsKey, FAILED_MSGS, QUEUE_ID_TAG, queueName, TENANT_ID_TAG, tenant);
+        this.tmpTimeoutMsgCounter = statsFactory.createStatsCounter(statsKey, TMP_TIMEOUT, QUEUE_ID_TAG, queueName, TENANT_ID_TAG, tenant);
+        this.tmpFailedMsgCounter = statsFactory.createStatsCounter(statsKey, TMP_FAILED, QUEUE_ID_TAG, queueName, TENANT_ID_TAG, tenant);
+        this.successIterationsCounter = statsFactory.createStatsCounter(statsKey, SUCCESSFUL_ITERATIONS, QUEUE_ID_TAG, queueName, TENANT_ID_TAG, tenant);
+        this.failedIterationsCounter = statsFactory.createStatsCounter(statsKey, FAILED_ITERATIONS, QUEUE_ID_TAG, queueName, TENANT_ID_TAG, tenant);
 
         counters.add(totalMsgCounter);
         counters.add(successMsgCounter);
@@ -96,8 +97,9 @@ public class TbRuleEngineConsumerStats {
 
     public Timer getTimer(TenantId tenantId, String status) {
         return tenantMsgProcessTimers.computeIfAbsent(tenantId,
-                id -> statsFactory.createTimer(StatsType.RULE_ENGINE.getName() + "." + queueName,
-                        "tenantId", tenantId.getId().toString(),
+                id -> statsFactory.createTimer(StatsType.RULE_ENGINE.getName(),
+                        QUEUE_ID_TAG, queueName,
+                        TENANT_ID_TAG, tenantId.getId().toString(),
                         "status", status
                 ));
     }

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -1866,6 +1866,9 @@ queue:
       print-interval-ms: "${TB_QUEUE_RULE_ENGINE_STATS_PRINT_INTERVAL_MS:60000}"
       # Max length of the error message that is printed by statistics
       max-error-message-length: "${TB_QUEUE_RULE_ENGINE_MAX_ERROR_MESSAGE_LENGTH:4096}"
+    prometheus-stats:
+      # Enables summary timers for rule_engine message processing (successful & failed)
+      enabled: "${TB_QUEUE_RULE_ENGINE_PROMETHEUS_PROCESSING_TIMING_ENABLED:false}"
     # After a queue is deleted (or the profile's isolation option was disabled), Rule Engine will continue reading related topics during this period before deleting the actual topics
     topic-deletion-delay: "${TB_QUEUE_RULE_ENGINE_TOPIC_DELETION_DELAY_SEC:15}"
     # Size of the thread pool that handles such operations as partition changes, config updates, queue deletion

--- a/common/stats/src/main/java/org/thingsboard/server/common/stats/DefaultStatsFactory.java
+++ b/common/stats/src/main/java/org/thingsboard/server/common/stats/DefaultStatsFactory.java
@@ -98,10 +98,10 @@ public class DefaultStatsFactory implements StatsFactory {
     }
 
     @Override
-    public MessagesStats createMessagesStats(String key) {
-        StatsCounter totalCounter = createStatsCounter(key, TOTAL_MSGS);
-        StatsCounter successfulCounter = createStatsCounter(key, SUCCESSFUL_MSGS);
-        StatsCounter failedCounter = createStatsCounter(key, FAILED_MSGS);
+    public MessagesStats createMessagesStats(String key, String... tags) {
+        StatsCounter totalCounter = createStatsCounter(key, TOTAL_MSGS, tags);
+        StatsCounter successfulCounter = createStatsCounter(key, SUCCESSFUL_MSGS, tags);
+        StatsCounter failedCounter = createStatsCounter(key, FAILED_MSGS, tags);
         return new DefaultMessagesStats(totalCounter, successfulCounter, failedCounter);
     }
 

--- a/common/stats/src/main/java/org/thingsboard/server/common/stats/StatsFactory.java
+++ b/common/stats/src/main/java/org/thingsboard/server/common/stats/StatsFactory.java
@@ -31,7 +31,7 @@ public interface StatsFactory {
 
     <S> void createGauge(String type, String name, S stateObject, ToDoubleFunction<S> numberProvider, String... tags);
 
-    MessagesStats createMessagesStats(String key);
+    MessagesStats createMessagesStats(String key, String... tags);
 
     Timer createTimer(String key, String... tags);
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/TbSqlBlockingQueueWrapper.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/TbSqlBlockingQueueWrapper.java
@@ -50,7 +50,7 @@ public class TbSqlBlockingQueueWrapper<E, R> {
 
     public void init(ScheduledLogExecutorComponent logExecutor, Function<List<E>, List<R>> saveFunction, Comparator<E> batchUpdateComparator, Function<List<TbSqlQueueElement<E, R>>, List<TbSqlQueueElement<E, R>>> filter) {
         for (int i = 0; i < maxThreads; i++) {
-            MessagesStats stats = statsFactory.createMessagesStats(params.getStatsNamePrefix() + ".queue." + i);
+            MessagesStats stats = statsFactory.createMessagesStats(params.getStatsNamePrefix() + ".queue", "index", String.valueOf(i));
             TbSqlBlockingQueue<E, R> queue = new TbSqlBlockingQueue<>(params, stats);
             queues.add(queue);
             queue.init(logExecutor, saveFunction, batchUpdateComparator, filter, i);

--- a/dao/src/main/java/org/thingsboard/server/dao/util/AbstractBufferedRateExecutor.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/AbstractBufferedRateExecutor.java
@@ -63,7 +63,7 @@ import java.util.regex.Matcher;
 @Slf4j
 public abstract class AbstractBufferedRateExecutor<T extends AsyncTask, F extends ListenableFuture<V>, V> implements BufferedRateExecutor<T, F> {
 
-    public static final String CONCURRENCY_LEVEL = "currBuffer";
+    public static final String BUFFER_NAME_TAG = "buffer";
 
     private final long maxWaitTime;
     private final long pollMs;
@@ -102,8 +102,8 @@ public abstract class AbstractBufferedRateExecutor<T extends AsyncTask, F extend
         this.callbackExecutor = ThingsBoardExecutors.newWorkStealingPool(callbackThreads, "nosql-" + bufferName + "-callback");
         this.timeoutExecutor = ThingsBoardExecutors.newSingleThreadScheduledExecutor("nosql-" + bufferName + "-timeout");
         this.stats = new BufferedRateExecutorStats(statsFactory);
-        String concurrencyLevelKey = StatsType.RATE_EXECUTOR.getName() + "." + CONCURRENCY_LEVEL + bufferName; //metric name may change with buffer name suffix
-        this.concurrencyLevel = statsFactory.createGauge(concurrencyLevelKey, new AtomicInteger(0));
+        String concurrencyLevelKey = StatsType.RATE_EXECUTOR.getName();
+        this.concurrencyLevel = statsFactory.createGauge(concurrencyLevelKey, new AtomicInteger(0), BUFFER_NAME_TAG, bufferName);
 
         this.entityService = entityService;
         this.rateLimitService = rateLimitService;
@@ -311,7 +311,7 @@ public abstract class AbstractBufferedRateExecutor<T extends AsyncTask, F extend
                 statsBuilder.append(counter.getName()).append(" = [").append(counter.get()).append("] ");
             });
             statsBuilder.append("totalRateLimitedTenants").append(" = [").append(rateLimitedTenantsCount).append("] ");
-            statsBuilder.append(CONCURRENCY_LEVEL).append(" = [").append(concurrencyLevel.get()).append("] ");
+            statsBuilder.append(BUFFER_NAME_TAG).append(" = [").append(concurrencyLevel.get()).append("] ");
 
             stats.getStatsCounters().forEach(StatsCounter::clear);
             log.info("[{}] Permits {}", bufferName, statsBuilder);

--- a/dao/src/main/java/org/thingsboard/server/dao/util/BufferedRateExecutorStats.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/BufferedRateExecutorStats.java
@@ -81,7 +81,7 @@ public class BufferedRateExecutorStats {
     public void incrementRateLimitedTenant(TenantId tenantId){
         rateLimitedTenants.computeIfAbsent(tenantId,
                 tId -> {
-                    String key = StatsType.RATE_EXECUTOR.getName() + ".tenant";
+                    String key = StatsType.RATE_EXECUTOR.getName() + ".ratelimited";
                     return statsFactory.createDefaultCounter(key, TENANT_ID_TAG, tId.toString());
                 }
         )

--- a/docker/monitoring/grafana/provisioning/dashboards/db_metrics.json
+++ b/docker/monitoring/grafana/provisioning/dashboards/db_metrics.json
@@ -67,31 +67,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName) (increase(attributes_queue_0_total[1m]))",
+          "expr": "sum by(statsName, index) (increase(attributes_queue_total[1m]))",
           "interval": "",
-          "legendFormat": "queue-0 {{statsName}}",
+          "legendFormat": "queue-{{index}} {{statsName}}",
           "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(attributes_queue_1_total[1m]))",
-          "interval": "",
-          "legendFormat": "queue-1 {{statsName}}",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(attributes_queue_2_total[1m]))",
-          "interval": "",
-          "legendFormat": "queue-2 {{statsName}}",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (rate(attributes_queue_3_total[1m]))",
-          "interval": "",
-          "legendFormat": "queue-3 {{statsName}}",
-          "refId": "D"
         }
       ],
       "thresholds": [],
@@ -184,34 +163,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_queue_0_total[1m]))",
+          "expr": "sum by(statsName, index) (increase(ts_queue_total[1m]))",
           "interval": "",
-          "legendFormat": "queue-0 {{statsName}}",
+          "legendFormat": "queue-{{index}} {{statsName}}",
           "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_queue_1_total[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "queue-1 {{statsName}}",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_queue_2_total[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "queue-2 {{statsName}}",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_queue_3_total[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "queue-3 {{statsName}}",
-          "refId": "D"
         }
       ],
       "thresholds": [],
@@ -304,34 +259,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_latest_queue_0_total[1m]))",
+          "expr": "sum by(statsName, index) (increase(ts_latest_queue_total[1m]))",
           "interval": "",
-          "legendFormat": "queue-0 {{statsName}}",
+          "legendFormat": "queue-{{index}} {{statsName}}",
           "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_latest_queue_1_total[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "queue-1 {{statsName}}",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_latest_queue_2_total[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "queue-2 {{statsName}}",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_latest_queue_3_total[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "queue-3 {{statsName}}",
-          "refId": "D"
         }
       ],
       "thresholds": [],

--- a/docker/monitoring/grafana/provisioning/dashboards/hybrid_db_metrics.json
+++ b/docker/monitoring/grafana/provisioning/dashboards/hybrid_db_metrics.json
@@ -67,31 +67,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName) (increase(attributes_queue_0_total[1m]))",
+          "expr": "sum by(statsName, index) (increase(attributes_queue_total[1m]))",
           "interval": "",
-          "legendFormat": "queue-0 {{statsName}}",
+          "legendFormat": "queue-{{index}} {{statsName}}",
           "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(attributes_queue_1_total[1m]))",
-          "interval": "",
-          "legendFormat": "queue-1 {{statsName}}",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(attributes_queue_2_total[1m]))",
-          "interval": "",
-          "legendFormat": "queue-2 {{statsName}}",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (rate(attributes_queue_3_total[1m]))",
-          "interval": "",
-          "legendFormat": "queue-3 {{statsName}}",
-          "refId": "D"
         }
       ],
       "thresholds": [],
@@ -372,34 +351,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_latest_queue_0_total[1m]))",
+          "expr": "sum by(statsName, index) (increase(ts_latest_queue_total[1m]))",
           "interval": "",
-          "legendFormat": "queue-0 {{statsName}}",
+          "legendFormat": "queue-{{index}} {{statsName}}",
           "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_latest_queue_1_total[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "queue-1 {{statsName}}",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_latest_queue_2_total[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "queue-2 {{statsName}}",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by(statsName) (increase(ts_latest_queue_3_total[1m]))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "queue-3 {{statsName}}",
-          "refId": "D"
         }
       ],
       "thresholds": [],

--- a/docker/monitoring/grafana/provisioning/dashboards/rule_engine_latency.json
+++ b/docker/monitoring/grafana/provisioning/dashboards/rule_engine_latency.json
@@ -67,26 +67,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by (job,quantile) (ruleEngine_Main_seconds)*1000",
+          "expr": "sum by (job, queue, quantile) (ruleEngine_seconds)*1000",
           "interval": "",
-          "legendFormat": "Main {{job}} Quantile - {{quantile}}, ms",
+          "legendFormat": "{{queue}} {{job}} Quantile - {{quantile}}, ms",
           "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by (job,quantile) (ruleEngine_HighPriority_seconds)*1000",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "HighPriority  {{job}} Quantile - {{quantile}}, ms",
-          "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "sum by (job,quantile) (ruleEngine_SequentialByOriginator_seconds)*1000",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "SequentialByOriginator  {{job}} Quantile - {{quantile}}, ms",
-          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -179,26 +163,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "ruleEngine_Main_seconds_max *1000",
+          "expr": "ruleEngine_seconds_max *1000",
           "interval": "",
-          "legendFormat": "Max - {{job}}, ms",
+          "legendFormat": "{{queue}} - {{job}}, ms",
           "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "ruleEngine_HighPriority_seconds_max *1000",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "HighPriority - {{job}}, ms",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "ruleEngine_SequentialByOriginator_seconds_max *1000",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "SequentialByOriginator - {{job}}, ms",
-          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -291,26 +259,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(increase(ruleEngine_Main_seconds_sum[1m])  / increase(ruleEngine_Main_seconds_count[1m])) * 1000",
+          "expr": "(increase(ruleEngine_seconds_sum[1m])  / increase(ruleEngine_seconds_count[1m])) * 1000",
           "interval": "",
-          "legendFormat": "Main  {{job}}",
+          "legendFormat": "{{queue}} {{job}}",
           "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "(increase(ruleEngine_HighPriority_seconds_sum[1m])  / increase(ruleEngine_HighPriority_seconds_count[1m])) * 1000",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "HighPriority {{job}}",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "(increase(ruleEngine_SequentialByOriginator_seconds_sum[1m])  / increase(ruleEngine_SequentialByOriginator_seconds_count[1m])) * 1000",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "SequentialByOriginator {{job}}",
-          "refId": "C"
         }
       ],
       "thresholds": [],

--- a/docker/monitoring/grafana/provisioning/dashboards/rule_engine_metrics.json
+++ b/docker/monitoring/grafana/provisioning/dashboards/rule_engine_metrics.json
@@ -67,7 +67,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName)(increase(ruleEngine_Main_total[1m]))",
+          "expr": "sum by(statsName)(increase(ruleEngine_total{queue=\"Main\"}[1m]))",
           "interval": "",
           "legendFormat": "{{statsName}}",
           "refId": "A"
@@ -163,7 +163,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName)(increase(ruleEngine_HighPriority_total[1m]))",
+          "expr": "sum by(statsName)(increase(ruleEngine_total{queue=\"HighPriority\"}[1m]))",
           "interval": "",
           "legendFormat": "{{statsName}}",
           "refId": "A"
@@ -259,7 +259,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName)(increase(ruleEngine_SequentialByOriginator_total[1m]))",
+          "expr": "sum by(statsName)(increase(ruleEngine_total{queue=\"SequentialByOriginator\"}[1m]))",
           "interval": "",
           "legendFormat": "{{statsName}}",
           "refId": "A"

--- a/docker/monitoring/grafana/provisioning/dashboards/single_service_metrics.json
+++ b/docker/monitoring/grafana/provisioning/dashboards/single_service_metrics.json
@@ -548,7 +548,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName)(increase(ruleEngine_Main_total{job=\"$job\"}[1m]))",
+          "expr": "sum by(statsName)(increase(ruleEngine_total{job=\"$job\", queue=\"Main\"}[1m]))",
           "interval": "",
           "legendFormat": "{{statsName}}",
           "refId": "A"
@@ -644,7 +644,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName)(increase(ruleEngine_HighPriority_total{job=\"$job\"}[1m]))",
+          "expr": "sum by(statsName)(increase(ruleEngine_total{job=\"$job\", queue=\"HighPriority\"}[1m]))",
           "interval": "",
           "legendFormat": "{{statsName}}",
           "refId": "A"
@@ -740,7 +740,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum by(statsName)(increase(ruleEngine_SequentialByOriginator_total{job=\"$job\"}[1m]))",
+          "expr": "sum by(statsName)(increase(ruleEngine_total{job=\"$job\", queue=\"SequentialByOriginator\"}[1m]))",
           "interval": "",
           "legendFormat": "{{statsName}}",
           "refId": "A"


### PR DESCRIPTION
## Pull Request description

In correspondence to #13769 this changes the metrics names themself to be static and move the dynamic part into the metric tags. Specifically
- ruleEngine metrics will now move the queue name to a tag named "queue" - `ruleEngine_Main_total` => `ruleEngine_total{queue="Main"}`
- sql queue metrics will move the thread index to a tag named "index" - `ts_queue_1_total` => `ts_queue_total{index="1"}`


Additionally:
- splits jsInvoke requests to evalRequests & invokeRequests to allow for proper % calculation without one polluting the other even if evals should be comparatively low
- renames `CONCURRENCY_LEVEL` in `AbstractBufferedRateExecutor` to `BUFFER_NAME_TAG` with corresponding value `buffer` as it never held any concurrency information
- renames `rateExecutor_tenant` to `rateExecutor_ratelimited` to make clear what information is stored in this metric. (tenant information is present in tag)
- Adds a new env var in thingsboard.yml `TB_QUEUE_RULE_ENGINE_PROMETHEUS_PROCESSING_TIMING_ENABLED` this sets the internal `queue.rule-engine.prometheus-stats.enabled` in `TbRuleEngineConsumerContext` which had no official way to configure this variable. (i've chosen a name that hopefully explains more what this setting toggles as all this does is enable the summary timers for rule engine executions)

### Notes
This will require anyone using these metrics to update their PromQL queries to match the new metric names.
I've tried updating the dashboards included in the docker/monitoring part.

What might need to be added to documentation is the new env var as it can be quite helpful to have a quantile summary of ruleEngine processings


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



