### PR TITLE
Fixed handling of RPC with missing additional info in cluster mode

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/device/DeviceActorMessageProcessor.java
@@ -270,8 +270,17 @@ public class DeviceActorMessageProcessor extends AbstractContextAwareMsgProcesso
         rpc.setExpirationTime(request.getExpirationTime());
         rpc.setRequest(JacksonUtil.valueToTree(request));
         rpc.setStatus(status);
-        rpc.setAdditionalInfo(JacksonUtil.toJsonNode(request.getAdditionalInfo()));
+        rpc.setAdditionalInfo(getAdditionalInfo(request));
         systemContext.getTbRpcService().save(tenantId, rpc);
+    }
+
+    private JsonNode getAdditionalInfo(ToDeviceRpcRequest request) {
+        try {
+            return JacksonUtil.toJsonNode(request.getAdditionalInfo());
+        } catch (IllegalArgumentException e) {
+            log.debug("Failed to parse additional info [{}]", request.getAdditionalInfo());
+            return JacksonUtil.valueToTree(request.getAdditionalInfo());
+        }
     }
 
     private ToDeviceRpcRequestMsg createToDeviceRpcRequestMsg(ToDeviceRpcRequest request) {

--- a/common/proto/src/main/java/org/thingsboard/server/common/util/ProtoUtils.java
+++ b/common/proto/src/main/java/org/thingsboard/server/common/util/ProtoUtils.java
@@ -529,8 +529,10 @@ public class ProtoUtils {
                 .setRequestIdMSB(msg.getMsg().getId().getMostSignificantBits())
                 .setRequestIdLSB(msg.getMsg().getId().getLeastSignificantBits())
                 .setOneway(msg.getMsg().isOneway())
-                .setPersisted(msg.getMsg().isPersisted())
-                .setAdditionalInfo(msg.getMsg().getAdditionalInfo());
+                .setPersisted(msg.getMsg().isPersisted());
+        if (msg.getMsg().getAdditionalInfo() != null) {
+            builder.setAdditionalInfo(msg.getMsg().getAdditionalInfo());
+        }
         if (msg.getMsg().getRetries() != null) {
             builder.setRetries(msg.getMsg().getRetries());
         }
@@ -555,7 +557,9 @@ public class ProtoUtils {
                 toDeviceRpcRequestMsg.getOneway(),
                 toDeviceRpcRequestMsg.getExpirationTime(),
                 new ToDeviceRpcRequestBody(toDeviceRpcRequestMsg.getMethodName(), toDeviceRpcRequestMsg.getParams()),
-                toDeviceRpcRequestMsg.getPersisted(), toDeviceRpcRequestMsg.hasRetries() ? toDeviceRpcRequestMsg.getRetries() : null, toDeviceRpcRequestMsg.getAdditionalInfo());
+                toDeviceRpcRequestMsg.getPersisted(),
+                toDeviceRpcRequestMsg.hasRetries() ? toDeviceRpcRequestMsg.getRetries() : null,
+                toDeviceRpcRequestMsg.hasAdditionalInfo() ? toDeviceRpcRequestMsg.getAdditionalInfo() : null);
         return new ToDeviceRpcRequestActorMsg(proto.getServiceId(), toDeviceRpcRequest);
     }
 

--- a/common/proto/src/main/proto/queue.proto
+++ b/common/proto/src/main/proto/queue.proto
@@ -699,7 +699,7 @@ message ToDeviceRpcRequestMsg {
   bool oneway = 7;
   bool persisted = 8;
   optional int32 retries = 9;
-  string additionalInfo = 10;
+  optional string additionalInfo = 10;
 }
 
 message ToDeviceRpcResponseMsg {

--- a/common/proto/src/test/java/org/thingsboard/server/common/util/ProtoUtilsTest.java
+++ b/common/proto/src/test/java/org/thingsboard/server/common/util/ProtoUtilsTest.java
@@ -21,6 +21,9 @@ import org.jeasy.random.EasyRandomParameters;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.ApiUsageState;
 import org.thingsboard.server.common.data.Device;
@@ -56,6 +59,7 @@ import org.thingsboard.server.common.data.security.DeviceCredentialsType;
 import org.thingsboard.server.common.data.sync.vc.RepositorySettings;
 import org.thingsboard.server.common.data.tenant.profile.DefaultTenantProfileConfiguration;
 import org.thingsboard.server.common.data.tenant.profile.TenantProfileConfiguration;
+import org.thingsboard.server.common.msg.ToDeviceActorNotificationMsg;
 import org.thingsboard.server.common.msg.edge.EdgeEventUpdateMsg;
 import org.thingsboard.server.common.msg.edge.EdgeHighPriorityMsg;
 import org.thingsboard.server.common.msg.edge.FromEdgeSyncResponse;
@@ -277,6 +281,67 @@ class ProtoUtilsTest {
 
     private void assertEqualDeserializedEntity(Object expected, Object actual, String entityName) {
         assertThat(actual).as(String.format(description, entityName, entityName)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"{\"key\":\"value\"}"})
+    void testRpcWithVariousAdditionalInfoToProtoAndBack(String additionalInfo) {
+        UUID requestId = UUID.fromString("93405c57-5787-46ff-806e-670bb60f49b6");
+        String methodName = "reboot";
+        String params = "";
+        String serviceId = "serviceId";
+        long expirationTime = System.currentTimeMillis();
+        int retries = 3;
+
+        ToDeviceRpcRequest request = new ToDeviceRpcRequest(
+                requestId,
+                tenantId,
+                deviceId,
+                false,
+                expirationTime,
+                new ToDeviceRpcRequestBody(methodName, params),
+                true,
+                retries,
+                additionalInfo
+        );
+        ToDeviceRpcRequestActorMsg msg = new ToDeviceRpcRequestActorMsg(serviceId, request);
+
+        // Serialize
+        TransportProtos.ToDeviceActorNotificationMsgProto toProto = ProtoUtils.toProto(msg);
+        assertThat(toProto).isNotNull();
+        assertThat(toProto.hasToDeviceRpcRequestMsg()).isTrue();
+
+        TransportProtos.ToDeviceRpcRequestActorMsgProto toDeviceRpcRequestActorMsgProto = toProto.getToDeviceRpcRequestMsg();
+        assertThat(toDeviceRpcRequestActorMsgProto.hasToDeviceRpcRequestMsg()).isTrue();
+
+        TransportProtos.ToDeviceRpcRequestMsg toDeviceRpcRequestMsg = toDeviceRpcRequestActorMsgProto.getToDeviceRpcRequestMsg();
+        assertThat(toDeviceRpcRequestMsg.getRequestIdMSB()).isEqualTo(requestId.getMostSignificantBits());
+        assertThat(toDeviceRpcRequestMsg.getRequestIdLSB()).isEqualTo(requestId.getLeastSignificantBits());
+        assertThat(toDeviceRpcRequestMsg.getMethodName()).isEqualTo(methodName);
+        assertThat(toDeviceRpcRequestMsg.getParams()).isEqualTo(params);
+        assertThat(toDeviceRpcRequestMsg.getExpirationTime()).isEqualTo(expirationTime);
+        assertThat(toDeviceRpcRequestMsg.getOneway()).isFalse();
+        assertThat(toDeviceRpcRequestMsg.getPersisted()).isTrue();
+        assertThat(toDeviceRpcRequestMsg.getRetries()).isEqualTo(retries);
+
+        if (additionalInfo != null) {
+            assertThat(toDeviceRpcRequestMsg.hasAdditionalInfo()).isTrue();
+            assertThat(toDeviceRpcRequestMsg.getAdditionalInfo()).isEqualTo(additionalInfo);
+        } else {
+            assertThat(toDeviceRpcRequestMsg.hasAdditionalInfo()).isFalse();
+        }
+
+        // Deserialize
+        ToDeviceActorNotificationMsg fromProto = ProtoUtils.fromProto(toProto);
+        assertThat(fromProto).isNotNull();
+        assertThat(fromProto).isInstanceOf(ToDeviceRpcRequestActorMsg.class);
+        ToDeviceRpcRequestActorMsg toDeviceRpcRequestActorMsg = (ToDeviceRpcRequestActorMsg) fromProto;
+
+        assertThat(toDeviceRpcRequestActorMsg.getDeviceId()).isEqualTo(deviceId);
+        assertThat(toDeviceRpcRequestActorMsg.getTenantId()).isEqualTo(tenantId);
+        assertThat(toDeviceRpcRequestActorMsg.getServiceId()).isEqualTo(serviceId);
+        assertThat(toDeviceRpcRequestActorMsg.getMsg()).isEqualTo(request);
     }
 
 }


### PR DESCRIPTION
## Pull Request description

```
java.lang.NullPointerException
    at org.thingsboard.server.gen.transport.TransportProtos$ToDeviceRpcRequestMsg$Builder.setAdditionalInfo(TransportProtos.java)
    at org.thingsboard.server.common.util.ProtoUtils.toProto(ProtoUtils.java:570)
    at org.thingsboard.server.common.util.ProtoUtils.toProto(ProtoUtils.java:679)
    at org.thingsboard.server.service.queue.DefaultTbClusterService.pushMsgToCore(DefaultTbClusterService.java:201)
    at org.thingsboard.server.service.rpc.DefaultTbRuleEngineRpcService.sendRpcRequestToDevice(DefaultTbRuleEngineRpcService.java:193)
    at org.thingsboard.server.service.rpc.DefaultTbRuleEngineRpcService.forwardRpcRequestToDeviceActor(DefaultTbRuleEngineRpcService.java:177)
    at org.thingsboard.server.service.rpc.DefaultTbRuleEngineRpcService.sendRpcRequestToDevice(DefaultTbRuleEngineRpcService.java:132)
    at jdk.internal.reflect.GeneratedMethodAccessor714.invoke(Unknown Source)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:569)
    at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:355)
    at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:216)
    at jdk.proxy2/jdk.proxy2.$Proxy408.sendRpcRequestToDevice(Unknown Source)
    at org.thingsboard.rule.engine.rpc.TbSendRPCRequestNode.onMsg(TbSendRPCRequestNode.java:131)
    at org.thingsboard.server.actors.ruleChain.RuleNodeActorMessageProcessor.onRuleChainToRuleNodeMsg(RuleNodeActorMessageProcessor.java:176)
    at org.thingsboard.server.actors.ruleChain.RuleNodeActor.onRuleChainToRuleNodeMsg(RuleNodeActor.java:117)
    at org.thingsboard.server.actors.ruleChain.RuleNodeActor.doProcess(RuleNodeActor.java:76)
    at org.thingsboard.server.actors.service.ContextAwareActor.process(ContextAwareActor.java:56)
    at org.thingsboard.server.actors.TbActorMailbox.processMailbox(TbActorMailbox.java:173)
    at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1395)
    at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
    at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
    at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
    at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
    at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

**Summary:**

Fixed a NullPointerException during serialization of RPC messages to Protobuf when the additionalInfo field is null.

**Details:**

The Protobuf setAdditionalInfo(String) method does not accept null values and throws a NullPointerException when invoked with null. To resolve this, the fix introduces a null check: additionalInfo is only set in the Protobuf builder if it is explicitly non-null.
This makes the serialization safe while preserving the optional semantics of the field.

**Usage Context:**

The additionalInfo field is used in the following scenarios:

- Persisting the RPC message – the logic for converting additionalInfo into a JsonNode is applied here. If the value is valid JSON, it is parsed into a structured node; otherwise, it is wrapped as a plain string node. This ensures safe and consistent storage regardless of input format.

- Edge-side processing – where the JsonNode is further consumed. Both null and malformed values are handled gracefully, with no risk of runtime failure.

<img width="1132" height="778" alt="image" src="https://github.com/user-attachments/assets/ba015fa1-4c5d-40ef-8282-2139501ca374" />


PE PR: https://github.com/thingsboard/thingsboard-pe/pull/3720

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



