### PR TITLE
Fixed line width for Cross connector HP SCADA symbol

### DIFF
--- a/application/src/main/data/json/system/scada_symbols/cross-connector-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/cross-connector-hp.svg
@@ -490,13 +490,13 @@
       "default": 6,
       "required": true,
       "subLabel": "Main",
-      "divider": true,
+      "divider": false,
       "fieldSuffix": "px",
-      "condition": "return model.mainLine;",
       "min": 0,
       "max": 99,
       "step": 1,
-      "disabled": false
+      "disabled": false,
+      "visible": true
     },
     {
       "id": "lineColor",

--- a/application/src/main/data/json/system/scada_symbols/cross-connector-hp.svg
+++ b/application/src/main/data/json/system/scada_symbols/cross-connector-hp.svg
@@ -489,7 +489,6 @@
       "type": "number",
       "default": 6,
       "required": true,
-      "subLabel": "Main",
       "divider": false,
       "fieldSuffix": "px",
       "min": 0,


### PR DESCRIPTION
## Pull Request description

Before fix:
<img width="1624" height="862" alt="image" src="https://github.com/user-attachments/assets/5427e37e-10cf-46bf-b040-62a9f2d353fd" />

After fix:
<img width="1638" height="864" alt="image" src="https://github.com/user-attachments/assets/760ff158-fa1d-4da5-8b6a-a8f80e060e34" />


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




