### PR TITLE
Add ellipsis to entity list and subtype list chip and fixed api usage state display value

### DIFF
--- a/ui-ngx/src/app/modules/home/components/entity/entity-filter-view.component.ts
+++ b/ui-ngx/src/app/modules/home/components/entity/entity-filter-view.component.ts
@@ -128,6 +128,9 @@ export class EntityFilterViewComponent implements ControlValueAccessor {
               {edgeTypes});
           }
           break;
+        case AliasFilterType.apiUsageState:
+          this.filterDisplayValue = this.translate.instant('alias.filter-type-apiUsageState');
+          break;
         case AliasFilterType.entityViewType:
           const entityViewTypesQuoted = [];
           this.filter.entityViewTypes.forEach((entityViewType) => {

--- a/ui-ngx/src/app/shared/components/entity/entity-list.component.html
+++ b/ui-ngx/src/app/shared/components/entity/entity-list.component.html
@@ -25,6 +25,7 @@
   <mat-chip-grid #chipList formControlName="entities">
     <mat-chip-row
       *ngFor="let entity of entities"
+      class="tb-chip-row-ellipsis"
       [removable]="!disabled"
       (removed)="remove(entity)">
       {{entity.name}}

--- a/ui-ngx/src/app/shared/components/entity/entity-subtype-list.component.html
+++ b/ui-ngx/src/app/shared/components/entity/entity-subtype-list.component.html
@@ -22,6 +22,7 @@
   <mat-chip-grid #chipList formControlName="entitySubtypeList">
     <mat-chip-row
       *ngFor="let entitySubtype of entitySubtypeList"
+      class="tb-chip-row-ellipsis"
       [removable]="!disabled"
       (removed)="remove(entitySubtype)">
       {{customTranslate(entitySubtype)}}

--- a/ui-ngx/src/styles.scss
+++ b/ui-ngx/src/styles.scss
@@ -1255,6 +1255,13 @@ pre.tb-highlight {
     }
   }
 
+  .tb-chip-row-ellipsis {
+    overflow: hidden;
+    .mdc-evolution-chip__cell--primary, .mdc-evolution-chip__text-label {
+      overflow: hidden;
+    }
+  }
+
   @media #{$mat-lt-md} {
     .mat-mdc-form-field {
       .mat-mdc-form-field-infix {


### PR DESCRIPTION
## Pull Request description

Add ellipsis to chip for entity list and entity subtype list:
<img width="1452" height="1182" alt="image" src="https://github.com/user-attachments/assets/6ac0f4d1-fe47-4ff0-9a66-63b0cc603a9d" />

Fixed display value for api usage state:
Before:
<img width="1778" height="804" alt="image" src="https://github.com/user-attachments/assets/6bf93841-b567-4202-a949-c684934f10d5" />

After:
<img width="1736" height="726" alt="image" src="https://github.com/user-attachments/assets/ee11028f-fd3b-491b-bb1a-e29bb9de5d4d" />


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




