### PR TITLE
Fixed widget preview height in widget type autocomplete

### DIFF
--- a/ui-ngx/src/app/modules/home/pages/widget/widget-type-autocomplete.component.scss
+++ b/ui-ngx/src/app/modules/home/pages/widget/widget-type-autocomplete.component.scss
@@ -24,7 +24,8 @@
       }
       .tb-widget-type-option-image-preview {
         width: 36px;
-        max-height: 100%;
+        height: 100%;
+        max-height: 36px;
         object-fit: contain;
         border-radius: 6px;
       }


### PR DESCRIPTION
## Pull Request description

Before:
Maximum height for widget preview is not set.
If the height is greater than the width, the widget preview scales to fit the maximum width and extends the height of the autocomplete option.
<img width="964" height="586" alt="image" src="https://github.com/user-attachments/assets/0d028349-d5f9-47c6-a4f6-7aeb75f42794" />

After:
Widget preview scales proportionally to fit the maximum width and height
<img width="975" height="587" alt="image" src="https://github.com/user-attachments/assets/a5afa214-5f4c-4b02-a316-59e6ed0f237f" />


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




