### PR TITLE
Fix topics creation for isolated tenants

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edqs/KafkaEdqsSyncService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edqs/KafkaEdqsSyncService.java
@@ -20,10 +20,8 @@ import org.springframework.stereotype.Service;
 import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
 import org.thingsboard.server.queue.discovery.TopicService;
 import org.thingsboard.server.queue.edqs.EdqsConfig;
-import org.thingsboard.server.queue.kafka.TbKafkaAdmin;
-import org.thingsboard.server.queue.kafka.TbKafkaSettings;
+import org.thingsboard.server.queue.kafka.KafkaAdmin;
 
-import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -33,8 +31,7 @@ public class KafkaEdqsSyncService extends EdqsSyncService {
 
     private final boolean syncNeeded;
 
-    public KafkaEdqsSyncService(TbKafkaSettings kafkaSettings, TopicService topicService, EdqsConfig edqsConfig) {
-        TbKafkaAdmin kafkaAdmin = new TbKafkaAdmin(kafkaSettings, Collections.emptyMap());
+    public KafkaEdqsSyncService(KafkaAdmin kafkaAdmin, TopicService topicService, EdqsConfig edqsConfig) {
         this.syncNeeded = kafkaAdmin.areAllTopicsEmpty(IntStream.range(0, edqsConfig.getPartitions())
                 .mapToObj(partition -> TopicPartitionInfo.builder()
                         .topic(topicService.buildTopicName(edqsConfig.getEventsTopic()))

--- a/application/src/main/java/org/thingsboard/server/service/entitiy/queue/DefaultTbQueueService.java
+++ b/application/src/main/java/org/thingsboard/server/service/entitiy/queue/DefaultTbQueueService.java
@@ -176,8 +176,8 @@ public class DefaultTbQueueService extends AbstractTbEntityService implements Tb
         for (int i = oldPartitions; i < newPartitions; i++) {
             tbQueueAdmin.createTopicIfNotExists(
                     new TopicPartitionInfo(queue.getTopic(), queue.getTenantId(), i, false).getFullTopicName(),
-                    queue.getCustomProperties()
-            );
+                    queue.getCustomProperties(),
+                    true); // forcing topic creation because the topic may still be cached on some nodes
         }
     }
 

--- a/application/src/main/java/org/thingsboard/server/service/ttl/KafkaEdgeTopicsCleanUpService.java
+++ b/application/src/main/java/org/thingsboard/server/service/ttl/KafkaEdgeTopicsCleanUpService.java
@@ -30,9 +30,7 @@ import org.thingsboard.server.dao.edge.EdgeService;
 import org.thingsboard.server.dao.tenant.TenantService;
 import org.thingsboard.server.queue.discovery.PartitionService;
 import org.thingsboard.server.queue.discovery.TopicService;
-import org.thingsboard.server.queue.kafka.TbKafkaAdmin;
-import org.thingsboard.server.queue.kafka.TbKafkaSettings;
-import org.thingsboard.server.queue.kafka.TbKafkaTopicConfigs;
+import org.thingsboard.server.queue.kafka.KafkaAdmin;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 
 import java.time.Instant;
@@ -57,7 +55,7 @@ public class KafkaEdgeTopicsCleanUpService extends AbstractCleanUpService {
     private final TenantService tenantService;
     private final EdgeService edgeService;
     private final AttributesService attributesService;
-    private final TbKafkaAdmin kafkaAdmin;
+    private final KafkaAdmin kafkaAdmin;
 
     @Value("${sql.ttl.edge_events.edge_events_ttl:2628000}")
     private long ttlSeconds;
@@ -67,13 +65,13 @@ public class KafkaEdgeTopicsCleanUpService extends AbstractCleanUpService {
 
     public KafkaEdgeTopicsCleanUpService(PartitionService partitionService, EdgeService edgeService,
                                          TenantService tenantService, AttributesService attributesService,
-                                         TopicService topicService, TbKafkaSettings kafkaSettings, TbKafkaTopicConfigs kafkaTopicConfigs) {
+                                         TopicService topicService, KafkaAdmin kafkaAdmin) {
         super(partitionService);
         this.topicService = topicService;
         this.tenantService = tenantService;
         this.edgeService = edgeService;
         this.attributesService = attributesService;
-        this.kafkaAdmin = new TbKafkaAdmin(kafkaSettings, kafkaTopicConfigs.getEdgeEventConfigs());
+        this.kafkaAdmin = kafkaAdmin;
     }
 
     @Scheduled(initialDelayString = "#{T(org.apache.commons.lang3.RandomUtils).nextLong(0, ${sql.ttl.edge_events.execution_interval_ms})}", fixedDelayString = "${sql.ttl.edge_events.execution_interval_ms}")

--- a/application/src/main/java/org/thingsboard/server/service/ttl/KafkaEdgeTopicsCleanUpService.java
+++ b/application/src/main/java/org/thingsboard/server/service/ttl/KafkaEdgeTopicsCleanUpService.java
@@ -80,8 +80,8 @@ public class KafkaEdgeTopicsCleanUpService extends AbstractCleanUpService {
             return;
         }
 
-        Set<String> topics = kafkaAdmin.getAllTopics();
-        if (topics == null || topics.isEmpty()) {
+        Set<String> topics = kafkaAdmin.listTopics();
+        if (topics.isEmpty()) {
             return;
         }
 

--- a/application/src/test/java/org/thingsboard/server/service/edge/EdgeStatsTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/EdgeStatsTest.java
@@ -33,7 +33,7 @@ import org.thingsboard.server.dao.edge.stats.EdgeStatsCounterService;
 import org.thingsboard.server.dao.edge.stats.MsgCounters;
 import org.thingsboard.server.dao.timeseries.TimeseriesService;
 import org.thingsboard.server.queue.discovery.TopicService;
-import org.thingsboard.server.queue.kafka.TbKafkaAdmin;
+import org.thingsboard.server.queue.kafka.KafkaAdmin;
 import org.thingsboard.server.service.edge.stats.EdgeStatsService;
 
 import java.util.List;
@@ -141,7 +141,7 @@ public class EdgeStatsTest {
         TopicPartitionInfo partitionInfo = new TopicPartitionInfo(topic, tenantId, 0, false);
         when(topicService.buildEdgeEventNotificationsTopicPartitionInfo(tenantId, edgeId)).thenReturn(partitionInfo);
 
-        TbKafkaAdmin kafkaAdmin = mock(TbKafkaAdmin.class);
+        KafkaAdmin kafkaAdmin = mock(KafkaAdmin.class);
         when(kafkaAdmin.getTotalLagForGroupsBulk(Set.of(topic)))
                 .thenReturn(Map.of(topic, 15L));
 

--- a/application/src/test/java/org/thingsboard/server/service/queue/ruleengine/TbRuleEngineQueueConsumerManagerTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/queue/ruleengine/TbRuleEngineQueueConsumerManagerTest.java
@@ -507,7 +507,7 @@ public class TbRuleEngineQueueConsumerManagerTest {
 
         consumerManager.delete(true);
 
-        await().atMost(2, TimeUnit.SECONDS)
+        await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     verify(ruleEngineMsgProducer).send(any(), any(), any());
                 });

--- a/common/cluster-api/src/main/java/org/thingsboard/server/queue/TbQueueAdmin.java
+++ b/common/cluster-api/src/main/java/org/thingsboard/server/queue/TbQueueAdmin.java
@@ -18,12 +18,13 @@ package org.thingsboard.server.queue;
 public interface TbQueueAdmin {
 
     default void createTopicIfNotExists(String topic) {
-        createTopicIfNotExists(topic, null);
+        createTopicIfNotExists(topic, null, false);
     }
 
-    void createTopicIfNotExists(String topic, String properties);
+    void createTopicIfNotExists(String topic, String properties, boolean force);
 
     void destroy();
 
     void deleteTopic(String topic);
+
 }

--- a/common/queue/src/main/java/org/thingsboard/server/queue/RuleEngineTbQueueAdminFactory.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/RuleEngineTbQueueAdminFactory.java
@@ -43,7 +43,7 @@ public class RuleEngineTbQueueAdminFactory {
         return new TbQueueAdmin() {
 
             @Override
-            public void createTopicIfNotExists(String topic, String properties) {
+            public void createTopicIfNotExists(String topic, String properties, boolean force) {
             }
 
             @Override

--- a/common/queue/src/main/java/org/thingsboard/server/queue/kafka/KafkaAdmin.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/kafka/KafkaAdmin.java
@@ -1,0 +1,298 @@
+/**
+ * Copyright © 2016-2025 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.queue.kafka;
+
+import jakarta.annotation.PreDestroy;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.concurrent.ConcurrentException;
+import org.apache.commons.lang3.concurrent.LazyInitializer;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.springframework.stereotype.Component;
+import org.thingsboard.server.queue.util.TbKafkaComponent;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+@TbKafkaComponent
+@Component
+@Slf4j
+public class KafkaAdmin {
+    /*
+    * TODO: Get rid of per consumer/producer TbKafkaAdmin,
+    *  use single KafkaAdmin instance that accepts topicConfigs.
+     * */
+
+    private final TbKafkaSettings settings;
+    private final LazyInitializer<AdminClient> adminClient;
+
+    private volatile Set<String> topics;
+
+    public KafkaAdmin(TbKafkaSettings settings) {
+        this.settings = settings;
+        this.adminClient = LazyInitializer.<AdminClient>builder()
+                .setInitializer(() -> AdminClient.create(settings.toAdminProps()))
+                .get();
+    }
+
+    public void createTopicIfNotExists(String topic, Map<String, String> properties, boolean force) {
+        if (!force) {
+            Set<String> topics = getTopics();
+            if (topics.contains(topic)) {
+                return;
+            }
+        }
+        try {
+            String numPartitionsStr = properties.remove(TbKafkaTopicConfigs.NUM_PARTITIONS_SETTING);
+            int partitions = numPartitionsStr != null ? Integer.parseInt(numPartitionsStr) : 1;
+
+            NewTopic newTopic = new NewTopic(topic, partitions, settings.getReplicationFactor()).configs(properties);
+            createTopic(newTopic).values().get(topic).get();
+            topics.add(topic);
+        } catch (ExecutionException ee) {
+            if (ee.getCause() instanceof TopicExistsException) {
+                //do nothing
+            } else {
+                log.warn("[{}] Failed to create topic", topic, ee);
+                throw new RuntimeException(ee);
+            }
+        } catch (Exception e) {
+            log.warn("[{}] Failed to create topic", topic, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void deleteTopic(String topic) {
+        Set<String> topics = getTopics();
+        if (topics.remove(topic)) {
+            getClient().deleteTopics(Collections.singletonList(topic));
+        } else {
+            try {
+                if (getClient().listTopics().names().get().contains(topic)) {
+                    getClient().deleteTopics(Collections.singletonList(topic));
+                } else {
+                    log.warn("Kafka topic [{}] does not exist.", topic);
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                log.error("Failed to delete kafka topic [{}].", topic, e);
+            }
+        }
+    }
+
+    private Set<String> getTopics() {
+        if (topics == null) {
+            synchronized (this) {
+                if (topics == null) {
+                    topics = ConcurrentHashMap.newKeySet();
+                    try {
+                        topics.addAll(getClient().listTopics().names().get());
+                    } catch (InterruptedException | ExecutionException e) {
+                        log.error("Failed to get all topics.", e);
+                    }
+                }
+            }
+        }
+        return topics;
+    }
+
+    public Set<String> getAllTopics() {
+        try {
+            return getClient().listTopics().names().get();
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Failed to get all topics.", e);
+        }
+        return null;
+    }
+
+
+    public CreateTopicsResult createTopic(NewTopic topic) {
+        return getClient().createTopics(Collections.singletonList(topic));
+    }
+
+    public Map<String, Long> getTotalLagForGroupsBulk(Set<String> groupIds) {
+        Map<String, Long> result = new HashMap<>();
+        for (String groupId : groupIds) {
+            result.put(groupId, getTotalConsumerGroupLag(groupId));
+        }
+        return result;
+    }
+
+    public long getTotalConsumerGroupLag(String groupId) {
+        try {
+            Map<TopicPartition, OffsetAndMetadata> committedOffsets = getConsumerGroupOffsets(groupId);
+            if (committedOffsets.isEmpty()) {
+                return 0L;
+            }
+
+            Map<TopicPartition, OffsetSpec> latestOffsetsSpec = committedOffsets.keySet().stream()
+                    .collect(Collectors.toMap(tp -> tp, tp -> OffsetSpec.latest()));
+
+            Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> endOffsets =
+                    getClient().listOffsets(latestOffsetsSpec)
+                            .all().get(10, TimeUnit.SECONDS);
+
+            return committedOffsets.entrySet().stream()
+                    .mapToLong(entry -> {
+                        TopicPartition tp = entry.getKey();
+                        long committed = entry.getValue().offset();
+                        long end = endOffsets.getOrDefault(tp,
+                                new ListOffsetsResult.ListOffsetsResultInfo(0L, 0L, Optional.empty())).offset();
+                        return end - committed;
+                    }).sum();
+
+        } catch (Exception e) {
+            log.error("Failed to get total lag for consumer group: {}", groupId, e);
+            return 0L;
+        }
+    }
+
+    @SneakyThrows
+    public Map<TopicPartition, OffsetAndMetadata> getConsumerGroupOffsets(String groupId) {
+        return getClient().listConsumerGroupOffsets(groupId).partitionsToOffsetAndMetadata().get(10, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Sync offsets from a fat group to a single-partition group
+     * Migration back from single-partition consumer to a fat group is not supported
+     * TODO: The best possible approach to synchronize the offsets is to do the synchronization as a part of the save Queue parameters with stop all consumers
+     * */
+    public void syncOffsets(String fatGroupId, String newGroupId, Integer partitionId) {
+        try {
+            log.info("syncOffsets [{}][{}][{}]", fatGroupId, newGroupId, partitionId);
+            if (partitionId == null) {
+                return;
+            }
+            syncOffsetsUnsafe(fatGroupId, newGroupId, "." + partitionId);
+        } catch (Exception e) {
+            log.warn("Failed to syncOffsets from {} to {} partitionId {}", fatGroupId, newGroupId, partitionId, e);
+        }
+    }
+
+    public void syncOffsetsUnsafe(String fatGroupId, String newGroupId, String topicSuffix) throws ExecutionException, InterruptedException, TimeoutException {
+        Map<TopicPartition, OffsetAndMetadata> oldOffsets = getConsumerGroupOffsets(fatGroupId);
+        if (oldOffsets.isEmpty()) {
+            return;
+        }
+
+        for (var consumerOffset : oldOffsets.entrySet()) {
+            var tp = consumerOffset.getKey();
+            if (!tp.topic().endsWith(topicSuffix)) {
+                continue;
+            }
+            var om = consumerOffset.getValue();
+            Map<TopicPartition, OffsetAndMetadata> newOffsets = getConsumerGroupOffsets(newGroupId);
+
+            var existingOffset = newOffsets.get(tp);
+            if (existingOffset == null) {
+                log.info("[{}] topic offset does not exists in the new node group {}, all found offsets {}", tp, newGroupId, newOffsets);
+            } else if (existingOffset.offset() >= om.offset()) {
+                log.info("[{}] topic offset {} >= than old node group offset {}", tp, existingOffset.offset(), om.offset());
+                break;
+            } else {
+                log.info("[{}] SHOULD alter topic offset [{}] less than old node group offset [{}]", tp, existingOffset.offset(), om.offset());
+            }
+            getClient().alterConsumerGroupOffsets(newGroupId, Map.of(tp, om)).all().get(10, TimeUnit.SECONDS);
+            log.info("[{}] altered new consumer groupId {}", tp, newGroupId);
+            break;
+        }
+    }
+
+    public boolean isTopicEmpty(String topic) {
+        return areAllTopicsEmpty(Set.of(topic));
+    }
+
+    public boolean areAllTopicsEmpty(Set<String> topics) {
+        try {
+            List<String> existingTopics = getTopics().stream().filter(topics::contains).toList();
+            if (existingTopics.isEmpty()) {
+                return true;
+            }
+
+            List<TopicPartition> allPartitions = getClient().describeTopics(existingTopics).topicNameValues().entrySet().stream()
+                    .flatMap(entry -> {
+                        String topic = entry.getKey();
+                        TopicDescription topicDescription;
+                        try {
+                            topicDescription = entry.getValue().get();
+                        } catch (InterruptedException | ExecutionException e) {
+                            throw new RuntimeException(e);
+                        }
+                        return topicDescription.partitions().stream().map(partitionInfo -> new TopicPartition(topic, partitionInfo.partition()));
+                    })
+                    .toList();
+
+            Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> beginningOffsets = getClient().listOffsets(allPartitions.stream()
+                    .collect(Collectors.toMap(partition -> partition, partition -> OffsetSpec.earliest()))).all().get();
+            Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> endOffsets = getClient().listOffsets(allPartitions.stream()
+                    .collect(Collectors.toMap(partition -> partition, partition -> OffsetSpec.latest()))).all().get();
+
+            for (TopicPartition partition : allPartitions) {
+                long beginningOffset = beginningOffsets.get(partition).offset();
+                long endOffset = endOffsets.get(partition).offset();
+
+                if (beginningOffset != endOffset) {
+                    log.debug("Partition [{}] of topic [{}] is not empty. Returning false.", partition.partition(), partition.topic());
+                    return false;
+                }
+            }
+            return true;
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Failed to check if topics [{}] empty.", topics, e);
+            return false;
+        }
+    }
+
+    public void deleteConsumerGroup(String consumerGroupId) {
+        try {
+            getClient().deleteConsumerGroups(Collections.singletonList(consumerGroupId));
+        } catch (Exception e) {
+            log.warn("Failed to delete consumer group {}", consumerGroupId, e);
+        }
+    }
+
+    public AdminClient getClient() {
+        try {
+            return adminClient.get();
+        } catch (ConcurrentException e) {
+            throw new RuntimeException("Failed to initialize Kafka admin client", e);
+        }
+    }
+
+    @PreDestroy
+    private void destroy() throws Exception {
+        if (adminClient.isInitialized()) {
+            adminClient.get().close();
+        }
+    }
+
+}

--- a/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaAdmin.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaAdmin.java
@@ -16,31 +16,12 @@
 package org.thingsboard.server.queue.kafka;
 
 import lombok.Getter;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
-import org.apache.kafka.clients.admin.ListOffsetsResult;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.admin.OffsetSpec;
-import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.TopicExistsException;
 import org.thingsboard.server.queue.TbEdgeQueueAdmin;
 import org.thingsboard.server.queue.TbQueueAdmin;
 import org.thingsboard.server.queue.util.PropertyUtils;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 /**
  * Created by ashvayka on 24.09.18.
@@ -52,116 +33,30 @@ public class TbKafkaAdmin implements TbQueueAdmin, TbEdgeQueueAdmin {
     private final Map<String, String> topicConfigs;
     @Getter
     private final int numPartitions;
-    private volatile Set<String> topics;
-
-    private final short replicationFactor;
 
     public TbKafkaAdmin(TbKafkaSettings settings, Map<String, String> topicConfigs) {
         this.settings = settings;
         this.topicConfigs = topicConfigs;
-
         String numPartitionsStr = topicConfigs.get(TbKafkaTopicConfigs.NUM_PARTITIONS_SETTING);
         if (numPartitionsStr != null) {
             numPartitions = Integer.parseInt(numPartitionsStr);
         } else {
             numPartitions = 1;
         }
-        replicationFactor = settings.getReplicationFactor();
     }
 
     @Override
     public void createTopicIfNotExists(String topic, String properties, boolean force) {
-        if (!force) {
-            Set<String> topics = getTopics();
-            if (topics.contains(topic)) {
-                return;
-            }
-        }
-        try {
-            Map<String, String> configs = PropertyUtils.getProps(topicConfigs, properties);
-            configs.remove(TbKafkaTopicConfigs.NUM_PARTITIONS_SETTING);
-            NewTopic newTopic = new NewTopic(topic, numPartitions, replicationFactor).configs(configs);
-            createTopic(newTopic).values().get(topic).get();
-            topics.add(topic);
-        } catch (ExecutionException ee) {
-            if (ee.getCause() instanceof TopicExistsException) {
-                //do nothing
-            } else {
-                log.warn("[{}] Failed to create topic", topic, ee);
-                throw new RuntimeException(ee);
-            }
-        } catch (Exception e) {
-            log.warn("[{}] Failed to create topic", topic, e);
-            throw new RuntimeException(e);
-        }
+        settings.getAdmin().createTopicIfNotExists(topic, PropertyUtils.getProps(topicConfigs, properties), force);
     }
 
     @Override
     public void deleteTopic(String topic) {
-        Set<String> topics = getTopics();
-        if (topics.remove(topic)) {
-            settings.getAdminClient().deleteTopics(Collections.singletonList(topic));
-        } else {
-            try {
-                if (settings.getAdminClient().listTopics().names().get().contains(topic)) {
-                    settings.getAdminClient().deleteTopics(Collections.singletonList(topic));
-                } else {
-                    log.warn("Kafka topic [{}] does not exist.", topic);
-                }
-            } catch (InterruptedException | ExecutionException e) {
-                log.error("Failed to delete kafka topic [{}].", topic, e);
-            }
-        }
-    }
-
-    private Set<String> getTopics() {
-        if (topics == null) {
-            synchronized (this) {
-                if (topics == null) {
-                    topics = ConcurrentHashMap.newKeySet();
-                    try {
-                        topics.addAll(settings.getAdminClient().listTopics().names().get());
-                    } catch (InterruptedException | ExecutionException e) {
-                        log.error("Failed to get all topics.", e);
-                    }
-                }
-            }
-        }
-        return topics;
-    }
-
-    public Set<String> getAllTopics() {
-        try {
-            return settings.getAdminClient().listTopics().names().get();
-        } catch (InterruptedException | ExecutionException e) {
-            log.error("Failed to get all topics.", e);
-        }
-        return null;
-    }
-
-    public CreateTopicsResult createTopic(NewTopic topic) {
-        return settings.getAdminClient().createTopics(Collections.singletonList(topic));
+        settings.getAdmin().deleteTopic(topic);
     }
 
     @Override
     public void destroy() {
-    }
-
-    /**
-     * Sync offsets from a fat group to a single-partition group
-     * Migration back from single-partition consumer to a fat group is not supported
-     * TODO: The best possible approach to synchronize the offsets is to do the synchronization as a part of the save Queue parameters with stop all consumers
-     * */
-    public void syncOffsets(String fatGroupId, String newGroupId, Integer partitionId) {
-        try {
-            log.info("syncOffsets [{}][{}][{}]", fatGroupId, newGroupId, partitionId);
-            if (partitionId == null) {
-                return;
-            }
-            syncOffsetsUnsafe(fatGroupId, newGroupId, "." + partitionId);
-        } catch (Exception e) {
-            log.warn("Failed to syncOffsets from {} to {} partitionId {}", fatGroupId, newGroupId, partitionId, e);
-        }
     }
 
     /**
@@ -170,134 +65,9 @@ public class TbKafkaAdmin implements TbQueueAdmin, TbEdgeQueueAdmin {
     public void syncEdgeNotificationsOffsets(String fatGroupId, String newGroupId) {
         try {
             log.info("syncEdgeNotificationsOffsets [{}][{}]", fatGroupId, newGroupId);
-            syncOffsetsUnsafe(fatGroupId, newGroupId, newGroupId);
+            settings.getAdmin().syncOffsetsUnsafe(fatGroupId, newGroupId, newGroupId);
         } catch (Exception e) {
             log.warn("Failed to syncEdgeNotificationsOffsets from {} to {}", fatGroupId, newGroupId, e);
-        }
-    }
-
-    @Override
-    public void deleteConsumerGroup(String consumerGroupId) {
-        try {
-            settings.getAdminClient().deleteConsumerGroups(Collections.singletonList(consumerGroupId));
-        } catch (Exception e) {
-            log.warn("Failed to delete consumer group {}", consumerGroupId, e);
-        }
-    }
-
-    void syncOffsetsUnsafe(String fatGroupId, String newGroupId, String topicSuffix) throws ExecutionException, InterruptedException, TimeoutException {
-        Map<TopicPartition, OffsetAndMetadata> oldOffsets = getConsumerGroupOffsets(fatGroupId);
-        if (oldOffsets.isEmpty()) {
-            return;
-        }
-
-        for (var consumerOffset : oldOffsets.entrySet()) {
-            var tp = consumerOffset.getKey();
-            if (!tp.topic().endsWith(topicSuffix)) {
-                continue;
-            }
-            var om = consumerOffset.getValue();
-            Map<TopicPartition, OffsetAndMetadata> newOffsets = getConsumerGroupOffsets(newGroupId);
-
-            var existingOffset = newOffsets.get(tp);
-            if (existingOffset == null) {
-                log.info("[{}] topic offset does not exists in the new node group {}, all found offsets {}", tp, newGroupId, newOffsets);
-            } else if (existingOffset.offset() >= om.offset()) {
-                log.info("[{}] topic offset {} >= than old node group offset {}", tp, existingOffset.offset(), om.offset());
-                break;
-            } else {
-                log.info("[{}] SHOULD alter topic offset [{}] less than old node group offset [{}]", tp, existingOffset.offset(), om.offset());
-            }
-            settings.getAdminClient().alterConsumerGroupOffsets(newGroupId, Map.of(tp, om)).all().get(10, TimeUnit.SECONDS);
-            log.info("[{}] altered new consumer groupId {}", tp, newGroupId);
-            break;
-        }
-    }
-
-    @SneakyThrows
-    public Map<TopicPartition, OffsetAndMetadata> getConsumerGroupOffsets(String groupId) {
-        return settings.getAdminClient().listConsumerGroupOffsets(groupId).partitionsToOffsetAndMetadata().get(10, TimeUnit.SECONDS);
-    }
-
-    public boolean isTopicEmpty(String topic) {
-        return areAllTopicsEmpty(Set.of(topic));
-    }
-
-    public boolean areAllTopicsEmpty(Set<String> topics) {
-        try {
-            List<String> existingTopics = getTopics().stream().filter(topics::contains).toList();
-            if (existingTopics.isEmpty()) {
-                return true;
-            }
-
-            List<TopicPartition> allPartitions = settings.getAdminClient().describeTopics(existingTopics).topicNameValues().entrySet().stream()
-                    .flatMap(entry -> {
-                        String topic = entry.getKey();
-                        TopicDescription topicDescription;
-                        try {
-                            topicDescription = entry.getValue().get();
-                        } catch (InterruptedException | ExecutionException e) {
-                            throw new RuntimeException(e);
-                        }
-                        return topicDescription.partitions().stream().map(partitionInfo -> new TopicPartition(topic, partitionInfo.partition()));
-                    })
-                    .toList();
-
-            Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> beginningOffsets = settings.getAdminClient().listOffsets(allPartitions.stream()
-                    .collect(Collectors.toMap(partition -> partition, partition -> OffsetSpec.earliest()))).all().get();
-            Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> endOffsets = settings.getAdminClient().listOffsets(allPartitions.stream()
-                    .collect(Collectors.toMap(partition -> partition, partition -> OffsetSpec.latest()))).all().get();
-
-            for (TopicPartition partition : allPartitions) {
-                long beginningOffset = beginningOffsets.get(partition).offset();
-                long endOffset = endOffsets.get(partition).offset();
-
-                if (beginningOffset != endOffset) {
-                    log.debug("Partition [{}] of topic [{}] is not empty. Returning false.", partition.partition(), partition.topic());
-                    return false;
-                }
-            }
-            return true;
-        } catch (InterruptedException | ExecutionException e) {
-            log.error("Failed to check if topics [{}] empty.", topics, e);
-            return false;
-        }
-    }
-
-    public Map<String, Long> getTotalLagForGroupsBulk(Set<String> groupIds) {
-        Map<String, Long> result = new HashMap<>();
-        for (String groupId : groupIds) {
-            result.put(groupId, getTotalConsumerGroupLag(groupId));
-        }
-        return result;
-    }
-
-    public long getTotalConsumerGroupLag(String groupId) {
-        try {
-            Map<TopicPartition, OffsetAndMetadata> committedOffsets = getConsumerGroupOffsets(groupId);
-            if (committedOffsets.isEmpty()) {
-                return 0L;
-            }
-
-            Map<TopicPartition, OffsetSpec> latestOffsetsSpec = committedOffsets.keySet().stream()
-                    .collect(Collectors.toMap(tp -> tp, tp -> OffsetSpec.latest()));
-
-            Map<TopicPartition, ListOffsetsResult.ListOffsetsResultInfo> endOffsets =
-                    settings.getAdminClient().listOffsets(latestOffsetsSpec)
-                            .all().get(10, TimeUnit.SECONDS);
-
-            return committedOffsets.entrySet().stream()
-                    .mapToLong(entry -> {
-                        TopicPartition tp = entry.getKey();
-                        long committed = entry.getValue().offset();
-                        long end = endOffsets.getOrDefault(tp,
-                                new ListOffsetsResult.ListOffsetsResultInfo(0L, 0L, Optional.empty())).offset();
-                        return end - committed;
-                    }).sum();
-
-        } catch (Exception e) {
-            log.error("Failed to get total lag for consumer group: {}", groupId, e);
-            return 0L;
         }
     }
 

--- a/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaAdmin.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaAdmin.java
@@ -70,10 +70,12 @@ public class TbKafkaAdmin implements TbQueueAdmin, TbEdgeQueueAdmin {
     }
 
     @Override
-    public void createTopicIfNotExists(String topic, String properties) {
-        Set<String> topics = getTopics();
-        if (topics.contains(topic)) {
-            return;
+    public void createTopicIfNotExists(String topic, String properties, boolean force) {
+        if (!force) {
+            Set<String> topics = getTopics();
+            if (topics.contains(topic)) {
+                return;
+            }
         }
         try {
             Map<String, String> configs = PropertyUtils.getProps(topicConfigs, properties);

--- a/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaConsumerStatisticConfig.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaConsumerStatisticConfig.java
@@ -19,11 +19,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+import org.thingsboard.server.queue.util.TbKafkaComponent;
 
 @Component
-@ConditionalOnProperty(prefix = "queue", value = "type", havingValue = "kafka")
+@TbKafkaComponent
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaConsumerStatsService.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaConsumerStatsService.java
@@ -26,10 +26,10 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.thingsboard.common.util.ThingsBoardExecutors;
 import org.thingsboard.server.common.data.StringUtils;
+import org.thingsboard.server.queue.util.TbKafkaComponent;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -44,11 +44,12 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@ConditionalOnProperty(prefix = "queue", value = "type", havingValue = "kafka")
+@TbKafkaComponent
 public class TbKafkaConsumerStatsService {
     private final Set<String> monitoredGroups = ConcurrentHashMap.newKeySet();
 
     private final TbKafkaSettings kafkaSettings;
+    private final KafkaAdmin kafkaAdmin;
     private final TbKafkaConsumerStatisticConfig statsConfig;
 
     private Consumer<String, byte[]> consumer;
@@ -77,7 +78,7 @@ public class TbKafkaConsumerStatsService {
             }
             for (String groupId : monitoredGroups) {
                 try {
-                    Map<TopicPartition, OffsetAndMetadata> groupOffsets = kafkaSettings.getAdminClient().listConsumerGroupOffsets(groupId).partitionsToOffsetAndMetadata()
+                    Map<TopicPartition, OffsetAndMetadata> groupOffsets = kafkaSettings.getAdmin().getClient().listConsumerGroupOffsets(groupId).partitionsToOffsetAndMetadata()
                             .get(statsConfig.getKafkaResponseTimeoutMs(), TimeUnit.MILLISECONDS);
                     Map<TopicPartition, Long> endOffsets = consumer.endOffsets(groupOffsets.keySet(), timeoutDuration);
 
@@ -159,12 +160,14 @@ public class TbKafkaConsumerStatsService {
         @Override
         public String toString() {
             return "[" +
-                    "topic=[" + topic + ']' +
-                    ", partition=[" + partition + "]" +
-                    ", committedOffset=[" + committedOffset + "]" +
-                    ", endOffset=[" + endOffset + "]" +
-                    ", lag=[" + lag + "]" +
-                    "]";
+                   "topic=[" + topic + ']' +
+                   ", partition=[" + partition + "]" +
+                   ", committedOffset=[" + committedOffset + "]" +
+                   ", endOffset=[" + endOffset + "]" +
+                   ", lag=[" + lag + "]" +
+                   "]";
         }
+
     }
+
 }

--- a/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaTopicConfigs.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/kafka/TbKafkaTopicConfigs.java
@@ -18,14 +18,14 @@ package org.thingsboard.server.queue.kafka;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.thingsboard.server.queue.util.PropertyUtils;
+import org.thingsboard.server.queue.util.TbKafkaComponent;
 
 import java.util.Map;
 
 @Component
-@ConditionalOnProperty(prefix = "queue", value = "type", havingValue = "kafka")
+@TbKafkaComponent
 public class TbKafkaTopicConfigs {
 
     public static final String NUM_PARTITIONS_SETTING = "partitions";

--- a/common/queue/src/main/java/org/thingsboard/server/queue/provider/InMemoryTbTransportQueueFactory.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/provider/InMemoryTbTransportQueueFactory.java
@@ -78,7 +78,7 @@ public class InMemoryTbTransportQueueFactory implements TbTransportQueueFactory 
 
         templateBuilder.queueAdmin(new TbQueueAdmin() {
             @Override
-            public void createTopicIfNotExists(String topic, String properties) {}
+            public void createTopicIfNotExists(String topic, String properties, boolean force) {}
 
             @Override
             public void destroy() {}

--- a/common/queue/src/main/java/org/thingsboard/server/queue/provider/KafkaMonolithQueueFactory.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/provider/KafkaMonolithQueueFactory.java
@@ -58,6 +58,7 @@ import org.thingsboard.server.queue.common.TbProtoQueueMsg;
 import org.thingsboard.server.queue.discovery.TbServiceInfoProvider;
 import org.thingsboard.server.queue.discovery.TopicService;
 import org.thingsboard.server.queue.edqs.EdqsConfig;
+import org.thingsboard.server.queue.kafka.KafkaAdmin;
 import org.thingsboard.server.queue.kafka.TbKafkaAdmin;
 import org.thingsboard.server.queue.kafka.TbKafkaConsumerStatsService;
 import org.thingsboard.server.queue.kafka.TbKafkaConsumerTemplate;
@@ -83,6 +84,7 @@ public class KafkaMonolithQueueFactory implements TbCoreQueueFactory, TbRuleEngi
 
     private final TopicService topicService;
     private final TbKafkaSettings kafkaSettings;
+    private final KafkaAdmin kafkaAdmin;
     private final TbServiceInfoProvider serviceInfoProvider;
     private final TbQueueCoreSettings coreSettings;
     private final TbQueueRuleEngineSettings ruleEngineSettings;
@@ -118,7 +120,9 @@ public class KafkaMonolithQueueFactory implements TbCoreQueueFactory, TbRuleEngi
     private final AtomicLong consumerCount = new AtomicLong();
     private final AtomicLong edgeConsumerCount = new AtomicLong();
 
-    public KafkaMonolithQueueFactory(TopicService topicService, TbKafkaSettings kafkaSettings,
+    public KafkaMonolithQueueFactory(TopicService topicService,
+                                     TbKafkaSettings kafkaSettings,
+                                     KafkaAdmin kafkaAdmin,
                                      TbServiceInfoProvider serviceInfoProvider,
                                      TbQueueCoreSettings coreSettings,
                                      TbQueueRuleEngineSettings ruleEngineSettings,
@@ -134,6 +138,7 @@ public class KafkaMonolithQueueFactory implements TbCoreQueueFactory, TbRuleEngi
                                      TasksQueueConfig tasksQueueConfig) {
         this.topicService = topicService;
         this.kafkaSettings = kafkaSettings;
+        this.kafkaAdmin = kafkaAdmin;
         this.serviceInfoProvider = serviceInfoProvider;
         this.coreSettings = coreSettings;
         this.ruleEngineSettings = ruleEngineSettings;
@@ -240,7 +245,7 @@ public class KafkaMonolithQueueFactory implements TbCoreQueueFactory, TbRuleEngi
         String queueName = configuration.getName();
         String groupId = topicService.buildConsumerGroupId("re-", configuration.getTenantId(), queueName, partitionId);
 
-        ruleEngineAdmin.syncOffsets(topicService.buildConsumerGroupId("re-", configuration.getTenantId(), queueName, null), // the fat groupId
+        kafkaAdmin.syncOffsets(topicService.buildConsumerGroupId("re-", configuration.getTenantId(), queueName, null), // the fat groupId
                 groupId, partitionId);
 
         TbKafkaConsumerTemplate.TbKafkaConsumerTemplateBuilder<TbProtoQueueMsg<ToRuleEngineMsg>> consumerBuilder = TbKafkaConsumerTemplate.builder();

--- a/common/queue/src/main/java/org/thingsboard/server/queue/provider/KafkaTbRuleEngineQueueFactory.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/provider/KafkaTbRuleEngineQueueFactory.java
@@ -52,6 +52,7 @@ import org.thingsboard.server.queue.common.TbProtoQueueMsg;
 import org.thingsboard.server.queue.discovery.TbServiceInfoProvider;
 import org.thingsboard.server.queue.discovery.TopicService;
 import org.thingsboard.server.queue.edqs.EdqsConfig;
+import org.thingsboard.server.queue.kafka.KafkaAdmin;
 import org.thingsboard.server.queue.kafka.TbKafkaAdmin;
 import org.thingsboard.server.queue.kafka.TbKafkaConsumerStatsService;
 import org.thingsboard.server.queue.kafka.TbKafkaConsumerTemplate;
@@ -74,6 +75,7 @@ public class KafkaTbRuleEngineQueueFactory implements TbRuleEngineQueueFactory {
 
     private final TopicService topicService;
     private final TbKafkaSettings kafkaSettings;
+    private final KafkaAdmin kafkaAdmin;
     private final TbServiceInfoProvider serviceInfoProvider;
     private final TbQueueCoreSettings coreSettings;
     private final TbQueueRuleEngineSettings ruleEngineSettings;
@@ -99,6 +101,7 @@ public class KafkaTbRuleEngineQueueFactory implements TbRuleEngineQueueFactory {
     private final AtomicLong consumerCount = new AtomicLong();
 
     public KafkaTbRuleEngineQueueFactory(TopicService topicService, TbKafkaSettings kafkaSettings,
+                                         KafkaAdmin kafkaAdmin,
                                          TbServiceInfoProvider serviceInfoProvider,
                                          TbQueueCoreSettings coreSettings,
                                          TbQueueRuleEngineSettings ruleEngineSettings,
@@ -111,6 +114,7 @@ public class KafkaTbRuleEngineQueueFactory implements TbRuleEngineQueueFactory {
                                          TbKafkaTopicConfigs kafkaTopicConfigs) {
         this.topicService = topicService;
         this.kafkaSettings = kafkaSettings;
+        this.kafkaAdmin = kafkaAdmin;
         this.serviceInfoProvider = serviceInfoProvider;
         this.coreSettings = coreSettings;
         this.ruleEngineSettings = ruleEngineSettings;
@@ -234,7 +238,7 @@ public class KafkaTbRuleEngineQueueFactory implements TbRuleEngineQueueFactory {
         String queueName = configuration.getName();
         String groupId = topicService.buildConsumerGroupId("re-", configuration.getTenantId(), queueName, partitionId);
 
-        ruleEngineAdmin.syncOffsets(topicService.buildConsumerGroupId("re-", configuration.getTenantId(), queueName, null), // the fat groupId
+        kafkaAdmin.syncOffsets(topicService.buildConsumerGroupId("re-", configuration.getTenantId(), queueName, null), // the fat groupId
                 groupId, partitionId);
 
         TbKafkaConsumerTemplate.TbKafkaConsumerTemplateBuilder<TbProtoQueueMsg<ToRuleEngineMsg>> consumerBuilder = TbKafkaConsumerTemplate.builder();

--- a/common/queue/src/main/java/org/thingsboard/server/queue/util/TbKafkaComponent.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/util/TbKafkaComponent.java
@@ -13,10 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.server.queue;
+package org.thingsboard.server.queue.util;
 
-public interface TbEdgeQueueAdmin extends TbQueueAdmin {
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-    void syncEdgeNotificationsOffsets(String fatGroupId, String newGroupId);
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-}
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({java.lang.annotation.ElementType.TYPE, java.lang.annotation.ElementType.METHOD})
+@ConditionalOnProperty(prefix = "queue", value = "type", havingValue = "kafka")
+public @interface TbKafkaComponent {}

--- a/common/queue/src/test/java/org/thingsboard/server/queue/kafka/TbKafkaSettingsTest.java
+++ b/common/queue/src/test/java/org/thingsboard/server/queue/kafka/TbKafkaSettingsTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 
-@SpringBootTest(classes = TbKafkaSettings.class)
+@SpringBootTest(classes = {TbKafkaSettings.class, KafkaAdmin.class})
 @TestPropertySource(properties = {
         "queue.type=kafka",
         "queue.kafka.bootstrap.servers=localhost:9092",

--- a/common/util/src/main/java/org/thingsboard/common/util/CachedValue.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/CachedValue.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright © 2016-2025 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.common.util;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class CachedValue<V> {
+
+    private static final Object KEY = new Object();
+
+    private final LoadingCache<Object, V> cache;
+
+    public CachedValue(Supplier<V> supplier, long valueTtlMs) {
+        this.cache = Caffeine.newBuilder()
+                .expireAfterWrite(valueTtlMs, TimeUnit.MILLISECONDS)
+                .build(__ -> supplier.get());
+    }
+
+    public V get() {
+        return cache.get(KEY);
+    }
+
+}

--- a/common/util/src/main/java/org/thingsboard/common/util/CachedValue.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/CachedValue.java
@@ -23,8 +23,6 @@ import java.util.function.Supplier;
 
 public class CachedValue<V> {
 
-    private static final Object KEY = new Object();
-
     private final LoadingCache<Object, V> cache;
 
     public CachedValue(Supplier<V> supplier, long valueTtlMs) {
@@ -34,7 +32,7 @@ public class CachedValue<V> {
     }
 
     public V get() {
-        return cache.get(KEY);
+        return cache.get(this);
     }
 
 }


### PR DESCRIPTION
## Pull Request description

After deleting a topic that has active producers, those producers get stuck waiting on metadata:
```
"integration-api-tb-core-consumer-67-thread-7" #182 prio=5 os_prio=0 cpu=4201.10ms elapsed=1030.78s tid=0x0000ffff4403b380 nid=0xc5 in Object.wait()  [0x0000ffff19ffd000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@17.0.15/Native Method)
	- waiting on <no object reference available>
	at org.apache.kafka.common.utils.SystemTime.waitObject(SystemTime.java:60)
	- locked <0x0000000708338c38> (a org.apache.kafka.clients.producer.internals.ProducerMetadata)
	at org.apache.kafka.clients.producer.internals.ProducerMetadata.awaitUpdate(ProducerMetadata.java:123)
	- locked <0x0000000708338c38> (a org.apache.kafka.clients.producer.internals.ProducerMetadata)
	at org.apache.kafka.clients.producer.KafkaProducer.waitOnMetadata(KafkaProducer.java:1178)
	at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:1027)
	at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:993)
	at org.thingsboard.server.queue.kafka.TbKafkaProducerTemplate.send(TbKafkaProducerTemplate.java:126)
	at org.thingsboard.server.queue.kafka.TbKafkaProducerTemplate.send(TbKafkaProducerTemplate.java:111)
	at org.thingsboard.server.queue.common.TbRuleEngineProducerService.sendToRuleEngine(TbRuleEngineProducerService.java:86)
	at org.thingsboard.server.queue.common.TbRuleEngineProducerService.sendToRuleEngine(TbRuleEngineProducerService.java:73)
	...
```

eventually falling with:
```
Producer template failure org.apache.kafka.common.errors.TimeoutException: 
Topic tb_rule_engine.main.isolated.307da149-xxxx-xxxx-xxxx-xxxxxxxxxx.2 not present in metadata after 60000 ms. 
Caused by: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: 
This server does not host this topic-partition.
```

This caused integration and transport message processors to stop working due to the bug that topics for isolated tenants were not created after upgrading their profile to the one with isolated queues (with preceding downgrade to non-isolated).
This PR fixes this bug, and also brings some other Kafka-related improvements.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



