### PR TITLE
Originator telemetry node: avoid adding extra quotes when writing result to metadata

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbGetTelemetryNodeConfiguration.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/metadata/TbGetTelemetryNodeConfiguration.java
@@ -24,9 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Created by mshvayka on 04.09.18.
- */
 @Data
 public class TbGetTelemetryNodeConfiguration implements NodeConfiguration<TbGetTelemetryNodeConfiguration> {
 
@@ -66,4 +63,5 @@ public class TbGetTelemetryNodeConfiguration implements NodeConfiguration<TbGetT
         configuration.setLimit(MAX_FETCH_SIZE);
         return configuration;
     }
+
 }


### PR DESCRIPTION
**WARNING: CURRENTLY IMPLEMENTED AS A BREAKING CHANGE - DISCUSSION REQUIRED**

Before:
```json
{
    "boolean": "\"false\"",
    "double": "\"12.5\"",
    "integer": "\"10\"",
    "json": "\"{\\\"key\\\":\\\"value\\\"}\"",
    "null": "\"null\"",
    "string": "\"hello\"",
    "string json": "\"{\\\"key\\\":\\\"value\\\"}\"",
    "string json unquoted": "\"{key:\\\"value\\\"}\""
}
````
After:
```json
{
    "boolean": "false",
    "double": "12.5",
    "integer": "10",
    "json": "{\"key\":\"value\"}",
    "null": "null",
    "string": "hello",
    "string json": "{\"key\":\"value\"}",
    "string json unquoted": "{key:\"value\"}"
}
```