### PR TITLE
Fixed flaky edqs tests

### DIFF
--- a/application/src/test/java/org/thingsboard/server/controller/EdqsEntityQueryControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/EdqsEntityQueryControllerTest.java
@@ -25,6 +25,9 @@ import org.thingsboard.server.common.data.edqs.EdqsState;
 import org.thingsboard.server.common.data.edqs.EdqsState.EdqsApiMode;
 import org.thingsboard.server.common.data.edqs.ToCoreEdqsRequest;
 import org.thingsboard.server.common.data.page.PageData;
+import org.thingsboard.server.common.data.query.AlarmCountQuery;
+import org.thingsboard.server.common.data.query.AlarmData;
+import org.thingsboard.server.common.data.query.AlarmDataQuery;
 import org.thingsboard.server.common.data.query.EntityCountQuery;
 import org.thingsboard.server.common.data.query.EntityData;
 import org.thingsboard.server.common.data.query.EntityDataQuery;
@@ -71,8 +74,20 @@ public class EdqsEntityQueryControllerTest extends EntityQueryControllerTest {
     }
 
     @Override
+    protected PageData<AlarmData> findAlarmsByQueryAndCheck(AlarmDataQuery query, int expectedResultSize) {
+        return await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> findAlarmsByQuery(query),
+                result -> result.getTotalElements() == expectedResultSize);
+    }
+
+    @Override
     protected Long countByQueryAndCheck(EntityCountQuery query, long expectedResult) {
         return await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> countByQuery(query),
+                result -> result == expectedResult);
+    }
+
+    @Override
+    protected Long countAlarmsByQueryAndCheck(AlarmCountQuery query, long expectedResult) {
+        return await().atMost(TIMEOUT, TimeUnit.SECONDS).until(() -> countAlarmsByQuery(query),
                 result -> result == expectedResult);
     }
 

--- a/application/src/test/java/org/thingsboard/server/controller/EntityQueryControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/EntityQueryControllerTest.java
@@ -278,8 +278,7 @@ public class EntityQueryControllerTest extends AbstractControllerTest {
         assetTypeFilter.setEntityType(EntityType.ASSET);
         AlarmCountQuery assetAlarmQuery = new AlarmCountQuery(assetTypeFilter);
 
-        Long assetAlamCount = doPostWithResponse("/api/alarmsQuery/count", assetAlarmQuery, Long.class);
-        Assert.assertEquals(assets.size(), assetAlamCount.longValue());
+        countAlarmsByQueryAndCheck(assetAlarmQuery, assets.size());
 
         KeyFilter nameFilter = buildStringKeyFilter(EntityKeyType.ENTITY_FIELD, "name", StringFilterPredicate.StringOperation.STARTS_WITH, "Asset1");
         List<KeyFilter> keyFilters = Collections.singletonList(nameFilter);
@@ -369,8 +368,7 @@ public class EntityQueryControllerTest extends AbstractControllerTest {
         assetTypeFilter.setEntityType(EntityType.ASSET);
         AlarmCountQuery assetAlarmQuery = new AlarmCountQuery(assetTypeFilter);
 
-        Long assetAlamCount = doPostWithResponse("/api/alarmsQuery/count", assetAlarmQuery, Long.class);
-        Assert.assertEquals(10, assetAlamCount.longValue());
+        countAlarmsByQueryAndCheck(assetAlarmQuery, 10);
 
         KeyFilter nameFilter = buildStringKeyFilter(EntityKeyType.ENTITY_FIELD, "name", StringFilterPredicate.StringOperation.STARTS_WITH, "Asset1");
         List<KeyFilter> keyFilters = Collections.singletonList(nameFilter);
@@ -438,9 +436,7 @@ public class EntityQueryControllerTest extends AbstractControllerTest {
         assetTypeFilter.setEntityType(EntityType.ASSET);
         AlarmDataQuery assetAlarmQuery =  new AlarmDataQuery(assetTypeFilter, pageLink, null, null, null, alarmFields);
 
-        PageData<AlarmData>  alarmPageData = doPostWithTypedResponse("/api/alarmsQuery/find", assetAlarmQuery, new TypeReference<>() {
-        });
-        Assert.assertEquals(10, alarmPageData.getTotalElements());
+        PageData<AlarmData> alarmPageData = findAlarmsByQueryAndCheck(assetAlarmQuery, 10);
         List<String> retrievedAlarmTypes = alarmPageData.getData().stream().map(Alarm::getType).toList();
         assertThat(retrievedAlarmTypes).containsExactlyInAnyOrderElementsOf(assetAlarmTypes);
 
@@ -511,9 +507,7 @@ public class EntityQueryControllerTest extends AbstractControllerTest {
         assetTypeFilter.setEntityType(EntityType.ASSET);
         AlarmDataQuery assetAlarmQuery =  new AlarmDataQuery(assetTypeFilter, pageLink, null, null, null, Collections.emptyList());
 
-        PageData<AlarmData>  alarmPageData = doPostWithTypedResponse("/api/alarmsQuery/find", assetAlarmQuery, new TypeReference<>() {
-        });
-        Assert.assertEquals(10, alarmPageData.getTotalElements());
+        PageData<AlarmData>  alarmPageData = findAlarmsByQueryAndCheck(assetAlarmQuery, 10);
         List<String> retrievedAlarmTypes = alarmPageData.getData().stream().map(Alarm::getType).toList();
         assertThat(retrievedAlarmTypes).containsExactlyInAnyOrderElementsOf(assetAlarmTypes);
 
@@ -1141,8 +1135,18 @@ public class EntityQueryControllerTest extends AbstractControllerTest {
         });
     }
 
+    protected PageData<AlarmData> findAlarmsByQuery(AlarmDataQuery query) throws Exception {
+        return doPostWithTypedResponse("/api/alarmsQuery/find", query, new TypeReference<>() {});
+    }
+
     protected PageData<EntityData> findByQueryAndCheck(EntityDataQuery query, int expectedResultSize) throws Exception {
         PageData<EntityData> result = findByQuery(query);
+        assertThat(result.getTotalElements()).isEqualTo(expectedResultSize);
+        return result;
+    }
+
+    protected PageData<AlarmData> findAlarmsByQueryAndCheck(AlarmDataQuery query, int expectedResultSize) throws Exception {
+        PageData<AlarmData> result = findAlarmsByQuery(query);
         assertThat(result.getTotalElements()).isEqualTo(expectedResultSize);
         return result;
     }
@@ -1151,8 +1155,18 @@ public class EntityQueryControllerTest extends AbstractControllerTest {
         return doPostWithResponse("/api/entitiesQuery/count", countQuery, Long.class);
     }
 
+    protected Long countAlarmsByQuery(AlarmCountQuery countQuery) throws Exception {
+        return doPostWithResponse("/api/alarmsQuery/count", countQuery, Long.class);
+    }
+
     protected Long countByQueryAndCheck(EntityCountQuery query, long expectedResult) throws Exception {
         Long result = countByQuery(query);
+        assertThat(result).isEqualTo(expectedResult);
+        return result;
+    }
+
+    protected Long countAlarmsByQueryAndCheck(AlarmCountQuery query, long expectedResult) throws Exception {
+        Long result = countAlarmsByQuery(query);
         assertThat(result).isEqualTo(expectedResult);
         return result;
     }


### PR DESCRIPTION
## Pull Request description

Fixed flaky edqs tests

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



