### PR TITLE
Fix: Robust Edge session cleanup to prevent resource leaks and message lag under unstable network conditions

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcService.java
@@ -219,6 +219,9 @@ public class EdgeGrpcService extends EdgeRpcServiceGrpc.EdgeRpcServiceImplBase i
         if (executorService != null) {
             executorService.shutdownNow();
         }
+        if(zombieSessionsExecutorService != null){
+            zombieSessionsExecutorService.shutdownNow();
+        }
     }
 
     @Override


### PR DESCRIPTION
### The Problem

Under unstable network conditions, ThingsBoard Edge instances can experience frequent disconnections and reconnections. This can lead to a state where the Edge stops receiving any downstream messages from the Cloud, even though it appears to be connected.The primary symptom is a continuously growing consumer lag on the Edge-specific Kafka topic (tb_edge_event.notifications.*). Restarting the Edge client does not resolve the issue; only a full restart of the ThingsBoard server clears the message backlog and restores normal data flow. This indicates a persistent state issue on the server side.
[iotcloud.2025-07-21.log](https://github.com/user-attachments/files/21703269/iotcloud.2025-07-21.log)

### Root Cause Analysis
The root cause is a race condition combined with incomplete resource cleanup, leading to both application-level resource leaks and Kafka-level "zombie consumers".
1. **Initial Trigger**: An Edge client on an unstable network triggers rapid onEdgeConnect and onEdgeDisconnect events in EdgeGrpcService.
2. **Cleanup Failure**: Under load or due to timeouts, the KafkaEdgeGrpcSession.destroy() method can fail to gracefully stop its underlying Kafka consumer. This was observed in logs with warnings like Failed to stop edge event consumer.
3. **Creation of a "Zombie Consumer"**: When destroy() fails, the KafkaConsumer thread remains active. This "zombie" consumer is still a member of the consumer group from the Kafka broker's perspective, but its corresponding gRPC stream to the Edge is gone.
4. **Application-Level Leak**: The onEdgeDisconnect method removes the EdgeGrpcSession object from the main sessions map before attempting the destroy() operation. If destroy() fails, the session object and its associated ExecutorService are orphaned in memory. They are no longer reachable by the sessions map, so the built-in periodic cleanup task (destroyKafkaSessionIfDisconnectedAndConsumerActive) cannot find and terminate them.
5. **Message Hijacking & Lag**: When the Edge reconnects, a new, valid session and consumer are created. However, the zombie consumer may still be assigned the topic partition by the Kafka group coordinator. When this zombie polls messages, it has no gRPC stream to forward them to. The messages are effectively lost, the offset is never committed, and the consumer lag grows indefinitely.

**The Solution**
This PR implements a “periodic defense” strategy to make the Edge session lifecycle management resilient to these failures.
1. **Long-Term Resource Management: Zombie Session Cleanup Queue** 
This addresses the application-level memory and thread leaks.
- A new ConcurrentLinkedQueue<EdgeGrpcSession> zombieSessions is introduced in EdgeGrpcService to track session objects that failed to be destroyed.
- The onEdgeDisconnect logic is modified: if destroySession() fails, the failed session object is added to this zombieSessions queue.
- A new periodic background task, cleanupZombieSessions(), iterates through this queue and repeatedly attempts to destroy the zombie sessions until it succeeds, ensuring the eventual reclamation of all leaked resources.

**How to Reproduce the Issue**
1. **Simulate Cleanup Failure**: Modify the KafkaEdgeGrpcSession.destroy() method to always return false; and bypass the actual cleanup logic to reliably create an orphaned session.
2. **Simulate Network Churn**: Create a simple gRPC test client that connects to the ThingsBoard server as an Edge instance. The client should run in a loop where it:
a. Connects and sends the ConnectRequestMsg.
b. Waits for 1-2 seconds.
c. Abruptly shuts down its channel (e.g., channel.shutdownNow()) to simulate a network drop.
d. Waits for 1 second before reconnecting.
3. **Generate Load**: Use a separate Kafka producer to continuously send messages to the target Edge's event topic (tb_edge_event.notifications.<tenantId>.<edgeId>).
4. **Observe**: Without the fix, the Kafka consumer lag for the Edge's consumer group will increase steadily. With the fix applied, the lag is correctly processed after each reconnection, and the system remains stable without resource leaks.