### PR TITLE
Add alarm details field to alarm widget

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/alarm/alarms-table-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/alarm/alarms-table-widget.component.ts
@@ -851,6 +851,9 @@ export class AlarmsTableWidgetComponent extends PageComponent implements OnInit,
               content = this.defaultContent(key, contentInfo, value);
             }
             if (isDefined(content)) {
+              if (typeof content === 'object') {
+                content = JSON.stringify(content);
+              }
               content = this.utils.customTranslation(content, content);
               switch (typeof content) {
                 case 'string':

--- a/ui-ngx/src/app/shared/models/alarm.models.ts
+++ b/ui-ngx/src/app/shared/models/alarm.models.ts
@@ -271,6 +271,11 @@ export const alarmFields: {[fieldName: string]: AlarmField} = {
     keyName: 'assignee',
     value: 'assignee',
     name: 'alarm.assignee'
+  },
+  details: {
+    keyName: 'details',
+    value: 'details',
+    name: 'alarm.details'
   }
 };
 


### PR DESCRIPTION
Improved alarm widget and added 'details' alarm field. The field is displayed as JSON by default:

<img width="2302" height="584" alt="image" src="https://github.com/user-attachments/assets/46249a26-74a8-475c-8f94-c60f2158d51a" />

You may use the cell content function to extract particular fields: 

<img width="920" height="422" alt="image" src="https://github.com/user-attachments/assets/685545db-7cd8-424a-afb0-d2507eaa849e" />

All legacy features like using 'details.msg' as field are preserved.

