### PR TITLE
rpm java-17-devel

### DIFF
--- a/packaging/java/build.gradle
+++ b/packaging/java/build.gradle
@@ -92,7 +92,7 @@ buildRpm {
     archiveVersion = projectVersion.replace('-', '')
     archiveFileName = "${pkgName}.rpm"
 
-    requires("(java-17 or java-17-headless or jre-17 or jre-17-headless)") // .or() notation does work in RPM plugin
+    requires("(java-17 or java-17-headless or jre-17 or jre-17-headless or java-17-devel)") // .or() notation does work in RPM plugin
 
     from("${buildDir}/conf") {
         include "${pkgName}.conf"


### PR DESCRIPTION
## Pull Request description

Added `java-17-devel` to match non-openJDK Java distributions for RPM install.

### An old AmazonLinux 2 LTS with old PRM 4.11 does not recognize multiple dependencies and should be installed with --nodeps

❌ AmazonLinux2 failed test

```
mvn clean install -DskipTests
docker run -it --rm --name rpmtest amazonlinux:2 bash
docker cp ./application/target/thingsboard.rpm rpmtest:/tmp/
# Successfully copied 349MB to rpmtest:/tmp/
yum install -y java-17-amazon-corretto-devel
java -version
# openjdk version "17.0.16" 2025-07-15 LTS
# OpenJDK Runtime Environment Corretto-17.0.16.8.1 (build 17.0.16+8-LTS)
# OpenJDK 64-Bit Server VM Corretto-17.0.16.8.1 (build 17.0.16+8-LTS, mixed mode, sharing)
rpm -Uvh /tmp/thingsboard.rpm
# error: Failed dependencies:
#         (java-17 or java-17-headless or jre-17 or jre-17-headless or java-17-devel) is needed by thingsboard-0:4.2.0~RC-1.noarch
rpm -q --provides java-17-amazon-corretto-devel.aarch64
# java-17-amazon-corretto-devel = 1:17.0.16+8-1.amzn2.1
# java-17-amazon-corretto-devel(aarch-64) = 1:17.0.16+8-1.amzn2.1
# java-17-devel = 1:17.0.16
# java-17-devel = 1:17.0.16+8-1.amzn2.1
# java-devel = 1:17.0.16
rpm --version
# RPM version 4.11.3

```

Run rpm --version → if it’s 4.11.x, then Amazon Linux 2 cannot handle rich dependencies. On AL2, either use --nodeps or rebuild the RPM without rich deps. On AL2023+, no issue.

### Example for Amazon Corretto Java:

#### JDK

⚠️ The tag added `java-17-devel`

```bash
docker run --rm -it amazonlinux:2 bash -c "yum install -y java-17-amazon-corretto-devel && rpm -q --provides java-17-amazon-corretto-devel.aarch64"   

java-17-amazon-corretto-devel = 1:17.0.16+8-1.amzn2.1
java-17-amazon-corretto-devel(aarch-64) = 1:17.0.16+8-1.amzn2.1
java-17-devel = 1:17.0.16
java-17-devel = 1:17.0.16+8-1.amzn2.1
java-devel = 1:17.0.16

```

#### JRE

✅ The tag `jre-17` already supported

```bash
docker run --rm -it amazonlinux:2 bash -c "yum install -y java-17-amazon-corretto && rpm -q --provides java-17-amazon-corretto.aarch64"

java = 1:17.0.16
java-17 = 1:17.0.16
java-17 = 1:17.0.16+8-1.amzn2.1
java-17-amazon-corretto = 1:17.0.16+8-1.amzn2.1
java-17-amazon-corretto(aarch-64) = 1:17.0.16+8-1.amzn2.1
jre = 17.0.16
jre-17 = 1:17.0.16+8-1.amzn2.1
jre-17-amazon-corretto = 1:17.0.16+8-1.amzn2.1
```

#### Headless

✅ The tag `jre-17-headless` already supported

```bash
docker run --rm -it amazonlinux:2  bash -c "yum install -y java-17-amazon-corretto-headless && rpm -q --provides java-17-amazon-corretto-headless.aarch64"

config(java-17-amazon-corretto-headless) = 1:17.0.16+8-1.amzn2.1
java-17-amazon-corretto-headless = 1:17.0.16+8-1.amzn2.1
java-17-amazon-corretto-headless(aarch-64) = 1:17.0.16+8-1.amzn2.1
java-17-headless = 1:17.0.16+8-1.amzn2.1
java-headless = 1:17.0.16
jre-17-amazon-corretto-headless = 1:17.0.16+8-1.amzn2.1
jre-17-headless = 1:17.0.16+8-1.amzn2.1
jre-headless = 1:17.0.16
``` 

Related PR to give more context: https://github.com/thingsboard/thingsboard/pull/13744

## Manual test on AmazonLinux:2023

⚠️ Requires `dnf install -y shadow-utils` ⚠️
otherwise 
```
/var/tmp/rpm-tmp.xxG9uG: line 9: groupadd: command not found
/var/tmp/rpm-tmp.xxG9uG: line 11: useradd: command not found
```

with JDK

```bash
mvn clean install -DskipTests
docker run -it --rm --name rpmtest amazonlinux:2023 bash
docker cp ./application/target/thingsboard.rpm rpmtest:/tmp/
# Successfully copied 349MB to rpmtest:/tmp/
yum install -y java-17-amazon-corretto-devel
java -version
# openjdk version "17.0.16" 2025-07-15 LTS
# OpenJDK Runtime Environment Corretto-17.0.16.8.1 (build 17.0.16+8-LTS)
# OpenJDK 64-Bit Server VM Corretto-17.0.16.8.1 (build 17.0.16+8-LTS, mixed mode, sharing)
dnf install -y shadow-utils
rpm -Uvh /tmp/thingsboard.rpm
# Verifying...                          ################################# [100%]
# Preparing...                          ################################# [100%]
# Updating / installing...
#    1:thingsboard-0:4.2.0~RC-1         ################################# [100%]
```

with JRE

```bash
docker run -it --rm --name rpmtest amazonlinux:2023 bash
docker cp ./application/target/thingsboard.rpm rpmtest:/tmp/

yum install -y java-17-amazon-corretto
java -version
# openjdk version "17.0.16" 2025-07-15 LTS
# OpenJDK Runtime Environment Corretto-17.0.16.8.1 (build 17.0.16+8-LTS)
# OpenJDK 64-Bit Server VM Corretto-17.0.16.8.1 (build 17.0.16+8-LTS, mixed mode, sharing)
dnf install -y shadow-utils
rpm -Uvh /tmp/thingsboard.rpm
# Verifying...                          ################################# [100%]
# Preparing...                          ################################# [100%]
# Updating / installing...
#    1:thingsboard-0:4.2.0~RC-1         ################################# [100%]
```

with headless

```bash
docker run -it --rm --name rpmtest amazonlinux:2023 bash
docker cp ./application/target/thingsboard.rpm rpmtest:/tmp/

yum install -y java-17-amazon-corretto-headless
java -version
# openjdk version "17.0.16" 2025-07-15 LTS
# OpenJDK Runtime Environment Corretto-17.0.16.8.1 (build 17.0.16+8-LTS)
# OpenJDK 64-Bit Server VM Corretto-17.0.16.8.1 (build 17.0.16+8-LTS, mixed mode, sharing)
dnf install -y shadow-utils
rpm -Uvh /tmp/thingsboard.rpm
# Verifying...                          ################################# [100%]
# Preparing...                          ################################# [100%]
# Updating / installing...
#    1:thingsboard-0:4.2.0~RC-1         ################################# [100%]
```

with no Java installed

```bash
docker run -it --rm --name rpmtest amazonlinux:2023 bash
docker cp ./application/target/thingsboard.rpm rpmtest:/tmp/

rpm -Uvh /tmp/thingsboard.rpm
# error: Failed dependencies:
#         (java-17 or java-17-headless or jre-17 or jre-17-headless or java-17-devel) is needed by thingsboard-0:4.2.0~RC-1.noarch
# bash-5.2# 
```

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



