### PR TITLE
Fixed column order for "On cell click" action in Entities Table widget

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/action/widget-action-dialog.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/action/widget-action-dialog.component.html
@@ -57,7 +57,7 @@
               <mat-option *ngFor="let column of configuredColumns; let $index = index"
                           [value]="$index"
                           [disabled]="usedCellClickColumns.includes($index)">
-                {{ getCellClickColumnInfo($index, column) }}
+                {{ getCellClickColumnInfo($index, column) | customTranslate }}
               </mat-option>
             </mat-select>
             <mat-icon matSuffix

--- a/ui-ngx/src/app/modules/home/components/widget/widget-config.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-config.component.ts
@@ -926,7 +926,26 @@ export class WidgetConfigComponent extends PageComponent implements OnInit, OnDe
     if (this.modelValue) {
       const configuredColumns = new Array<CellClickColumnInfo>();
       if (this.modelValue.config?.datasources[0]?.dataKeys?.length) {
-        configuredColumns.push(...this.keysToCellClickColumns(this.modelValue.config.datasources[0].dataKeys));
+        const {
+          displayEntityLabel,
+          displayEntityName,
+          displayEntityType,
+          entityNameColumnTitle,
+          entityLabelColumnTitle
+        } = this.modelValue.config.settings;
+        const displayEntitiesArray = [];
+        if (isDefined(displayEntityName)) {
+          const displayName = entityNameColumnTitle ? entityNameColumnTitle : 'entityName';
+          displayEntitiesArray.push({name: displayName, label: displayName});
+        }
+        if (isDefined(displayEntityLabel)) {
+          const displayLabel = entityLabelColumnTitle ? entityLabelColumnTitle : 'entityLabel';
+          displayEntitiesArray.push({name: displayLabel, label: displayLabel});
+        }
+        if (isDefined(displayEntityType)) {
+          displayEntitiesArray.push({name: 'entityType', label: 'entityType'});
+        }
+        configuredColumns.push(...displayEntitiesArray, ...this.keysToCellClickColumns(this.modelValue.config.datasources[0].dataKeys));
       }
       if (this.modelValue.config?.alarmSource?.dataKeys?.length) {
         configuredColumns.push(...this.keysToCellClickColumns(this.modelValue.config.alarmSource.dataKeys));


### PR DESCRIPTION
## Pull Request description

The Entities table widget has a feature that allows users to trigger an action when they click a cell in the table. This is configured using the "On cell click" action and a specific column index. The bug occurs when any of the following columns are enabled under the Appearance tab:
- Display entity name column
- Display entity label column
- Display entity type column

When any of these columns are active, they are added to the table before any data keys. This shifts the index order of the data keys. 
This fix ensures that the column index for the "On cell click" action is correctly calculated based on all currently displayed columns, including the built-in ones. 

<img width="929" height="310" alt="Screenshot from 2025-09-17 12-10-42" src="https://github.com/user-attachments/assets/5a1e4741-252a-4b0d-af14-2700bc7df752" />
<img width="980" height="347" alt="Screenshot from 2025-09-17 12-10-11" src="https://github.com/user-attachments/assets/3fabe701-de15-41b7-9dd5-e103f4a4697a" />


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



