### PR TITLE
Timewindow: clear configuration parameters depending on selected aggregation function

### DIFF
--- a/ui-ngx/src/app/shared/models/time/time.models.ts
+++ b/ui-ngx/src/app/shared/models/time/time.models.ts
@@ -1125,6 +1125,7 @@ export const cloneSelectedTimewindow = (timewindow: Timewindow): Timewindow => {
 
 export const clearTimewindowConfig = (timewindow: Timewindow, quickIntervalOnly: boolean,
                                       historyOnly: boolean, hasAggregation: boolean, hasTimezone = true): Timewindow => {
+  const noneAggregation = hasAggregation && timewindow.aggregation?.type === AggregationType.NONE;
   if (timewindow.selectedTab === TimewindowType.REALTIME) {
     if (quickIntervalOnly || timewindow.realtime.realtimeType === RealtimeWindowType.INTERVAL) {
       delete timewindow.realtime.timewindowMs;
@@ -1138,7 +1139,7 @@ export const clearTimewindowConfig = (timewindow: Timewindow, quickIntervalOnly:
     delete timewindow.history?.quickInterval;
 
     delete timewindow.history?.interval;
-    if (!hasAggregation) {
+    if (!hasAggregation || noneAggregation) {
       delete timewindow.realtime.interval;
     }
   } else {
@@ -1162,13 +1163,15 @@ export const clearTimewindowConfig = (timewindow: Timewindow, quickIntervalOnly:
     delete timewindow.realtime?.quickInterval;
 
     delete timewindow.realtime?.interval;
-    if (!hasAggregation) {
+    if (!hasAggregation || noneAggregation) {
       delete timewindow.history.interval;
     }
   }
 
   if (!hasAggregation) {
     delete timewindow.aggregation;
+  } else if (!noneAggregation) {
+    delete timewindow.aggregation.limit;
   }
 
   if (historyOnly) {


### PR DESCRIPTION
## Pull Request description

Depending on the selected aggregation function, unused parameters are removed from the timewindow configuration:
  - NONE aggregation selected - aggregation interval is removed
  - another aggregation function is selected - datapoint limit is removed

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



