### PR TITLE
ix: Store LWM2M Time as raw Epoch for precision and UTC consistency

### DIFF
--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportServerHelper.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportServerHelper.java
@@ -38,6 +38,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -180,8 +181,16 @@ public class LwM2mTransportServerHelper {
                 case BOOLEAN:
                     kvProto.setType(BOOLEAN_V).setBoolV((Boolean) value).build();
                     break;
-                case STRING:
                 case TIME:
+                    if (value instanceof Date) {
+                        kvProto.setType(TransportProtos.KeyValueType.LONG_V).setLongV(((Date) value).getTime());
+                    } else if (value instanceof Integer || value instanceof Long) {
+                        kvProto.setType(TransportProtos.KeyValueType.LONG_V).setLongV((long) (value));
+                    } else {
+                        kvProto.setType(TransportProtos.KeyValueType.STRING_V).setStringV(value.toString());
+                    }
+                    break;
+                case STRING:
                 case OPAQUE:
                 case OBJLNK:
                     kvProto.setType(TransportProtos.KeyValueType.STRING_V).setStringV((String) value);

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2mValueConverterImpl.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2mValueConverterImpl.java
@@ -33,6 +33,7 @@ import java.util.Date;
 
 import static org.eclipse.leshan.core.model.ResourceModel.Type.NONE;
 import static org.eclipse.leshan.core.model.ResourceModel.Type.OPAQUE;
+import static org.eclipse.leshan.core.model.ResourceModel.Type.TIME;
 
 @Slf4j
 public class LwM2mValueConverterImpl implements LwM2mValueConverter {
@@ -58,7 +59,7 @@ public class LwM2mValueConverterImpl implements LwM2mValueConverter {
             currentType = OPAQUE;
         }
 
-        if (currentType == expectedType || currentType == NONE) {
+        if (currentType == expectedType || currentType == NONE || currentType == TIME) {
             /** expected type */
             return value;
         }
@@ -135,7 +136,7 @@ public class LwM2mValueConverterImpl implements LwM2mValueConverter {
                              **/
                         } catch (IllegalArgumentException e) {
                             log.debug("Unable to convert string to date", e);
-                            throw new CodecException("Unable to convert string (%s) to date for resource %s", value,
+                            throw new CodecException("Unable to convert string (%s) to %s for resource %s", value, TIME.name(),
                                     resourcePath);
                         }
                     default:
@@ -149,7 +150,7 @@ public class LwM2mValueConverterImpl implements LwM2mValueConverter {
                     case FLOAT:
                         return String.valueOf(value);
                     case TIME:
-                        String DATE_FORMAT = "MMM d, yyyy HH:mm a";
+                        String DATE_FORMAT = "yyyy-MM-dd[[ ]['T']HH:mm[:ss[.SSS]][ ][XXX][Z][z][VV][O]]";
                         Long timeValue;
                         try {
                             timeValue = ((Date) value).getTime();


### PR DESCRIPTION
## Pull Request description

Problem Summary
Currently, LWM2M resources defined as type Time are converted and stored in the database as a localized string (e.g., Sep 25, 2025 13:05 PM). This conversion introduces ambiguity and data loss, particularly in multi-timezone environments.

The expected and correct behavior is to store the raw numeric value (UTC Epoch Time, signed integer) sent directly by the device, deferring all formatting and timezone adjustments to the presentation layer (dashboards/widgets/browser).

This PR Fixes the Following Critical Issues
Loss of Precision: The current string format truncates the time, leading to a loss of precision to the minute. Storing the raw integer preserves the full time value (typically in seconds or milliseconds).

Timezone Inconsistency/Ambiguity: The existing conversion uses the server's local timezone offset, resulting in an ambiguous stored value. This makes data retrieval and display inconsistent when clients/dashboards access the data from a different timezone.

Non-Standard Practice: Storing LWM2M Time (which is defined as a numeric epoch) as a localized string contradicts standard best practices for time management.

Solution Implemented
This change modifies the resource management logic to treat LWM2M Time resources as a numeric data type (e.g., double or long for Epoch), ensuring that the raw, non-converted UTC Epoch value is persisted directly to the database.

Before: 3/0/13 (currentTime) = 1759400476 (raw) → Stored as "Sep 29, 2025 14:00 PM" (string).

After (This PR): 3/0/13 (currentTime) = 1759400476 (raw) → Stored as 1759400476 (numeric).

This guarantees that the stored data is unambiguous and always represents the exact time reported by the device in UTC, allowing for reliable and consistent display across all timezones.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



