### PR TITLE
Cassandra DAO: Safety trigger to fall back to use_ts_key_value_partitioning_on_read as true if estimated partitions count is greater than safety trigger value

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -303,8 +303,11 @@ cassandra:
     default_fetch_size: "${CASSANDRA_DEFAULT_FETCH_SIZE:2000}"
     # Specify partitioning size for timestamp key-value storage. Example: MINUTES, HOURS, DAYS, MONTHS, INDEFINITE
     ts_key_value_partitioning: "${TS_KV_PARTITIONING:MONTHS}"
-    # Enable/Disable timestamp key-value partioning on read queries
+    # Enable/Disable timestamp key-value partitioning on read queries
     use_ts_key_value_partitioning_on_read: "${USE_TS_KV_PARTITIONING_ON_READ:true}"
+    # Safety trigger to fall back to use_ts_key_value_partitioning_on_read as true if estimated partitions count is greater than safety trigger value.
+    # It helps to prevent building huge partition list (OOM) for corner cases (like from 0 to infinity) and prefer fewer reads strategy from NoSQL database
+    use_ts_key_value_partitioning_on_read_max_estimated_partition_count: "${USE_TS_KV_PARTITIONING_ON_READ_MAX_ESTIMATED_PARTITION_COUNT:40}"
     # The number of partitions that are cached in memory of each service. It is useful to decrease the load of re-inserting the same partitions again
     ts_key_value_partitions_max_cache_size: "${TS_KV_PARTITIONS_MAX_CACHE_SIZE:100000}"
     # Timeseries Time To Live (in seconds) for Cassandra Record. 0 - record has never expired

--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/NoSqlTsPartitionDate.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/NoSqlTsPartitionDate.java
@@ -15,32 +15,29 @@
  */
 package org.thingsboard.server.dao.timeseries;
 
+import lombok.Getter;
+
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+@Getter
 public enum NoSqlTsPartitionDate {
 
     MINUTES("yyyy-MM-dd-HH-mm", ChronoUnit.MINUTES), HOURS("yyyy-MM-dd-HH", ChronoUnit.HOURS), DAYS("yyyy-MM-dd", ChronoUnit.DAYS), MONTHS("yyyy-MM", ChronoUnit.MONTHS), YEARS("yyyy", ChronoUnit.YEARS),INDEFINITE("",ChronoUnit.FOREVER);
 
     private final String pattern;
     private final transient TemporalUnit truncateUnit;
+    private final transient long durationMs;
     public final static LocalDateTime EPOCH_START = LocalDateTime.ofEpochSecond(0,0, ZoneOffset.UTC);
 
     NoSqlTsPartitionDate(String pattern, TemporalUnit truncateUnit) {
         this.pattern = pattern;
         this.truncateUnit = truncateUnit;
-    }
-
-
-    public String getPattern() {
-        return pattern;
-    }
-
-    public TemporalUnit getTruncateUnit() {
-        return truncateUnit;
+        this.durationMs = TimeUnit.SECONDS.toMillis(this.truncateUnit.getDuration().getSeconds());
     }
 
     public LocalDateTime truncatedTo(LocalDateTime time) {

--- a/dao/src/test/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDaoPartitioningMinutesAlwaysExistsTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDaoPartitioningMinutesAlwaysExistsTest.java
@@ -117,4 +117,16 @@ public class CassandraBaseTimeseriesDaoPartitioningMinutesAlwaysExistsTest {
                 ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2022-10-10T00:10:00Z").getTime()));
     }
 
+    @Test
+    public void testEstimatePartitionCount() throws ParseException {
+        assertThat(tsDao.estimatePartitionCount(0, Long.MAX_VALUE)).as("centuries").isEqualTo(153_722_867_280_914L);
+        assertThat(tsDao.estimatePartitionCount(0, 0)).as("single").isEqualTo(1L);
+        long startTs = tsDao.toPartitionTs(
+                ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2019-12-12T00:00:00Z").getTime());
+        long endTs = tsDao.toPartitionTs(
+                ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2021-01-31T23:59:59Z").getTime());
+        assertThat(tsDao.estimatePartitionCount(startTs, endTs)).as("600,479 minutes + 2 spare periods").isEqualTo(600479 + 2);
+        assertThat(tsDao.estimatePartitionCount(endTs, startTs)).as("wrong period estimated as 1").isEqualTo(1L);
+    }
+
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDaoPartitioningMonthsAlwaysExistsTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDaoPartitioningMonthsAlwaysExistsTest.java
@@ -15,25 +15,35 @@
  */
 package org.thingsboard.server.dao.timeseries;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.TsKvQuery;
 import org.thingsboard.server.dao.cassandra.CassandraCluster;
 import org.thingsboard.server.dao.nosql.CassandraBufferedRateReadExecutor;
 import org.thingsboard.server.dao.nosql.CassandraBufferedRateWriteExecutor;
 
 import java.text.ParseException;
 import java.util.List;
+import java.util.UUID;
 
 import static org.apache.commons.lang3.time.DateFormatUtils.ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = CassandraBaseTimeseriesDao.class)
@@ -50,7 +60,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Slf4j
 public class CassandraBaseTimeseriesDaoPartitioningMonthsAlwaysExistsTest {
 
-    @Autowired
+    @MockitoSpyBean
     CassandraBaseTimeseriesDao tsDao;
 
     @MockBean(answer = Answers.RETURNS_MOCKS)
@@ -129,6 +139,55 @@ public class CassandraBaseTimeseriesDaoPartitioningMonthsAlwaysExistsTest {
                 ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2020-11-01T00:00:00Z").getTime(),
                 ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2020-12-01T00:00:00Z").getTime(),
                 ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2021-01-01T00:00:00Z").getTime()));
+    }
+
+    @Test
+    public void testEstimatePartitionCount() throws ParseException {
+        assertThat(tsDao.estimatePartitionCount(0, Long.MAX_VALUE)).as("centuries").isEqualTo(3_507_324_297L);
+        assertThat(tsDao.estimatePartitionCount(0, 0)).as("single").isEqualTo(1L);
+        long startTs = tsDao.toPartitionTs(
+                ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2019-12-12T00:00:00Z").getTime());
+        long endTs = tsDao.toPartitionTs(
+                ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2021-01-31T23:59:59Z").getTime());
+        assertThat(tsDao.estimatePartitionCount(startTs, endTs)).as("13 month + 2 spare periods").isEqualTo(13 + 2);
+        assertThat(tsDao.estimatePartitionCount(endTs, startTs)).as("wrong period estimated as 1").isEqualTo(1L);
+    }
+
+    @Test
+    public void testGetPartitionsFutureModeratePartitionsCount() throws ParseException {
+        TenantId tenantId = TenantId.fromUUID(UUID.randomUUID());
+        TsKvQuery query = mock(TsKvQuery.class);
+        long startTs = tsDao.toPartitionTs(
+                ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2019-12-12T00:00:00Z").getTime());
+        long endTs = tsDao.toPartitionTs(
+                ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2021-01-31T23:59:59Z").getTime());
+
+        willReturn(mock(ListenableFuture.class)).given(tsDao).getPartitionsFromDB(tenantId, query, tenantId, startTs, endTs);
+
+        tsDao.getPartitionsFuture(tenantId, query, tenantId, startTs, endTs);
+
+        verify(tsDao).estimatePartitionCount(startTs, endTs);
+        verify(tsDao).calculatePartitions(eq(startTs), eq(endTs), anyInt());
+        verify(tsDao, never()).getPartitionsFromDB(tenantId, query, tenantId, startTs, endTs);
+    }
+
+    @Test
+    public void testGetPartitionsFutureHugePartitionsCountPreventOOMFallbackToDB() throws ParseException {
+
+        TenantId tenantId = TenantId.fromUUID(UUID.randomUUID());
+        TsKvQuery query = mock(TsKvQuery.class);
+        long startTs = tsDao.toPartitionTs(
+                ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2000-12-12T00:00:00Z").getTime());
+        long endTs = tsDao.toPartitionTs(
+                ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("3000-01-31T23:59:59Z").getTime());
+
+        willReturn(mock(ListenableFuture.class)).given(tsDao).getPartitionsFromDB(tenantId, query, tenantId, startTs, endTs);
+
+        tsDao.getPartitionsFuture(tenantId, query, tenantId, startTs, endTs);
+
+        verify(tsDao).estimatePartitionCount(startTs, endTs);
+        verify(tsDao, never()).calculatePartitions(eq(startTs), eq(endTs), anyInt());
+        verify(tsDao).getPartitionsFromDB(tenantId, query, tenantId, startTs, endTs);
     }
 
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDaoPartitioningYearsAlwaysExistsTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/timeseries/CassandraBaseTimeseriesDaoPartitioningYearsAlwaysExistsTest.java
@@ -112,4 +112,16 @@ public class CassandraBaseTimeseriesDaoPartitioningYearsAlwaysExistsTest {
                 ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2025-01-01T00:00:00Z").getTime()));
     }
 
+    @Test
+    public void testEstimatePartitionCount() throws ParseException {
+        assertThat(tsDao.estimatePartitionCount(0, Long.MAX_VALUE)).as("centuries").isEqualTo(292_277_026L);
+        assertThat(tsDao.estimatePartitionCount(0, 0)).as("single").isEqualTo(1L);
+        long startTs = tsDao.toPartitionTs(
+                ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2019-12-12T00:00:00Z").getTime());
+        long endTs = tsDao.toPartitionTs(
+                ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.parse("2021-01-31T23:59:59Z").getTime());
+        assertThat(tsDao.estimatePartitionCount(startTs, endTs)).as("2 years + 2 spare periods").isEqualTo(2 + 2);
+        assertThat(tsDao.estimatePartitionCount(endTs, startTs)).as("wrong period estimated as 1").isEqualTo(1L);
+    }
+
 }

--- a/dao/src/test/java/org/thingsboard/server/dao/timeseries/NoSqlTsPartitionDateTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/timeseries/NoSqlTsPartitionDateTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright © 2016-2025 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao.timeseries;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoSqlTsPartitionDateTest {
+
+    @ParameterizedTest
+    @EnumSource(NoSqlTsPartitionDate.class)
+    void getDurationMsTest(NoSqlTsPartitionDate tsPartitionDate) throws Exception {
+        final Long durationMs = switch (tsPartitionDate) {
+            case MINUTES -> 60000L;
+            case HOURS -> 3600000L;
+            case DAYS -> 86400000L;
+            case MONTHS -> 2629746000L;
+            case YEARS -> 31556952000L;
+            case INDEFINITE -> Long.MAX_VALUE;
+            default -> null; //should be here in case a new enum value will be added in future
+        };
+        assertThat(durationMs).isNotNull();
+        assertThat(tsPartitionDate.getDurationMs()).isEqualTo(durationMs);
+    }
+
+}


### PR DESCRIPTION

## Pull Request description

Cassandra DAO: Safety trigger to fall back to use_ts_key_value_partitioning_on_read as true if estimated partitions count is greater than safety trigger value

ThingsBoard version affected: 4.2

The Issue addressed is the OOM on very long period requests to Cassandra from entity view or potentially wrong user request (endTs timestamp in nanoseconds instead of milleseco). when `cassandra.query.use_ts_key_value_partitioning_on_read=false` (`USE_TS_KV_PARTITIONING_ON_READ:false`)


Screenshot from the heap dump analysis:

<img width="2394" height="898" alt="image" src="https://github.com/user-attachments/assets/1491ce4b-0487-47fc-8746-52bc6d33793b" />

<img width="1758" height="746" alt="image" src="https://github.com/user-attachments/assets/edc06ce0-4847-4f0d-be26-28f4e9ef6ec8" />

Stacktrace:
```
JpaExecutorService-0-545
  at java.lang.OutOfMemoryError.<init>()V (OutOfMemoryError.java:48)
  at java.util.Arrays.copyOf([Ljava/lang/Object;I)[Ljava/lang/Object; (Arrays.java:3481)
  at java.util.ArrayList.grow(I)[Ljava/lang/Object; (ArrayList.java:237)
  at java.util.ArrayList.grow()[Ljava/lang/Object; (ArrayList.java:244)
  at java.util.ArrayList.add(Ljava/lang/Object;[Ljava/lang/Object;I)V (ArrayList.java:454)
  at java.util.ArrayList.add(Ljava/lang/Object;)Z (ArrayList.java:467)
  at org.thingsboard.server.dao.timeseries.CassandraBaseTimeseriesDao.calculatePartitions(JJ)Ljava/util/List; (CassandraBaseTimeseriesDao.java:478)
  at org.thingsboard.server.dao.timeseries.CassandraBaseTimeseriesDao.getPartitionsFuture(Lorg/thingsboard/server/common/data/id/TenantId;Lorg/thingsboard/server/common/data/kv/TsKvQuery;Lorg/thingsboard/server/common/data/id/EntityId;JJ)Lcom/google/common/util/concurrent/ListenableFuture; (CassandraBaseTimeseriesDao.java:462)
  at org.thingsboard.server.dao.timeseries.CassandraBaseTimeseriesDao.findAllAsyncWithLimit(Lorg/thingsboard/server/common/data/id/TenantId;Lorg/thingsboard/server/common/data/id/EntityId;Lorg/thingsboard/server/common/data/kv/ReadTsKvQuery;)Lcom/google/common/util/concurrent/ListenableFuture; (CassandraBaseTimeseriesDao.java:356)
  at org.thingsboard.server.dao.timeseries.CassandraBaseTimeseriesDao.findAllAsync(Lorg/thingsboard/server/common/data/id/TenantId;Lorg/thingsboard/server/common/data/id/EntityId;Lorg/thingsboard/server/common/data/kv/ReadTsKvQuery;)Lcom/google/common/util/concurrent/ListenableFuture; (CassandraBaseTimeseriesDao.java:304)
  at org.thingsboard.server.dao.timeseries.CassandraBaseTimeseriesDao.lambda$findAllAsync$1(Lorg/thingsboard/server/common/data/id/TenantId;Lorg/thingsboard/server/common/data/id/EntityId;Lorg/thingsboard/server/common/data/kv/ReadTsKvQuery;)Lcom/google/common/util/concurrent/ListenableFuture; (CassandraBaseTimeseriesDao.java:196)
  at org.thingsboard.server.dao.timeseries.CassandraBaseTimeseriesDao$$Lambda$4497+0x0000000802e21460.apply(Ljava/lang/Object;)Ljava/lang/Object; ()
  at java.util.stream.ReferencePipeline$3$1.accept(Ljava/lang/Object;)V (ReferencePipeline.java:197)
  at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Ljava/util/function/Consumer;)V (ArrayList.java:1625)
  at java.util.stream.AbstractPipeline.copyInto(Ljava/util/stream/Sink;Ljava/util/Spliterator;)V (AbstractPipeline.java:509)
  at java.util.stream.AbstractPipeline.wrapAndCopyInto(Ljava/util/stream/Sink;Ljava/util/Spliterator;)Ljava/util/stream/Sink; (AbstractPipeline.java:499)
  at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Ljava/util/stream/PipelineHelper;Ljava/util/Spliterator;)Ljava/lang/Object; (ReduceOps.java:921)
  at java.util.stream.AbstractPipeline.evaluate(Ljava/util/stream/TerminalOp;)Ljava/lang/Object; (AbstractPipeline.java:234)
  at java.util.stream.ReferencePipeline.collect(Ljava/util/stream/Collector;)Ljava/lang/Object; (ReferencePipeline.java:682)
  at org.thingsboard.server.dao.timeseries.CassandraBaseTimeseriesDao.findAllAsync(Lorg/thingsboard/server/common/data/id/TenantId;Lorg/thingsboard/server/common/data/id/EntityId;Ljava/util/List;)Lcom/google/common/util/concurrent/ListenableFuture; (CassandraBaseTimeseriesDao.java:196)
  at org.thingsboard.server.dao.timeseries.BaseTimeseriesService.findAllByQueries(Lorg/thingsboard/server/common/data/id/TenantId;Lorg/thingsboard/server/common/data/id/EntityId;Ljava/util/List;)Lcom/google/common/util/concurrent/ListenableFuture; (BaseTimeseriesService.java:135)
  at org.thingsboard.server.dao.timeseries.BaseTimeseriesService.findAll(Lorg/thingsboard/server/common/data/id/TenantId;Lorg/thingsboard/server/common/data/id/EntityId;Ljava/util/List;)Lcom/google/common/util/concurrent/ListenableFuture; (BaseTimeseriesService.java:140)
  at org.thingsboard.server.service.entitiy.entityview.DefaultTbEntityViewService.lambda$copyLatestFromEntityToEntityView$10(JJLorg/thingsboard/server/common/data/id/TenantId;Lorg/thingsboard/server/common/data/EntityView;Ljava/util/List;)Lcom/google/common/util/concurrent/ListenableFuture; (DefaultTbEntityViewService.java:276)
  at org.thingsboard.server.service.entitiy.entityview.DefaultTbEntityViewService$$Lambda$6720+0x00000008035858f0.apply(Ljava/lang/Object;)Lcom/google/common/util/concurrent/ListenableFuture; ()
  at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(Lcom/google/common/util/concurrent/AsyncFunction;Ljava/lang/Object;)Lcom/google/common/util/concurrent/ListenableFuture; (AbstractTransformFuture.java:225)
  at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object; (AbstractTransformFuture.java:212)
  at com.google.common.util.concurrent.AbstractTransformFuture.run()V (AbstractTransformFuture.java:125)
  at com.google.common.util.concurrent.DirectExecutor.execute(Ljava/lang/Runnable;)V (DirectExecutor.java:31)
  at com.google.common.util.concurrent.AbstractFuture.executeListener(Ljava/lang/Runnable;Ljava/util/concurrent/Executor;)V (AbstractFuture.java:1298)
  at com.google.common.util.concurrent.AbstractFuture.complete(Lcom/google/common/util/concurrent/AbstractFuture;Z)V (AbstractFuture.java:1059)
  at com.google.common.util.concurrent.AbstractFuture.set(Ljava/lang/Object;)Z (AbstractFuture.java:784)
  at com.google.common.util.concurrent.AbstractTransformFuture$TransformFuture.setResult(Ljava/lang/Object;)V (AbstractTransformFuture.java:259)
  at com.google.common.util.concurrent.AbstractTransformFuture.run()V (AbstractTransformFuture.java:171)
  at com.google.common.util.concurrent.DirectExecutor.execute(Ljava/lang/Runnable;)V (DirectExecutor.java:31)
  at com.google.common.util.concurrent.AbstractFuture.executeListener(Ljava/lang/Runnable;Ljava/util/concurrent/Executor;)V (AbstractFuture.java:1298)
  at com.google.common.util.concurrent.AbstractFuture.complete(Lcom/google/common/util/concurrent/AbstractFuture;Z)V (AbstractFuture.java:1059)
  at com.google.common.util.concurrent.AbstractFuture.set(Ljava/lang/Object;)Z (AbstractFuture.java:784)
  at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.afterRanInterruptiblySuccess(Ljava/lang/Object;)V (TrustedListenableFutureTask.java:136)
  at com.google.common.util.concurrent.InterruptibleTask.run()V (InterruptibleTask.java:89)
  at com.google.common.util.concurrent.TrustedListenableFutureTask.run()V (TrustedListenableFutureTask.java:82)
  at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec()Z (ForkJoinTask.java:1395)
  at java.util.concurrent.ForkJoinTask.doExec()I (ForkJoinTask.java:373)
  at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Ljava/util/concurrent/ForkJoinTask;Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V (ForkJoinPool.java:1182)
  at java.util.concurrent.ForkJoinPool.scan(Ljava/util/concurrent/ForkJoinPool$WorkQueue;II)I (ForkJoinPool.java:1655)
  at java.util.concurrent.ForkJoinPool.runWorker(Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V (ForkJoinPool.java:1622)
  at java.util.concurrent.ForkJoinWorkerThread.run()V (ForkJoinWorkerThread.java:165)
```

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



