### PR TITLE
Updated ctx in cache if expression is invalid after CF update

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/CalculatedFieldCtx.java
+++ b/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/CalculatedFieldCtx.java
@@ -110,6 +110,7 @@ public class CalculatedFieldCtx {
                 this.calculatedFieldScriptEngine = initEngine(tenantId, expression, tbelInvokeService);
                 initialized = true;
             } catch (Exception e) {
+                initialized = false;
                 throw new RuntimeException("Failed to init calculated field ctx. Invalid expression syntax.", e);
             }
         } else {
@@ -123,6 +124,7 @@ public class CalculatedFieldCtx {
                 );
                 initialized = true;
             } else {
+                initialized = false;
                 throw new RuntimeException("Failed to init calculated field ctx. Invalid expression syntax.");
             }
         }


### PR DESCRIPTION
## Pull Request description

Previously, when a CF was updated with an invalid expression, we got a debug event with error "Failed to initialize CF context", but evaluation still continued using the previous valid script.

This happened because the new ctx was not stored in the cache with the updated `initialized` flag, so the old valid ctx was reused.

What was done:
- update initialized flag when expression is invalid
- always put new ctx in the cache after CF updates
- added test

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



