### PR TITLE
Remove deprecated Sonatype repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1929,9 +1929,6 @@
             <name>Typesafe Repository</name>
             <url>https://repo.typesafe.com/typesafe/releases/</url>
         </repository>
-        <repository>
-            <id>sonatype</id>
-            <url>https://oss.sonatype.org/content/groups/public</url>
-        </repository>
     </repositories>
+
 </project>


### PR DESCRIPTION
PE build was failing due to the MQTT integrations module trying to fetch dependencies from the deprecated Sonatype repo, which responded with 501 Not Implemented. Maven Central is the default repository for Maven and no explicit repository configuration is needed.

Changes:
- Removed deprecated Sonatype repo configuration so Maven Central is used by default