### PR TITLE
fix_coaps_x509_tests

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/coap/security/AbstractCoapSecurityIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/coap/security/AbstractCoapSecurityIntegrationTest.java
@@ -64,6 +64,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "coap.server.enabled=true",
         "coap.dtls.enabled=true",
         "coap.dtls.credentials.pem.cert_file=coap/credentials/server/cert.pem",
+        "coap.dtls.x509.skip_validity_check_for_client_cert=true",
         "device.connectivity.coaps.enabled=true",
         "service.integrations.supported=ALL",
         "transport.coap.enabled=true",


### PR DESCRIPTION


## Pull Request description
before:

<img width="3666" height="1390" alt="open_ai_request_all_2" src="https://github.com/user-attachments/assets/6536ed43-18a3-4f2b-81f7-1e45c5998277" />

after:

<img width="3630" height="756" alt="open_ai_request_all" src="https://github.com/user-attachments/assets/f1f8c42c-d3d4-4fa7-bf53-1c309cafb70d" />



## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [ x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



