### PR TITLE
LwM2M: Fixed firmware update by URL

### DIFF
--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/DefaultLwM2mTransportService.java
@@ -20,7 +20,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.californium.core.CoapResource;
 import org.eclipse.californium.core.CoapServer;
-import org.eclipse.californium.core.config.CoapConfig;
 import org.eclipse.californium.elements.config.Configuration;
 import org.eclipse.californium.scandium.config.DtlsConfig;
 import org.eclipse.californium.scandium.dtls.cipher.CipherSuite;
@@ -196,14 +195,13 @@ public class DefaultLwM2mTransportService implements LwM2MTransportService {
                 root = new CoapResource("");
                 coapServer.add(root);
             }
-            root.add(new LwM2mTransportCoapResource(otaPackageDataCache, FIRMWARE_UPDATE_COAP_RESOURCE, serverCoapConfig.get(CoapConfig.PREFERRED_BLOCK_SIZE), serverCoapConfig.get(CoapConfig.MAX_RESOURCE_BODY_SIZE)));
-            root.add(new LwM2mTransportCoapResource(otaPackageDataCache, SOFTWARE_UPDATE_COAP_RESOURCE,serverCoapConfig.get(CoapConfig.PREFERRED_BLOCK_SIZE), serverCoapConfig.get(CoapConfig.MAX_RESOURCE_BODY_SIZE)));
+            root.add(new LwM2mTransportCoapResource(otaPackageDataCache, FIRMWARE_UPDATE_COAP_RESOURCE));
+            root.add(new LwM2mTransportCoapResource(otaPackageDataCache, SOFTWARE_UPDATE_COAP_RESOURCE));
         }
         return leshanServer;
     }
 
     private void setServerWithCredentials(LeshanServerBuilder builder) {
-//    private void setServerWithCredentials(LeshanServerBuilder builder) {
         if (this.config.getSslCredentials() != null) {
             SslCredentials sslCredentials = this.config.getSslCredentials();
             builder.setPublicKey(sslCredentials.getPublicKey());

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportCoapResource.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/LwM2mTransportCoapResource.java
@@ -34,21 +34,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.thingsboard.server.transport.lwm2m.server.ota.DefaultLwM2MOtaUpdateService.FIRMWARE_UPDATE_COAP_RESOURCE;
 import static org.thingsboard.server.transport.lwm2m.server.ota.DefaultLwM2MOtaUpdateService.SOFTWARE_UPDATE_COAP_RESOURCE;
-import static org.thingsboard.server.transport.lwm2m.utils.LwM2MTransportUtil.calculateSzx;
 
 @Slf4j
 public class LwM2mTransportCoapResource extends AbstractLwM2mTransportResource {
-    private final ConcurrentMap<String, ObserveRelation> tokenToObserveRelationMap = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, AtomicInteger> tokenToObserveNotificationSeqMap = new ConcurrentHashMap<>();
     private final OtaPackageDataCache otaPackageDataCache;
-    private final int chunkSize;
-    private final int maxResourceBodySize;
 
-    public LwM2mTransportCoapResource(OtaPackageDataCache otaPackageDataCache, String name, int chunkSize, int maxResourceBodySize) {
+    public LwM2mTransportCoapResource(OtaPackageDataCache otaPackageDataCache, String name) {
         super(name);
         this.otaPackageDataCache = otaPackageDataCache;
-        this.chunkSize = chunkSize;
-        this.maxResourceBodySize = maxResourceBodySize;
         this.setObservable(true); // enable observing
         this.addObserver(new CoapResourceObserver());
     }
@@ -141,29 +135,23 @@ public class LwM2mTransportCoapResource extends AbstractLwM2mTransportResource {
         String idStr = exchange.getRequestOptions().getUriPath().get(exchange.getRequestOptions().getUriPath().size() - 1
         );
         UUID currentId = UUID.fromString(idStr);
-        log.info("Start Read ota data (path): [{}]", exchange.getRequestOptions().getUriPath().toString());
         Response response = new Response(CoAP.ResponseCode.CONTENT);
         byte[] otaData = this.getOtaData(currentId);
         if (otaData != null && otaData.length > 0) {
-            if (otaData.length <= this.maxResourceBodySize) {
-                log.info("Read ota data (length): [{}]", otaData.length);
-                response.setPayload(otaData);
-                int chunkSize = calculateSzx(this.chunkSize);
-                if (exchange.getRequestOptions().hasBlock2()) {
-                    chunkSize = exchange.getRequestOptions().getBlock2().getSzx();
-                } else if (exchange.getRequestOptions().hasBlock1()) {
-                    chunkSize = exchange.getRequestOptions().getBlock1().getSzx();
-                }
-                log.info("With block2 Send currentId: [{}], length: [{}], chunkSize [{}], moreFlag [{}]", currentId.toString(), otaData.length, chunkSize, false);
-                boolean lastFlag = otaData.length <= this.chunkSize;
-                response.getOptions().setBlock2(chunkSize, lastFlag, 0);
-                response.setType(CoAP.Type.CON);
-                exchange.respond(response);
+            log.debug("Read ota data (length): [{}]", otaData.length);
+            response.setPayload(otaData);
+            if (exchange.getRequestOptions().getBlock2() != null) {
+                int szx = exchange.getRequestOptions().getBlock2().getSzx();
+                int chunkSize = exchange.getRequestOptions().getBlock2().getSize();
+                boolean lastFlag = otaData.length <= chunkSize;
+                response.getOptions().setBlock2(szx, lastFlag, 0);
+                log.trace("With block2 Send currentId: [{}], length: [{}], chunkSize [{}], szx [{}], moreFlag [{}]", currentId, otaData.length, chunkSize, szx, lastFlag);
             } else {
-                log.info("Ota package size: [{}] is larger than server's MAX_RESOURCE_BODY_SIZE [{}]", otaData.length, this.maxResourceBodySize);
+                log.trace("With block1 Send currentId: [{}], length: [{}], ", currentId, otaData.length);
             }
+            exchange.respond(response);
         } else {
-            log.info("Ota packaged currentId: [{}] is not found.", currentId.toString());
+            log.trace("Ota packaged currentId: [{}] is not found.", currentId);
         }
     }
 

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/utils/LwM2MTransportUtil.java
@@ -120,10 +120,6 @@ public class LwM2MTransportUtil {
         }
     }
 
-    public static List<LwM2MBootstrapServerCredential> getBootstrapParametersFromThingsboard(DeviceProfile deviceProfile) {
-        return toLwM2MClientProfile(deviceProfile).getBootstrap();
-    }
-
     public static String fromVersionedIdToObjectId(String pathIdVer) {
         try {
             if (pathIdVer == null) {
@@ -396,13 +392,6 @@ public class LwM2MTransportUtil {
         } else {
             serverCoapConfig.set(DTLS_CONNECTION_ID_NODE_ID, null);
         }
-    }
-
-    public static int calculateSzx(int size) {
-        if (size < 16 || size > 1024 || (size & (size - 1)) != 0) {
-            throw new IllegalArgumentException("Size must be a power of 2 between 16 and 1024.");
-        }
-        return (int) (Math.log(size / 16) / Math.log(2));
     }
 
     public static ConcurrentHashMap<Integer, String[]> groupByObjectIdVersionedIds(Set<String> targetIds) {


### PR DESCRIPTION
## Pull Request description
Fix: Firmware Update Timeout Due to Incorrect Block2 Configuration
This PR addresses an issue where LWM2M firmware updates using the URL strategy failed to be fully delivered to the client and timed out.

### Problem Description
The root cause was an incorrect configuration of the Block2 mechanism within the LWM2M client, leading to timeouts during the firmware download process, especially for larger firmware images. The client was not requesting subsequent blocks or was timing out before the entire file could be transferred.

###  Changes
Corrected/Adjusted Block2 configuration parameters to ensure successful and timely reception of all firmware data blocks.

The relevant configuration change ensures proper handling of block transfers, preventing premature timeouts.

### Additional Note on Timeouts
The current default value for the LWM2M transport timeout is set as: transport.lwm2m.timeout: "${LWM2M_TIMEOUT:120000}" (120,000 milliseconds or 2 minutes).

For firmware files up to approximately 70 KB, this timeout is generally sufficient.

For larger firmware files, this timeout value will likely need to be increased to accommodate the longer transfer time. Future consideration should be given to making this parameter more flexible or dynamic based on the expected file size.

### Verification
Tested firmware updates using the URL strategy with both small and moderately sized images.

The firmware update process now completes successfully without encountering timeouts.

<img width="1714" height="672" alt="image" src="https://github.com/user-attachments/assets/2cfed060-efd0-45f0-839e-7b1553282abb" />

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



