### PR TITLE
Fixed 'TypeError: Missing parameter name ...' when running web-ui with TB_ENABLE_PROXY=true

### DIFF
--- a/msa/web-ui/server.ts
+++ b/msa/web-ui/server.ts
@@ -81,12 +81,12 @@ let connections: Socket[] = [];
                     }
                 }
             });
-            app.all('/api/*', (req, res) => {
+            app.all('/api/*splat', (req, res) => {
               logger.debug(req.method + ' ' + req.originalUrl);
               apiProxy.web(req, res);
             });
 
-            app.all('/static/rulenode/*', (req, res) => {
+            app.all('/static/rulenode/*splat', (req, res) => {
               apiProxy.web(req, res);
             });
 


### PR DESCRIPTION
## Pull Request description

Fixed error 'TypeError: Missing parameter name ...'  in #14492 

The error was caused by [incompatibility](https://expressjs.com/en/guide/migrating-5.html#path-syntax) between Express 4 and Express 5. Express 5 uses a newer version of path-to-regexp which has stricter syntax rules compared to Express 4.

Updated path pattern in msa/web-ui/server.ts to make every `*` have a name.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)
