### PR TITLE
Enhancement for calculated fields

### DIFF
--- a/ui-ngx/src/app/modules/home/components/calculated-fields/components/output/calculated-field-output.component.ts
+++ b/ui-ngx/src/app/modules/home/components/calculated-fields/components/output/calculated-field-output.component.ts
@@ -120,6 +120,10 @@ export class CalculatedFieldOutputComponent implements ControlValueAccessor, Val
         this.updatedStrategy();
       });
 
+    this.outputForm.get('strategy.saveTimeSeries').valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(value => this.updateTimeSeriesTtl(value));
+
     merge(
       this.outputForm.get('strategy.type').valueChanges,
       this.outputForm.get('strategy.useCustomTtl').valueChanges
@@ -178,6 +182,7 @@ export class CalculatedFieldOutputComponent implements ControlValueAccessor, Val
       this.updatedFormWithMode();
       this.toggleScopeByOutputType(this.outputForm.get('type').value);
       this.updatedStrategy();
+      this.updateTimeSeriesTtl(this.outputForm.get('strategy.saveTimeSeries').value);
     }
   }
 
@@ -240,6 +245,15 @@ export class CalculatedFieldOutputComponent implements ControlValueAccessor, Val
           this.outputForm.get('strategy.ttl').enable({emitEvent: false});
         }
       }
+    }
+  }
+
+  private updateTimeSeriesTtl(value: boolean) {
+    if (value) {
+      this.outputForm.get('strategy.useCustomTtl').enable({emitEvent: true});
+    } else {
+      this.outputForm.get('strategy.useCustomTtl').disable({emitEvent: false});
+      this.outputForm.get('strategy.ttl').disable({emitEvent: false});
     }
   }
 }

--- a/ui-ngx/src/app/modules/home/components/calculated-fields/components/propagation-configuration/propagation-configuration.component.html
+++ b/ui-ngx/src/app/modules/home/components/calculated-fields/components/propagation-configuration/propagation-configuration.component.html
@@ -55,6 +55,7 @@
                                   [tenantId]="tenantId"
                                   [entityName]="entityName"
                                   [ownerId]="ownerId"
+                                  [watchKeyChange]="true"
                                   [isScript]="this.propagateConfiguration.get('applyExpressionToResolvedArguments').value"/>
   </div>
   <div class="tb-form-panel no-gap" [class.!hidden]="!this.propagateConfiguration.get('applyExpressionToResolvedArguments').value">


### PR DESCRIPTION
## Pull Request description

Enabled auto fill argument name for propagation calculation result.
<img width="1760" height="1552" alt="image" src="https://github.com/user-attachments/assets/79b132e8-e2fe-47ca-969b-dc353bc16598" />


For output configuration if disabled save to time series disabled Custom TTL configuration.
<img width="1760" height="1552" alt="image" src="https://github.com/user-attachments/assets/8b3475e4-817a-4883-9391-e2d772851450" />

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




