### PR TITLE
Fixed NPE for LwM2M client context after reboot

### DIFF
--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClientContextImpl.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/client/LwM2mClientContextImpl.java
@@ -289,6 +289,7 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
     @Override
     public String getObjectIdByKeyNameFromProfile(LwM2mClient client, String keyName) {
         Lwm2mDeviceProfileTransportConfiguration profile = getProfile(client.getRegistration());
+        if (profile == null) throw new IllegalArgumentException(keyName + " is not configured in the device profile! Device profile is null");
         for (Map.Entry<String, String> entry : profile.getObserveAttr().getKeyName().entrySet()) {
             String k = entry.getKey();
             String v = entry.getValue();
@@ -347,6 +348,7 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
         PowerMode powerMode = lwM2MClient.getPowerMode();
         if (powerMode == null) {
             Lwm2mDeviceProfileTransportConfiguration deviceProfile = getProfile(lwM2MClient.getRegistration());
+            if (deviceProfile == null) return null;
             powerMode = deviceProfile.getClientLwM2mSettings().getPowerMode();
         }
         return powerMode;
@@ -377,8 +379,8 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
                 }
             }
         } else {
-            log.warn("Device profile not found! The device profile ID is null. Return Lwm2mDeviceProfileTransportConfiguration with default.");
-            result = new Lwm2mDeviceProfileTransportConfiguration();
+            log.warn("Device profile not found! The device profile ID is null. Return Lwm2mDeviceProfileTransportConfiguration with null.");
+            result = null;
         }
         return result;
     }
@@ -413,6 +415,7 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
         OtherConfiguration profileSettings = null;
         if (powerMode == null && client.getProfileId() != null) {
             var clientProfile = getProfile(client.getRegistration());
+            if (clientProfile == null) return true;
             profileSettings = clientProfile.getClientLwM2mSettings();
             powerMode = profileSettings.getPowerMode();
         }
@@ -459,8 +462,10 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
         OtherConfiguration profileSettings = null;
         if (powerMode == null && client.getProfileId() != null) {
             var clientProfile = getProfile(client.getRegistration());
-            profileSettings = clientProfile.getClientLwM2mSettings();
-            powerMode = profileSettings.getPowerMode();
+            if (clientProfile != null) {
+                profileSettings = clientProfile.getClientLwM2mSettings();
+                powerMode = profileSettings.getPowerMode();
+            }
         }
         if (powerMode == null || PowerMode.DRX.equals(powerMode)) {
             client.updateLastUplinkTime();
@@ -515,9 +520,11 @@ public class LwM2mClientContextImpl implements LwM2mClientContext {
             timeout = client.getEdrxCycle();
         } else {
             var clientProfile = getProfile(client.getRegistration());
-            OtherConfiguration clientLwM2mSettings = clientProfile.getClientLwM2mSettings();
-            if (PowerMode.E_DRX.equals(clientLwM2mSettings.getPowerMode())) {
-                timeout = clientLwM2mSettings.getEdrxCycle();
+            if (clientProfile != null) {
+                OtherConfiguration clientLwM2mSettings = clientProfile.getClientLwM2mSettings();
+                if (PowerMode.E_DRX.equals(clientLwM2mSettings.getPowerMode())) {
+                    timeout = clientLwM2mSettings.getEdrxCycle();
+                }
             }
         }
         if (timeout == null || timeout == 0L) {

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/DefaultLwM2MOtaUpdateService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/ota/DefaultLwM2MOtaUpdateService.java
@@ -200,7 +200,8 @@ public class DefaultLwM2MOtaUpdateService extends LwM2MExecutorAwareService impl
             attributesToFetch.add(SOFTWARE_URL);
         }
 
-        var clientSettings = clientContext.getProfile(client.getRegistration()).getClientLwM2mSettings();
+        var clientProfile = clientContext.getProfile(client.getRegistration());
+        var clientSettings = clientProfile != null ? clientProfile.getClientLwM2mSettings() : null;
         if (clientSettings != null) {
             initFwStrategy(client, clientSettings);
             initSwStrategy(client, clientSettings);
@@ -532,7 +533,8 @@ public class DefaultLwM2MOtaUpdateService extends LwM2MExecutorAwareService impl
             } else {
                 strategy = info.getDeliveryMethod() == FirmwareDeliveryMethod.PULL.code ? LwM2MFirmwareUpdateStrategy.OBJ_5_TEMP_URL : LwM2MFirmwareUpdateStrategy.OBJ_5_BINARY;
             }
-            Boolean useObject19ForOtaInfo = clientContext.getProfile(client.getRegistration()).getClientLwM2mSettings().getUseObject19ForOtaInfo();
+            var clientProfile =  clientContext.getProfile(client.getRegistration());
+            Boolean useObject19ForOtaInfo = clientProfile != null ? clientProfile.getClientLwM2mSettings().getUseObject19ForOtaInfo() : null;
             if (useObject19ForOtaInfo != null && useObject19ForOtaInfo){
                 sendInfoToObject19ForOta(client, FW_INFO_19_INSTANCE_ID, response, otaPackageId);
             }
@@ -558,7 +560,8 @@ public class DefaultLwM2MOtaUpdateService extends LwM2MExecutorAwareService impl
         if (TransportProtos.ResponseStatus.SUCCESS.equals(response.getResponseStatus())) {
             UUID otaPackageId = new UUID(response.getOtaPackageIdMSB(), response.getOtaPackageIdLSB());
             LwM2MSoftwareUpdateStrategy strategy = info.getStrategy();
-            Boolean useObject19ForOtaInfo = clientContext.getProfile(client.getRegistration()).getClientLwM2mSettings().getUseObject19ForOtaInfo();
+            var clientProfile = clientContext.getProfile(client.getRegistration());
+            Boolean useObject19ForOtaInfo = clientProfile != null ? clientProfile.getClientLwM2mSettings().getUseObject19ForOtaInfo() : null;
             if (useObject19ForOtaInfo != null && useObject19ForOtaInfo){
                 sendInfoToObject19ForOta(client, SW_INFO_19_INSTANCE_ID, response, otaPackageId);
             }
@@ -647,8 +650,9 @@ public class DefaultLwM2MOtaUpdateService extends LwM2MExecutorAwareService impl
             LwM2MClientSwOtaInfo info = otaInfoStore.getSw(endpoint);
             if (info == null) {
                 var profile = clientContext.getProfile(client.getRegistration());
-                info = new LwM2MClientSwOtaInfo(endpoint, profile.getClientLwM2mSettings().getSwUpdateResource(),
-                        LwM2MSoftwareUpdateStrategy.fromStrategySwByCode(profile.getClientLwM2mSettings().getSwUpdateStrategy()));
+                OtherConfiguration clientLwM2mSettings = profile == null ? new OtherConfiguration() : profile.getClientLwM2mSettings();
+                info = new LwM2MClientSwOtaInfo(endpoint, clientLwM2mSettings.getSwUpdateResource(),
+                        LwM2MSoftwareUpdateStrategy.fromStrategySwByCode(clientLwM2mSettings.getSwUpdateStrategy()));
                 update(info);
             }
             return info;

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/DefaultLwM2mUplinkMsgHandler.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/server/uplink/DefaultLwM2mUplinkMsgHandler.java
@@ -418,7 +418,7 @@ public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService impl
             });
             if (!clients.isEmpty()) {
                 var oldProfile = clientContext.getProfile(clients.get(0).getRegistration());
-                this.onDeviceProfileUpdate(clients, oldProfile, deviceProfile);
+                if (oldProfile != null) this.onDeviceProfileUpdate(clients, oldProfile, deviceProfile);
             }
         } catch (Exception e) {
             log.warn("[{}] failed to update profile: {} [{}]", deviceProfile.getId(), e.getMessage(), deviceProfile);
@@ -714,8 +714,10 @@ public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService impl
 
     private void onDeviceUpdate(LwM2mClient lwM2MClient, Device device, Optional<DeviceProfile> deviceProfileOpt) {
         var oldProfile = clientContext.getProfile(lwM2MClient.getRegistration());
-        deviceProfileOpt.ifPresent(deviceProfile -> this.onDeviceProfileUpdate(Collections.singletonList(lwM2MClient), oldProfile, deviceProfile));
-        lwM2MClient.onDeviceUpdate(device, deviceProfileOpt);
+        if (oldProfile != null) {
+            deviceProfileOpt.ifPresent(deviceProfile -> this.onDeviceProfileUpdate(Collections.singletonList(lwM2MClient), oldProfile, deviceProfile));
+            lwM2MClient.onDeviceUpdate(device, deviceProfileOpt);
+        }
     }
 
     /**
@@ -729,45 +731,12 @@ public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService impl
         Set<String> paths = updateResource.getPaths();
         ResultsAddKeyValueProto results = new ResultsAddKeyValueProto();
         var profile = clientContext.getProfile(registration);
-        List<TransportProtos.KeyValueProto> resultAttributes = new ArrayList<>();
-        Set<String> attributes = profile.getObserveAttr().getAttribute().stream()
-                .filter(paths::contains)
-                .collect(Collectors.toSet());
-        if (!attributes.isEmpty()){
-            attributes.stream()
-                    .map(attr -> this.getKvToThingsBoard(attr, registration))
-                    .filter(Objects::nonNull)
-                    .forEach(resultAttributes::add);
-        }
-        List<TransportProtos.KeyValueProto> resultTelemetries = new ArrayList<>();
-        Set<String> telemetries = profile.getObserveAttr().getTelemetry().stream()
-                .filter(paths::contains)
-                .collect(Collectors.toSet());
-        if (!telemetries.isEmpty()){
-            telemetries.stream()
-                    .map(telemetry -> this.getKvToThingsBoard(telemetry, registration))
-                    .filter(Objects::nonNull)
-                    .forEach(resultTelemetries::add);
-        }
-        if (resultAttributes.size() > 0) {
-            results.setResultAttributes(resultAttributes);
-        }
-        if (resultTelemetries.size() > 0) {
-            results.setResultTelemetries(resultTelemetries);
-        }
-        return results;
-    }
-
-    private ResultsAddKeyValueProto getParametersFromProfile(Registration registration, Set<String> path) {
-        if (!path.isEmpty()) {
-            ResultsAddKeyValueProto results = new ResultsAddKeyValueProto();
-            var profile = clientContext.getProfile(registration);
+        if (profile != null) {
             List<TransportProtos.KeyValueProto> resultAttributes = new ArrayList<>();
             Set<String> attributes = profile.getObserveAttr().getAttribute().stream()
-                    .map(LwM2MTransportUtil::fromVersionedIdToObjectId)
-                    .filter(path::contains)
+                    .filter(paths::contains)
                     .collect(Collectors.toSet());
-            if (!attributes.isEmpty()){
+            if (!attributes.isEmpty()) {
                 attributes.stream()
                         .map(attr -> this.getKvToThingsBoard(attr, registration))
                         .filter(Objects::nonNull)
@@ -775,10 +744,9 @@ public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService impl
             }
             List<TransportProtos.KeyValueProto> resultTelemetries = new ArrayList<>();
             Set<String> telemetries = profile.getObserveAttr().getTelemetry().stream()
-                    .map(LwM2MTransportUtil::fromVersionedIdToObjectId)
-                    .filter(path::contains)
+                    .filter(paths::contains)
                     .collect(Collectors.toSet());
-            if (!telemetries.isEmpty()){
+            if (!telemetries.isEmpty()) {
                 telemetries.stream()
                         .map(telemetry -> this.getKvToThingsBoard(telemetry, registration))
                         .filter(Objects::nonNull)
@@ -790,14 +758,15 @@ public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService impl
             if (resultTelemetries.size() > 0) {
                 results.setResultTelemetries(resultTelemetries);
             }
-            return results;
         }
-        return null;
+        return results;
     }
 
     private TransportProtos.KeyValueProto getKvToThingsBoard(String pathIdVer, Registration registration) {
         LwM2mClient lwM2MClient = this.clientContext.getClientByEndpoint(registration.getEndpoint());
-        Map<String, String> names = clientContext.getProfile(lwM2MClient.getRegistration()).getObserveAttr().getKeyName();
+        var clientProfile = clientContext.getProfile(lwM2MClient.getRegistration());
+        if (clientProfile == null) return null;
+        Map<String, String> names = clientProfile.getObserveAttr().getKeyName();
         if (names != null && names.containsKey(pathIdVer)) {
             String resourceName = names.get(pathIdVer);
             if (resourceName != null && !resourceName.isEmpty()) {
@@ -887,10 +856,12 @@ public class DefaultLwM2mUplinkMsgHandler extends LwM2MExecutorAwareService impl
     private void onDeviceProfileUpdate(List<LwM2mClient> clients, Lwm2mDeviceProfileTransportConfiguration oldProfileTransportConfiguration, DeviceProfile deviceProfile) {
         if (clientContext.profileUpdate(deviceProfile) != null) {
             var newProfileTransportConfiguration = clientContext.getProfile(clients.get(0).getRegistration());
-            ParametersUpdateAnalyzeResult parametersUpdate = getParametersUpdate(oldProfileTransportConfiguration, newProfileTransportConfiguration);
-            ParametersObserveAnalyzeResult parametersObserve = getParametersObserve(oldProfileTransportConfiguration.getObserveAttr(), newProfileTransportConfiguration.getObserveAttr(), deviceProfile.getId().getId());
-            compareAndSetWriteAttributesObservations(clients, parametersUpdate, parametersObserve);
-            updateValueOta(clients, newProfileTransportConfiguration, oldProfileTransportConfiguration);
+            if (newProfileTransportConfiguration != null) {
+                ParametersUpdateAnalyzeResult parametersUpdate = getParametersUpdate(oldProfileTransportConfiguration, newProfileTransportConfiguration);
+                ParametersObserveAnalyzeResult parametersObserve = getParametersObserve(oldProfileTransportConfiguration.getObserveAttr(), newProfileTransportConfiguration.getObserveAttr(), deviceProfile.getId().getId());
+                compareAndSetWriteAttributesObservations(clients, parametersUpdate, parametersObserve);
+                updateValueOta(clients, newProfileTransportConfiguration, oldProfileTransportConfiguration);
+            }
         }
     }
 


### PR DESCRIPTION
## Pull Request description

### Before
```
2025-12-17 10:02:53,904 [LwM2M uplink-0-2] INFO  o.t.s.t.l.s.u.DefaultLwM2mUplinkMsgHandler - Client close session: [hrsx4sMFQr] unReg [urn:imei:350457793179084] name  [DaMo_S2_007] profile 
2025-12-17 10:02:53,906 [CoapServer(main)#1] ERROR o.e.l.core.response.SendableResponse - Exception while calling the reponse sent callback
java.lang.NullPointerException: Cannot invoke "org.thingsboard.server.common.data.device.profile.Lwm2mDeviceProfileTransportConfiguration.getClientLwM2mSettings()" because the return value of "org.thingsboard.server.transport.lwm2m.server.client.LwM2mClientContext.getProfile(org.eclipse.leshan.server.registration.Registration)" is null
```
### After
```
2025-12-17 16:27:24,930 [CoapServer(main)#1] DEBUG o.t.s.t.l.server.LwM2mServerListener - Client: registered: [urn:imei:350457793179084]
2025-12-17 16:27:24,930 [LwM2M uplink-0-2] INFO  o.t.s.t.l.s.u.DefaultLwM2mUplinkMsgHandler - Client close session: [Ed0xOQVtsb] unReg [urn:imei:350457793179084] name  [DaMo_S2_007] profile 
2025-12-17 16:27:24,930 [LwM2M uplink-0-2] INFO  o.t.s.t.l.s.c.LwM2mClientContextImpl - [urn:imei:350457793179084] initialized new client.
2025-12-17 16:27:24,930 [LwM2M uplink-0-2] DEBUG o.t.s.t.l.s.u.DefaultLwM2mUplinkMsgHandler - [urn:imei:350457793179084] [{sQDVHTOvoa] Client: create after Registration
2025-12-17 16:27:24,930 [LwM2M uplink-0-2] TRACE o.t.s.t.l.s.c.LwM2mClientContextImpl - [urn:imei:350457793179084] Client is already at sleeping: false, ignoring event: false
2025-12-17 16:27:24,931 [LwM2M uplink-0-2] DEBUG o.t.s.t.l.s.u.DefaultLwM2mUplinkMsgHandler - info: Endpoint [urn:imei:350457793179084] Client registered with registration id:
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
 
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



