### PR TITLE
REST client: add few missing endpoints

### DIFF
--- a/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/AbstractContainerTest.java
+++ b/msa/black-box-tests/src/test/java/org/thingsboard/server/msa/AbstractContainerTest.java
@@ -44,7 +44,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.function.Consumer;
 
-
 @Slf4j
 @Listeners(TestListener.class)
 public abstract class AbstractContainerTest {
@@ -170,19 +169,14 @@ public abstract class AbstractContainerTest {
         DeviceProfileProvisionConfiguration provisionConfiguration;
         String testProvisionDeviceKey = TEST_PROVISION_DEVICE_KEY;
         deviceProfile.setProvisionType(provisionType);
-        switch(provisionType) {
-            case ALLOW_CREATE_NEW_DEVICES:
-                provisionConfiguration = new AllowCreateNewDevicesDeviceProfileProvisionConfiguration(TEST_PROVISION_DEVICE_SECRET);
-                break;
-            case CHECK_PRE_PROVISIONED_DEVICES:
-                provisionConfiguration = new CheckPreProvisionedDevicesDeviceProfileProvisionConfiguration(TEST_PROVISION_DEVICE_SECRET);
-                break;
-            default:
-            case DISABLED:
+        provisionConfiguration = switch (provisionType) {
+            case ALLOW_CREATE_NEW_DEVICES -> new AllowCreateNewDevicesDeviceProfileProvisionConfiguration(TEST_PROVISION_DEVICE_SECRET);
+            case CHECK_PRE_PROVISIONED_DEVICES -> new CheckPreProvisionedDevicesDeviceProfileProvisionConfiguration(TEST_PROVISION_DEVICE_SECRET);
+            default -> {
                 testProvisionDeviceKey = null;
-                provisionConfiguration = new DisabledDeviceProfileProvisionConfiguration(null);
-                break;
-        }
+                yield new DisabledDeviceProfileProvisionConfiguration(null);
+            }
+        };
         DeviceProfileData deviceProfileData = deviceProfile.getProfileData();
         deviceProfileData.setProvisionConfiguration(provisionConfiguration);
         deviceProfile.setProfileData(deviceProfileData);

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -51,6 +51,10 @@
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Changes:
- Added REST client methods for the following endpoints:
    - `getDeviceProfileInfosByIds`
    - `getAssetProfilesByIds`
    
Note: using Apache's `URIBuilder` for consistency with PE (see PE PR).