### PR TITLE
Fixed CoAP Unicast/Multicast MID Conflict and Silent ACK Rejection

### DIFF
--- a/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/callback/AbstractSyncSessionCallback.java
+++ b/common/transport/coap/src/main/java/org/thingsboard/server/transport/coap/callback/AbstractSyncSessionCallback.java
@@ -78,6 +78,12 @@ public abstract class AbstractSyncSessionCallback implements SessionMsgListener 
             return false;
         }
     }
+    public static boolean isMulticastRequest(TbCoapObservationState state) {
+        if (state != null) {
+            return state.getExchange().advanced().getRequest().isMulticast();
+        }
+        return false;
+    }
 
     protected void respond(Response response) {
         response.getOptions().setContentFormat(TbCoapContentFormatUtil.getContentFormat(exchange.getRequestOptions().getContentFormat(), state.getContentFormat()));


### PR DESCRIPTION
## Pull Request description
https://thingsboard-portal.atlassian.net/browse/PROD-7458

- This PR addresses a critical issue in the CoAP transport layer where the server intermittently ignores valid Acknowledgement (ACK) messages from devices during Unicast sessions (e.g., Shared Attribute updates or RPC calls).
- The Problem (Root Cause)The embedded Eclipse Californium library (coap-core) uses a strict Message ID (MID) partitioning logic based on the DEFAULT_MULTICAST_BASE_MID setting (default: 65000).
- MID Partitioning: Californium reserves the range [65000, 65535] exclusively for Multicast trackers. 
- The Conflict: Currently, ThingsBoard generates MIDs using a random provider across the full 16-bit range [0, 65535].
- The Failure: When a random MID  65000 is assigned to a Unicast request, the server sends the packet successfully. However, when the device responds with an ACK (carrying the same MID), the Californium library misinterprets it as a Multicast response. Since no corresponding Multicast request exists in the tracker, the library silently drops the ACK.
- Symptoms: Logs show DEBUG o.e.c.core.network.CoapEndpoint - coaps silently ignoring empty messages for multicast request. 
- The server enters a retransmission loop and eventually terminates the session.

### Comparison Table (Server → Client)
Property           | Unicast Request             | Multicast Request
----------------------- | --------------------------- | -----------------------
Source Port  (Server)   | 5683/5684                   | 5683/5684
Destination IP (Client) | 127.0.0.1/192.168.1.2       | 224.0.1.187 / ff02::fd
Destination Port        | 49152                       | 49152
MID tracker             | unicast                     | multicast
MID діапазон            | < 65000                     | ≥ 65000
Тип CoAP                | NON / CON / ACK             | NON / CON / ACK
Code                    | POST / PUT                  | POST / PUT
Payload                 | shared attributes JSON      | shared attributes JSON

### Logs
<img width="1080" height="233" alt="image" src="https://github.com/user-attachments/assets/753c3061-170b-4f27-9ed5-b9715c1d7daf" />

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
 
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



