### PR TITLE
Sparkplugl-Metrics-with-empty-string-BIRTH-not-processed

### DIFF
--- a/common/proto/src/main/java/org/thingsboard/server/common/adaptor/ProtoConverter.java
+++ b/common/proto/src/main/java/org/thingsboard/server/common/adaptor/ProtoConverter.java
@@ -156,11 +156,7 @@ public class ProtoConverter {
                 case BOOLEAN_V:
                 case LONG_V:
                 case DOUBLE_V:
-                    break;
                 case STRING_V:
-                    if (StringUtils.isEmpty(keyValueProto.getStringV())) {
-                        throw new IllegalArgumentException("Value is empty for key: " + key + "!");
-                    }
                     break;
                 case JSON_V:
                     try {


### PR DESCRIPTION
## Pull Request description

### To Reproduce

    Configure Sparkplug client with metrics including empty string values.
    Publish BIRTH message to ThingsBoard EU cloud instance.
    Observe that empty string metrics are missing or ignored.

### Before
```
2026-01-07 15:40:43,511 [main] INFO  o.t.sparkplug.SparkplugEmulation - Sparkplug Device 2: [NodeDeviceMetric(nameMetric=Device Control/Reboot, dataType=Boolean, value=false, autoChange=false), NodeDeviceMetric(nameMetric=Device Control/Rebirth, dataType=Boolean, value=false, autoChange=false), NodeDeviceMetric(nameMetric=MyNodeMetric01_Int32, dataType=Int32, value=1000, autoChange=true), NodeDeviceMetric(nameMetric=MyNodeMetric02_LongInt64, dataType=Int64, value=100000, autoChange=true), NodeDeviceMetric(nameMetric=MyNodeMetric03_Double, dataType=Double, value=45.5, autoChange=true), NodeDeviceMetric(nameMetric=MyNodeMetric04_Float, dataType=Float, value=32.4, autoChange=true), NodeDeviceMetric(nameMetric=MyNodeMetric05_String, dataType=String, value=MyNodeMetric05 String: changed, autoChange=true), NodeDeviceMetric(nameMetric=MyNodeMetric06_Json_Bytes, dataType=Bytes, value=[12, 4, -120], autoChange=true)]
2026-01-07 15:40:43,916 [pool-2-thread-1] INFO  o.t.sparkplug.SparkplugEmulation - Publishing [Sparkplug Node 1] NBIRTH
2026-01-07 15:40:43,918 [MQTT Call: Sparkplug Node 1] ERROR o.t.sparkplug.SparkplugEmulation - Listener topic [spBv1.0/Sparkplug Group 1/NBIRTH/Sparkplug Node 1] Response code: [PAYLOAD_FORMAT_INVALID]
2026-01-07 15:40:43,918 [pool-2-thread-1] INFO  o.t.sparkplug.SparkplugEmulation - Publishing [Sparkplug Device 1] DBIRTH
2026-01-07 15:40:43,918 [pool-2-thread-1] INFO  o.t.sparkplug.SparkplugEmulation - Publishing [Sparkplug Device 2] DBIRTH
```

### After
```
2026-01-07 15:43:03,384 [main] INFO  o.t.sparkplug.SparkplugEmulation - Sparkplug Device 1: [NodeDeviceMetric(nameMetric=Device Control/Reboot, dataType=Boolean, value=false, autoChange=false), NodeDeviceMetric(nameMetric=Device Control/Rebirth, dataType=Boolean, value=false, autoChange=false), NodeDeviceMetric(nameMetric=Device Control/Next Server, dataType=Boolean, value=false, autoChange=false), NodeDeviceMetric(nameMetric=Device Control/Scan Rate, dataType=Int64, value=60000, autoChange=false), NodeDeviceMetric(nameMetric=Properties/Hardware Make, dataType=String, value=, autoChange=false), NodeDeviceMetric(nameMetric=Last Update FW, dataType=DateTime, value=1486144501056, autoChange=false), NodeDeviceMetric(nameMetric=Current Grid Voltage, dataType=Float, value=5.12, autoChange=true), NodeDeviceMetric(nameMetric=Outputs/LEDs/Green, dataType=Boolean, value=false, autoChange=true), NodeDeviceMetric(nameMetric=Outputs/LEDs/Yellow, dataType=Boolean, value=true, autoChange=true)]
2026-01-07 15:43:03,384 [main] INFO  o.t.sparkplug.SparkplugEmulation - Sparkplug Device 2: [NodeDeviceMetric(nameMetric=Device Control/Reboot, dataType=Boolean, value=false, autoChange=false), NodeDeviceMetric(nameMetric=Device Control/Rebirth, dataType=Boolean, value=false, autoChange=false), NodeDeviceMetric(nameMetric=MyNodeMetric01_Int32, dataType=Int32, value=1000, autoChange=true), NodeDeviceMetric(nameMetric=MyNodeMetric02_LongInt64, dataType=Int64, value=100000, autoChange=true), NodeDeviceMetric(nameMetric=MyNodeMetric03_Double, dataType=Double, value=45.5, autoChange=true), NodeDeviceMetric(nameMetric=MyNodeMetric04_Float, dataType=Float, value=32.4, autoChange=true), NodeDeviceMetric(nameMetric=MyNodeMetric05_String, dataType=String, value=MyNodeMetric05 String: changed, autoChange=true), NodeDeviceMetric(nameMetric=MyNodeMetric06_Json_Bytes, dataType=Bytes, value=[12, 4, -120], autoChange=true)]
2026-01-07 15:43:03,997 [pool-2-thread-1] INFO  o.t.sparkplug.SparkplugEmulation - Publishing [Sparkplug Node 1] NBIRTH
2026-01-07 15:43:04,000 [pool-2-thread-1] INFO  o.t.sparkplug.SparkplugEmulation - Publishing [Sparkplug Device 1] DBIRTH
2026-01-07 15:43:04,000 [pool-2-thread-1] INFO  o.t.sparkplug.SparkplugEmulation - Publishing [Sparkplug Device 2] DBIRTH
2026-01-07 15:43:04,062 [MQTT Call: Sparkplug Node 1] INFO  o.t.sparkplug.SparkplugMqttCallback - Message Arrived on topic v1/gateway/disconnect
2026-01-07 15:43:04,063 [MQTT Call: Sparkplug Node 1] INFO  o.t.sparkplug.SparkplugMqttCallback - Message Arrived on topic v1/gateway/disconnect
2026-01-07 15:43:04,064 [MQTT Call: Sparkplug Node 1] INFO  o.t.sparkplug.SparkplugMqttCallback - Message Arrived on topic v1/gateway/disconnect
```

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



