### PR TITLE
Improved errors handling for Geofencing CF

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/geofencing/GeofencingZoneState.java
+++ b/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/geofencing/GeofencingZoneState.java
@@ -51,9 +51,10 @@ public class GeofencingZoneState {
         this.ts = attributeKvEntry.getLastUpdateTs();
         this.version = attributeKvEntry.getVersion();
         if (entry.getValueAsString() == null) {
-            throw new IllegalArgumentException("Perimeter attribute key '" + entry.getKey() + "' not found for Zone with id: " + zoneId);
+            throw new IllegalArgumentException("Perimeter attribute '" + entry.getKey() + "' not found for Zone with id: " + zoneId);
         }
-        this.perimeterDefinition = JacksonUtil.fromString(entry.getValueAsString(), PerimeterDefinition.class);
+        this.perimeterDefinition = JacksonUtil.fromString(entry.getValueAsString(), PerimeterDefinition.class,
+                "Invalid perimeter definition format for Zone with id: " + zoneId + ". Failed to parse attribute '" + entry.getKey() + "'");
     }
 
     public GeofencingZoneState(GeofencingZoneProto proto) {

--- a/application/src/test/java/org/thingsboard/server/service/cf/ctx/state/GeofencingValueArgumentEntryTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/cf/ctx/state/GeofencingValueArgumentEntryTest.java
@@ -177,7 +177,7 @@ public class GeofencingValueArgumentEntryTest {
         BaseAttributeKvEntry invalidZoneEntry = new BaseAttributeKvEntry(new StringDataEntry("zone", "someString"), 363L, 155L);
         assertThatThrownBy(() -> new GeofencingArgumentEntry(Map.of(ZONE_1_ID, invalidZoneEntry)))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("The given string value cannot be transformed to Json object: someString");
+                .hasMessage("Invalid perimeter definition format for Zone with id: " + ZONE_1_ID + ". Failed to parse attribute 'zone'");
     }
 
     @Test
@@ -185,7 +185,7 @@ public class GeofencingValueArgumentEntryTest {
         BaseAttributeKvEntry invalidZoneEntry = new BaseAttributeKvEntry(new JsonDataEntry("zone", "\"{}\""), 363L, 155L);
         assertThatThrownBy(() -> new GeofencingArgumentEntry(Map.of(ZONE_1_ID, invalidZoneEntry)))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("The given string value cannot be transformed to Json object: \"{}\"");
+                .hasMessage("Invalid perimeter definition format for Zone with id: " + ZONE_1_ID + ". Failed to parse attribute 'zone'");
     }
 
 }

--- a/common/util/src/main/java/org/thingsboard/common/util/JacksonUtil.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/JacksonUtil.java
@@ -115,10 +115,15 @@ public class JacksonUtil {
 
     @Contract("null, _ -> null") // so that IDE doesn't show NPE warning when input is not null
     public static <T> T fromString(String string, Class<T> clazz) {
+        return fromString(string, clazz, "The given string value cannot be transformed to Json object: " + string);
+    }
+
+    @Contract("null, _, _ -> null") // so that IDE doesn't show NPE warning when input is not null
+    public static <T> T fromString(String string, Class<T> clazz, String errorMsg) {
         try {
             return string != null ? OBJECT_MAPPER.readValue(string, clazz) : null;
         } catch (IOException e) {
-            throw new IllegalArgumentException("The given string value cannot be transformed to Json object: " + string, e);
+            throw new IllegalArgumentException(errorMsg, e);
         }
     }
 

--- a/common/util/src/main/java/org/thingsboard/common/util/geo/PerimeterDefinitionDeserializer.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/geo/PerimeterDefinitionDeserializer.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -32,6 +33,9 @@ public class PerimeterDefinitionDeserializer extends JsonDeserializer<PerimeterD
         JsonNode node = codec.readTree(p);
 
         if (node.isObject()) {
+            if (!node.has("latitude") || !node.has("longitude") || !node.has("radius")) {
+                throw JsonMappingException.from(p, "CirclePerimeterDefinition missing required fields. Received: " + node);
+            }
             double latitude = node.get("latitude").asDouble();
             double longitude = node.get("longitude").asDouble();
             double radius = node.get("radius").asDouble();
@@ -42,7 +46,7 @@ public class PerimeterDefinitionDeserializer extends JsonDeserializer<PerimeterD
             String polygonStrDefinition = mapper.writeValueAsString(node);
             return new PolygonPerimeterDefinition(polygonStrDefinition);
         }
-        throw new IOException("Failed to deserialize PerimeterDefinition from node: " + node);
+        throw JsonMappingException.from(p, "Unknown JSON format for PerimeterDefinition. Expected OBJECT (Circle) or ARRAY (Polygon), but found: " + node.getNodeType());
     }
 
 }


### PR DESCRIPTION
## Pull Request description

<img width="1999" height="270" alt="image" src="https://github.com/user-attachments/assets/6c73c60d-b0af-48dd-ab03-22aa6b205714" />
<img width="1670" height="270" alt="image" src="https://github.com/user-attachments/assets/2aca1114-b2b2-40b9-a62c-3a8124695273" />
<img width="1472" height="448" alt="image" src="https://github.com/user-attachments/assets/f7dcc4ed-3c3e-43e5-945c-4f4a5b768bce" />
<img width="1520" height="462" alt="image" src="https://github.com/user-attachments/assets/66c3d35d-0f49-4b91-ba64-e77d70afa80b" />



## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



