### PR TITLE
Fixed errors in alarm rules

### DIFF
--- a/ui-ngx/src/app/modules/home/components/alarm-rules/alarm-rule-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/alarm-rules/alarm-rule-dialog.component.ts
@@ -180,7 +180,7 @@ export class AlarmRuleDialogComponent extends DialogComponent<AlarmRuleDialogCom
         });
     } else {
       this.fieldFormGroup.get('name').markAsTouched();
-      this.entitySelect.entityAutocompleteMarkAsTouched();
+      this.entitySelect?.entityAutocompleteMarkAsTouched();
     }
   }
 

--- a/ui-ngx/src/app/modules/home/components/alarm-rules/cf-alarm-rule-condition-dialog.component.html
+++ b/ui-ngx/src/app/modules/home/components/alarm-rules/cf-alarm-rule-condition-dialog.component.html
@@ -125,7 +125,7 @@
       <section class="tb-form-panel stroked">
         <div class="flex flex-row items-center justify-between">
           <div class="tb-form-panel-title">{{ 'alarm-rule.type' | translate }}</div>
-          <tb-toggle-select formControlName="type" selectMediaBreakpoint="xs" [disabled]="isNoData">
+          <tb-toggle-select formControlName="type" selectMediaBreakpoint="xs">
             <tb-toggle-option *ngFor="let alarmConditionType of alarmConditionTypes" [value]="alarmConditionType">
               {{ alarmConditionTypeTranslation.get(alarmConditionType) | translate }}
             </tb-toggle-option>

--- a/ui-ngx/src/app/modules/home/components/alarm-rules/cf-alarm-rule-condition-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/alarm-rules/cf-alarm-rule-condition-dialog.component.ts
@@ -228,6 +228,11 @@ export class CfAlarmRuleConditionDialogComponent extends DialogComponent<CfAlarm
     if (this.isNoData && this.conditionFormGroup.get('type').value !== AlarmRuleConditionType.SIMPLE) {
       this.conditionFormGroup.get('type').patchValue(AlarmRuleConditionType.SIMPLE);
     }
+    if (this.isNoData) {
+      this.conditionFormGroup.get('type').disable({emitEvent: false});
+    } else {
+      this.conditionFormGroup.get('type').enable({emitEvent: false});
+    }
   }
 
   private hasNoData(data: Array<AlarmRuleFilter>) {

--- a/ui-ngx/src/app/modules/home/components/alarm-rules/cf-alarm-rule-condition.component.ts
+++ b/ui-ngx/src/app/modules/home/components/alarm-rules/cf-alarm-rule-condition.component.ts
@@ -295,6 +295,9 @@ export class CfAlarmRuleConditionComponent implements ControlValueAccessor, Vali
       }
     }).afterClosed().subscribe((result) => {
       if (result) {
+        if (!this.modelValue) {
+          this.modelValue = {} as AlarmRuleCondition;
+        }
         this.modelValue.schedule = result;
         this.updateModel();
       }


### PR DESCRIPTION
## Pull Request description

Fixed error in entity tab: Cannot read properties of undefined (reading 'entityAutocompleteMarkAsTouched').

Fixed error if scheduler define before condition:  Cannot set properties of null (setting 'schedule').

Fixed disabled for toggle select if missing for operation is selected.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)



