### PR TITLE
fix: respect forward_headers_strategy for client IP in audit logs

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/security/auth/rest/RestAuthenticationDetails.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/auth/rest/RestAuthenticationDetails.java
@@ -29,16 +29,8 @@ public class RestAuthenticationDetails implements Serializable {
     private final Client userAgent;
 
     public RestAuthenticationDetails(HttpServletRequest request) {
-        this.clientAddress = getClientIP(request);
+        this.clientAddress = request.getRemoteAddr();
         this.userAgent = getUserAgent(request);
-    }
-
-    private static String getClientIP(HttpServletRequest request) {
-        String xfHeader = request.getHeader("X-Forwarded-For");
-        if (xfHeader == null) {
-            return request.getRemoteAddr();
-        }
-        return xfHeader.split(",")[0];
     }
 
     private static Client getUserAgent(HttpServletRequest request) {


### PR DESCRIPTION
## Summary

The `RestAuthenticationDetails.getClientIP()` method manually parsed the `X-Forwarded-For` header, ignoring the `server.forward_headers_strategy` configuration. When this setting is `framework` (the default), Spring's `ForwardedHeaderFilter` already handles forwarded headers and updates `request.getRemoteAddr()` accordingly. The manual parsing was redundant and could produce inconsistent results.

## Changes

- Remove the redundant `getClientIP()` method from `RestAuthenticationDetails`
- Use `request.getRemoteAddr()` directly, which respects the configured `forward_headers_strategy`