### PR TITLE
fix: resolve race condition in TbRestApiCallNodeTest

### DIFF
--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/rest/TbRestApiCallNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/rest/TbRestApiCallNodeTest.java
@@ -56,6 +56,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -115,18 +116,7 @@ public class TbRestApiCallNodeTest extends AbstractRuleNodeUpgradeTest {
                     assertTrue(request.containsHeader("Foo"), "Custom header included");
                     assertEquals("Bar", request.getFirstHeader("Foo").getValue(), "Custom header value");
                     response.setStatusCode(200);
-                    new Thread(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                Thread.sleep(1000L);
-                            } catch (InterruptedException e) {
-                                // ignore
-                            } finally {
-                                latch.countDown();
-                            }
-                        }
-                    }).start();
+                    latch.countDown();
                 } catch (Exception e) {
                     System.out.println("Exception handling request: " + e.toString());
                     e.printStackTrace();
@@ -158,7 +148,7 @@ public class TbRestApiCallNodeTest extends AbstractRuleNodeUpgradeTest {
         ArgumentCaptor<TbMsg> msgCaptor = ArgumentCaptor.forClass(TbMsg.class);
         ArgumentCaptor<TbMsgMetaData> metadataCaptor = ArgumentCaptor.forClass(TbMsgMetaData.class);
         ArgumentCaptor<String> dataCaptor = ArgumentCaptor.forClass(String.class);
-        verify(ctx).transformMsg(msgCaptor.capture(), metadataCaptor.capture(), dataCaptor.capture());
+        verify(ctx, timeout(10_000)).transformMsg(msgCaptor.capture(), metadataCaptor.capture(), dataCaptor.capture());
 
         assertNotSame(metaData, metadataCaptor.getValue());
         assertEquals(TbMsg.EMPTY_JSON_OBJECT, dataCaptor.getValue());
@@ -184,18 +174,7 @@ public class TbRestApiCallNodeTest extends AbstractRuleNodeUpgradeTest {
                     assertTrue(request.containsHeader("Foo"), "Custom header included");
                     assertEquals("Bar", request.getFirstHeader("Foo").getValue(), "Custom header value");
                     response.setStatusCode(200);
-                    new Thread(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                Thread.sleep(1000L);
-                            } catch (InterruptedException e) {
-                                // ignore
-                            } finally {
-                                latch.countDown();
-                            }
-                        }
-                    }).start();
+                    latch.countDown();
                 } catch (Exception e) {
                     System.out.println("Exception handling request: " + e.toString());
                     e.printStackTrace();
@@ -227,7 +206,7 @@ public class TbRestApiCallNodeTest extends AbstractRuleNodeUpgradeTest {
         ArgumentCaptor<TbMsg> msgCaptor = ArgumentCaptor.forClass(TbMsg.class);
         ArgumentCaptor<TbMsgMetaData> metadataCaptor = ArgumentCaptor.forClass(TbMsgMetaData.class);
         ArgumentCaptor<String> dataCaptor = ArgumentCaptor.forClass(String.class);
-        verify(ctx).transformMsg(msgCaptor.capture(), metadataCaptor.capture(), dataCaptor.capture());
+        verify(ctx, timeout(10_000)).transformMsg(msgCaptor.capture(), metadataCaptor.capture(), dataCaptor.capture());
 
         assertNotSame(metaData, metadataCaptor.getValue());
         assertEquals(TbMsg.EMPTY_JSON_OBJECT, dataCaptor.getValue());


### PR DESCRIPTION
## Summary

The `deleteRequestWithBody` and `deleteRequestWithoutBody` tests in `TbRestApiCallNodeTest` were flaky due to a race condition. The tests used `Thread.sleep(1000)` in the server handler to wait for the async WebClient response callback to complete before verification, which is unreliable under CI load.

## Changes

- Replace `Thread.sleep`-based synchronization with `Mockito.timeout()` on `verify()` calls, which properly polls for the async interaction
- Simplify server handlers by removing the unnecessary sleep thread and calling `latch.countDown()` directly