### PR TITLE
feat: add RestClient support for getCalculatedFields API

### DIFF
--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -51,6 +51,10 @@
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary

Add `getCalculatedFields` method to `RestClient` to support the `/api/calculatedFields` endpoint from `CalculatedFieldController`, enabling filtering by types, entity type, entities, and names.

## Changes

- Add `httpcore5` dependency to `rest-client` module
- Add `getCalculatedFields(PageLink, Set<CalculatedFieldType>, EntityType, Set<UUID>, Set<String>)` method to `RestClient` using Apache `URIBuilder` for URL construction