### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ rebuild-docker.sh
 */.run/**
 .run/**
 .run
+.claude/


### PR DESCRIPTION
## Summary
Add `.claude/` directory to `.gitignore` to prevent Claude Code project-specific configuration files from being tracked in version control.

## Changes
- Add `.claude/` entry to `.gitignore`