### PR TITLE
Fix flaky TbRateLimitsTest test

### DIFF
--- a/common/message/src/test/java/org/thingsboard/server/common/msg/tools/TbRateLimitsTest.java
+++ b/common/message/src/test/java/org/thingsboard/server/common/msg/tools/TbRateLimitsTest.java
@@ -42,7 +42,7 @@ public class TbRateLimitsTest {
         assertThat(rateLimits.tryConsume()).as("new token is available").isFalse();
 
         int expectedRefillTime = (int) (((double) period / capacity) * 1000);
-        int gap = 500;
+        int gap = 1000;
 
         for (int i = 0; i < capacity; i++) {
             await("token refill for rate limit " + rateLimitConfig)
@@ -71,7 +71,7 @@ public class TbRateLimitsTest {
         assertThat(rateLimits.tryConsume()).as("new token is available").isFalse();
 
         int expectedRefillTime = period * 1000;
-        int gap = 500;
+        int gap = 1000;
 
         await("tokens refill for rate limit " + rateLimitConfig)
                 .pollInterval(new FixedPollInterval(10, TimeUnit.MILLISECONDS))


### PR DESCRIPTION
## Summary
- Increased timing tolerance gap from 500ms to 1000ms in both `testRateLimitWithGreedyRefill` and `testRateLimitWithIntervalRefill` to fix flaky `ConditionTimeoutException` caused by scheduling jitter (e.g. condition evaluated at 4449ms vs 4500ms minimum)

## Test plan
- [x] Run `TbRateLimitsTest.testRateLimits_greedyRefill` repeatedly to verify it no longer fails intermittently
- [x] Run `TbRateLimitsTest.testRateLimits_intervalRefill` repeatedly to verify it no longer fails intermittently

🤖 Generated with [Claude Code](https://claude.com/claude-code)