### PR TITLE
Fix flaky SsrfProtectionValidatorTest parallel execution

### DIFF
--- a/common/util/src/test/java/org/thingsboard/common/util/SsrfProtectionValidatorTest.java
+++ b/common/util/src/test/java/org/thingsboard/common/util/SsrfProtectionValidatorTest.java
@@ -27,11 +27,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@ResourceLock("SsrfProtectionValidatorTest") // some tests mutate static additional-blocked-hosts
 public class SsrfProtectionValidatorTest {
-
-    // JUnit 5 @ResourceLock ensures that tests modifying SsrfProtectionValidator's static
-    // additional blocked hosts never run concurrently with each other (parallel execution is enabled).
-    private static final String SYNC_LOCK = "SsrfProtectionValidatorTest";
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -207,7 +204,6 @@ public class SsrfProtectionValidatorTest {
     }
 
     @Test
-    @ResourceLock(SYNC_LOCK)
     void testAdditionalBlockedSingleIp() {
         try {
             SsrfProtectionValidator.setAdditionalBlockedHosts(List.of("8.8.8.8"));
@@ -222,7 +218,6 @@ public class SsrfProtectionValidatorTest {
     }
 
     @Test
-    @ResourceLock(SYNC_LOCK)
     void testAdditionalBlockedCidrSlash10() {
         try {
             // Use 44.0.0.0/10 (not blocked by default) to verify CIDR /10 matching
@@ -243,7 +238,6 @@ public class SsrfProtectionValidatorTest {
     }
 
     @Test
-    @ResourceLock(SYNC_LOCK)
     void testAdditionalBlockedCidrSlash24() {
         try {
             SsrfProtectionValidator.setAdditionalBlockedHosts(List.of("198.51.100.0/24"));
@@ -261,7 +255,6 @@ public class SsrfProtectionValidatorTest {
     }
 
     @Test
-    @ResourceLock(SYNC_LOCK)
     void testAdditionalBlockedHostnameViaValidateUri() {
         try {
             SsrfProtectionValidator.setAdditionalBlockedHosts(List.of("evil.corp"));
@@ -275,7 +268,6 @@ public class SsrfProtectionValidatorTest {
     }
 
     @Test
-    @ResourceLock(SYNC_LOCK)
     void testAdditionalBlockedHostnameCaseInsensitive() {
         try {
             SsrfProtectionValidator.setAdditionalBlockedHosts(List.of("My-Service.Corp"));
@@ -289,7 +281,6 @@ public class SsrfProtectionValidatorTest {
     }
 
     @Test
-    @ResourceLock(SYNC_LOCK)
     void testSetAdditionalBlockedHostsEmptyAndNull() {
         // Should not throw
         SsrfProtectionValidator.setAdditionalBlockedHosts(Collections.emptyList());
@@ -307,7 +298,6 @@ public class SsrfProtectionValidatorTest {
     }
 
     @Test
-    @ResourceLock(SYNC_LOCK)
     void testAdditionalBlockedCidrViaValidateUri() {
         // 203.0.113.0/24 (TEST-NET-3) is not blocked by default
         URI uri = URI.create("http://203.0.113.1");
@@ -323,7 +313,6 @@ public class SsrfProtectionValidatorTest {
     }
 
     @Test
-    @ResourceLock(SYNC_LOCK)
     void testAdditionalBlockedMixedConfig() {
         try {
             SsrfProtectionValidator.setAdditionalBlockedHosts(List.of("203.0.113.0/24", "evil.corp", "8.8.8.8"));


### PR DESCRIPTION
## Summary
- Moved `@ResourceLock` from individual test methods to the class level on `SsrfProtectionValidatorTest`
- Several tests mutate `SsrfProtectionValidator`'s static additional-blocked-hosts, but read-only tests (e.g. `testAllowedUrls` with `8.8.8.8`) lacked the lock and could run concurrently, causing intermittent failures

## Test plan
- [ ] Run `mvn test -pl common/util -Dtest=SsrfProtectionValidatorTest` multiple times to confirm no flakiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)