### PR TITLE
RPC monitoring for the monitoring microservice

### DIFF
--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -44,6 +44,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.thingsboard.common</groupId>
             <artifactId>data</artifactId>
         </dependency>

--- a/monitoring/src/main/java/org/thingsboard/monitoring/config/rpc/MqttRpcMonitoringConfig.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/config/rpc/MqttRpcMonitoringConfig.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.config.rpc;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = "monitoring.rpc.mqtt.enabled", havingValue = "true")
+@ConfigurationProperties(prefix = "monitoring.rpc.mqtt")
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class MqttRpcMonitoringConfig extends RpcMonitoringConfig {
+
+    private Integer qos;
+
+    @Override
+    public RpcTransportType getTransportType() {
+        return RpcTransportType.MQTT;
+    }
+
+}

--- a/monitoring/src/main/java/org/thingsboard/monitoring/config/rpc/RpcMonitoringConfig.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/config/rpc/RpcMonitoringConfig.java
@@ -13,25 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.monitoring.data;
+package org.thingsboard.monitoring.config.rpc;
 
-public class Latencies {
+import lombok.Data;
+import org.thingsboard.monitoring.config.MonitoringConfig;
 
-    public static final String WS_CONNECT = "wsConnect";
-    public static final String WS_SUBSCRIBE = "wsSubscribe";
-    public static final String LOG_IN = "logIn";
-    public static final String EDQS_QUERY = "edqsQuery";
+import java.util.List;
 
-    public static String request(String key) {
-        return String.format("%sRequest", key);
-    }
+@Data
+public abstract class RpcMonitoringConfig implements MonitoringConfig<RpcMonitoringTarget> {
 
-    public static String wsUpdate(String key) {
-        return String.format("%sWsUpdate", key);
-    }
+    private List<RpcMonitoringTarget> targets;
+    private int requestTimeoutMs;
 
-    public static String rpcRoundTrip(String key) {
-        return String.format("%sRpcRoundTrip", key);
-    }
+    public abstract RpcTransportType getTransportType();
 
 }

--- a/monitoring/src/main/java/org/thingsboard/monitoring/config/rpc/RpcMonitoringTarget.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/config/rpc/RpcMonitoringTarget.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.config.rpc;
+
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+import org.thingsboard.monitoring.config.MonitoringTarget;
+
+import java.util.UUID;
+
+@Data
+public class RpcMonitoringTarget implements MonitoringTarget {
+
+    private String baseUrl;
+    private String deviceId;
+    private String accessToken;
+    // Human-readable label used in metric keys and logs; defaults to first 8 chars of deviceId
+    private String label;
+
+    @Override
+    public UUID getDeviceId() {
+        return UUID.fromString(deviceId);
+    }
+
+    @Override
+    public boolean isCheckDomainIps() {
+        return false;
+    }
+
+    public String getLabel() {
+        return StringUtils.isNotBlank(label) ? label : deviceId.substring(0, 8);
+    }
+
+}

--- a/monitoring/src/main/java/org/thingsboard/monitoring/config/rpc/RpcTransportType.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/config/rpc/RpcTransportType.java
@@ -13,25 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.thingsboard.monitoring.data;
+package org.thingsboard.monitoring.config.rpc;
 
-public class Latencies {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.thingsboard.monitoring.service.rpc.BaseRpcHealthChecker;
+import org.thingsboard.monitoring.service.rpc.impl.MqttRpcHealthChecker;
 
-    public static final String WS_CONNECT = "wsConnect";
-    public static final String WS_SUBSCRIBE = "wsSubscribe";
-    public static final String LOG_IN = "logIn";
-    public static final String EDQS_QUERY = "edqsQuery";
+@AllArgsConstructor
+@Getter
+public enum RpcTransportType {
 
-    public static String request(String key) {
-        return String.format("%sRequest", key);
-    }
+    MQTT("MQTT", MqttRpcHealthChecker.class);
 
-    public static String wsUpdate(String key) {
-        return String.format("%sWsUpdate", key);
-    }
-
-    public static String rpcRoundTrip(String key) {
-        return String.format("%sRpcRoundTrip", key);
-    }
+    private final String name;
+    private final Class<? extends BaseRpcHealthChecker<?>> serviceClass;
 
 }

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
@@ -48,9 +48,9 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
     @Autowired
     protected MonitoringEntityService entityService;
     @Autowired
-    private MonitoringReporter reporter;
+    protected MonitoringReporter reporter;
     @Autowired
-    private TbStopWatch stopWatch;
+    protected TbStopWatch stopWatch;
     @Value("${monitoring.check_timeout_ms}")
     private int resultCheckTimeoutMs;
 
@@ -67,7 +67,7 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
 
     protected abstract void initialize();
 
-    public final void check(WsClient wsClient) {
+    public void check(WsClient wsClient) {
         log.debug("[{}] Checking", info);
         try {
             int expectedUpdatesCount = isCfMonitoringEnabled() ? 2 : 1;

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/rpc/BaseRpcHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/rpc/BaseRpcHealthChecker.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.service.rpc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.monitoring.client.TbClient;
+import org.thingsboard.monitoring.client.WsClient;
+import org.thingsboard.monitoring.config.rpc.RpcMonitoringConfig;
+import org.thingsboard.monitoring.config.rpc.RpcMonitoringTarget;
+import org.thingsboard.monitoring.config.rpc.RpcTransportType;
+import org.thingsboard.monitoring.data.Latencies;
+import org.thingsboard.monitoring.data.MonitoredServiceKey;
+import org.thingsboard.monitoring.data.ServiceFailureException;
+import org.thingsboard.monitoring.service.BaseHealthChecker;
+import org.thingsboard.server.common.data.id.DeviceId;
+
+import java.util.UUID;
+
+@Slf4j
+public abstract class BaseRpcHealthChecker<C extends RpcMonitoringConfig> extends BaseHealthChecker<C, RpcMonitoringTarget> {
+
+    @Autowired
+    private TbClient tbClient;
+
+    protected BaseRpcHealthChecker(C config, RpcMonitoringTarget target) {
+        super(config, target);
+    }
+
+    @Override
+    protected void initialize() {
+        try {
+            initClient();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to initialize RPC health checker for " + getInfo(), e);
+        }
+    }
+
+    @Override
+    public void check(WsClient wsClient) {
+        log.debug("[{}] Checking RPC", getInfo());
+        try {
+            String testValue = UUID.randomUUID().toString();
+
+            ObjectNode requestBody = JacksonUtil.newObjectNode();
+            requestBody.put("method", "monitoringCheck");
+            requestBody.set("params", JacksonUtil.newObjectNode().put("value", testValue));
+            requestBody.put("timeout", config.getRequestTimeoutMs());
+
+            stopWatch.start();
+            JsonNode response;
+            try {
+                response = tbClient.handleTwoWayDeviceRPCRequest(new DeviceId(target.getDeviceId()), requestBody);
+            } catch (Throwable e) {
+                throw new ServiceFailureException(getInfo(), e);
+            }
+            reporter.reportLatency(Latencies.rpcRoundTrip(getKey()), stopWatch.getTime());
+
+            String actualValue = response != null ? response.path("value").asText(null) : null;
+            if (!testValue.equals(actualValue)) {
+                String got = response != null ? response.toString() : "null";
+                throw new ServiceFailureException(getInfo(), "Expected value " + testValue + " but got " + got);
+            }
+
+            reporter.serviceIsOk(getInfo());
+            reporter.serviceIsOk(MonitoredServiceKey.GENERAL);
+        } catch (ServiceFailureException e) {
+            reporter.serviceFailure(e.getServiceKey(), e);
+        } catch (Exception e) {
+            reporter.serviceFailure(MonitoredServiceKey.GENERAL, e);
+        }
+    }
+
+    @Override
+    protected String createTestPayload(String testValue) {
+        return testValue;
+    }
+
+    @Override
+    protected void sendTestPayload(String payload) throws Exception {
+        // not used — check() drives the flow directly
+    }
+
+    @Override
+    protected Object getInfo() {
+        return String.format("*%s RPC* %s (%s)", getTransportType().getName(), target.getLabel(), target.getBaseUrl());
+    }
+
+    @Override
+    protected String getKey() {
+        return getTransportType().name().toLowerCase() + "Rpc_" + target.getLabel();
+    }
+
+    @Override
+    protected boolean isCfMonitoringEnabled() {
+        return false;
+    }
+
+    protected abstract RpcTransportType getTransportType();
+
+}

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/rpc/RpcMonitoringService.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/rpc/RpcMonitoringService.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.service.rpc;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.thingsboard.monitoring.config.rpc.RpcMonitoringConfig;
+import org.thingsboard.monitoring.config.rpc.RpcMonitoringTarget;
+import org.thingsboard.monitoring.service.BaseHealthChecker;
+import org.thingsboard.monitoring.service.BaseMonitoringService;
+
+@Service
+@Slf4j
+public class RpcMonitoringService extends BaseMonitoringService<RpcMonitoringConfig, RpcMonitoringTarget> {
+
+    @Override
+    protected BaseHealthChecker<?, ?> createHealthChecker(RpcMonitoringConfig config, RpcMonitoringTarget target) {
+        return applicationContext.getBean(config.getTransportType().getServiceClass(), config, target);
+    }
+
+    @Override
+    protected RpcMonitoringTarget createTarget(String baseUrl) {
+        RpcMonitoringTarget target = new RpcMonitoringTarget();
+        target.setBaseUrl(baseUrl);
+        return target;
+    }
+
+    @Override
+    protected String getName() {
+        return "rpc check";
+    }
+
+}

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/rpc/impl/MqttRpcHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/rpc/impl/MqttRpcHealthChecker.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.service.rpc.impl;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.monitoring.config.rpc.MqttRpcMonitoringConfig;
+import org.thingsboard.monitoring.config.rpc.RpcMonitoringTarget;
+import org.thingsboard.monitoring.config.rpc.RpcTransportType;
+import org.thingsboard.monitoring.service.rpc.BaseRpcHealthChecker;
+
+@Component
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@Slf4j
+public class MqttRpcHealthChecker extends BaseRpcHealthChecker<MqttRpcMonitoringConfig> {
+
+    private static final String RPC_REQUEST_TOPIC = "v1/devices/me/rpc/request/+";
+    private static final String RPC_REQUEST_TOPIC_PREFIX = "v1/devices/me/rpc/request/";
+    private static final String RPC_RESPONSE_TOPIC_PREFIX = "v1/devices/me/rpc/response/";
+
+    private MqttClient mqttClient;
+
+    protected MqttRpcHealthChecker(MqttRpcMonitoringConfig config, RpcMonitoringTarget target) {
+        super(config, target);
+    }
+
+    @Override
+    protected void initClient() throws Exception {
+        if (mqttClient != null && mqttClient.isConnected()) {
+            return;
+        }
+        String clientId = MqttAsyncClient.generateClientId();
+        mqttClient = createMqttClient(target.getBaseUrl(), clientId);
+        mqttClient.setTimeToWait(config.getRequestTimeoutMs());
+
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setUserName(target.getAccessToken());
+        options.setConnectionTimeout(config.getRequestTimeoutMs() / 1000);
+
+        IMqttToken result = mqttClient.connectWithResult(options);
+        if (result.getException() != null) {
+            throw result.getException();
+        }
+
+        // Subscribe to server-side RPC requests and echo params back as the response.
+        // The callback runs on Paho's internal thread while the two-way RPC REST call
+        // blocks the checker thread, so TB receives the reply and unblocks the caller.
+        mqttClient.subscribe(RPC_REQUEST_TOPIC, config.getQos(), (topic, message) -> {
+            String requestId = topic.substring(RPC_REQUEST_TOPIC_PREFIX.length());
+            JsonNode request = JacksonUtil.toJsonNode(new String(message.getPayload()));
+            JsonNode params = request.path("params");
+
+            MqttMessage response = new MqttMessage(params.toString().getBytes());
+            response.setQos(config.getQos());
+            mqttClient.publish(RPC_RESPONSE_TOPIC_PREFIX + requestId, response);
+            log.trace("[{}] Replied to RPC request {}", getInfo(), requestId);
+        });
+
+        log.info("[{}] Connected and subscribed for RPC", getInfo());
+    }
+
+    @Override
+    protected void destroyClient() throws Exception {
+        if (mqttClient != null) {
+            mqttClient.disconnect();
+            mqttClient = null;
+            log.info("[{}] Disconnected MQTT RPC client", getInfo());
+        }
+    }
+
+    @Override
+    protected RpcTransportType getTransportType() {
+        return RpcTransportType.MQTT;
+    }
+
+    protected MqttClient createMqttClient(String brokerUrl, String clientId) throws MqttException {
+        return new MqttClient(brokerUrl, clientId, new MemoryPersistence());
+    }
+
+}

--- a/monitoring/src/main/resources/tb-monitoring.yml
+++ b/monitoring/src/main/resources/tb-monitoring.yml
@@ -113,6 +113,27 @@ monitoring:
         # To add more targets, use following environment variables:
         # monitoring.transports.lwm2m.targets[1].base_url, monitoring.transports.lwm2m.targets[2].base_url, etc.
 
+  rpc:
+    mqtt:
+      # Enable MQTT RPC checks
+      enabled: '${RPC_MQTT_MONITORING_ENABLED:false}'
+      # Timeout for the two-way RPC round-trip in milliseconds.
+      # Must be less than monitoring.rest.request_timeout_ms so the REST call doesn't
+      # time out on the client side before TB times out on the server side.
+      request_timeout_ms: '${RPC_MQTT_REQUEST_TIMEOUT_MS:4000}'
+      # MQTT QoS for RPC subscription and response publishing
+      qos: '${RPC_MQTT_QOS_LEVEL:1}'
+      targets:
+          # Each target represents one pre-existing device and covers one partition shard.
+          # Add more targets (targets[1], targets[2], ...) to probe additional partitions.
+        - base_url: '${RPC_MQTT_BASE_URL:tcp://${monitoring.domain}:1883}'
+          # UUID of the existing device that will act as the RPC echo responder
+          device_id: '${RPC_MQTT_DEVICE_ID:}'
+          # Access token of that device
+          access_token: '${RPC_MQTT_ACCESS_TOKEN:}'
+          # Optional human-readable label used in metric keys (e.g. "shard0")
+          label: '${RPC_MQTT_LABEL:}'
+
   edqs:
     enabled: "${EDQS_MONITORING_ENABLED:false}"
 

--- a/monitoring/src/test/java/org/thingsboard/monitoring/config/rpc/RpcMonitoringTargetTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/config/rpc/RpcMonitoringTargetTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.config.rpc;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RpcMonitoringTargetTest {
+
+    @Test
+    void getLabel_returnsConfiguredLabel() {
+        RpcMonitoringTarget target = new RpcMonitoringTarget();
+        target.setDeviceId(UUID.randomUUID().toString());
+        target.setLabel("shard0");
+
+        assertThat(target.getLabel()).isEqualTo("shard0");
+    }
+
+    @Test
+    void getLabel_fallsBackToDeviceIdPrefix_whenLabelIsNull() {
+        String deviceId = "a1b2c3d4-0000-0000-0000-000000000000";
+        RpcMonitoringTarget target = new RpcMonitoringTarget();
+        target.setDeviceId(deviceId);
+        target.setLabel(null);
+
+        assertThat(target.getLabel()).isEqualTo("a1b2c3d4");
+    }
+
+    @Test
+    void getLabel_fallsBackToDeviceIdPrefix_whenLabelIsBlank() {
+        String deviceId = "ffee1122-0000-0000-0000-000000000000";
+        RpcMonitoringTarget target = new RpcMonitoringTarget();
+        target.setDeviceId(deviceId);
+        target.setLabel("   ");
+
+        assertThat(target.getLabel()).isEqualTo("ffee1122");
+    }
+
+    @Test
+    void getDeviceId_parsesUuidString() {
+        UUID expected = UUID.randomUUID();
+        RpcMonitoringTarget target = new RpcMonitoringTarget();
+        target.setDeviceId(expected.toString());
+
+        assertThat(target.getDeviceId()).isEqualTo(expected);
+    }
+
+    @Test
+    void isCheckDomainIps_alwaysReturnsFalse() {
+        assertThat(new RpcMonitoringTarget().isCheckDomainIps()).isFalse();
+    }
+
+}

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/rpc/BaseRpcHealthCheckerTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/rpc/BaseRpcHealthCheckerTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.service.rpc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.monitoring.client.TbClient;
+import org.thingsboard.monitoring.config.rpc.MqttRpcMonitoringConfig;
+import org.thingsboard.monitoring.config.rpc.RpcMonitoringTarget;
+import org.thingsboard.monitoring.config.rpc.RpcTransportType;
+import org.thingsboard.monitoring.data.MonitoredServiceKey;
+import org.thingsboard.monitoring.service.MonitoringReporter;
+import org.thingsboard.monitoring.util.TbStopWatch;
+import org.thingsboard.server.common.data.id.DeviceId;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BaseRpcHealthCheckerTest {
+
+    @Mock TbClient tbClient;
+    @Mock MonitoringReporter reporter;
+    @Mock TbStopWatch stopWatch;
+
+    TestRpcChecker checker;
+    RpcMonitoringTarget target;
+
+    @BeforeEach
+    void setUp() {
+        MqttRpcMonitoringConfig config = new MqttRpcMonitoringConfig();
+        config.setRequestTimeoutMs(5000);
+        config.setQos(1);
+
+        target = new RpcMonitoringTarget();
+        target.setDeviceId("00000000-0000-0000-0000-000000000001");
+        target.setAccessToken("test-token");
+        target.setLabel("shard0");
+        target.setBaseUrl("tcp://localhost:1883");
+
+        checker = new TestRpcChecker(config, target);
+        ReflectionTestUtils.setField(checker, "tbClient", tbClient);
+        ReflectionTestUtils.setField(checker, "reporter", reporter);
+        ReflectionTestUtils.setField(checker, "stopWatch", stopWatch);
+    }
+
+    @Test
+    void check_happyPath_reportsOkAndLatency() {
+        when(tbClient.handleTwoWayDeviceRPCRequest(any(DeviceId.class), any())).thenAnswer(inv -> {
+            JsonNode body = inv.getArgument(1, JsonNode.class);
+            String value = body.path("params").path("value").asText();
+            return JacksonUtil.newObjectNode().put("value", value);
+        });
+
+        checker.check(null);
+
+        verify(reporter).serviceIsOk(checker.getInfo());
+        verify(reporter).serviceIsOk(MonitoredServiceKey.GENERAL);
+        verify(reporter).reportLatency(contains("RpcRoundTrip"), anyLong());
+        verify(reporter, never()).serviceFailure(any(), any(Throwable.class));
+    }
+
+    @Test
+    void check_requestBodyHasCorrectStructure() {
+        when(tbClient.handleTwoWayDeviceRPCRequest(any(DeviceId.class), any())).thenAnswer(inv -> {
+            JsonNode body = inv.getArgument(1, JsonNode.class);
+            String value = body.path("params").path("value").asText();
+            return JacksonUtil.newObjectNode().put("value", value);
+        });
+
+        checker.check(null);
+
+        ArgumentCaptor<JsonNode> bodyCaptor = ArgumentCaptor.forClass(JsonNode.class);
+        verify(tbClient).handleTwoWayDeviceRPCRequest(any(), bodyCaptor.capture());
+        JsonNode body = bodyCaptor.getValue();
+
+        assertThat(body.path("method").asText()).isEqualTo("monitoringCheck");
+        assertThat(body.path("params").path("value").asText()).isNotBlank();
+        assertThat(body.path("timeout").asInt()).isEqualTo(5000);
+    }
+
+    @Test
+    void check_requestTargetsCorrectDevice() {
+        when(tbClient.handleTwoWayDeviceRPCRequest(any(), any())).thenAnswer(inv -> {
+            JsonNode body = inv.getArgument(1, JsonNode.class);
+            return JacksonUtil.newObjectNode().put("value", body.path("params").path("value").asText());
+        });
+
+        checker.check(null);
+
+        ArgumentCaptor<DeviceId> deviceCaptor = ArgumentCaptor.forClass(DeviceId.class);
+        verify(tbClient).handleTwoWayDeviceRPCRequest(deviceCaptor.capture(), any());
+        assertThat(deviceCaptor.getValue().getId()).isEqualTo(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+    }
+
+    @Test
+    void check_wrongEchoedValue_reportsFailure() {
+        when(tbClient.handleTwoWayDeviceRPCRequest(any(), any()))
+                .thenReturn(JacksonUtil.newObjectNode().put("value", "wrong-value"));
+
+        checker.check(null);
+
+        verify(reporter).serviceFailure(eq(checker.getInfo()), any(Throwable.class));
+        verify(reporter, never()).serviceIsOk(checker.getInfo());
+    }
+
+    @Test
+    void check_nullResponse_reportsFailure() {
+        when(tbClient.handleTwoWayDeviceRPCRequest(any(), any())).thenReturn(null);
+
+        checker.check(null);
+
+        verify(reporter).serviceFailure(eq(checker.getInfo()), any(Throwable.class));
+        verify(reporter, never()).serviceIsOk(checker.getInfo());
+    }
+
+    @Test
+    void check_restCallThrows_reportsFailure() {
+        when(tbClient.handleTwoWayDeviceRPCRequest(any(), any()))
+                .thenThrow(new RuntimeException("connection refused"));
+
+        checker.check(null);
+
+        verify(reporter).serviceFailure(eq(checker.getInfo()), any(Throwable.class));
+        verify(reporter, never()).serviceIsOk(checker.getInfo());
+    }
+
+    @Test
+    void check_restCallThrows_doesNotReportLatency() {
+        when(tbClient.handleTwoWayDeviceRPCRequest(any(), any()))
+                .thenThrow(new RuntimeException("timeout"));
+
+        checker.check(null);
+
+        verify(reporter, never()).reportLatency(any(), anyLong());
+    }
+
+    @Test
+    void getKey_includesTransportTypeAndLabel() {
+        assertThat(checker.getKey()).isEqualTo("mqttRpc_shard0");
+    }
+
+    // Minimal concrete subclass — initClient/destroyClient are no-ops
+    private static class TestRpcChecker extends BaseRpcHealthChecker<MqttRpcMonitoringConfig> {
+        TestRpcChecker(MqttRpcMonitoringConfig config, RpcMonitoringTarget target) {
+            super(config, target);
+        }
+
+        @Override protected void initClient() {}
+        @Override protected void destroyClient() {}
+        @Override protected RpcTransportType getTransportType() { return RpcTransportType.MQTT; }
+
+        // expose getInfo() for assertions
+        @Override public Object getInfo() { return super.getInfo(); }
+    }
+
+}

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/rpc/impl/MqttRpcHealthCheckerTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/rpc/impl/MqttRpcHealthCheckerTest.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.service.rpc.impl;
+
+import org.eclipse.paho.client.mqttv3.IMqttMessageListener;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.monitoring.config.rpc.MqttRpcMonitoringConfig;
+import org.thingsboard.monitoring.config.rpc.RpcMonitoringTarget;
+import org.thingsboard.monitoring.service.MonitoringReporter;
+import org.thingsboard.monitoring.util.TbStopWatch;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MqttRpcHealthCheckerTest {
+
+    @Mock MqttClient mqttClient;
+    @Mock IMqttToken connectToken;
+
+    TestMqttRpcHealthChecker checker;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MqttRpcMonitoringConfig config = new MqttRpcMonitoringConfig();
+        config.setRequestTimeoutMs(5000);
+        config.setQos(1);
+
+        RpcMonitoringTarget target = new RpcMonitoringTarget();
+        target.setBaseUrl("tcp://localhost:1883");
+        target.setDeviceId(UUID.randomUUID().toString());
+        target.setAccessToken("my-access-token");
+        target.setLabel("test-shard");
+
+        checker = new TestMqttRpcHealthChecker(config, target, mqttClient);
+        // Inject no-op reporter and stopWatch so check() doesn't NPE if called
+        ReflectionTestUtils.setField(checker, "reporter", mock(MonitoringReporter.class));
+        ReflectionTestUtils.setField(checker, "stopWatch", mock(TbStopWatch.class));
+
+        lenient().when(connectToken.getException()).thenReturn(null);
+        lenient().when(mqttClient.connectWithResult(any())).thenReturn(connectToken);
+    }
+
+    @Test
+    void initClient_connectsWithAccessTokenAsUsername() throws Exception {
+        checker.initClient();
+
+        ArgumentCaptor<MqttConnectOptions> optionsCaptor = ArgumentCaptor.forClass(MqttConnectOptions.class);
+        verify(mqttClient).connectWithResult(optionsCaptor.capture());
+        assertThat(optionsCaptor.getValue().getUserName()).isEqualTo("my-access-token");
+    }
+
+    @Test
+    void initClient_setsConnectionTimeout() throws Exception {
+        checker.initClient();
+
+        ArgumentCaptor<MqttConnectOptions> optionsCaptor = ArgumentCaptor.forClass(MqttConnectOptions.class);
+        verify(mqttClient).connectWithResult(optionsCaptor.capture());
+        assertThat(optionsCaptor.getValue().getConnectionTimeout()).isEqualTo(5); // 5000ms / 1000
+    }
+
+    @Test
+    void initClient_subscribesToRpcRequestTopic() throws Exception {
+        checker.initClient();
+
+        verify(mqttClient).subscribe(eq("v1/devices/me/rpc/request/+"), eq(1), any(IMqttMessageListener.class));
+    }
+
+    @Test
+    void initClient_isIdempotentWhenAlreadyConnected() throws Exception {
+        checker.initClient();
+        when(mqttClient.isConnected()).thenReturn(true);
+        checker.initClient();
+
+        verify(mqttClient, times(1)).connectWithResult(any());
+        verify(mqttClient, times(1)).subscribe(any(), anyInt(), any(IMqttMessageListener.class));
+    }
+
+    @Test
+    void rpcCallback_echosParamsToResponseTopic() throws Exception {
+        checker.initClient();
+
+        ArgumentCaptor<IMqttMessageListener> listenerCaptor = ArgumentCaptor.forClass(IMqttMessageListener.class);
+        verify(mqttClient).subscribe(any(), anyInt(), listenerCaptor.capture());
+        IMqttMessageListener listener = listenerCaptor.getValue();
+
+        MqttMessage incoming = new MqttMessage(
+                "{\"method\":\"monitoringCheck\",\"params\":{\"value\":\"abc-123\"}}".getBytes());
+        listener.messageArrived("v1/devices/me/rpc/request/42", incoming);
+
+        ArgumentCaptor<MqttMessage> responseCaptor = ArgumentCaptor.forClass(MqttMessage.class);
+        verify(mqttClient).publish(eq("v1/devices/me/rpc/response/42"), responseCaptor.capture());
+        assertThat(new String(responseCaptor.getValue().getPayload())).isEqualTo("{\"value\":\"abc-123\"}");
+    }
+
+    @Test
+    void rpcCallback_extractsRequestIdFromTopic() throws Exception {
+        checker.initClient();
+
+        ArgumentCaptor<IMqttMessageListener> listenerCaptor = ArgumentCaptor.forClass(IMqttMessageListener.class);
+        verify(mqttClient).subscribe(any(), anyInt(), listenerCaptor.capture());
+
+        MqttMessage incoming = new MqttMessage(
+                "{\"method\":\"monitoringCheck\",\"params\":{\"value\":\"x\"}}".getBytes());
+        listenerCaptor.getValue().messageArrived("v1/devices/me/rpc/request/99", incoming);
+
+        verify(mqttClient).publish(eq("v1/devices/me/rpc/response/99"), any());
+    }
+
+    @Test
+    void rpcCallback_usesConfiguredQos() throws Exception {
+        checker.initClient();
+
+        ArgumentCaptor<IMqttMessageListener> listenerCaptor = ArgumentCaptor.forClass(IMqttMessageListener.class);
+        verify(mqttClient).subscribe(any(), anyInt(), listenerCaptor.capture());
+
+        MqttMessage incoming = new MqttMessage(
+                "{\"method\":\"monitoringCheck\",\"params\":{\"value\":\"v\"}}".getBytes());
+        listenerCaptor.getValue().messageArrived("v1/devices/me/rpc/request/7", incoming);
+
+        ArgumentCaptor<MqttMessage> responseCaptor = ArgumentCaptor.forClass(MqttMessage.class);
+        verify(mqttClient).publish(any(), responseCaptor.capture());
+        assertThat(responseCaptor.getValue().getQos()).isEqualTo(1);
+    }
+
+    @Test
+    void destroyClient_disconnectsAndClearsClient() throws Exception {
+        checker.initClient();
+        checker.destroyClient();
+
+        verify(mqttClient).disconnect();
+        // A second destroyClient call should be a no-op (client is null)
+        checker.destroyClient();
+        verify(mqttClient, times(1)).disconnect();
+    }
+
+    @Test
+    void destroyClient_beforeInit_isNoOp() throws Exception {
+        checker.destroyClient();
+        verify(mqttClient, never()).disconnect();
+    }
+
+    // Subclass that injects a mock MqttClient instead of creating a real one
+    private static class TestMqttRpcHealthChecker extends MqttRpcHealthChecker {
+        private final MqttClient mockClient;
+
+        TestMqttRpcHealthChecker(MqttRpcMonitoringConfig config, RpcMonitoringTarget target, MqttClient mockClient) {
+            super(config, target);
+            this.mockClient = mockClient;
+        }
+
+        @Override
+        protected MqttClient createMqttClient(String brokerUrl, String clientId) throws MqttException {
+            return mockClient;
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

- Adds two-way RPC health checking alongside the existing transport telemetry checks
- Probes the full round-trip: REST API → rule engine partition → transport microservice → device → response, with value validation
- Multiple devices per target cover different topic/partition assignments by hash, so partial microservice failures (affecting only a fraction of devices) are detectable
- Starting with MQTT; extensible to other transports via `RpcTransportType` enum

## Design

```
monitoring.rpc.mqtt:
  enabled: true
  request_timeout_ms: 4000
  qos: 1
  targets:
    - base_url: tcp://mqtt.example.com:1883
      device_id: <uuid>        # pre-existing device
      access_token: <token>
      label: shard0            # used in metric keys
    - ...                      # add one per partition shard
```

**Check flow per device:**
1. On startup: persistent MQTT connection, subscribed to `v1/devices/me/rpc/request/+`
2. On each check: `POST /api/rpc/twoway/{deviceId}` with `{"method":"monitoringCheck","params":{"value":"<uuid>"}}`
3. Paho callback thread receives the request, publishes params back to `v1/devices/me/rpc/response/{requestId}`
4. REST call returns the echoed value; checker validates it matches and reports `mqttRpc_<label>RpcRoundTrip` latency

**Key changes to base classes:**
- `BaseHealthChecker.check(WsClient)` — `final` removed to allow RPC override (WsClient-based validation is skipped for RPC)
- `reporter` and `stopWatch` — made `protected` for subclass access

## Test plan

- [ ] `RpcMonitoringTargetTest` — label fallback, UUID parsing
- [ ] `BaseRpcHealthCheckerTest` — happy path, wrong value, null response, REST exception, request body structure, correct device ID
- [ ] `MqttRpcHealthCheckerTest` — connect options, RPC topic subscription, callback echo, idempotent init, destroy

🤖 Generated with [Claude Code](https://claude.com/claude-code)