### PR TITLE
fix test: delay LwM2M FW client stop to prevent Execute response race

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/FwLwM2MDevice.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/FwLwM2MDevice.java
@@ -193,7 +193,7 @@ public class FwLwM2MDevice extends BaseInstanceEnabler implements Destroyable {
             } catch (Exception e) {
                 log.error("Error during firmware update", e);
             }
-        }, 0, TimeUnit.SECONDS); // start immediately, without further delay
+        }, 1, TimeUnit.SECONDS); // delay 1 sec to allow CoAP Execute response to be delivered before client stops
     }
 
     protected void setLeshanClient(LeshanClient leshanClient) {


### PR DESCRIPTION
## Root Cause

`RpcLwm2mIntegrationExecuteTest.testExecuteUpdateFWById_Result_CHANGED` was flaky because of a race condition in the test's `FwLwM2MDevice` simulation client.

When the server sends an Execute RPC to `/5/0/2` (FW Update, Update resource):
1. `execute()` is called → calls `startUpdating()` then returns `ExecuteResponse.success()`
2. Leshan/Californium serializes the 2.04 Changed response and sends it over the network
3. **Race**: `startUpdating()` scheduled `leshanClient.stop(false)` with **0 delay** on a background thread

If `leshanClient.stop(false)` ran before the CoAP ACK was delivered to the server, Californium cancelled the in-flight request, producing `RequestCanceledException` on the server side — which was then surfaced as `INTERNAL_SERVER_ERROR` instead of `CHANGED`.

## Fix

Change the scheduler delay from `0` to `1` second in `FwLwM2MDevice.startUpdating()`. This gives the CoAP stack sufficient time to transmit and deliver the Execute response before the client disconnects.

The 1-second delay has no impact on OTA integration tests (`Ota5LwM2MIntegrationTest`) since those already await state transitions with 60-second timeouts.

## Test plan
- [ ] `RpcLwm2mIntegrationExecuteTest.testExecuteUpdateFWById_Result_CHANGED` — previously flaky, should now pass consistently
- [ ] `Ota5LwM2MIntegrationTest` — unaffected (awaits with 60s timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)