### PR TITLE
fix: Mqtt test await RPC re-queuing after session close on delivery timeout

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv5/rpc/MqttV5CloseTransportSessionOnRpcDeliveryTimeoutIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv5/rpc/MqttV5CloseTransportSessionOnRpcDeliveryTimeoutIntegrationTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.thingsboard.server.common.data.device.profile.MqttTopics.DEVICE_RPC_REQUESTS_SUB_TOPIC;
 
@@ -97,7 +98,13 @@ public class MqttV5CloseTransportSessionOnRpcDeliveryTimeoutIntegrationTest exte
         callback.getDisconnectLatch().await(DEFAULT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         assertThat(callback.getReturnCode()).isEqualTo(MqttReturnCode.RETURN_CODE_ADMINISTRITIVE_ACTION);
 
-        Rpc persistedRpc = doGet("/api/rpc/persistent/" + response.get("rpcId").asText(), Rpc.class);
+        // The server re-queues the RPC asynchronously after closing the session.
+        // Poll until the status transitions from SENT to QUEUED.
+        String rpcId = response.get("rpcId").asText();
+        Rpc persistedRpc = await("RPC re-queued after session close")
+                .atMost(DEFAULT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .until(() -> doGet("/api/rpc/persistent/" + rpcId, Rpc.class),
+                        rpc -> RpcStatus.QUEUED.equals(rpc.getStatus()));
         assertThat(persistedRpc).isNotNull();
         assertThat(persistedRpc.getStatus()).isEqualTo(RpcStatus.QUEUED);
         assertThat(persistedRpc.getResponse()).isInstanceOf(NullNode.class);


### PR DESCRIPTION
## Root Cause

`MqttV5CloseTransportSessionOnRpcDeliveryTimeoutIntegrationTest.testOneWayRpcCloseSessionOnRpcDeliveryTimeout` (and `testTwoWayRpcCloseSessionOnRpcDeliveryTimeout`) was flaky.

The test scenario:
1. Client subscribes with manual ACK (QoS 1)
2. Server sends RPC request — device receives it but never sends PUBACK
3. Server's 100ms MQTT timeout fires → server disconnects the session (DISCONNECT with reason code 152)
4. Because `actors.rpc.close_session_on_rpc_delivery_timeout=true`, the server should re-queue the RPC (status: `SENT` → `QUEUED`)

The test asserted `persistedRpc.getStatus() == QUEUED` **immediately** after the disconnect latch fired. But the server's re-queuing is **asynchronous** — the status was still `SENT` at that point.

## Fix

Replace the direct `doGet` assertion with an Awaitility poll that waits up to `DEFAULT_WAIT_TIMEOUT_SECONDS` (30s) for the RPC status to transition from `SENT` to `QUEUED`.

## Test plan
- [x] `testOneWayRpcCloseSessionOnRpcDeliveryTimeout` — previously flaky, should pass consistently
- [x] `testTwoWayRpcCloseSessionOnRpcDeliveryTimeout` — same fix path, should also benefit

🤖 Generated with [Claude Code](https://claude.com/claude-code)