### PR TITLE
Fix flaky AuditLogControllerTest#testAuditLogsSysAdmin

### DIFF
--- a/application/src/test/java/org/thingsboard/server/controller/AuditLogControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/AuditLogControllerTest.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.uuid.Uuids;
 import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -136,9 +137,10 @@ public class AuditLogControllerTest extends AbstractControllerTest {
             doPost("/api/tenantProfile", tenantProfile, TenantProfile.class);
         }
 
-        List<AuditLog> loadedAuditLogs = getAuditLogs(100, "/api/audit/logs?");
-
-        Assert.assertEquals("Have X audit log before this test + New tenant profiles in the test", loadedAuditLogsBefore.size() + 3, loadedAuditLogs.size());
+        int expectedSize = loadedAuditLogsBefore.size() + 3;
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals("Have X audit log before this test + New tenant profiles in the test",
+                        expectedSize, getAuditLogs(100, "/api/audit/logs?").size()));
     }
 
     private List<AuditLog> getAuditLogs(int pageSize, String urlTemplate) throws Exception {


### PR DESCRIPTION
## Summary
- `testAuditLogsSysAdmin` was flaky because audit logs are saved **asynchronously** via `executor.submit()` in `AuditLogServiceImpl` — querying immediately after tenant profile creation could miss logs not yet persisted
- Replaced direct `assertEquals` with `Awaitility.await().atMost(10, SECONDS).untilAsserted(...)` to tolerate the async save delay

## Root cause
```java
// AuditLogServiceImpl.java
return executor.submit(() -> {
    AuditLog auditLog = auditLogDao.save(tenantId, auditLogEntry); // async
    ...
});
```
The HTTP response from `POST /api/tenantProfile` returns before the audit log is persisted, so `getAuditLogs()` called immediately after would intermittently return `N+2` instead of `N+3`.

## Test plan
- [x] `mvn test -pl application -Dtest=org.thingsboard.server.controller.AuditLogControllerTest#testAuditLogsSysAdmin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)