### PR TITLE
[FIX]Fixed navigation error: dynamic components access uninitialized stateController

### DIFF
--- a/ui-ngx/src/app/core/api/alias-controller.ts
+++ b/ui-ngx/src/app/core/api/alias-controller.ts
@@ -141,10 +141,14 @@ export class AliasController implements IAliasController {
   }
 
   dashboardStateChanged() {
+    const stateController = this.stateControllerHolder();
+    if (!stateController) {
+      return;
+    }
     const changedAliasIds: Array<string> = [];
     for (const aliasId of Object.keys(this.resolvedAliasesToStateEntities)) {
       const stateEntityInfo = this.resolvedAliasesToStateEntities[aliasId];
-      const newEntityId = this.stateControllerHolder().getEntityId(stateEntityInfo.entityParamName);
+      const newEntityId = stateController.getEntityId(stateEntityInfo.entityParamName);
       const prevEntityId = stateEntityInfo.entityId;
       if (!isEqual(newEntityId, prevEntityId)) {
         changedAliasIds.push(aliasId);
@@ -212,14 +216,16 @@ export class AliasController implements IAliasController {
       this.resolvedAliasesObservable[aliasId] = resolvedAliasSubject.asObservable();
       const entityAlias = this.entityAliases[aliasId];
       if (entityAlias) {
-        this.entityService.resolveAlias(entityAlias, this.stateControllerHolder().getStateParams()).subscribe(
+        const stateController = this.stateControllerHolder();
+        const stateParams = stateController ? stateController.getStateParams() : null;
+        this.entityService.resolveAlias(entityAlias, stateParams).subscribe(
           (resolvedAliasInfo) => {
             this.resolvedAliases[aliasId] = resolvedAliasInfo;
             delete this.resolvedAliasesObservable[aliasId];
             if (resolvedAliasInfo.stateEntity) {
               this.resolvedAliasesToStateEntities[aliasId] = {
                 entityParamName: resolvedAliasInfo.entityParamName,
-                entityId: this.stateControllerHolder().getEntityId(resolvedAliasInfo.entityParamName)
+                entityId: stateController ? stateController.getEntityId(resolvedAliasInfo.entityParamName) : null
               };
             }
             this.entityAliasResolvedSubject.next(aliasId);


### PR DESCRIPTION
## Pull Request description

When navigating using the "Navigate to other dashboard" action, the dynamic data components of the new dashboard attempt to resolve aliases before the stateController is initialized, resulting in the error "Cannot read properties of null (reading 'getStateParams')".

Fix: Add null check after calling stateControllerHolder()

Change 1: In dashboardStateChanged() method

`dashboardStateChanged() {
    const stateController = this.stateControllerHolder();
    if (!stateController) {
        return;  // Added: safely return when stateController is not initialized
    }
    // ... subsequent code using stateController variable
}
`

Change 2: In getAliasInfo() method

`
const stateController = this.stateControllerHolder();
const stateParams = stateController ? stateController.getStateParams() : null;
// ... pass stateParams (which may be null) when resolving aliases
`

This ensures the code executes safely even when stateController is null, preventing null pointer exceptions.

Before:
<img width="1083" height="808" alt="image" src="https://github.com/user-attachments/assets/f259af96-dc3f-4939-8880-276f4002b5ab" />


After:
<img width="1222" height="812" alt="image" src="https://github.com/user-attachments/assets/0c851586-f382-427c-bcf7-3fd8dd0104c0" />


## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)




