### PR TITLE
Fix NotificationRuleRecipientsConfig serialization with Jackson 2.18.x

### DIFF
--- a/common/data/src/main/java/org/thingsboard/server/common/data/notification/rule/NotificationRuleRecipientsConfig.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/notification/rule/NotificationRuleRecipientsConfig.java
@@ -17,6 +17,7 @@ package org.thingsboard.server.common.data.notification.rule;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -29,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-@JsonIgnoreProperties
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "triggerType", visible = true, include = JsonTypeInfo.As.EXISTING_PROPERTY, defaultImpl = DefaultNotificationRuleRecipientsConfig.class)
 @JsonSubTypes({
         @Type(name = "ALARM", value = EscalatedNotificationRuleRecipientsConfig.class),
@@ -38,6 +39,7 @@ import java.util.UUID;
 public abstract class NotificationRuleRecipientsConfig implements Serializable {
 
     @NotNull
+    @JsonProperty("triggerType")
     private NotificationRuleTriggerType triggerType;
 
     @JsonIgnore


### PR DESCRIPTION
## Summary

- In Jackson 2.18.x, `EXISTING_PROPERTY` type info combined with the no-arg `@JsonIgnoreProperties` causes the `triggerType` discriminator field to be silently excluded from the serialized JSON
- When the server tries to deserialize the POST body for `/api/notification/rule`, Jackson throws `"missing type id property 'triggerType'"` → 500 response
- `NotificationEdgeTest.testNotificationRule` fails consistently with this error

## Root cause

`NotificationRuleRecipientsConfig` used `@JsonIgnoreProperties` (no args) together with `@JsonTypeInfo(include = EXISTING_PROPERTY, property = "triggerType")`. In Jackson 2.18.6, the EXISTING_PROPERTY type info machinery suppresses the `triggerType` field from normal bean serialization (treating it as a "handled" type discriminator property), but the EXISTING_PROPERTY type serializer is a no-op and never writes it. Result: `triggerType` is absent from the serialized JSON.

## Fix

1. Add `@JsonProperty("triggerType")` to the `triggerType` field — forces it into normal bean serialization regardless of type info machinery suppression
2. Replace no-arg `@JsonIgnoreProperties` with `@JsonIgnoreProperties(ignoreUnknown = true)` — makes deserialization robust to unknown/extra properties

## Test plan

- [x] Run `NotificationEdgeTest.testNotificationRule` — should pass instead of failing with 500
- [x] Run `NotificationRuleApiTest` — should continue to pass
- [x] Verify existing notification rule data in DB still loads correctly (backward compatible — `triggerType` was always stored, just wasn't being serialized in HTTP requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)