### PR TITLE
Fix flaky AuditLogControllerTest: wrap async audit log assertions with Awaitility

### DIFF
--- a/application/src/test/java/org/thingsboard/server/controller/AuditLogControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/AuditLogControllerTest.java
@@ -170,8 +170,9 @@ public class AuditLogControllerTest extends AbstractControllerTest {
             savedDevice = doPost("/api/device", savedDevice, Device.class);
         }
 
+        Device finalSavedDevice = savedDevice;
         Awaitility.await().atMost(TIMEOUT, TimeUnit.SECONDS).untilAsserted(() ->
-                assertThat(getAuditLogs(SMALL_PAGE_SIZE, "/api/audit/logs/entity/DEVICE/" + savedDevice.getId().getId() + "?")).hasSize(11 + 1));
+                assertThat(getAuditLogs(SMALL_PAGE_SIZE, "/api/audit/logs/entity/DEVICE/" + finalSavedDevice.getId().getId() + "?")).hasSize(11 + 1));
     }
 
     @Test
@@ -187,8 +188,9 @@ public class AuditLogControllerTest extends AbstractControllerTest {
         tenantProfile.setName(tenantProfile.getName() + "(old)");
         tenantProfile = doPost("/api/tenantProfile", tenantProfile, TenantProfile.class);
 
+        TenantProfile finalTenantProfile = tenantProfile;
         Awaitility.await().atMost(TIMEOUT, TimeUnit.SECONDS).untilAsserted(() ->
-                assertThat(getAuditLogs(SMALL_PAGE_SIZE, "/api/audit/logs/entity/" + tenantProfile.getId().getEntityType() + "/" + tenantProfile.getId().getId() + "?"))
+                assertThat(getAuditLogs(SMALL_PAGE_SIZE, "/api/audit/logs/entity/" + finalTenantProfile.getId().getEntityType() + "/" + finalTenantProfile.getId().getId() + "?"))
                         .as("Audit logs count by Tenant Profile entity").hasSize(2));
 
         //cleanup


### PR DESCRIPTION
## Summary

- `AuditLogServiceImpl.logAction()` saves audit logs asynchronously via `executor.submit()`, so counts queried immediately after HTTP API calls are subject to a race condition
- `testAuditLogs_byTenantIdAndEntityId_Sysadmin` was confirmed broken: only 2 API calls before the assertion, so the second log reliably wasn't persisted yet (`expected:<2> but was:<1>`)
- `testAuditLogs` and `testAuditLogs_byTenantIdAndEntityId` have the same structural issue (no Awaitility guard), just less likely to fail due to more sequential calls giving implicit time
- Replaced bare `Assert.assertEquals` / `List` captures with `Awaitility.await().atMost(TIMEOUT, ...).untilAsserted(...)` using the existing `TIMEOUT` constant from `AbstractWebTest`
- Replaced the hardcoded `10` in `testAuditLogsSysAdmin` with `TIMEOUT` for consistency
- Extracted `SMALL_PAGE_SIZE = 5` constant — intentionally small to force multiple pages and verify the pagination loop, replacing the previously unexplained magic number

## Test plan
- [x] `AuditLogControllerTest.testAuditLogs`
- [x] `AuditLogControllerTest.testAuditLogs_byTenantIdAndEntityId`
- [x] `AuditLogControllerTest.testAuditLogs_byTenantIdAndEntityId_Sysadmin`
- [x] `AuditLogControllerTest.testAuditLogsSysAdmin`
- [x] `AuditLogControllerTest_DedicatedEventsDataSource` (all of the above via subclass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)