### PR TITLE
Fix flaky tests: await async save futures before assertions

### DIFF
--- a/application/src/test/java/org/thingsboard/server/service/entitiy/EntityServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/entitiy/EntityServiceTest.java
@@ -115,6 +115,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -1749,13 +1751,13 @@ public class EntityServiceTest extends AbstractControllerTest {
     }
 
     @Test
-    public void testFindTenantTelemetry() {
+    public void testFindTenantTelemetry() throws ExecutionException, InterruptedException, TimeoutException {
         // save timeseries by sys admin
         BasicTsKvEntry timeseries = new BasicTsKvEntry(42L, new DoubleDataEntry("temperature", 45.5));
-        timeseriesService.save(TenantId.SYS_TENANT_ID, tenantId, timeseries);
+        timeseriesService.save(TenantId.SYS_TENANT_ID, tenantId, timeseries).get(TIMEOUT, TimeUnit.SECONDS);
 
         AttributeKvEntry attr = new BaseAttributeKvEntry(new LongDataEntry("attr", 10L), 42L);
-        attributesService.save(TenantId.SYS_TENANT_ID, tenantId, SERVER_SCOPE, List.of(attr));
+        attributesService.save(TenantId.SYS_TENANT_ID, tenantId, SERVER_SCOPE, List.of(attr)).get(TIMEOUT, TimeUnit.SECONDS);
 
         SingleEntityFilter singleEntityFilter = new SingleEntityFilter();
         singleEntityFilter.setSingleEntity(AliasEntityId.fromEntityId(tenantId));

--- a/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlTest.java
@@ -65,7 +65,7 @@ public class TimeseriesServiceNoSqlTest extends BaseTimeseriesServiceTest {
                 new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(5), new JsonDataEntry("test", "{\"test\":\"testValue\"}")));
 
         DeviceId deviceId = new DeviceId(Uuids.timeBased());
-        tsService.save(tenantId, deviceId, timeseries, ttlInSec);
+        tsService.save(tenantId, deviceId, timeseries, ttlInSec).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         List<TsKvEntry> fullList = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("test", 0L,
                 TimeUnit.MINUTES.toMillis(6), 1000, 10, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);


### PR DESCRIPTION
## Summary
- `TimeseriesServiceNoSqlTest.shouldSaveEntryOfEachTypeWithTtl`: `tsService.save()` result was not awaited before querying, causing intermittent `expected:<5> but was:<2>` failures
- `EntityServiceTest.testFindTenantTelemetry`: `timeseriesService.save()` and `attributesService.save()` results were not awaited, causing intermittent `expected ["45.5"] but got [""]` failures

Both failures observed in TeamCity builds (build 94962 for smoke/logic, build 94863 for controller/edge):
- https://builds.thingsboard.io/buildConfiguration/ThingsBoard_TestSmokeLogic/94962
- https://builds.thingsboard.io/buildConfiguration/ThingsBoard_TestServiceControllerEdge_2/94863

## Root cause
The async save futures were not awaited (`.get()` not called), so the immediately following query would sometimes execute before the data was persisted to the database.

## Fix
Call `.get()` on the returned `ListenableFuture` from `tsService.save()`, `timeseriesService.save()`, and `attributesService.save()` to ensure writes complete before assertions.

## Test plan
- [x] Verify `TimeseriesServiceNoSqlTest.shouldSaveEntryOfEachTypeWithTtl` passes consistently
- [x] Verify `EntityServiceTest.testFindTenantTelemetry` passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)