### PR TITLE
fix: await timeseries batch save to prevent flaky NoSQL test

### DIFF
--- a/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/nosql/TimeseriesServiceNoSqlTest.java
@@ -65,7 +65,7 @@ public class TimeseriesServiceNoSqlTest extends BaseTimeseriesServiceTest {
                 new BasicTsKvEntry(TimeUnit.MINUTES.toMillis(5), new JsonDataEntry("test", "{\"test\":\"testValue\"}")));
 
         DeviceId deviceId = new DeviceId(Uuids.timeBased());
-        tsService.save(tenantId, deviceId, timeseries, ttlInSec);
+        tsService.save(tenantId, deviceId, timeseries, ttlInSec).get(MAX_TIMEOUT, TimeUnit.SECONDS);
 
         List<TsKvEntry> fullList = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery("test", 0L,
                 TimeUnit.MINUTES.toMillis(6), 1000, 10, Aggregation.NONE))).get(MAX_TIMEOUT, TimeUnit.SECONDS);


### PR DESCRIPTION
## Summary
- The `shouldSaveEntryOfEachTypeWithTtl` test in `TimeseriesServiceNoSqlTest` intermittently fails with `expected:<5> but was:<2>` because the batch `tsService.save()` returns a `ListenableFuture` that is not awaited before querying Cassandra
- Added `.get(MAX_TIMEOUT, TimeUnit.SECONDS)` to the save call, consistent with other tests in the same file (lines 89-90, 117) that already await their save futures

## Failed build
https://builds.thingsboard.io/buildConfiguration/ThingsBoard_TestSmokeLogic/94962

## Test plan
- [ ] Run `TimeseriesServiceNoSqlTest#shouldSaveEntryOfEachTypeWithTtl` repeatedly to confirm it no longer flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)