### PR TITLE
Validate customer ID in getAuditLogsByCustomerId, allow NULL_UUID

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/AuditLogController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/AuditLogController.java
@@ -36,6 +36,7 @@ import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.TimePageLink;
 import org.thingsboard.server.config.annotations.ApiOperation;
 import org.thingsboard.server.queue.util.TbCoreComponent;
+import org.thingsboard.server.service.security.permission.Operation;
 
 import java.util.Arrays;
 import java.util.List;
@@ -96,10 +97,14 @@ public class AuditLogController extends BaseController {
             @Parameter(description = AUDIT_LOG_QUERY_ACTION_TYPES_DESCRIPTION)
             @RequestParam(name = "actionTypes", required = false) String actionTypesStr) throws ThingsboardException {
         checkParameter("CustomerId", strCustomerId);
+        CustomerId customerId = new CustomerId(toUUID(strCustomerId));
+        if (!customerId.isNullUid()) {
+            checkCustomerId(customerId, Operation.READ);
+        }
         TenantId tenantId = getCurrentUser().getTenantId();
         TimePageLink pageLink = createTimePageLink(pageSize, page, textSearch, sortProperty, sortOrder, getStartTime(startTime), getEndTime(endTime));
         List<ActionType> actionTypes = parseActionTypesStr(actionTypesStr);
-        return checkNotNull(auditLogService.findAuditLogsByTenantIdAndCustomerId(tenantId, new CustomerId(UUID.fromString(strCustomerId)), actionTypes, pageLink));
+        return checkNotNull(auditLogService.findAuditLogsByTenantIdAndCustomerId(tenantId, customerId, actionTypes, pageLink));
     }
 
     @ApiOperation(value = "Get audit logs by user id (getAuditLogsByUserId)",


### PR DESCRIPTION
## Problem

`GET /api/audit/logs/customer/{customerId}` accepts any UUID string without verifying it belongs to a real customer in the tenant. This is inconsistent with other entity-by-ID endpoints (assets, devices, etc.) which all call `checkCustomerId()` / `checkEntityId()`.

Additionally, `AuditLogControllerTest.testAuditLogs` queries this endpoint with `ModelConstants.NULL_UUID` (`13814000-1dd2-11b2-8080-808080808080`) to retrieve audit logs for devices not assigned to any customer — a valid use case that would break if `checkCustomerId` were added naively.

## Fix

Add `checkCustomerId(customerId, Operation.READ)` to validate the customer exists and belongs to the caller's tenant, **guarded by `!customerId.isNullUid()`**.

`NULL_UUID` is a system sentinel — the implicit `customer_id` of entities not assigned to any customer. It is never stored as a real `Customer` entity, so the existence check must be skipped for it. Tenant admins querying audit logs by `NULL_UUID` is an explicitly supported and tested use case.

```java
CustomerId customerId = new CustomerId(toUUID(strCustomerId));
if (!customerId.isNullUid()) {
    checkCustomerId(customerId, Operation.READ);
}
```

## Test plan

- [x] `AuditLogControllerTest.testAuditLogs` continues to pass (NULL_UUID query still works)
- [x] `GET /api/audit/logs/customer/{nonExistentId}` returns 404
- [x] `GET /api/audit/logs/customer/{otherTenantCustomerId}` returns 403/404

🤖 Generated with [Claude Code](https://claude.com/claude-code)