### PR TITLE
Fix flaky Ota5LwM2MIntegrationTest.testFirmwareUpdateByObject5_Ok

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/FwLwM2MDevice.java
+++ b/application/src/test/java/org/thingsboard/server/transport/lwm2m/client/FwLwM2MDevice.java
@@ -171,7 +171,14 @@ public class FwLwM2MDevice extends BaseInstanceEnabler implements Destroyable {
 
                 if (this.leshanClient != null) {
                     log.info("Stop/reboot LwM2M client {}", this.leshanClient.getEndpoint(identity));
-                    this.leshanClient.stop(false);
+                    try {
+                        this.leshanClient.stop(false);
+                    } catch (Exception stopEx) {
+                        // Leshan may throw NPE during CoAP observe-relation cleanup when the server
+                        // reference is null (race condition in NotificationDataStore.toKey()).
+                        // The client is still considered stopped at this point — proceed with restart.
+                        log.warn("Exception during LwM2M client stop, proceeding with restart: {}", stopEx.getMessage());
+                    }
 
                     log.info("Start after update fw LwM2M client {}", this.leshanClient.getEndpoint(identity));
                     this.leshanClient.start();


### PR DESCRIPTION
## Summary

- `testFirmwareUpdateByObject5_Ok` flakes when `LeshanClient.stop(false)` throws an NPE internally during CoAP observe-relation cleanup
- The NPE originates in `NotificationDataStore.toKey()` when `server` is `null` (a race in Leshan's notification shutdown path)
- The exception was caught by the outer `try-catch` in `FwLwM2MDevice.startUpdating()`, which silently aborted execution before `leshanClient.start()` was called
- Result: the simulated device never re-registered after the fake reboot, so `fw_state` stayed at `UPDATING` and the 1-minute awaitility timeout fired

**Fix:** wrap `leshanClient.stop(false)` in its own try-catch so a Leshan-internal exception during stop does not prevent the subsequent `leshanClient.start()` call.

## Test plan

- [x] Verify `testFirmwareUpdateByObject5_Ok` passes consistently in CI (was flaking ~1 in N runs before this fix)
- [x] Check `Ota19LwM2MIntegrationTest` and other OTA tests still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)