### PR TITLE
Fixed WS reconnect loop and notification spam when session limit is reached

### DIFF
--- a/ui-ngx/src/app/core/ws/websocket.service.ts
+++ b/ui-ngx/src/app/core/ws/websocket.service.ts
@@ -64,9 +64,10 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
   // This prevents the open→immediately-closed cycle from resetting the counter.
   private reconnectAttempts = 0;
 
-  // Suppress duplicate close-event notifications while retrying.
-  // Set on first close with an error code; cleared after receiving a successful message.
-  private reconnectErrorShown = false;
+  // Stores the last close-event error code shown to the user during a reconnect cycle.
+  // Only suppresses duplicate notifications for the same error code; a new error code is still shown.
+  // Cleared after receiving a successful message.
+  private lastShownCloseCode: number | null = null;
 
   protected constructor(protected store: Store<AppState>,
                         protected authService: AuthService,
@@ -138,7 +139,7 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
     this.cmdWrapper.clear();
     if (close) {
       this.reconnectAttempts = 0;
-      this.reconnectErrorShown = false;
+      this.lastShownCloseCode = null;
       this.closeSocket();
     }
   }
@@ -236,7 +237,7 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
     this.checkToClose();
     if (this.reconnectAttempts) {
       this.reconnectAttempts = 0;
-      this.reconnectErrorShown = false;
+      this.lastShownCloseCode = null;
     }
   }
 
@@ -248,11 +249,13 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
   }
 
   private onClose(closeEvent: CloseEvent) {
-    // Show error notification only once per reconnect cycle to prevent notification spam.
-    // reconnectErrorShown is cleared only after a productive connection (onMessage).
-    if (!this.reconnectErrorShown && closeEvent && closeEvent.code > 1001 && closeEvent.code !== 1006
-      && closeEvent.code !== 1011 && closeEvent.code !== 1012 && closeEvent.code !== 4500) {
-      this.reconnectErrorShown = true;
+    // Show error notification only when the error code changes to prevent notification spam,
+    // while still surfacing new, potentially actionable errors during a reconnect cycle.
+    // lastShownCloseCode is cleared only after a productive connection (onMessage).
+    if (closeEvent && closeEvent.code > 1001 && closeEvent.code !== 1006
+      && closeEvent.code !== 1011 && closeEvent.code !== 1012 && closeEvent.code !== 4500
+      && this.lastShownCloseCode !== closeEvent.code) {
+      this.lastShownCloseCode = closeEvent.code;
       this.showWsError(closeEvent.code, closeEvent.reason);
     }
     this.isOpening = false;


### PR DESCRIPTION
## Problem

When a tenant or customer hits the WebSocket session limit, the server closes the connection with **code 1008** (Policy Violation) and a reason like *"Max tenant sessions limit reached!"*. The client then entered a tight reconnect loop:

1. **No backoff** — the client reconnected every fixed 2 s, continuously hammering the server while it was still over the limit. The production HAR captured **560+ connections in ~33 minutes** (one every ~2–3 s), each lasting ~400 ms with zero received messages.

2. **Notification spam** — `onOpen()` always resets `isReconnect = false`, so every subsequent `onClose` was treated as the *first* failure in a cycle. This caused a new red error notification to be dispatched on every attempt, resulting in **fast-blinking red alerts** that the user could not dismiss.

The same symptoms appeared for a tenant whose public dashboard was switched back to private: the public WS session began failing immediately, and the aggressive reconnect loop prevented the tenant user from operating the home page.

## Root cause

`onOpen()` unconditionally sets `isReconnect = false`. When the server rate-limits a connection (opens the WS handshake then immediately closes with 1008), `onOpen` runs, resets the flag, and the next `onClose` sees `!isReconnect = true` again — showing another notification and resetting the 2 s timer. This repeats indefinitely.

## Changes (`ui-ngx/src/app/core/ws/websocket.service.ts`)

| | Before | After |
|---|---|---|
| Reconnect interval | Fixed 2 s forever | Exponential backoff: 2 s → 4 s → 8 s … capped at **60 s** |
| Error notification | Shown on **every** `onClose` with error code | Shown **once** per reconnect cycle; suppressed until a productive connection (first message received) |
| On logout / re-login | — | Backoff and notification state fully reset |

Key design decisions:
- `reconnectAttempts` is reset to 0 only in `onMessage()` (connection is productive), **not** in `onOpen()`. This prevents the open→immediately-closed cycle from resetting the counter.
- `reconnectErrorShown` guards `showWsError()` so the blinking notification appears only once per outage.