### PR TITLE
Fix flaky AuditLogControllerTest.testAuditLogs_byTenantIdAndEntityId_Sysadmin

### DIFF
--- a/application/src/test/java/org/thingsboard/server/controller/AuditLogControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/AuditLogControllerTest.java
@@ -188,9 +188,10 @@ public class AuditLogControllerTest extends AbstractControllerTest {
         tenantProfile.setName(tenantProfile.getName() + "(old)");
         tenantProfile = doPost("/api/tenantProfile", tenantProfile, TenantProfile.class);
 
-        List<AuditLog> loadedAuditLogs = getAuditLogs(5, "/api/audit/logs/entity/" +tenantProfile.getId().getEntityType()+ "/" + tenantProfile.getId().getId() + "?");
-
-        Assert.assertEquals("Audit logs count by Tenant Profile entity", 2, loadedAuditLogs.size());
+        TenantProfile finalTenantProfile = tenantProfile;
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                assertThat(getAuditLogs(5, "/api/audit/logs/entity/" + finalTenantProfile.getId().getEntityType() + "/" + finalTenantProfile.getId().getId() + "?"))
+                        .as("Audit logs count by Tenant Profile entity").hasSize(2));
 
         //cleanup
         doDelete("/api/tenantProfile/" + tenantProfile.getId().getId().toString());


### PR DESCRIPTION
## Summary

- `testAuditLogs_byTenantIdAndEntityId_Sysadmin` fails on every ~3rd run on master with \`expected:<2> but was:<1>\`
- Root cause: audit logs are saved asynchronously via \`executor.submit()\` in \`AuditLogServiceImpl\`; the test issued two API calls (CREATE + UPDATE TenantProfile) then immediately asserted 2 log entries existed — but the second log entry was still in-flight
- The same async-save race is already fixed in the sibling \`testAuditLogs()\` method in this file (using \`Awaitility.await().atMost(10, SECONDS).untilAsserted(...)\`) and in the same test on the \`rc\` branch
- Fix: apply the same `Awaitility` pattern to the failing assertion

## Test plan
- [ ] `testAuditLogs_byTenantIdAndEntityId_Sysadmin` passes consistently on CI after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)