### PR TITLE
fix: remove unused isConnected() stub from MqttRpcHealthCheckerTest setUp

### DIFF
--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/rpc/impl/MqttRpcHealthCheckerTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/rpc/impl/MqttRpcHealthCheckerTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -70,8 +71,8 @@ class MqttRpcHealthCheckerTest {
         ReflectionTestUtils.setField(checker, "reporter", mock(MonitoringReporter.class));
         ReflectionTestUtils.setField(checker, "stopWatch", mock(TbStopWatch.class));
 
-        when(connectToken.getException()).thenReturn(null);
-        when(mqttClient.connectWithResult(any())).thenReturn(connectToken);
+        lenient().when(connectToken.getException()).thenReturn(null);
+        lenient().when(mqttClient.connectWithResult(any())).thenReturn(connectToken);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes `UnnecessaryStubbingException` in `MqttRpcHealthCheckerTest` introduced in #15226.

Two stubs in `setUp()` — `when(connectToken.getException()).thenReturn(null)` and `when(mqttClient.connectWithResult(any())).thenReturn(connectToken)` — are consumed by 8 of 9 tests but not by `destroyClient_beforeInit_isNoOp`, which never calls `initClient()`. Mockito strict stubbing (`@ExtendWith(MockitoExtension.class)`) flags them as `UnnecessaryStubbingException`.

Switched both stubs to `lenient()` so they remain shared in `setUp()` without requiring consumption by every test.

**Depends on:** #15226

## Test plan

- [x] All 9 `MqttRpcHealthCheckerTest` tests pass without `UnnecessaryStubbingException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)