### PR TITLE
Fix Gradle parallel build timeout: switch --warning-mode from all to summary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -534,7 +534,7 @@
                                     <arg>-PpkgCopyInstallScripts=${pkg.copyInstallScripts}</arg>
                                     <arg>-PpkgLogFolder=${pkg.unixLogFolder}</arg>
                                     <arg>--warning-mode</arg>
-                                    <arg>all</arg>
+                                    <arg>summary</arg>
                                 </args>
                             </configuration>
                             <executions>


### PR DESCRIPTION
## Problem

After PR #15135 bumped `gradle-maven-plugin` from `1.0.12` to `1.0.15`, the default Gradle version changed from `7.3.3` to `9.3.1`. Gradle 9.3.1 introduced an `[Incubating] Problems report` feature that writes an HTML report to `target/reports/problems/` after **every** Gradle build invocation.

Under a parallel Maven `-T6` build, multiple Gradle processes run concurrently. The concurrent file writes cause I/O contention, and the last Gradle invocation (`packaging/js @ web-ui`) times out:

```
BUILD FAILED in 55s
java.util.concurrent.TimeoutException
    Problems-report is taking too long to write...
```

This broke the `ThingsBoard_TestSmokeLogic` CI build configuration.

## Fix

Switch `--warning-mode all` → `--warning-mode summary` in the packaging profile's Gradle invocation args.

- `summary` still prints warning counts in the console output
- `summary` does **not** generate the HTML problems report, eliminating the timeout

## Testing

The fix removes the root cause of the I/O contention. No functional change to the packaging output — only the HTML diagnostic report is suppressed.