### PR TITLE
Fix Gradle 9.3.1 parallel build TimeoutException by disabling problems report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -537,7 +537,6 @@
                                     <arg>${project.build.directory}/.gradle</arg>
                                     <arg>--warning-mode</arg>
                                     <arg>all</arg>
-                                    <arg>--no-problems-report</arg>
                                 </args>
                             </configuration>
                             <executions>
@@ -654,7 +653,7 @@
                 <plugin>
                     <groupId>org.thingsboard</groupId>
                     <artifactId>gradle-maven-plugin</artifactId>
-                    <version>1.0.16</version>
+                    <version>1.0.15</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.eirslett</groupId>


### PR DESCRIPTION
## Problem

After PR #15135 bumped `gradle-maven-plugin` from `1.0.12` to `1.0.15`, the default Gradle version changed from `7.3.3` to `9.3.1`. Gradle 9.3.1 introduced an `[Incubating] Problems report` feature that writes an HTML report **asynchronously** at the end of each build.

Under Maven `-T6` parallel builds on CI, the async report writer times out on slow build agent disks, causing the `web-ui` module to fail:

```
Problems-report is taking too long to write... The build might finish before the report has been completely written.
java.util.concurrent.TimeoutException (no error message)
BUILD FAILED in 55s
```

See build: https://builds.thingsboard.io/viewLog.html?buildId=96112

## Fix

Add `--no-problems-report` to the Gradle invocation args in the root `pom.xml` packaging profile. This is the dedicated CLI flag to suppress the HTML problems report generation (also documented as `org.gradle.problems.report=false` in `gradle.properties`).

`--warning-mode all` is preserved so deprecation warnings remain visible in build output.

## Notes

- The reports are written per-module to separate `target/reports/problems/` directories, so there is no file collision between parallel builds
- The issue is purely the async writer timing out under high CI disk I/O load
- Gradle source: `StartParameterBuildOptions.ProblemReportGenerationOption`; also tracked in Gradle issue #33625