### PR TITLE
Fix Gradle parallel build cache contention in Maven -T builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,8 @@
                                     <arg>-PpkgInstallFolder=${pkg.installFolder}</arg>
                                     <arg>-PpkgCopyInstallScripts=${pkg.copyInstallScripts}</arg>
                                     <arg>-PpkgLogFolder=${pkg.unixLogFolder}</arg>
+                                    <arg>--project-cache-dir</arg>
+                                    <arg>${project.build.directory}/.gradle</arg>
                                     <arg>--warning-mode</arg>
                                     <arg>all</arg>
                                 </args>
@@ -887,6 +889,21 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <inherited>false</inherited>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>${main.dir}/packaging/java/.gradle</directory>
+                        </fileset>
+                        <fileset>
+                            <directory>${main.dir}/packaging/js/.gradle</directory>
+                        </fileset>
+                    </filesets>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Problem

### Parallel build cache contention

When Maven runs with `-T N`, all modules using the packaging profile invoke `gradle-maven-plugin` with the same `gradleProjectDirectory` — either `packaging/java` or `packaging/js`. All parallel Gradle invocations share and contend on the same `.gradle/` project cache directory simultaneously, causing Gradle file lock races.

### Cross-branch Gradle version pollution

`lts-4.2` and `lts-4.3` use Gradle 7.x; `master` uses Gradle 9.x. When builds from different branches run on the same CI agent, they both write to the shared `packaging/java/.gradle` and `packaging/js/.gradle` directories. Gradle detects the foreign version's caches and deletes them ("Deleting unused version-specific caches"), which itself races when multiple builds run concurrently, and leaves the directories in inconsistent states.

## Fix

**1. `--project-cache-dir` per Maven module**

Redirects each Gradle invocation's project cache into the module's own `target/.gradle/`. Each parallel build gets a fully isolated cache — no shared state, no lock contention, no cross-version pollution between branches.

**2. `maven-clean-plugin` filesets for `packaging/java/.gradle` and `packaging/js/.gradle`**

Gradle always writes some project-level metadata to the Gradle project directory (wrapper, version caches) regardless of `--project-cache-dir`. Adding these directories to the clean plugin ensures they are removed on `mvn clean`, preventing accumulation and cross-version contamination on CI agents with persistent home directories.

`<inherited>false</inherited>` ensures the cleanup only runs once in the root module, not repeated for every child module in the reactor.

## Result

<img width="654" height="624" alt="image" src="https://github.com/user-attachments/assets/19cad323-1288-4bda-b373-aa5886c41752" />