### PR TITLE
Fixed missing translation for Polylines toggle in map settings

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/map/map-settings.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/map/map-settings.component.html
@@ -45,8 +45,7 @@
         <tb-toggle-option value="markers" [error]="mapSettingsFormGroup.get('markers').invalid ? ('common.required-fields' | translate) : null">{{ 'widgets.maps.overlays.markers' | translate }}</tb-toggle-option>
         <tb-toggle-option value="polygons" [error]="mapSettingsFormGroup.get('polygons').invalid ? ('common.required-fields' | translate) : null">{{ 'widgets.maps.overlays.polygons' | translate }}</tb-toggle-option>
         <tb-toggle-option value="circles" [error]="mapSettingsFormGroup.get('circles').invalid ? ('common.required-fields' | translate) : null">{{ 'widgets.maps.overlays.circles' | translate }}</tb-toggle-option>
-        //todo translation
-        <tb-toggle-option value="polylines" [error]="mapSettingsFormGroup.get('polylines').invalid ? ('common.required-fields' | translate) : null"> Polylines </tb-toggle-option>
+        <tb-toggle-option value="polylines" [error]="mapSettingsFormGroup.get('polylines').invalid ? ('common.required-fields' | translate) : null">{{ 'widgets.maps.overlays.polylines' | translate }}</tb-toggle-option>
       </tb-toggle-select>
     </div>
     <tb-map-data-layers *ngIf="trip"


### PR DESCRIPTION
## Summary
- Replaced hardcoded "Polylines" text with existing i18n translation key `widgets.maps.overlays.polylines` in map-settings component
- Removed leftover `//todo translation` comment

## Test plan
- [ ] Open map widget settings and verify the "Polylines" overlay toggle displays correctly
- [ ] Switch locale and verify the Polylines label is translated

Fixes #15234