### PR TITLE
Sanitize database error messages

### DIFF
--- a/application/src/main/java/org/thingsboard/server/exception/ThingsboardErrorResponseHandler.java
+++ b/application/src/main/java/org/thingsboard/server/exception/ThingsboardErrorResponseHandler.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.exception;
 
+import jakarta.persistence.PersistenceException;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -50,6 +51,7 @@ import org.thingsboard.server.common.data.exception.ThingsboardErrorCode;
 import org.thingsboard.server.common.data.exception.ThingsboardException;
 import org.thingsboard.server.common.msg.tools.MaxPayloadSizeExceededException;
 import org.thingsboard.server.common.msg.tools.TbRateLimitsException;
+import org.thingsboard.server.dao.DaoUtil;
 import org.thingsboard.server.service.security.exception.AuthMethodNotSupportedException;
 import org.thingsboard.server.service.security.exception.JwtExpiredTokenException;
 import org.thingsboard.server.service.security.exception.UserPasswordExpiredException;
@@ -154,8 +156,8 @@ public class ThingsboardErrorResponseHandler extends ResponseEntityExceptionHand
                     handleAuthenticationException((AuthenticationException) exception, response);
                 } else if (exception instanceof MaxPayloadSizeExceededException) {
                     handleMaxPayloadSizeExceededException(response, (MaxPayloadSizeExceededException) exception);
-                } else if (exception instanceof DataAccessException e) {
-                    handleDatabaseException(e, response);
+                } else if (exception instanceof DataAccessException || exception instanceof PersistenceException) {
+                    handleDatabaseException(exception, response);
                 } else {
                     response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
                     JacksonUtil.writeValue(response.getWriter(), ThingsboardErrorResponse.of(exception.getMessage(),
@@ -209,8 +211,17 @@ public class ThingsboardErrorResponseHandler extends ResponseEntityExceptionHand
 
     private void handleDatabaseException(Throwable databaseException, HttpServletResponse response) throws IOException {
         ThingsboardErrorResponse errorResponse;
-        if (databaseException instanceof ConstraintViolationException) {
-            errorResponse = ThingsboardErrorResponse.of(ExceptionUtils.getRootCause(databaseException).getMessage(), ThingsboardErrorCode.BAD_REQUEST_PARAMS, HttpStatus.BAD_REQUEST);
+        ConstraintViolationException constraintViolationException = DaoUtil.extractConstraintViolation(databaseException);
+        if (constraintViolationException != null) {
+            log.debug("Constraint violation: {}", ExceptionUtils.getRootCauseMessage(databaseException));
+            String constraintName = constraintViolationException.getConstraintName();
+            String userMessage;
+            if (constraintName != null && !constraintName.isEmpty()) {
+                userMessage = "Constraint violation: " + constraintName;
+            } else {
+                userMessage = "Constraint violation";
+            }
+            errorResponse = ThingsboardErrorResponse.of(userMessage, ThingsboardErrorCode.BAD_REQUEST_PARAMS, HttpStatus.BAD_REQUEST);
         } else {
             log.warn("Database error: {} - {}", databaseException.getClass().getSimpleName(), ExceptionUtils.getRootCauseMessage(databaseException));
             errorResponse = ThingsboardErrorResponse.of("Database error", ThingsboardErrorCode.DATABASE, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/application/src/test/java/org/thingsboard/server/controller/AbstractWebTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/AbstractWebTest.java
@@ -1061,7 +1061,7 @@ public abstract class AbstractWebTest extends AbstractInMemoryStorageTest {
             assertThat(findRelationsByTo(entityTo)).hasSize(1);
 
             doDelete(urlDelete)
-                    .andExpect(status().isInternalServerError());
+                    .andExpect(status().isBadRequest());
 
             assertThat(findRelationsByTo(entityTo)).hasSize(1);
         } finally {

--- a/application/src/test/java/org/thingsboard/server/controller/TenantControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/TenantControllerTest.java
@@ -43,6 +43,7 @@ import org.thingsboard.server.common.data.User;
 import org.thingsboard.server.common.data.exception.TenantNotFoundException;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.id.TenantProfileId;
 import org.thingsboard.server.common.data.msg.TbMsgType;
 import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
@@ -866,6 +867,26 @@ public class TenantControllerTest extends AbstractControllerTest {
         TenantId tenantId = cntTime == 1 ? tenant.getId() : (TenantId) createEntityId_NULL_UUID(tenant);
         testBroadcastEntityStateChangeEventTime(tenantId, tenantId, cntTime);
         Mockito.reset(tbClusterService);
+    }
+
+    @Test
+    public void testSaveTenantWithNonExistentTenantProfileId() throws Exception {
+        loginSysAdmin();
+        Tenant tenant = new Tenant();
+        tenant.setTitle("My tenant");
+        tenant.setTenantProfileId(new TenantProfileId(UUID.randomUUID()));
+
+        String responseBody = doPost("/api/tenant", tenant)
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+
+        // Verify sanitized message format
+        assertThat(responseBody).contains("Constraint violation: fk_tenant_profile");
+        // Verify raw SQL details are not returned
+        assertThat(responseBody).doesNotContain("could not execute statement");
+        assertThat(responseBody).doesNotContain("insert or update on table");
+        assertThat(responseBody).doesNotContain("tenant_profile_id");
+        assertThat(responseBody).doesNotContain("is not present in table");
     }
 
     private void testBroadcastEntityStateChangeEventNeverTenant() {

--- a/dao/src/main/java/org/thingsboard/server/dao/DaoUtil.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/DaoUtil.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.dao;
 
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -200,6 +201,15 @@ public final class DaoUtil {
                 .map(info -> new EntitySubtype(tenantId, entityType, info.getName()))
                 .sorted(Comparator.comparing(EntitySubtype::getType))
                 .collect(Collectors.toList());
+    }
+
+    public static ConstraintViolationException extractConstraintViolation(Throwable t) {
+        if (t instanceof ConstraintViolationException cve) {
+            return cve;
+        } else if (t != null && t.getCause() instanceof ConstraintViolationException cve) {
+            return cve;
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
## Pull Request description

Route DataAccessException and PersistenceException (including bare ConstraintViolationException) to a unified handler that extracts the constraint name and returns "Constraint violation: <name>" instead of the raw PSQLException message. Other DB errors continue to return the generic "Database error" response.

Adds DaoUtil.extractConstraintViolation helper and an integration test that verifies no SQL details leak when an FK constraint is violated.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



