### PR TITLE
No activity reporting on device disconnect event

### DIFF
--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/service/DefaultTransportService.java
@@ -508,7 +508,9 @@ public class DefaultTransportService extends TransportActivityManager implements
     @Override
     public void process(TransportProtos.SessionInfoProto sessionInfo, TransportProtos.SessionEventMsg msg, TransportServiceCallback<Void> callback) {
         if (checkLimits(sessionInfo, msg, callback)) {
-            recordActivityInternal(sessionInfo);
+            if (msg.getEvent() != TransportProtos.SessionEvent.CLOSED) {
+                recordActivityInternal(sessionInfo);
+            }
             sendToDeviceActor(sessionInfo, TransportToDeviceActorMsg.newBuilder().setSessionInfo(sessionInfo)
                     .setSessionEvent(msg).build(), callback);
         }

--- a/common/transport/transport-api/src/test/java/org/thingsboard/server/common/transport/service/TransportActivityManagerTest.java
+++ b/common/transport/transport-api/src/test/java/org/thingsboard/server/common/transport/service/TransportActivityManagerTest.java
@@ -26,12 +26,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.transport.SessionMsgListener;
 import org.thingsboard.server.common.transport.TransportServiceCallback;
 import org.thingsboard.server.common.transport.activity.ActivityReportCallback;
 import org.thingsboard.server.common.transport.activity.ActivityState;
 import org.thingsboard.server.common.transport.activity.strategy.ActivityStrategy;
 import org.thingsboard.server.common.transport.activity.strategy.ActivityStrategyType;
+import org.thingsboard.server.common.transport.limits.TransportRateLimitService;
 import org.thingsboard.server.gen.transport.TransportProtos;
 
 import java.util.UUID;
@@ -41,7 +43,12 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -512,6 +519,57 @@ public class TransportActivityManagerTest {
         assertThat(sessions.containsKey(SESSION_ID)).isFalse();
         verify(transportServiceMock, never()).deregisterSession(sessionInfo);
         verify(transportServiceMock, never()).process(sessionInfo, SESSION_EVENT_MSG_CLOSED, null);
+    }
+
+    @Test
+    void givenSessionClosedEvent_whenProcessingSessionEvent_thenShouldNotRecordActivity() {
+        // GIVEN - simulates the session-expiry path: session already removed from sessions map,
+        // then process(SESSION_CLOSED) is called. Activity must NOT be recorded to avoid active
+        // status update from false to true
+        var rateLimitServiceMock = mock(TransportRateLimitService.class);
+        ReflectionTestUtils.setField(transportServiceMock, "rateLimitService", rateLimitServiceMock);
+        when(rateLimitServiceMock.checkLimits(any(), nullable(DeviceId.class), any(), anyInt(), anyBoolean())).thenReturn(null);
+
+        TransportProtos.SessionInfoProto sessionInfo = TransportProtos.SessionInfoProto.newBuilder()
+                .setSessionIdMSB(SESSION_ID.getMostSignificantBits())
+                .setSessionIdLSB(SESSION_ID.getLeastSignificantBits())
+                .build();
+        doCallRealMethod().when(transportServiceMock).process(sessionInfo, SESSION_EVENT_MSG_CLOSED, null);
+
+        // WHEN
+        transportServiceMock.process(sessionInfo, SESSION_EVENT_MSG_CLOSED, null);
+
+        // THEN
+        verify(transportServiceMock, never()).onActivity(any(), any(), anyLong());
+        verify(transportServiceMock).sendToDeviceActor(eq(sessionInfo), any(), isNull());
+    }
+
+    @Test
+    void givenSessionOpenEvent_whenProcessingSessionEvent_thenShouldRecordActivity() {
+        // GIVEN
+        var rateLimitServiceMock = mock(TransportRateLimitService.class);
+        ReflectionTestUtils.setField(transportServiceMock, "rateLimitService", rateLimitServiceMock);
+        when(rateLimitServiceMock.checkLimits(any(), nullable(DeviceId.class), any(), anyInt(), anyBoolean())).thenReturn(null);
+
+        TransportProtos.SessionInfoProto sessionInfo = TransportProtos.SessionInfoProto.newBuilder()
+                .setSessionIdMSB(SESSION_ID.getMostSignificantBits())
+                .setSessionIdLSB(SESSION_ID.getLeastSignificantBits())
+                .build();
+        var sessionOpenMsg = TransportProtos.SessionEventMsg.newBuilder()
+                .setSessionType(TransportProtos.SessionType.ASYNC)
+                .setEvent(TransportProtos.SessionEvent.OPEN)
+                .build();
+        when(transportServiceMock.toSessionId(sessionInfo)).thenReturn(SESSION_ID);
+        long expectedActivityTime = 100L;
+        when(transportServiceMock.getCurrentTimeMillis()).thenReturn(expectedActivityTime);
+        doCallRealMethod().when(transportServiceMock).process(sessionInfo, sessionOpenMsg, null);
+
+        // WHEN
+        transportServiceMock.process(sessionInfo, sessionOpenMsg, null);
+
+        // THEN
+        verify(transportServiceMock).onActivity(SESSION_ID, sessionInfo, expectedActivityTime);
+        verify(transportServiceMock).sendToDeviceActor(eq(sessionInfo), any(), isNull());
     }
 
 }


### PR DESCRIPTION
## Pull Request description

The current logic for reporting activity on device disconnect is not adequate if the device was already inactive (i.e., the device state was updated from false to true upon device disconnect). Therefore, an appropriate fix was applied.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



