### PR TITLE
Fix race condition in notification deduplication check

### DIFF
--- a/common/queue/src/main/java/org/thingsboard/server/queue/notification/DefaultNotificationDeduplicationService.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/notification/DefaultNotificationDeduplicationService.java
@@ -32,6 +32,7 @@ import org.thingsboard.server.queue.util.PropertyUtils;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 import static org.springframework.util.ConcurrentReferenceHashMap.ReferenceType.SOFT;
 
@@ -59,41 +60,48 @@ public class DefaultNotificationDeduplicationService implements NotificationDedu
     }
 
     private boolean alreadyProcessed(NotificationRuleTrigger trigger, String deduplicationKey, boolean onlyLocalCache) {
-        Long lastProcessedTs = localCache.get(deduplicationKey);
-        if (lastProcessedTs == null && !onlyLocalCache) {
-            Cache externalCache = getExternalCache();
-            if (externalCache != null) {
-                lastProcessedTs = externalCache.get(deduplicationKey, Long.class);
-            } else {
-                log.warn("Sent notifications cache is not set up");
-            }
-        }
-
-        boolean alreadyProcessed = false;
         long deduplicationDuration = getDeduplicationDuration(trigger);
-        if (lastProcessedTs != null) {
-            long passed = System.currentTimeMillis() - lastProcessedTs;
-            log.trace("Deduplicating trigger {} by key '{}'. Deduplication duration: {} ms, passed: {} ms",
-                    trigger.getType(), deduplicationKey, deduplicationDuration, passed);
-            if (deduplicationDuration == 0 || passed <= deduplicationDuration) {
-                alreadyProcessed = true;
-            }
-        }
+        final long now = System.currentTimeMillis();
+        boolean[] result = {false};
 
-        if (!alreadyProcessed) {
-            lastProcessedTs = System.currentTimeMillis();
-        }
-        localCache.put(deduplicationKey, lastProcessedTs);
+        localCache.compute(deduplicationKey, (key, lastProcessedTs) -> {
+            if (lastProcessedTs == null && !onlyLocalCache) {
+                Cache externalCache = getExternalCache();
+                if (externalCache != null) {
+                    lastProcessedTs = externalCache.get(key, Long.class);
+                    if (lastProcessedTs != null && lastProcessedTs > now + TimeUnit.HOURS.toMillis(1)) {
+                        log.warn("Discarding dedup entry from external cache for key '{}': timestamp is {} ms in the future",
+                                key, lastProcessedTs - now);
+                        lastProcessedTs = null;
+                    }
+                } else {
+                    log.warn("Sent notifications cache is not set up");
+                }
+            }
+
+            if (lastProcessedTs != null) {
+                long passed = now - lastProcessedTs;
+                log.trace("Deduplicating trigger {} by key '{}'. Deduplication duration: {} ms, passed: {} ms",
+                        trigger.getType(), key, deduplicationDuration, passed);
+                if (deduplicationDuration == 0 || passed <= deduplicationDuration) {
+                    result[0] = true;
+                    return lastProcessedTs;
+                }
+            }
+
+            return now;
+        });
+
         if (!onlyLocalCache) {
-            if (!alreadyProcessed || deduplicationDuration == 0) {
+            if (!result[0] || deduplicationDuration == 0) {
                 // if lastProcessedTs is changed or if deduplicating infinitely (so that cache value not removed by ttl)
                 Cache externalCache = getExternalCache();
                 if (externalCache != null) {
-                    externalCache.put(deduplicationKey, lastProcessedTs);
+                    externalCache.put(deduplicationKey, now);
                 }
             }
         }
-        return alreadyProcessed;
+        return result[0];
     }
 
     public static String getDeduplicationKey(NotificationRuleTrigger trigger, NotificationRule rule) {

--- a/common/queue/src/test/java/org/thingsboard/server/queue/notification/DefaultNotificationDeduplicationServiceTest.java
+++ b/common/queue/src/test/java/org/thingsboard/server/queue/notification/DefaultNotificationDeduplicationServiceTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.queue.notification;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.server.common.data.CacheConstants;
+import org.thingsboard.server.common.data.notification.rule.NotificationRule;
+import org.thingsboard.server.common.data.notification.rule.trigger.NotificationRuleTrigger;
+import org.thingsboard.server.common.data.notification.rule.trigger.config.NotificationRuleTriggerType;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DefaultNotificationDeduplicationServiceTest {
+
+    private static final int TIMEOUT = 30;
+
+    private DefaultNotificationDeduplicationService deduplicationService;
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        deduplicationService = new DefaultNotificationDeduplicationService();
+        deduplicationService.setDeduplicationDurations("");
+        cacheManager = new ConcurrentMapCacheManager(CacheConstants.SENT_NOTIFICATIONS_CACHE);
+        ReflectionTestUtils.setField(deduplicationService, "cacheManager", cacheManager);
+    }
+
+    @Test
+    void testFirstTriggerIsNotDeduplicated() {
+        NotificationRuleTrigger trigger = mockTrigger(TimeUnit.HOURS.toMillis(1));
+        NotificationRule rule = mockRule();
+
+        assertThat(deduplicationService.alreadyProcessed(trigger, rule)).isFalse();
+    }
+
+    @Test
+    void testSecondTriggerIsDeduplicated() {
+        NotificationRuleTrigger trigger = mockTrigger(TimeUnit.HOURS.toMillis(1));
+        NotificationRule rule = mockRule();
+
+        assertThat(deduplicationService.alreadyProcessed(trigger, rule)).isFalse();
+        assertThat(deduplicationService.alreadyProcessed(trigger, rule)).isTrue();
+    }
+
+    @Test
+    void testTriggerPassesAfterDeduplicationWindowExpires() {
+        NotificationRuleTrigger trigger = mockTrigger(50); // 50ms dedup window
+        NotificationRule rule = mockRule();
+
+        assertThat(deduplicationService.alreadyProcessed(trigger, rule)).isFalse();
+
+        try {
+            Thread.sleep(200); // wait well past the 50ms window
+        } catch (InterruptedException ignored) {}
+
+        assertThat(deduplicationService.alreadyProcessed(trigger, rule)).isFalse();
+    }
+
+    @Test
+    void testFutureTimestampFromExternalCacheIsDiscarded() {
+        NotificationRuleTrigger trigger = mockTrigger(TimeUnit.HOURS.toMillis(1));
+        NotificationRule rule = mockRule();
+        String dedupKey = DefaultNotificationDeduplicationService.getDeduplicationKey(trigger, rule);
+
+        // Put a timestamp 2 hours in the future into external cache
+        Cache externalCache = cacheManager.getCache(CacheConstants.SENT_NOTIFICATIONS_CACHE);
+        externalCache.put(dedupKey, System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2));
+
+        // Should NOT be deduplicated — future timestamp must be discarded
+        assertThat(deduplicationService.alreadyProcessed(trigger, rule)).isFalse();
+    }
+
+    @Test
+    void testValidTimestampFromExternalCacheIsDeduplicated() {
+        NotificationRuleTrigger trigger = mockTrigger(TimeUnit.HOURS.toMillis(1));
+        NotificationRule rule = mockRule();
+        String dedupKey = DefaultNotificationDeduplicationService.getDeduplicationKey(trigger, rule);
+
+        // Put a recent timestamp into external cache
+        Cache externalCache = cacheManager.getCache(CacheConstants.SENT_NOTIFICATIONS_CACHE);
+        externalCache.put(dedupKey, System.currentTimeMillis());
+
+        // Should be deduplicated — valid external cache entry
+        assertThat(deduplicationService.alreadyProcessed(trigger, rule)).isTrue();
+    }
+
+    @Test
+    void testConcurrentTriggersProduceExactlyOneNonDeduplicated() throws Exception {
+        NotificationRuleTrigger trigger = mockTrigger(TimeUnit.HOURS.toMillis(1));
+        NotificationRule rule = mockRule();
+
+        int threadCount = 10;
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        List<Boolean> results = new CopyOnWriteArrayList<>();
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                executor.submit(() -> {
+                    try {
+                        barrier.await(TIMEOUT, TimeUnit.SECONDS);
+                    } catch (Exception ignored) {}
+                    results.add(deduplicationService.alreadyProcessed(trigger, rule));
+                });
+            }
+            executor.shutdown();
+            assertThat(executor.awaitTermination(TIMEOUT, TimeUnit.SECONDS)).isTrue();
+
+            assertThat(results).hasSize(threadCount);
+            assertThat(results.stream().filter(r -> !r).count())
+                    .as("exactly one trigger should pass through deduplication")
+                    .isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private NotificationRuleTrigger mockTrigger(long deduplicationDurationMs) {
+        NotificationRuleTrigger trigger = mock(NotificationRuleTrigger.class);
+        when(trigger.getType()).thenReturn(NotificationRuleTriggerType.RESOURCES_SHORTAGE);
+        when(trigger.getDeduplicationKey()).thenReturn("test:dedup:key");
+        when(trigger.getDefaultDeduplicationDuration()).thenReturn(deduplicationDurationMs);
+        when(trigger.getDeduplicationStrategy()).thenReturn(NotificationRuleTrigger.DeduplicationStrategy.ONLY_MATCHING);
+        return trigger;
+    }
+
+    private NotificationRule mockRule() {
+        NotificationRule rule = mock(NotificationRule.class);
+        when(rule.getDeduplicationKey()).thenReturn("rule:key");
+        return rule;
+    }
+
+}


### PR DESCRIPTION
Jira: [PROD-7951](https://thingsboard-portal.atlassian.net/browse/PROD-7951)

## Summary
- The `alreadyProcessed()` method in `DefaultNotificationDeduplicationService` used separate `get()` and `put()` calls on the local cache, allowing concurrent threads in the notification executor pool to both read `null` and bypass deduplication, creating duplicate notifications.
- Replace with a single `compute()` call that atomically checks and updates the cache entry.
- Discard external cache timestamps more than 1 hour in the future (clock skew protection).
- Avoid reading back from the SOFT ref local cache when writing to external cache (GC could null it out between `get()` and `put()`).

## GC safety analysis for `compute()` with external cache IO inside lambda

`ConcurrentReferenceHashMap` overrides `compute()` via its `Segment.doTask()` mechanism. `Segment extends ReentrantLock`, and `doTask()` acquires the segment lock before invoking the lambda:

```
Segment.doTask() {
    lock();          // ReentrantLock
    try {
        // resolve entry, invoke lambda (including external cache IO)
        // store returned value as new SOFT ref
    } finally {
        unlock();
    }
}
```

**What happens if GC triggers during the IO-blocked external cache call inside the lambda:**

1. **Atomicity is preserved** — the segment lock prevents any concurrent `get()`/`put()`/`compute()` on the same segment from observing intermediate state. Other threads block until the lambda completes.
2. **GC CAN clear SOFT refs concurrently** (GC doesn't respect Java locks), but no application thread can act on the cleared state while the lock is held by our lambda.
3. **The current entry's key and value are held by strong references** on the stack inside `doTask()` — they won't be collected during lambda execution.
4. **The value returned by the lambda** is stored as a new SOFT ref entry under the same lock, before unlock.
5. **After unlock** — the new entry is a fresh SOFT ref. If GC collects it later (between two separate `alreadyProcessed()` calls), that's acceptable best-effort dedup behavior.

**Conclusion**: the `compute()` call is segment-locked and GC-safe. The external cache IO inside the lambda does hold the segment lock longer, but notification dedup is low-contention (few keys, infrequent triggers), so this is acceptable.

## Test plan
- [x] New unit test `DefaultNotificationDeduplicationServiceTest` (6 tests, all pass < 1s):
  - `testFirstTriggerIsNotDeduplicated` — basic: first trigger passes through
  - `testSecondTriggerIsDeduplicated` — basic: repeat trigger is blocked
  - `testTriggerPassesAfterDeduplicationWindowExpires` — window expiry works
  - `testFutureTimestampFromExternalCacheIsDiscarded` — clock skew guard (>1h future timestamp ignored)
  - `testValidTimestampFromExternalCacheIsDeduplicated` — external cache fallback works
  - `testConcurrentTriggersProduceExactlyOneNonDeduplicated` — 10 threads via CyclicBarrier, exactly 1 passes
- [x] `NotificationRuleApiTest#testNotificationsDeduplication_resourcesShortage` passes locally
- [x] `NotificationRuleApiTest#testNotificationsResourcesShortage_whenThresholdChangeToMatchingFilter_thenSendNotification` passes locally
- [x] CI build passes
