### PR TITLE
SNMP: defer querying tasks until transport session is registered

### DIFF
--- a/common/transport/snmp/src/main/java/org/thingsboard/server/transport/snmp/SnmpTransportContext.java
+++ b/common/transport/snmp/src/main/java/org/thingsboard/server/transport/snmp/SnmpTransportContext.java
@@ -160,7 +160,6 @@ public class SnmpTransportContext extends TransportContext {
             return;
         }
         sessions.put(device.getId(), sessionContext);
-        snmpTransportService.createQueryingTasks(sessionContext);
         log.info("Established SNMP device session for device {}", device.getId());
     }
 
@@ -224,6 +223,8 @@ public class SnmpTransportContext extends TransportContext {
                                 registerTransportSession(sessionContext, msg);
                             });
                             transportService.lifecycleEvent(sessionContext.getTenantId(), sessionContext.getDeviceId(), ComponentLifecycleEvent.STARTED, true, null);
+                            snmpTransportService.createQueryingTasks(sessionContext);
+                            log.info("[{}] Session registered and querying tasks created", sessionContext.getDeviceId());
                         } else {
                             log.warn("[{}] Failed to process device auth", sessionContext.getDeviceId());
                         }

--- a/common/transport/snmp/src/main/java/org/thingsboard/server/transport/snmp/service/SnmpTransportService.java
+++ b/common/transport/snmp/src/main/java/org/thingsboard/server/transport/snmp/service/SnmpTransportService.java
@@ -164,7 +164,7 @@ public class SnmpTransportService implements TbTransportService, CommandResponde
                     ScheduledTask scheduledTask = new ScheduledTask();
                     scheduledTask.init(() -> {
                         try {
-                            if (sessionContext.isActive()) {
+                            if (sessionContext.isActive() && sessionContext.isConnected()) {
                                 return sendRequest(sessionContext, repeatingCommunicationConfig);
                             }
                         } catch (Exception e) {
@@ -390,7 +390,9 @@ public class SnmpTransportService implements TbTransportService, CommandResponde
 
         JsonObject responseData = responseDataMappers.get(requestContext.getCommunicationSpec()).map(response, requestContext);
         if (responseData.size() == 0) {
-            log.warn("[{}] No values in the response", sessionContext.getDeviceId());
+            log.warn("[{}] No values in the response for spec {}. Response PDUs: {}, Mappings count: {}",
+                    sessionContext.getDeviceId(), requestContext.getCommunicationSpec(),
+                    response, requestContext.getResponseMappings() != null ? requestContext.getResponseMappings().size() : 0);
             throw new IllegalArgumentException("No values in the response");
         }
 

--- a/common/transport/snmp/src/main/java/org/thingsboard/server/transport/snmp/service/SnmpTransportService.java
+++ b/common/transport/snmp/src/main/java/org/thingsboard/server/transport/snmp/service/SnmpTransportService.java
@@ -390,9 +390,11 @@ public class SnmpTransportService implements TbTransportService, CommandResponde
 
         JsonObject responseData = responseDataMappers.get(requestContext.getCommunicationSpec()).map(response, requestContext);
         if (responseData.size() == 0) {
-            log.warn("[{}] No values in the response for spec {}. Response PDUs: {}, Mappings count: {}",
+            log.warn("[{}] No values in the response for spec {}. Response PDUs count: {}, Mappings count: {}",
                     sessionContext.getDeviceId(), requestContext.getCommunicationSpec(),
-                    response, requestContext.getResponseMappings() != null ? requestContext.getResponseMappings().size() : 0);
+                    response.size(), requestContext.getResponseMappings().size());
+            log.debug("[{}] No values in the response for spec {}. Response PDUs: {}",
+                    sessionContext.getDeviceId(), requestContext.getCommunicationSpec(), response);
             throw new IllegalArgumentException("No values in the response");
         }
 


### PR DESCRIPTION
## Pull Request description

Fixes a race condition in the SNMP transport where querying tasks could start polling a device before its transport session was fully registered, leading to dropped responses and noisy No values in the response warnings with no actionable context.

Scope of changes

SnmpTransportContext.establishDeviceSession() — no longer creates querying tasks immediately after putting the session into the sessions map. Tasks are now created later, once registration is confirmed.

SnmpTransportContext.onSuccess() (ValidateDeviceCredentialsResponse callback) — moved snmpTransportService.createQueryingTasks(sessionContext) to run after registerTransportSession(...) and the STARTED lifecycle event have completed. Added an info log to make the ordering visible in production logs.

SnmpTransportService.createQueryingTasks() — the scheduled task now checks both sessionContext.isActive() and sessionContext.isConnected() before sending a request, preventing requests on sessions that are active but not yet/no longer connected.

SnmpTransportService.processResponse() — enriched the No values in the response warning to include the communication spec, response PDUs, and the response mapping count, so the warning is actually diagnosable.

Why

Previously, createQueryingTasks was invoked synchronously inside establishDeviceSession — before the asynchronous validateDeviceCredentials / registerTransportSession callback chain completed. The first poll could fire against a session that was not yet registered with the transport service, producing empty responses and confusing logs.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



