### PR TITLE
Fixed resolve stale WebSocket cmdId after reconnect causing lost subscription updates

### DIFF
--- a/ui-ngx/src/app/core/ws/telemetry-websocket.service.ts
+++ b/ui-ngx/src/app/core/ws/telemetry-websocket.service.ts
@@ -81,6 +81,12 @@ export class TelemetryWebsocketService extends WebsocketService<TelemetrySubscri
         const cmdId = this.nextCmdId();
         if (!(subscriptionCommand instanceof MarkAsReadCmd) && !(subscriptionCommand instanceof MarkAllAsReadCmd)) {
           this.subscribersMap.set(cmdId, subscriber);
+          let cmdIds = this.subscriberCmdIds.get(subscriber);
+          if (!cmdIds) {
+            cmdIds = new Set<number>();
+            this.subscriberCmdIds.set(subscriber, cmdIds);
+          }
+          cmdIds.add(cmdId);
         }
         subscriptionCommand.cmdId = cmdId;
         this.cmdWrapper.cmds.push(subscriptionCommand);
@@ -141,6 +147,13 @@ export class TelemetryWebsocketService extends WebsocketService<TelemetrySubscri
           const cmdId = subscriptionCommand.cmdId;
           if (cmdId) {
             this.subscribersMap.delete(cmdId);
+            const cmdIds = this.subscriberCmdIds.get(subscriber);
+            if (cmdIds) {
+              cmdIds.delete(cmdId);
+              if (cmdIds.size === 0) {
+                this.subscriberCmdIds.delete(subscriber);
+              }
+            }
           }
         }
       );
@@ -183,11 +196,9 @@ export class TelemetryWebsocketService extends WebsocketService<TelemetrySubscri
 
   private syncCommandId(subscriptionCommand: WebsocketCmd, subscriber: TelemetrySubscriber) {
     if (!this.subscribersMap.has(subscriptionCommand.cmdId)) {
-      for (const [cmdId, sub] of this.subscribersMap.entries()) {
-        if (sub === subscriber) {
-          subscriptionCommand.cmdId = cmdId;
-          break;
-        }
+      const cmdIds = this.subscriberCmdIds.get(subscriber);
+      if (cmdIds?.size) {
+        subscriptionCommand.cmdId = cmdIds.values().next().value;
       }
     }
   }

--- a/ui-ngx/src/app/core/ws/telemetry-websocket.service.ts
+++ b/ui-ngx/src/app/core/ws/telemetry-websocket.service.ts
@@ -195,7 +195,7 @@ export class TelemetryWebsocketService extends WebsocketService<TelemetrySubscri
   }
 
   private syncCommandId(subscriptionCommand: WebsocketCmd, subscriber: TelemetrySubscriber) {
-    if (!this.subscribersMap.has(subscriptionCommand.cmdId)) {
+    if (this.subscribersMap.get(subscriptionCommand.cmdId) !== subscriber) {
       const cmdIds = this.subscriberCmdIds.get(subscriber);
       if (cmdIds?.size) {
         subscriptionCommand.cmdId = cmdIds.values().next().value;

--- a/ui-ngx/src/app/core/ws/telemetry-websocket.service.ts
+++ b/ui-ngx/src/app/core/ws/telemetry-websocket.service.ts
@@ -50,6 +50,7 @@ import {
   UnreadCountSubCmd,
   UnreadSubCmd,
   UnsubscribeCmd,
+  WebsocketCmd,
   WebsocketDataMsg
 } from '@app/shared/models/telemetry/telemetry.models';
 import { Store } from '@ngrx/store';
@@ -94,11 +95,14 @@ export class TelemetryWebsocketService extends WebsocketService<TelemetrySubscri
       subscriber.subscriptionCommands.forEach(
         (subscriptionCommand) => {
           if (subscriptionCommand.cmdId && (subscriptionCommand instanceof EntityDataCmd || subscriptionCommand instanceof UnreadSubCmd)) {
+            this.syncCommandId(subscriptionCommand, subscriber);
             this.cmdWrapper.cmds.push(subscriptionCommand);
           }
         }
       );
       this.publishCommands();
+    } else {
+      this.pendingUpdates.add(subscriber);
     }
   }
 
@@ -173,6 +177,17 @@ export class TelemetryWebsocketService extends WebsocketService<TelemetrySubscri
       subscriber = this.subscribersMap.get(message.subscriptionId) as TelemetrySubscriber;
       if (subscriber) {
         subscriber.onData(new SubscriptionUpdate(message));
+      }
+    }
+  }
+
+  private syncCommandId(subscriptionCommand: WebsocketCmd, subscriber: TelemetrySubscriber) {
+    if (!this.subscribersMap.has(subscriptionCommand.cmdId)) {
+      for (const [cmdId, sub] of this.subscribersMap.entries()) {
+        if (sub === subscriber) {
+          subscriptionCommand.cmdId = cmdId;
+          break;
+        }
       }
     }
   }

--- a/ui-ngx/src/app/core/ws/websocket.service.ts
+++ b/ui-ngx/src/app/core/ws/websocket.service.ts
@@ -52,6 +52,7 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
   subscribersMap = new Map<number, TelemetrySubscriber | NotificationSubscriber>();
 
   reconnectSubscribers = new Set<WsSubscriber>();
+  pendingUpdates = new Set<T>();
 
   wsUri: string;
 
@@ -140,6 +141,7 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
     if (close) {
       this.reconnectAttempts = 0;
       this.lastShownCloseCode = null;
+      this.pendingUpdates.clear();
       this.closeSocket();
     }
   }
@@ -223,6 +225,7 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
         }
       );
       this.reconnectSubscribers.clear();
+      this.processPendingUpdates();
     } else {
       this.publishCommands();
     }
@@ -297,5 +300,14 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
     this.store.dispatch(new ActionNotificationShow({
       message, type: notificationType
     }));
+  }
+
+  private processPendingUpdates() {
+    if (this.pendingUpdates.size > 0) {
+      this.pendingUpdates.forEach((subscriber) => {
+        this.update(subscriber);
+      });
+      this.pendingUpdates.clear();
+    }
   }
 }

--- a/ui-ngx/src/app/core/ws/websocket.service.ts
+++ b/ui-ngx/src/app/core/ws/websocket.service.ts
@@ -50,6 +50,7 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
   lastCmdId = 0;
   subscribersCount = 0;
   subscribersMap = new Map<number, TelemetrySubscriber | NotificationSubscriber>();
+  subscriberCmdIds = new Map<WsSubscriber, Set<number>>();
 
   reconnectSubscribers = new Set<WsSubscriber>();
   pendingUpdates = new Set<T>();
@@ -136,6 +137,7 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
     }
     this.lastCmdId = 0;
     this.subscribersMap.clear();
+    this.subscriberCmdIds.clear();
     this.subscribersCount = 0;
     this.cmdWrapper.clear();
     if (close) {
@@ -304,10 +306,13 @@ export abstract class WebsocketService<T extends WsSubscriber> implements WsServ
 
   private processPendingUpdates() {
     if (this.pendingUpdates.size > 0) {
-      this.pendingUpdates.forEach((subscriber) => {
-        this.update(subscriber);
-      });
+      const subscribers = Array.from(this.pendingUpdates);
       this.pendingUpdates.clear();
+      for (const subscriber of subscribers) {
+        if (this.subscriberCmdIds.has(subscriber)) {
+          this.update(subscriber);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes an issue where dashboard widgets stop receiving data after a WebSocket
reconnect (commonly triggered on mobile when the screen turns off/on, but also
reproducible on desktop via network interruption or server restart).

## Root cause

When the WebSocket connection drops and reconnects, `subscribe()` assigns **new
cmdIds** to the subscriber's `subscriptionCommands`. However, other command
objects held by `entity-data-subscription` (e.g. `this.dataCommand`) retain the
**old cmdId** from the previous WS session.

When `update()` is called (e.g. time window refresh on resume, or user changing
the date range), it sends commands with the stale cmdId. The server responds
using that cmdId, but `subscribersMap` only contains the new cmdId — so the
response is silently dropped and the widget spinner never stops.

A secondary issue: `update()` is blocked by `if (!this.isReconnect)` during the
reconnect window. If an update is triggered between `onClose` and `onOpen`
(common on Android where `onWindowFocus` fires before the reconnect timer), the
update is silently dropped and never replayed.

## Changes

**`websocket.service.ts`**
- Added `pendingUpdates` set to queue updates requested during reconnect
- Added `processPendingUpdates()` — replays queued updates after reconnect
  completes and subscribers are re-registered with fresh cmdIds
- `pendingUpdates` cleared on full reset (logout) but preserved during reconnect

**`telemetry-websocket.service.ts`**
- Added `syncCommandId()` — when `update()` detects a command with a cmdId not
  present in `subscribersMap`, it resolves the subscriber's actual registered
  cmdId via reverse lookup and corrects the command before sending
- `update()` now queues to `pendingUpdates` when `isReconnect` is true instead
  of silently dropping the update

## Test plan

- [ ] Open a dashboard with a timeseries widget on mobile
- [ ] Turn screen off, wait a few seconds until WebSocket closes (code 1006)
- [ ] Turn screen on — dashboard should display data without stuck spinner
- [ ] Change the date range — widget should load new data normally
- [ ] Verify normal desktop WebSocket behavior is unaffected
- [ ] Verify reconnect after server restart works correctly