### PR TITLE
Fixed SSRF and file access vulnerabilities in TBEL script sandbox

### DIFF
--- a/application/src/test/java/org/thingsboard/server/service/script/TbelInvokeServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/script/TbelInvokeServiceTest.java
@@ -217,6 +217,90 @@ class TbelInvokeServiceTest extends AbstractTbelInvokeTest {
         assertThat(compiledScriptsCache.getIfPresent(scriptIdToHash.get(scriptRemovedFromCache))).isNotNull();
     }
 
+    @Test
+    void givenForbiddenSocketHandler_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.logging.SocketHandler(\"127.0.0.1\", 9999)");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.logging.SocketHandler");
+                });
+    }
+
+    @Test
+    void givenForbiddenZipFile_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.zip.ZipFile(\"/tmp/test.zip\")");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.zip.ZipFile");
+                });
+    }
+
+    @Test
+    void givenForbiddenFileHandler_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.logging.FileHandler(\"/tmp/test.log\")");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.logging.FileHandler");
+                });
+    }
+
+    @Test
+    void givenForbiddenJarFile_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.jar.JarFile(\"/tmp/test.jar\")");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.jar.JarFile");
+                });
+    }
+
+    @Test
+    void givenForbiddenPreferences_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("java.util.prefs.Preferences.userRoot()");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getMessage()).contains("unresolvable property or identifier: java");
+                });
+    }
+
+    @Test
+    void givenForbiddenLocaleServiceProvider_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.spi.LocaleServiceProvider()");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.spi.LocaleServiceProvider");
+                });
+    }
+
     private void assertThatScriptIsBlocked(UUID scriptId) {
         assertThatThrownBy(() -> {
             invokeScriptResultString(scriptId, "{}");

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <zookeeper.version>3.9.5</zookeeper.version> <!-- to fix CVE-2026-24308 and CVE-2026-24281. TODO: remove override when fixed in curator-client -->
         <protobuf.version>3.25.5</protobuf.version> <!-- A Major v4 does not support by the pubsub yet-->
         <grpc.version>1.76.0</grpc.version>
-        <tbel.version>1.2.9</tbel.version>
+        <tbel.version>1.2.10</tbel.version>
         <lombok.version>1.18.44</lombok.version> <!-- must be in sync with spring-boot-dependencies; needed for maven-compiler-plugin annotationProcessorPaths -->
         <paho.client.version>1.2.5</paho.client.version>
         <paho.mqttv5.client.version>1.2.5</paho.mqttv5.client.version>


### PR DESCRIPTION
## Summary
- Bump `tbel` dependency 1.2.9 → 1.2.10 (see thingsboard/tbel#48)
- Add 7 integration tests in `TbelInvokeServiceTest` verifying sandbox blocks dangerous `java.util` subpackage classes

## Problem
The TBEL sandbox `allowedPackages` entry `"java.util"` uses `startsWith` prefix matching, which inadvertently permits all subpackages. This allows a Tenant Admin to:
1. **SSRF** via `java.util.logging.SocketHandler`
2. **Arbitrary file read** via `java.util.zip.ZipFile` / `java.util.jar.JarFile`
3. **Arbitrary file write** via `java.util.logging.FileHandler`

## Fix
tbel 1.2.10 adds `java.util.logging`, `java.util.zip`, `java.util.jar`, `java.util.prefs`, `java.util.spi` to `forbiddenPackages` in `SandboxedClassLoader`, following the existing pattern used for `java.util.concurrent`. `java.util.prefs` and `java.util.spi` are not part of the documented TBEL API and are blocked as a precaution — user scripts should not have access to system preferences or service provider loading.

## Test plan

Automated tests in `TbelInvokeServiceTest`:
- `givenForbiddenSocketHandler_whenInvoking_thenThrowsRuntimeError`
- `givenForbiddenZipFile_whenInvoking_thenThrowsRuntimeError`
- `givenForbiddenFileHandler_whenInvoking_thenThrowsRuntimeError`
- `givenForbiddenJarFile_whenInvoking_thenThrowsRuntimeError`
- `givenForbiddenPreferences_whenInvoking_thenThrowsRuntimeError`
- `givenForbiddenLocaleServiceProvider_whenInvoking_thenThrowsRuntimeError`

Manual E2E verification (Rule chains → Root Rule Chain → Script filter → Test script function):

1. `java.util.logging.SocketHandler` blocked — SSRF prevention
<img width="735" height="756" alt="Screenshot 2026-04-05 at 18 29 56" src="https://github.com/user-attachments/assets/eb838913-c033-482c-a905-4c3bf4fce962" />

2. `java.util.zip.ZipFile` blocked — arbitrary file read prevention
<img width="735" height="764" alt="Screenshot 2026-04-05 at 18 32 20" src="https://github.com/user-attachments/assets/869776ab-b1c7-4dda-9892-ec9b8436bea3" />

3. `java.util.jar.JarFile` blocked — arbitrary file read prevention
<img width="739" height="759" alt="Screenshot 2026-04-05 at 18 34 29" src="https://github.com/user-attachments/assets/8f0076c8-2be3-424a-8735-63ef7ac803f4" />

4. `java.util.logging.FileHandler` blocked — arbitrary file write prevention
<img width="734" height="754" alt="Screenshot 2026-04-05 at 18 35 21" src="https://github.com/user-attachments/assets/9670de05-b7c3-49c9-b482-69117b64a202" />

5. `java.util.prefs.Preferences` blocked — system preferences access prevention
<img width="948" height="751" alt="Screenshot 2026-04-05 at 18 36 44" src="https://github.com/user-attachments/assets/fc43d79f-fed9-481f-ad8b-c858f5b295a5" />

6. `java.util.spi.LocaleServiceProvider` blocked — service provider loading prevention
<img width="737" height="758" alt="Screenshot 2026-04-05 at 19 37 13" src="https://github.com/user-attachments/assets/cfde3ff8-ddd1-4b2e-8352-678fe415d384" />