### PR TITLE
Fixed CWE-770 in Jackson Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,7 @@
         <pkg.implementationTitle>${project.name}</pkg.implementationTitle>
         <pkg.unixLogFolder>/var/log/${pkg.name}</pkg.unixLogFolder>
         <pkg.installFolder>/usr/share/${pkg.name}</pkg.installFolder>
-        <spring-boot.version>3.5.12</spring-boot.version>
-        <jackson-bom.version>2.21.1</jackson-bom.version> <!-- to fix GHSA-72hv-8253-57qq. TODO: remove when fixed in spring-boot-dependencies -->
-        <netty.version>4.1.132.Final</netty.version> <!-- to fix CVE-2026-33870 and CVE-2026-33871. TODO: remove when fixed in spring-boot-dependencies -->
+        <spring-boot.version>3.5.13</spring-boot.version>
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -993,24 +991,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Temporary jackson-bom version override -->
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- End of jackson-bom version override -->
-            <!-- Temporary netty-bom version override -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- End of netty-bom version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Context

Core vulnerability: Allocation of Resources Without Limits or Throttling.
Upgrade com.fasterxml.jackson.core:jackson-core to version 2.21.2 or higher needed.

## Fix

Bumped `spring-boot` from 3.5.12 to 3.5.13 — the new version, already includes fixed jackson-bom (2.21.2) and netty-bom" 
<img width="849" height="123" alt="Screenshot 2026-04-06 at 13 55 26" src="https://github.com/user-attachments/assets/5852efb4-cf34-48c5-aa62-4e023e8edf49" />



### Clean up `TODO: remove when fixed in spring-boot-dependencies`

1. Removed temporary `jackson-bom.version` override (2.21.1) — no longer needed as Spring Boot 3.5.13 pulls the higher version (2.21.2). Previously added to fix GHSA-72hv-8253-57qq
<img width="844" height="72" alt="Screenshot 2026-04-06 at 13 52 07" src="https://github.com/user-attachments/assets/1980bc9a-b439-4669-a9d9-e703e98a7cb8" />



2. Removed temporary `netty.version` override (4.1.132.Final) — no longer needed as Spring Boot 3.5.13 pulls the correct version. Previously added to fix CVE-2026-33870 and CVE-2026-33871
<img width="845" height="67" alt="Screenshot 2026-04-06 at 13 53 35" src="https://github.com/user-attachments/assets/de226151-3852-460b-bc34-e189771b3817" />



3. Removed corresponding blocks in `<dependencyManagement>` — `jackson-bom` and `netty-bom` overrides are no longer required
4. commons-lang3 version 3.18.0 is kept with a TODO comment because Spring Boot 3.5.13 still includes commons-lang3 3.17.0.

## Result

Dependency tree check

```
mvn dependency:tree -pl application | grep com.fasterxml.jackson
```
```
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.21.2:compile
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.21.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.21.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.21:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.21.2:compile
[INFO] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.21.2:compile
[INFO] |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.21.2:compile
[INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.21.2:compile
[INFO] |  |        \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.21.2:compile
```
```
mvn dependency:tree > depfinal.txt
```
```
--- dependency:3.7.0:tree (default-cli) @ application ---
[INFO] org.thingsboard:application:jar:4.2.2.2-SNAPSHOT
[INFO] +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.132.Final:compile
[INFO] |  +- io.netty:netty-common:jar:4.1.132.Final:compile
[INFO] |  +- io.netty:netty-buffer:jar:4.1.132.Final:compile
[INFO] |  +- io.netty:netty-transport:jar:4.1.132.Final:compile
[INFO] |  +- io.netty:netty-transport-native-unix-common:jar:4.1.132.Final:compile
[INFO] |  \- io.netty:netty-transport-classes-epoll:jar:4.1.132.Final:compile
```
