### PR TITLE
Fixed select options being clipped in widget settings form

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/dynamic-form/dynamic-form-property-panel.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/dynamic-form/dynamic-form-property-panel.component.html
@@ -214,7 +214,7 @@
           </mat-panel-title>
         </mat-expansion-panel-header>
         <ng-template matExpansionPanelContent>
-          <tb-dynamic-form-properties formControlName="properties" noBorder noMargin>
+          <tb-dynamic-form-properties formControlName="properties" noBorder noMargin class="!overflow-visible">
           </tb-dynamic-form-properties>
         </ng-template>
       </mat-expansion-panel>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/dynamic-form/dynamic-form-select-items.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/common/dynamic-form/dynamic-form-select-items.component.ts
@@ -66,7 +66,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 export class DynamicFormSelectItemsComponent implements ControlValueAccessor, OnInit, Validator {
 
   @HostBinding('style.display') styleDisplay = 'flex';
-  @HostBinding('style.overflow') styleOverflow = 'hidden';
 
   @ViewChildren(DynamicFormSelectItemRowComponent)
   selectItemRows: QueryList<DynamicFormSelectItemRowComponent>;


### PR DESCRIPTION
## Summary
- Fixed select options (Value/Label table and "No options configured" placeholder) being clipped in the dynamic form property panel
- Removed `overflow: hidden` from `DynamicFormSelectItemsComponent` that was hiding the content
- Added `overflow-visible` to nested properties expansion panel to prevent clipping

Before:
<img width="589" height="784" alt="image" src="https://github.com/user-attachments/assets/324a195a-f7e4-47d4-ab4a-1457d9d855b2" />

After:
<img width="589" height="784" alt="image" src="https://github.com/user-attachments/assets/14cc897b-998f-4c3f-9413-6cc161e3ff99" />

## Test plan
- [ ] Open widget settings form → Add property → set Type to "Select"
- [ ] Verify "Select options" section shows Value/Label column headers
- [ ] Verify "No options configured" message is visible
- [ ] Add options and verify they display correctly
- [ ] Check nested group properties with select type work correctly