### PR TITLE
Add v2 short MQTT topic for device claiming

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/claim/MqttClaimDeviceTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/claim/MqttClaimDeviceTest.java
@@ -31,6 +31,7 @@ import org.thingsboard.server.transport.mqtt.mqttv3.MqttTestClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.thingsboard.server.common.data.device.profile.MqttTopics.DEVICE_CLAIM_SHORT_TOPIC;
 import static org.thingsboard.server.common.data.device.profile.MqttTopics.DEVICE_CLAIM_TOPIC;
 import static org.thingsboard.server.common.data.device.profile.MqttTopics.GATEWAY_CLAIM_TOPIC;
 
@@ -58,6 +59,16 @@ public class MqttClaimDeviceTest extends AbstractMqttIntegrationTest {
     }
 
     @Test
+    public void testClaimingDeviceOnShortTopic() throws Exception {
+        processTestClaimingDevice(false, DEVICE_CLAIM_SHORT_TOPIC);
+    }
+
+    @Test
+    public void testClaimingDeviceOnShortTopicWithoutSecretAndDuration() throws Exception {
+        processTestClaimingDevice(true, DEVICE_CLAIM_SHORT_TOPIC);
+    }
+
+    @Test
     public void testGatewayClaimingDevice() throws Exception {
         processTestGatewayClaimingDevice("Test claiming gateway device", false);
     }
@@ -69,6 +80,10 @@ public class MqttClaimDeviceTest extends AbstractMqttIntegrationTest {
 
 
     protected void processTestClaimingDevice(boolean emptyPayload) throws Exception {
+        processTestClaimingDevice(emptyPayload, DEVICE_CLAIM_TOPIC);
+    }
+
+    protected void processTestClaimingDevice(boolean emptyPayload, String claimTopic) throws Exception {
         MqttTestClient client = new MqttTestClient();
         client.connectAndWait(accessToken);
         byte[] payloadBytes;
@@ -80,11 +95,11 @@ public class MqttClaimDeviceTest extends AbstractMqttIntegrationTest {
             payloadBytes = "{\"secretKey\":\"value\", \"durationMs\":60000}".getBytes();
             failurePayloadBytes = "{\"secretKey\":\"value\", \"durationMs\":1}".getBytes();
         }
-        validateClaimResponse(emptyPayload, client, payloadBytes, failurePayloadBytes);
+        validateClaimResponse(emptyPayload, client, payloadBytes, failurePayloadBytes, claimTopic);
     }
 
-    protected void validateClaimResponse(boolean emptyPayload, MqttTestClient client, byte[] payloadBytes, byte[] failurePayloadBytes) throws Exception {
-        client.publishAndWait(DEVICE_CLAIM_TOPIC, failurePayloadBytes);
+    protected void validateClaimResponse(boolean emptyPayload, MqttTestClient client, byte[] payloadBytes, byte[] failurePayloadBytes, String claimTopic) throws Exception {
+        client.publishAndWait(claimTopic, failurePayloadBytes);
         awaitForClaimingInfoToBeRegistered(savedDevice.getId());
 
         loginCustomerUser();
@@ -103,7 +118,7 @@ public class MqttClaimDeviceTest extends AbstractMqttIntegrationTest {
 
         assertEquals(claimResponse, ClaimResponse.FAILURE);
 
-        client.publishAndWait(DEVICE_CLAIM_TOPIC, payloadBytes);
+        client.publishAndWait(claimTopic, payloadBytes);
         client.disconnect();
         awaitForClaimingInfoToBeRegistered(savedDevice.getId());
 

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/claim/MqttClaimJsonDeviceTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/claim/MqttClaimJsonDeviceTest.java
@@ -22,6 +22,8 @@ import org.thingsboard.server.common.data.TransportPayloadType;
 import org.thingsboard.server.dao.service.DaoSqlTest;
 import org.thingsboard.server.transport.mqtt.MqttTestConfigProperties;
 
+import static org.thingsboard.server.common.data.device.profile.MqttTopics.DEVICE_CLAIM_SHORT_JSON_TOPIC;
+
 @Slf4j
 @DaoSqlTest
 public class MqttClaimJsonDeviceTest extends MqttClaimDeviceTest {
@@ -44,6 +46,16 @@ public class MqttClaimJsonDeviceTest extends MqttClaimDeviceTest {
     @Test
     public void testClaimingDeviceWithoutSecretAndDuration() throws Exception {
         processTestClaimingDevice(true);
+    }
+
+    @Test
+    public void testClaimingDeviceOnShortJsonTopic() throws Exception {
+        processTestClaimingDevice(false, DEVICE_CLAIM_SHORT_JSON_TOPIC);
+    }
+
+    @Test
+    public void testClaimingDeviceOnShortJsonTopicWithoutSecretAndDuration() throws Exception {
+        processTestClaimingDevice(true, DEVICE_CLAIM_SHORT_JSON_TOPIC);
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/claim/MqttClaimProtoDeviceTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/claim/MqttClaimProtoDeviceTest.java
@@ -24,6 +24,9 @@ import org.thingsboard.server.gen.transport.TransportApiProtos;
 import org.thingsboard.server.transport.mqtt.MqttTestConfigProperties;
 import org.thingsboard.server.transport.mqtt.mqttv3.MqttTestClient;
 
+import static org.thingsboard.server.common.data.device.profile.MqttTopics.DEVICE_CLAIM_SHORT_PROTO_TOPIC;
+import static org.thingsboard.server.common.data.device.profile.MqttTopics.DEVICE_CLAIM_TOPIC;
+
 @Slf4j
 @DaoSqlTest
 public class MqttClaimProtoDeviceTest extends MqttClaimDeviceTest {
@@ -49,6 +52,16 @@ public class MqttClaimProtoDeviceTest extends MqttClaimDeviceTest {
     }
 
     @Test
+    public void testClaimingDeviceOnShortProtoTopic() throws Exception {
+        processTestClaimingDevice(false, DEVICE_CLAIM_SHORT_PROTO_TOPIC);
+    }
+
+    @Test
+    public void testClaimingDeviceOnShortProtoTopicWithoutSecretAndDuration() throws Exception {
+        processTestClaimingDevice(true, DEVICE_CLAIM_SHORT_PROTO_TOPIC);
+    }
+
+    @Test
     public void testGatewayClaimingDevice() throws Exception {
         processTestGatewayClaimingDevice("Test claiming gateway device Proto", false);
     }
@@ -59,6 +72,11 @@ public class MqttClaimProtoDeviceTest extends MqttClaimDeviceTest {
     }
 
     protected void processTestClaimingDevice(boolean emptyPayload) throws Exception {
+        processTestClaimingDevice(emptyPayload, DEVICE_CLAIM_TOPIC);
+    }
+
+    @Override
+    protected void processTestClaimingDevice(boolean emptyPayload, String claimTopic) throws Exception {
         MqttTestClient client = new MqttTestClient();
         client.connectAndWait(accessToken);
         byte[] payloadBytes;
@@ -68,7 +86,7 @@ public class MqttClaimProtoDeviceTest extends MqttClaimDeviceTest {
             payloadBytes = getClaimDevice(60000, emptyPayload).toByteArray();
         }
         byte[] failurePayloadBytes = getClaimDevice(1, emptyPayload).toByteArray();
-        validateClaimResponse(emptyPayload, client, payloadBytes, failurePayloadBytes);
+        validateClaimResponse(emptyPayload, client, payloadBytes, failurePayloadBytes, claimTopic);
     }
 
     protected void processTestGatewayClaimingDevice(String deviceName, boolean emptyPayload) throws Exception {

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv5/claim/AbstractMqttV5ClaimTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv5/claim/AbstractMqttV5ClaimTest.java
@@ -26,23 +26,32 @@ import org.thingsboard.server.transport.mqtt.mqttv5.MqttV5TestClient;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.thingsboard.server.common.data.device.profile.MqttTopics.DEVICE_CLAIM_SHORT_TOPIC;
 import static org.thingsboard.server.common.data.device.profile.MqttTopics.DEVICE_CLAIM_TOPIC;
 
 @Slf4j
 public abstract class AbstractMqttV5ClaimTest extends AbstractMqttV5Test {
 
     protected void processTestClaimingDevice() throws Exception {
+        processTestClaimingDevice(DEVICE_CLAIM_TOPIC);
+    }
+
+    protected void processTestClaimingDeviceOnShortTopic() throws Exception {
+        processTestClaimingDevice(DEVICE_CLAIM_SHORT_TOPIC);
+    }
+
+    protected void processTestClaimingDevice(String claimTopic) throws Exception {
         MqttV5TestClient client = new MqttV5TestClient();
         client.connectAndWait(accessToken);
         byte[] payloadBytes;
         byte[] failurePayloadBytes;
         payloadBytes = "{\"secretKey\":\"value\", \"durationMs\":60000}".getBytes();
         failurePayloadBytes = "{\"secretKey\":\"value\", \"durationMs\":1}".getBytes();
-        validateClaimResponse(client, payloadBytes, failurePayloadBytes);
+        validateClaimResponse(client, payloadBytes, failurePayloadBytes, claimTopic);
     }
 
-    protected void validateClaimResponse(MqttV5TestClient client, byte[] payloadBytes, byte[] failurePayloadBytes) throws Exception {
-        client.publishAndWait(DEVICE_CLAIM_TOPIC, failurePayloadBytes);
+    protected void validateClaimResponse(MqttV5TestClient client, byte[] payloadBytes, byte[] failurePayloadBytes, String claimTopic) throws Exception {
+        client.publishAndWait(claimTopic, failurePayloadBytes);
         awaitForClaimingInfoToBeRegistered(savedDevice.getId());
 
         loginCustomerUser();
@@ -56,7 +65,7 @@ public abstract class AbstractMqttV5ClaimTest extends AbstractMqttV5Test {
 
         assertEquals(claimResponse, ClaimResponse.FAILURE);
 
-        client.publishAndWait(DEVICE_CLAIM_TOPIC, payloadBytes);
+        client.publishAndWait(claimTopic, payloadBytes);
         client.disconnect();
         awaitForClaimingInfoToBeRegistered(savedDevice.getId());
 

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv5/claim/MqttV5ClaimTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv5/claim/MqttV5ClaimTest.java
@@ -35,4 +35,9 @@ public class MqttV5ClaimTest extends AbstractMqttV5ClaimTest {
     public void testClaimingDevice() throws Exception {
         processTestClaimingDevice();
     }
+
+    @Test
+    public void testClaimingDeviceOnShortTopic() throws Exception {
+        processTestClaimingDeviceOnShortTopic();
+    }
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/device/profile/MqttTopics.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/device/profile/MqttTopics.java
@@ -37,6 +37,7 @@ public class MqttTopics {
     private static final String TELEMETRY_SHORT = "/t";
     private static final String ATTRIBUTES_SHORT = "/a";
     private static final String RPC_SHORT = "/r";
+    private static final String CLAIM_SHORT = "/c";
     private static final String REQUEST_SHORT = "/req";
     private static final String RESPONSE_SHORT = "/res";
     private static final String JSON_SHORT = "j";
@@ -113,6 +114,9 @@ public class MqttTopics {
     public static final String DEVICE_ATTRIBUTES_REQUEST_SHORT_TOPIC_PREFIX = BASE_DEVICE_API_TOPIC_V2 + ATTRIBUTES_REQUEST_SHORT;
     public static final String DEVICE_ATTRIBUTES_REQUEST_SHORT_JSON_TOPIC_PREFIX = DEVICE_ATTRIBUTES_REQUEST_SHORT_TOPIC_PREFIX + JSON_SHORT + "/";
     public static final String DEVICE_ATTRIBUTES_REQUEST_SHORT_PROTO_TOPIC_PREFIX = DEVICE_ATTRIBUTES_REQUEST_SHORT_TOPIC_PREFIX + PROTO_SHORT + "/";
+    public static final String DEVICE_CLAIM_SHORT_TOPIC = BASE_DEVICE_API_TOPIC_V2 + CLAIM_SHORT;
+    public static final String DEVICE_CLAIM_SHORT_JSON_TOPIC = BASE_DEVICE_API_TOPIC_V2 + CLAIM_SHORT + "/" + JSON_SHORT;
+    public static final String DEVICE_CLAIM_SHORT_PROTO_TOPIC = BASE_DEVICE_API_TOPIC_V2 + CLAIM_SHORT + "/" + PROTO_SHORT;
 
     private MqttTopics() {
     }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -612,6 +612,15 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                 TransportProtos.PostAttributeMsg postAttributeMsg = context.getProtoMqttAdaptor().convertToPostAttributes(deviceSessionCtx, mqttMsg);
                 transportService.process(deviceSessionCtx.getSessionInfo(), postAttributeMsg, getMetadata(deviceSessionCtx, topicName),
                         getPubAckCallback(ctx, msgId, postAttributeMsg));
+            } else if (topicName.equals(MqttTopics.DEVICE_CLAIM_SHORT_TOPIC)) {
+                TransportProtos.ClaimDeviceMsg claimDeviceMsg = payloadAdaptor.convertToClaimDevice(deviceSessionCtx, mqttMsg);
+                transportService.process(deviceSessionCtx.getSessionInfo(), claimDeviceMsg, getPubAckCallback(ctx, msgId, claimDeviceMsg));
+            } else if (topicName.equals(MqttTopics.DEVICE_CLAIM_SHORT_JSON_TOPIC)) {
+                TransportProtos.ClaimDeviceMsg claimDeviceMsg = context.getJsonMqttAdaptor().convertToClaimDevice(deviceSessionCtx, mqttMsg);
+                transportService.process(deviceSessionCtx.getSessionInfo(), claimDeviceMsg, getPubAckCallback(ctx, msgId, claimDeviceMsg));
+            } else if (topicName.equals(MqttTopics.DEVICE_CLAIM_SHORT_PROTO_TOPIC)) {
+                TransportProtos.ClaimDeviceMsg claimDeviceMsg = context.getProtoMqttAdaptor().convertToClaimDevice(deviceSessionCtx, mqttMsg);
+                transportService.process(deviceSessionCtx.getSessionInfo(), claimDeviceMsg, getPubAckCallback(ctx, msgId, claimDeviceMsg));
             } else if (topicName.startsWith(MqttTopics.DEVICE_RPC_RESPONSE_SHORT_JSON_TOPIC)) {
                 TransportProtos.ToDeviceRpcResponseMsg rpcResponseMsg = context.getJsonMqttAdaptor().convertToDeviceRpcResponse(deviceSessionCtx, mqttMsg, MqttTopics.DEVICE_RPC_RESPONSE_SHORT_JSON_TOPIC);
                 transportService.process(deviceSessionCtx.getSessionInfo(), rpcResponseMsg, getPubAckCallback(ctx, msgId, rpcResponseMsg));


### PR DESCRIPTION
## Pull Request description
  
  - Add v2 short topic support for device claiming (v2/c), filling a gap where all other device API operations (telemetry, attributes, RPC) already had v2 short topic equivalents but claiming did not                                                                                                             
  - Support all three content type variants: auto-detect (v2/c), explicit JSON (v2/c/j), and explicit Protobuf (v2/c/p), consistent with existing v2 short topic conventions
  - Add integration tests covering all three variants across MQTTv3 (default, JSON, Proto payload types) and MQTTv5                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



