### PR TITLE
Fixed server crash on upload of large images

### DIFF
--- a/application/src/test/java/org/thingsboard/server/controller/ImageControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/ImageControllerTest.java
@@ -333,25 +333,26 @@ public class ImageControllerTest extends AbstractControllerTest {
         });
         loginTenantAdmin();
 
-        String filename = "large_decoded_image.png";
-        TbResourceInfo imageInfo = uploadImage(HttpMethod.POST, "/api/image", filename, "image/png", PNG_IMAGE);
+        try {
+            String filename = "large_decoded_image.png";
+            TbResourceInfo imageInfo = uploadImage(HttpMethod.POST, "/api/image", filename, "image/png", PNG_IMAGE);
 
-        ImageDescriptor imageDescriptor = imageInfo.getDescriptor(ImageDescriptor.class);
-        assertThat(imageDescriptor.getWidth()).isEqualTo(200);
-        assertThat(imageDescriptor.getHeight()).isEqualTo(160);
+            ImageDescriptor imageDescriptor = imageInfo.getDescriptor(ImageDescriptor.class);
+            assertThat(imageDescriptor.getWidth()).isEqualTo(200);
+            assertThat(imageDescriptor.getHeight()).isEqualTo(160);
 
-        ImageDescriptor previewDescriptor = imageDescriptor.getPreviewDescriptor();
-        assertThat(previewDescriptor.getMediaType()).isEqualTo("image/gif");
-        assertThat(previewDescriptor.getWidth()).isEqualTo(1);
-        assertThat(previewDescriptor.getHeight()).isEqualTo(1);
+            ImageDescriptor previewDescriptor = imageDescriptor.getPreviewDescriptor();
+            assertThat(previewDescriptor.getMediaType()).isEqualTo("image/gif");
+            assertThat(previewDescriptor.getWidth()).isEqualTo(1);
+            assertThat(previewDescriptor.getHeight()).isEqualTo(1);
 
-        assertThat(downloadImagePreview("tenant", filename)).containsExactly(ImageUtils.PLACEHOLDER_PREVIEW);
-
-        // Reset maxResourceSize
-        loginSysAdmin();
-        updateDefaultTenantProfileConfig(tenantProfileConfig -> {
-            tenantProfileConfig.setMaxResourceSize(0);
-        });
+            assertThat(downloadImagePreview("tenant", filename)).containsExactly(ImageUtils.PLACEHOLDER_PREVIEW);
+        } finally {
+            loginSysAdmin();
+            updateDefaultTenantProfileConfig(tenantProfileConfig -> {
+                tenantProfileConfig.setMaxResourceSize(0);
+            });
+        }
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/server/controller/ImageControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/ImageControllerTest.java
@@ -36,6 +36,7 @@ import org.thingsboard.server.common.data.page.PageData;
 import org.thingsboard.server.common.data.page.PageLink;
 import org.thingsboard.server.dao.service.DaoSqlTest;
 import org.thingsboard.server.dao.sql.resource.TbResourceRepository;
+import org.thingsboard.server.dao.util.ImageUtils;
 
 import java.util.Base64;
 import java.util.List;
@@ -320,6 +321,37 @@ public class ImageControllerTest extends AbstractControllerTest {
         loginTenantAdmin();
         systemParams = doGet("/api/system/params", SystemParams.class);
         assertThat(systemParams.getMaxResourceSize()).isEqualTo(0);
+    }
+
+    @Test
+    public void testSkipPreviewForLargeImage() throws Exception {
+        // PNG_IMAGE is 200x160 = 128000 bytes decoded (200*160*4)
+        // maxResourceSize must be > file size (so upload passes) but < decoded size (so preview is skipped)
+        loginSysAdmin();
+        updateDefaultTenantProfileConfig(tenantProfileConfig -> {
+            tenantProfileConfig.setMaxResourceSize(50000);
+        });
+        loginTenantAdmin();
+
+        String filename = "large_decoded_image.png";
+        TbResourceInfo imageInfo = uploadImage(HttpMethod.POST, "/api/image", filename, "image/png", PNG_IMAGE);
+
+        ImageDescriptor imageDescriptor = imageInfo.getDescriptor(ImageDescriptor.class);
+        assertThat(imageDescriptor.getWidth()).isEqualTo(200);
+        assertThat(imageDescriptor.getHeight()).isEqualTo(160);
+
+        ImageDescriptor previewDescriptor = imageDescriptor.getPreviewDescriptor();
+        assertThat(previewDescriptor.getMediaType()).isEqualTo("image/gif");
+        assertThat(previewDescriptor.getWidth()).isEqualTo(1);
+        assertThat(previewDescriptor.getHeight()).isEqualTo(1);
+
+        assertThat(downloadImagePreview("tenant", filename)).containsExactly(ImageUtils.PLACEHOLDER_PREVIEW);
+
+        // Reset maxResourceSize
+        loginSysAdmin();
+        updateDefaultTenantProfileConfig(tenantProfileConfig -> {
+            tenantProfileConfig.setMaxResourceSize(0);
+        });
     }
 
     @Test

--- a/dao/src/main/java/org/thingsboard/server/dao/resource/BaseImageService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/resource/BaseImageService.java
@@ -138,8 +138,8 @@ public class BaseImageService extends BaseResourceService implements ImageServic
         resourceValidator.validate(image, TbResourceInfo::getTenantId);
 
         ImageDescriptor descriptor = image.getDescriptor(ImageDescriptor.class);
-        long maxDecodedImageSize = resourceValidator.getMaxResourceSize(image.getTenantId());
-        Pair<ImageDescriptor, byte[]> result = processImage(image.getData(), descriptor, maxDecodedImageSize);
+        long maxResourceSize = resourceValidator.getMaxResourceSize(image.getTenantId());
+        Pair<ImageDescriptor, byte[]> result = processImage(image.getData(), descriptor, maxResourceSize);
         descriptor = result.getLeft();
         image.setEtag(descriptor.getEtag());
         image.setDescriptorValue(descriptor);
@@ -153,14 +153,14 @@ public class BaseImageService extends BaseResourceService implements ImageServic
         return new TbResourceInfo(doSaveResource(image));
     }
 
-    private Pair<ImageDescriptor, byte[]> processImage(byte[] data, ImageDescriptor descriptor, long maxDecodedImageSize) throws Exception {
-        if (maxDecodedImageSize > 0) {
+    private Pair<ImageDescriptor, byte[]> processImage(byte[] data, ImageDescriptor descriptor, long maxResourceSize) throws Exception {
+        if (maxResourceSize > 0) {
             int[] dimensions = ImageUtils.getImageDimensions(data, descriptor.getMediaType());
             if (dimensions != null) {
                 long decodedSize = (long) dimensions[0] * dimensions[1] * 4;
-                if (decodedSize > maxDecodedImageSize) {
-                    log.info("Image decoded size ({} bytes) exceeds max decoded image size ({} bytes), skipping preview generation",
-                            decodedSize, maxDecodedImageSize);
+                if (decodedSize > maxResourceSize) {
+                    log.info("Image decoded size ({} bytes) exceeds maxResourceSize ({} bytes), skipping preview generation",
+                            decodedSize, maxResourceSize);
                     descriptor.setWidth(dimensions[0]);
                     descriptor.setHeight(dimensions[1]);
                     descriptor.setSize(data.length);

--- a/dao/src/main/java/org/thingsboard/server/dao/resource/BaseImageService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/resource/BaseImageService.java
@@ -138,7 +138,8 @@ public class BaseImageService extends BaseResourceService implements ImageServic
         resourceValidator.validate(image, TbResourceInfo::getTenantId);
 
         ImageDescriptor descriptor = image.getDescriptor(ImageDescriptor.class);
-        Pair<ImageDescriptor, byte[]> result = processImage(image.getData(), descriptor);
+        long maxDecodedImageSize = resourceValidator.getMaxResourceSize(image.getTenantId());
+        Pair<ImageDescriptor, byte[]> result = processImage(image.getData(), descriptor, maxDecodedImageSize);
         descriptor = result.getLeft();
         image.setEtag(descriptor.getEtag());
         image.setDescriptorValue(descriptor);
@@ -152,7 +153,32 @@ public class BaseImageService extends BaseResourceService implements ImageServic
         return new TbResourceInfo(doSaveResource(image));
     }
 
-    private Pair<ImageDescriptor, byte[]> processImage(byte[] data, ImageDescriptor descriptor) throws Exception {
+    private Pair<ImageDescriptor, byte[]> processImage(byte[] data, ImageDescriptor descriptor, long maxDecodedImageSize) throws Exception {
+        if (maxDecodedImageSize > 0) {
+            int[] dimensions = ImageUtils.getImageDimensions(data, descriptor.getMediaType());
+            if (dimensions != null) {
+                long decodedSize = (long) dimensions[0] * dimensions[1] * 4;
+                if (decodedSize > maxDecodedImageSize) {
+                    log.info("Image decoded size ({} bytes) exceeds max decoded image size ({} bytes), skipping preview generation",
+                            decodedSize, maxDecodedImageSize);
+                    descriptor.setWidth(dimensions[0]);
+                    descriptor.setHeight(dimensions[1]);
+                    descriptor.setSize(data.length);
+                    descriptor.setEtag(calculateEtag(data));
+
+                    ImageDescriptor previewDescriptor = new ImageDescriptor();
+                    previewDescriptor.setWidth(1);
+                    previewDescriptor.setHeight(1);
+                    previewDescriptor.setMediaType("image/gif");
+                    previewDescriptor.setSize(ImageUtils.PLACEHOLDER_PREVIEW.length);
+                    previewDescriptor.setEtag(calculateEtag(ImageUtils.PLACEHOLDER_PREVIEW));
+                    descriptor.setPreviewDescriptor(previewDescriptor);
+
+                    return Pair.of(descriptor, ImageUtils.PLACEHOLDER_PREVIEW);
+                }
+            }
+        }
+
         ProcessedImage image = ImageUtils.processImage(data, descriptor.getMediaType(), 250);
         ProcessedImage preview = image.getPreview();
 

--- a/dao/src/main/java/org/thingsboard/server/dao/service/validator/ResourceDataValidator.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/service/validator/ResourceDataValidator.java
@@ -89,6 +89,13 @@ public class ResourceDataValidator extends DataValidator<TbResource> {
         }
     }
 
+    public long getMaxResourceSize(TenantId tenantId) {
+        if (tenantId.isSysTenantId()) {
+            return 0;
+        }
+        return tenantProfileCache.get(tenantId).getDefaultProfileConfiguration().getMaxResourceSize();
+    }
+
     public void validateResourceSize(TenantId tenantId, TbResourceId resourceId, long dataSize) {
         if (!tenantId.isSysTenantId()) {
             DefaultTenantProfileConfiguration profileConfiguration = tenantProfileCache.get(tenantId).getDefaultProfileConfiguration();

--- a/dao/src/main/java/org/thingsboard/server/dao/util/ImageUtils.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/ImageUtils.java
@@ -41,13 +41,16 @@ import org.thingsboard.common.util.JacksonUtil;
 
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageInputStream;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
@@ -56,6 +59,9 @@ import java.util.regex.Pattern;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
 public class ImageUtils {
+
+    public static final byte[] PLACEHOLDER_PREVIEW = Base64.getDecoder().decode(
+            "R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==");
 
     private static final Map<String, String> mediaTypeMappings = Map.of(
             "jpeg", "jpg",
@@ -73,6 +79,27 @@ public class ImageUtils {
                 .filter(mapping -> mapping.getValue().equals(extension))
                 .map(Map.Entry::getKey).findFirst().orElse(extension);
         return new MimeType("image", subtype).toString();
+    }
+
+    public static int[] getImageDimensions(byte[] data, String mediaType) {
+        if (mediaTypeToFileExtension(mediaType).equals("svg")) {
+            return null;
+        }
+        try (ImageInputStream iis = ImageIO.createImageInputStream(new ByteArrayInputStream(data))) {
+            var readers = ImageIO.getImageReaders(iis);
+            if (readers.hasNext()) {
+                ImageReader reader = readers.next();
+                try {
+                    reader.setInput(iis);
+                    return new int[]{reader.getWidth(0), reader.getHeight(0)};
+                } finally {
+                    reader.dispose();
+                }
+            }
+        } catch (IOException e) {
+            log.warn("Couldn't read image dimensions from metadata: {}", ExceptionUtils.getMessage(e));
+        }
+        return null;
     }
 
     public static ProcessedImage processImage(byte[] data, String mediaType, int thumbnailMaxDimension) throws Exception {

--- a/dao/src/main/java/org/thingsboard/server/dao/util/ImageUtils.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/ImageUtils.java
@@ -86,6 +86,9 @@ public class ImageUtils {
             return null;
         }
         try (ImageInputStream iis = ImageIO.createImageInputStream(new ByteArrayInputStream(data))) {
+            if (iis == null) {
+                return null;
+            }
             var readers = ImageIO.getImageReaders(iis);
             if (readers.hasNext()) {
                 ImageReader reader = readers.next();


### PR DESCRIPTION
## Summary

- Large resolution images (e.g. 17869×12802, 25MB file) cause OOM during upload because the decoded `BufferedImage` occupies ~915MB of heap
- Preview generation is now skipped when decoded image size exceeds tenant's `maxResourceSize`, saving a 1×1 transparent GIF placeholder instead
- Original image is still saved to the database as-is

## How it works

Before generating a preview thumbnail, the server reads image dimensions from metadata via `ImageReader` (without decoding the full image into memory). If the decoded size (`width × height × 4 bytes`) exceeds the tenant's `Maximum resource file size` limit, preview generation is skipped and a placeholder is saved instead.

SVG images are not affected — they use a separate processing path. For system tenants (`maxResourceSize=0`), preview is always generated as before.

**Changed files:**
- `ImageUtils.java` — added `getImageDimensions()` and `PLACEHOLDER_PREVIEW` constant
- `ResourceDataValidator.java` — added `getMaxResourceSize()` public method
- `BaseImageService.java` — added decoded size check before calling `ImageUtils.processImage()`

## Automated tests

Added `testSkipPreviewForLargeImage` in `ImageControllerTest` — sets `maxResourceSize` to 50KB, uploads a PNG whose decoded size (200×160×4 = 128KB) exceeds the limit, and verifies the preview is a placeholder GIF with dimensions 1×1.

Existing tests cover the normal path (`maxResourceSize=0`, unlimited) and remain unchanged.

## Manual testing (screenshots below)

Adding 5Mb limit 
<img width="1195" height="551" alt="Screenshot 2026-04-13 at 09 18 20" src="https://github.com/user-attachments/assets/94923d7a-ff69-4aa9-84c2-597785519872" />


Uploading the image with size 2.2Mb and decoded size: 4096 × 1844 × 4 = 30,212,096b (~30Mb). The image is uploaded but without preview.
<img width="1195" height="551" alt="Screenshot 2026-04-13 at 09 32 49" src="https://github.com/user-attachments/assets/5a46bf8b-08a9-4f6a-bbf8-bf1527af9d27" />
