### PR TITLE
Fixed CVE-2026-34487, CVE-2026-34486, CVE-2026-34483

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <metrics.version>4.2.25</metrics.version>
         <cassandra-all.version>5.0.4</cassandra-all.version> <!-- tools -->
         <guava.version>33.1.0-jre</guava.version>
+        <tomcat.version>10.1.54</tomcat.version> <!-- to fix CVE-2026-34487, CVE-2026-34486, CVE-2026-34483. TODO: remove when fixed in spring-boot-dependencies -->
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <commons-io.version>2.16.1</commons-io.version>
         <commons-logging.version>1.3.1</commons-logging.version>
@@ -1225,6 +1226,23 @@
                 <artifactId>jaxb-api</artifactId>
                 <version>${javax.xml.bind-api.version}</version>
             </dependency>
+            <!-- Temporary tomcat version override to fix CVE-2026-34487, CVE-2026-34486, CVE-2026-34483. TODO: remove when fixed in spring-boot-dependencies -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <!-- End of tomcat version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -992,6 +992,25 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Temporary tomcat version override to fix CVE-2026-34487, CVE-2026-34486, CVE-2026-34483.
+                 Must be declared before the spring-boot-dependencies BOM import to take precedence.
+                 TODO: remove when fixed in spring-boot-dependencies -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <!-- End of tomcat version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -1226,23 +1245,6 @@
                 <artifactId>jaxb-api</artifactId>
                 <version>${javax.xml.bind-api.version}</version>
             </dependency>
-            <!-- Temporary tomcat version override to fix CVE-2026-34487, CVE-2026-34486, CVE-2026-34483. TODO: remove when fixed in spring-boot-dependencies -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-el</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <!-- End of tomcat version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
## Context

Three high-severity (CVSS 7.5) vulnerabilities in Apache Tomcat ≤ 10.1.53:

- **CVE-2026-34487** — Insertion of Sensitive Information into Log File (cloud membership clustering exposes Kubernetes bearer token)
- **CVE-2026-34486** — Missing Encryption of Sensitive Data (bypass of EncryptInterceptor)
- **CVE-2026-34483** — Improper Encoding or Escaping of Output (JsonAccessLogValve)

## Fix

Overrode Tomcat version from 10.1.53 to 10.1.54 in `<properties>` and `<dependencyManagement>` — Spring Boot 3.5.13 still ships Tomcat 10.1.53, and Spring Boot 3.5.14 is not yet released.

## Result

```
mvn dependency:tree -pl application | grep tomcat
```
```
[INFO] |  +- org.springframework.boot:spring-boot-starter-tomcat:jar:3.5.13:compile
[INFO] |  |  +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.54:compile
[INFO] |  |  +- org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.54:compile
[INFO] |  |  \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.54:compile
```