### PR TITLE
Added config property to control null ordering in dashboards

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -446,6 +446,7 @@ sql:
   log_tenant_stats: "${SQL_LOG_TENANT_STATS:true}"
   # Interval in milliseconds for printing the latest statistic information about the tenant
   log_tenant_stats_interval_ms: "${SQL_LOG_TENANT_STATS_INTERVAL_MS:60000}"
+  entity_data_query_nulls_order_strategy: "${SQL_ENTITY_DATA_QUERY_NULLS_ORDER_STRATEGY:default}" # Nulls ordering strategy for sql entity data query. Possible values: default, nulls_first, nulls_last. The default value is 'default', which means postgres default behavior will be applied: NULLS LAST for ASC and NULLS FIRST for DESC. The 'nulls_first' value means that NULL values will be ordered before non-NULL values regardless of the sort order. The 'nulls_last' value means that NULL values will be ordered after non-NULL values regardless of the sort order.
   postgres:
     # Specify partitioning size for timestamp key-value storage. Example: DAYS, MONTHS, YEARS, INDEFINITE.
     ts_key_value_partitioning: "${SQL_POSTGRES_TS_KV_PARTITIONING:MONTHS}"

--- a/application/src/test/java/org/thingsboard/server/service/entitiy/EdqsEntityServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/entitiy/EdqsEntityServiceTest.java
@@ -16,19 +16,27 @@
 package org.thingsboard.server.service.entitiy;
 
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
+import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.asset.Asset;
 import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.IdBased;
+import org.thingsboard.server.common.data.kv.TimeseriesSaveResult;
 import org.thingsboard.server.common.data.page.PageData;
+import org.thingsboard.server.common.data.query.DeviceTypeFilter;
 import org.thingsboard.server.common.data.query.EntityCountQuery;
 import org.thingsboard.server.common.data.query.EntityData;
+import org.thingsboard.server.common.data.query.EntityDataPageLink;
 import org.thingsboard.server.common.data.query.EntityDataQuery;
+import org.thingsboard.server.common.data.query.EntityDataSortOrder;
+import org.thingsboard.server.common.data.query.EntityKey;
 import org.thingsboard.server.common.data.query.EntityKeyType;
 import org.thingsboard.server.common.data.query.RelationsQueryFilter;
 import org.thingsboard.server.common.data.relation.EntitySearchDirection;
@@ -43,10 +51,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.thingsboard.server.common.data.query.EntityKeyType.ENTITY_FIELD;
 
 @DaoSqlTest
 @TestPropertySource(properties = {
@@ -101,6 +112,100 @@ public class EdqsEntityServiceTest extends EntityServiceTest {
 
         deviceService.deleteDevicesByTenantId(tenantId);
         assetService.deleteAssetsByTenantId(tenantId);
+    }
+
+    // edqs has no nulls order strategies, always returns NULLs first for ASC and NULLs last for DESC
+    @Override
+    @Test
+    public void testSortByNumericTelemetryKeyWithDifferentNullsOrderStrategy() throws ExecutionException, InterruptedException {
+        List<Device> devices = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Device device = new Device();
+            device.setTenantId(tenantId);
+            device.setName("Device" + i);
+            device.setType("default");
+            devices.add(deviceService.saveDevice(device));
+            Thread.sleep(1);
+        }
+
+        List<Long> values = List.of(1L, 0L, 0L);
+        List<ListenableFuture<TimeseriesSaveResult>> timeseriesFutures = new ArrayList<>();
+        for (int i = 0; i < values.size(); i++) {
+            timeseriesFutures.add(saveTimeseries(devices.get(i).getId(), "test", values.get(i)));
+        }
+        Futures.allAsList(timeseriesFutures).get();
+
+        DeviceTypeFilter filter = new DeviceTypeFilter();
+        filter.setDeviceTypes(List.of("default"));
+        filter.setDeviceNameFilter("");
+
+        List<EntityKey> entityFields = Collections.singletonList(new EntityKey(ENTITY_FIELD, "name"));
+        List<EntityKey> latestValues = Collections.singletonList(new EntityKey(EntityKeyType.TIME_SERIES, "test"));
+
+        EntityDataSortOrder ascSortOrder = new EntityDataSortOrder(
+                new EntityKey(EntityKeyType.TIME_SERIES, "test"), EntityDataSortOrder.Direction.ASC);
+        EntityDataQuery ascQuery = new EntityDataQuery(filter,
+                new EntityDataPageLink(10, 0, null, ascSortOrder), entityFields, latestValues, null);
+        List<String> ascTelemetry = loadAllData(ascQuery, devices.size()).stream()
+                .map(ed -> ed.getLatest().get(EntityKeyType.TIME_SERIES).get("test").getValue())
+                .toList();
+        assertThat(ascTelemetry).containsExactlyElementsOf(List.of("", "", "0", "0", "1"));
+
+        EntityDataSortOrder descSortOrder = new EntityDataSortOrder(
+                new EntityKey(EntityKeyType.TIME_SERIES, "test"), EntityDataSortOrder.Direction.DESC);
+        EntityDataQuery descQuery = new EntityDataQuery(filter,
+                new EntityDataPageLink(10, 0, null, descSortOrder), entityFields, latestValues, null);
+        List<String> descTelemetry = loadAllData(descQuery, devices.size()).stream()
+                .map(ed -> ed.getLatest().get(EntityKeyType.TIME_SERIES).get("test").getValue())
+                .toList();
+        assertThat(descTelemetry).containsExactlyElementsOf(List.of("1", "0", "0", "", ""));
+    }
+
+    // edqs has no nulls order strategies, always returns NULLs first for ASC and NULLs last for DESC
+    @Override
+    @Test
+    public void testSortByBooleanKeyWithDifferentNullsOrderStrategy() throws ExecutionException, InterruptedException {
+        List<Device> devices = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            Device device = new Device();
+            device.setTenantId(tenantId);
+            device.setName("Device" + i);
+            device.setType("default");
+            devices.add(deviceService.saveDevice(device));
+            Thread.sleep(1);
+        }
+
+        List<Boolean> values = List.of(true, false, false);
+        List<ListenableFuture<TimeseriesSaveResult>> timeseriesFutures = new ArrayList<>();
+        for (int i = 0; i < values.size(); i++) {
+            timeseriesFutures.add(saveTimeseries(devices.get(i).getId(), "test", values.get(i)));
+        }
+        Futures.allAsList(timeseriesFutures).get();
+
+        DeviceTypeFilter filter = new DeviceTypeFilter();
+        filter.setDeviceTypes(List.of("default"));
+        filter.setDeviceNameFilter("");
+
+        List<EntityKey> entityFields = Collections.singletonList(new EntityKey(ENTITY_FIELD, "name"));
+        List<EntityKey> latestValues = Collections.singletonList(new EntityKey(EntityKeyType.TIME_SERIES, "test"));
+
+        EntityDataSortOrder ascSortOrder = new EntityDataSortOrder(
+                new EntityKey(EntityKeyType.TIME_SERIES, "test"), EntityDataSortOrder.Direction.ASC);
+        EntityDataQuery ascQuery = new EntityDataQuery(filter,
+                new EntityDataPageLink(10, 0, null, ascSortOrder), entityFields, latestValues, null);
+        List<String> ascTelemetry = loadAllData(ascQuery, devices.size()).stream()
+                .map(ed -> ed.getLatest().get(EntityKeyType.TIME_SERIES).get("test").getValue())
+                .toList();
+        assertThat(ascTelemetry).containsExactlyElementsOf(List.of("", "", "false", "false", "true"));
+
+        EntityDataSortOrder descSortOrder = new EntityDataSortOrder(
+                new EntityKey(EntityKeyType.TIME_SERIES, "test"), EntityDataSortOrder.Direction.DESC);
+        EntityDataQuery descQuery = new EntityDataQuery(filter,
+                new EntityDataPageLink(10, 0, null, descSortOrder), entityFields, latestValues, null);
+        List<String> descTelemetry = loadAllData(descQuery, devices.size()).stream()
+                .map(ed -> ed.getLatest().get(EntityKeyType.TIME_SERIES).get("test").getValue())
+                .toList();
+        assertThat(descTelemetry).containsExactlyElementsOf(List.of("true", "false", "false", "", ""));
     }
 
     @Override

--- a/application/src/test/java/org/thingsboard/server/service/entitiy/EntityServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/entitiy/EntityServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.server.common.data.AttributeScope;
 import org.thingsboard.server.common.data.Customer;
@@ -47,6 +48,7 @@ import org.thingsboard.server.common.data.kv.AttributeKvEntry;
 import org.thingsboard.server.common.data.kv.AttributesSaveResult;
 import org.thingsboard.server.common.data.kv.BaseAttributeKvEntry;
 import org.thingsboard.server.common.data.kv.BasicTsKvEntry;
+import org.thingsboard.server.common.data.kv.BooleanDataEntry;
 import org.thingsboard.server.common.data.kv.DoubleDataEntry;
 import org.thingsboard.server.common.data.kv.KvEntry;
 import org.thingsboard.server.common.data.kv.LongDataEntry;
@@ -79,7 +81,6 @@ import org.thingsboard.server.common.data.query.RelationsQueryFilter;
 import org.thingsboard.server.common.data.query.SingleEntityFilter;
 import org.thingsboard.server.common.data.query.StringFilterPredicate;
 import org.thingsboard.server.common.data.query.StringFilterPredicate.StringOperation;
-import org.thingsboard.server.common.data.query.TsValue;
 import org.thingsboard.server.common.data.relation.EntityRelation;
 import org.thingsboard.server.common.data.relation.EntitySearchDirection;
 import org.thingsboard.server.common.data.relation.RelationEntityTypeFilter;
@@ -100,6 +101,7 @@ import org.thingsboard.server.dao.entityview.EntityViewDao;
 import org.thingsboard.server.dao.entityview.EntityViewService;
 import org.thingsboard.server.dao.relation.RelationService;
 import org.thingsboard.server.dao.service.DaoSqlTest;
+import org.thingsboard.server.dao.sql.query.DefaultEntityQueryRepository;
 import org.thingsboard.server.dao.sql.relation.RelationRepository;
 import org.thingsboard.server.dao.timeseries.TimeseriesService;
 import org.thingsboard.server.dao.usagerecord.ApiUsageStateService;
@@ -124,7 +126,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.thingsboard.server.common.data.AttributeScope.SERVER_SCOPE;
 import static org.thingsboard.server.common.data.query.EntityKeyType.ATTRIBUTE;
 import static org.thingsboard.server.common.data.query.EntityKeyType.ENTITY_FIELD;
-import static org.thingsboard.server.common.data.query.EntityKeyType.SERVER_ATTRIBUTE;
 
 @Slf4j
 @DaoSqlTest
@@ -153,6 +154,8 @@ public class EntityServiceTest extends AbstractControllerTest {
     EntityService entityService;
     @Autowired
     RelationRepository relationRepository;
+    @Autowired
+    DefaultEntityQueryRepository entityQueryRepository;
     @Autowired
     RelationService relationService;
     @Autowired
@@ -1751,6 +1754,117 @@ public class EntityServiceTest extends AbstractControllerTest {
     }
 
     @Test
+    public void testSortByNumericTelemetryKeyWithDifferentNullsOrderStrategy() throws ExecutionException, InterruptedException {
+        try {
+            List<Device> devices = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                Device device = new Device();
+                device.setTenantId(tenantId);
+                device.setName("Device" + i);
+                device.setType("default");
+                devices.add(deviceService.saveDevice(device));
+                Thread.sleep(1);
+            }
+
+            List<Long> values = List.of(1L, 0L, 0L);
+            List<ListenableFuture<TimeseriesSaveResult>> timeseriesFutures = new ArrayList<>();
+            for (int i = 0; i < values.size(); i++) {
+                timeseriesFutures.add(saveTimeseries(devices.get(i).getId(), "test", values.get(i)));
+            }
+            Futures.allAsList(timeseriesFutures).get();
+
+            assertNullsOrdering("default",
+                    List.of("0", "0", "1", "", ""),
+                    List.of("", "", "1", "0", "0"),
+                    devices.size());
+
+            assertNullsOrdering("nulls_first",
+                    List.of("", "", "0", "0", "1"),
+                    List.of("", "", "1", "0", "0"),
+                    devices.size());
+
+            assertNullsOrdering("nulls_last",
+                    List.of("0", "0", "1", "", ""),
+                    List.of("1", "0", "0", "", ""),
+                    devices.size());
+        } finally {
+            deviceService.deleteDevicesByTenantId(tenantId);
+        }
+    }
+
+    @Test
+    public void testSortByBooleanKeyWithDifferentNullsOrderStrategy() throws ExecutionException, InterruptedException {
+        try {
+            List<Device> devices = new ArrayList<>();
+            for (int i = 0; i < 5; i++) {
+                Device device = new Device();
+                device.setTenantId(tenantId);
+                device.setName("Device" + i);
+                device.setType("default");
+                devices.add(deviceService.saveDevice(device));
+                Thread.sleep(1);
+            }
+
+            List<Boolean> values = List.of(true, false, false);
+            List<ListenableFuture<TimeseriesSaveResult>> timeseriesFutures = new ArrayList<>();
+            for (int i = 0; i < values.size(); i++) {
+                timeseriesFutures.add(saveTimeseries(devices.get(i).getId(), "test", values.get(i)));
+            }
+            Futures.allAsList(timeseriesFutures).get();
+
+            assertNullsOrdering("default",
+                    List.of("false", "false", "true", "", ""),
+                    List.of("", "", "true", "false", "false"),
+                    devices.size());
+
+            assertNullsOrdering("nulls_first",
+                    List.of("", "", "false", "false", "true"),
+                    List.of("", "", "true", "false", "false"),
+                    devices.size());
+
+            assertNullsOrdering("nulls_last",
+                    List.of("false", "false", "true", "", ""),
+                    List.of("true", "false", "false", "", ""),
+                    devices.size());
+        } finally {
+            deviceService.deleteDevicesByTenantId(tenantId);
+        }
+    }
+
+    private void assertNullsOrdering(String strategy, List<String> expectedAsc, List<String> expectedDesc, int deviceSize) {
+        String originalStrategy = entityQueryRepository.getNullsOrderStrategy();
+        ReflectionTestUtils.setField(entityQueryRepository, "nullsOrderStrategy", strategy);
+        try {
+            DeviceTypeFilter filter = new DeviceTypeFilter();
+            filter.setDeviceTypes(List.of("default"));
+            filter.setDeviceNameFilter("");
+
+            List<EntityKey> entityFields = Collections.singletonList(new EntityKey(ENTITY_FIELD, "name"));
+            List<EntityKey> latestValues = Collections.singletonList(new EntityKey(EntityKeyType.TIME_SERIES, "test"));
+
+            EntityDataSortOrder ascSortOrder = new EntityDataSortOrder(
+                    new EntityKey(EntityKeyType.TIME_SERIES, "test"), EntityDataSortOrder.Direction.ASC);
+            EntityDataQuery ascQuery = new EntityDataQuery(filter,
+                    new EntityDataPageLink(10, 0, null, ascSortOrder), entityFields, latestValues, null);
+            List<String> ascTelemetry = loadAllData(ascQuery, deviceSize).stream()
+                    .map(ed -> ed.getLatest().get(EntityKeyType.TIME_SERIES).get("test").getValue())
+                    .toList();
+            assertThat(ascTelemetry).as("ASC with strategy '%s'", strategy).containsExactlyElementsOf(expectedAsc);
+
+            EntityDataSortOrder descSortOrder = new EntityDataSortOrder(
+                    new EntityKey(EntityKeyType.TIME_SERIES, "test"), EntityDataSortOrder.Direction.DESC);
+            EntityDataQuery descQuery = new EntityDataQuery(filter,
+                    new EntityDataPageLink(10, 0, null, descSortOrder), entityFields, latestValues, null);
+            List<String> descTelemetry = loadAllData(descQuery, deviceSize).stream()
+                    .map(ed -> ed.getLatest().get(EntityKeyType.TIME_SERIES).get("test").getValue())
+                    .toList();
+            assertThat(descTelemetry).as("DESC with strategy '%s'", strategy).containsExactlyElementsOf(expectedDesc);
+        } finally {
+            ReflectionTestUtils.setField(entityQueryRepository, "nullsOrderStrategy", originalStrategy);
+        }
+    }
+
+    @Test
     public void testFindTenantTelemetry() throws ExecutionException, InterruptedException, TimeoutException {
         // save timeseries by sys admin
         BasicTsKvEntry timeseries = new BasicTsKvEntry(42L, new DoubleDataEntry("temperature", 45.5));
@@ -2321,8 +2435,14 @@ public class EntityServiceTest extends AbstractControllerTest {
         return timeseriesService.save(tenantId, entityId, timeseries);
     }
 
-    private ListenableFuture<TimeseriesSaveResult> saveTimeseries(EntityId entityId, String key, Long value) {
+    protected ListenableFuture<TimeseriesSaveResult> saveTimeseries(EntityId entityId, String key, Long value) {
         KvEntry telemetryValue = new LongDataEntry(key, value);
+        BasicTsKvEntry timeseries = new BasicTsKvEntry(42L, telemetryValue);
+        return timeseriesService.save(tenantId, entityId, timeseries);
+    }
+
+    protected ListenableFuture<TimeseriesSaveResult> saveTimeseries(EntityId entityId, String key, Boolean value) {
+        KvEntry telemetryValue = new BooleanDataEntry(key, value);
         BasicTsKvEntry timeseries = new BasicTsKvEntry(42L, telemetryValue);
         return timeseriesService.save(tenantId, entityId, timeseries);
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultEntityQueryRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultEntityQueryRepository.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.dao.sql.query;
 
+import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -60,6 +61,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -318,6 +320,11 @@ public class DefaultEntityQueryRepository implements EntityQueryRepository {
             .replace("$in", "from").replace("$out", "to")
             .replace("$rootIdCondition", "in (:relation_root_ids)");
 
+    private static final String NULLS_ORDER_DEFAULT = "default";
+    private static final String NULLS_ORDER_FIRST = "nulls_first";
+    private static final String NULLS_ORDER_LAST = "nulls_last";
+    private static final Set<String> ACCEPTED_NULLS_ORDER_STRATEGIES = Set.of(NULLS_ORDER_DEFAULT, NULLS_ORDER_FIRST, NULLS_ORDER_LAST);
+
     @Getter
     @Value("${sql.relations.max_level:50}")
     int maxLevelAllowed; //This value has to be reasonable small to prevent infinite recursion as early as possible
@@ -334,6 +341,15 @@ public class DefaultEntityQueryRepository implements EntityQueryRepository {
         this.jdbcTemplate = jdbcTemplate;
         this.transactionTemplate = transactionTemplate;
         this.queryLog = queryLog;
+    }
+
+    @PostConstruct
+    void validateNullsOrderStrategy() {
+        if (!ACCEPTED_NULLS_ORDER_STRATEGIES.contains(nullsOrderStrategy)) {
+            log.error("Invalid value '{}' for sql.entity_data_query_nulls_order_strategy. Accepted values are: {}. Falling back to '{}'.",
+                    nullsOrderStrategy, ACCEPTED_NULLS_ORDER_STRATEGIES, NULLS_ORDER_DEFAULT);
+            nullsOrderStrategy = NULLS_ORDER_DEFAULT;
+        }
     }
 
     @Override
@@ -532,8 +548,8 @@ public class DefaultEntityQueryRepository implements EntityQueryRepository {
 
     private String resolveNullsOrder() {
         return switch (nullsOrderStrategy) {
-            case "nulls_first" -> " NULLS FIRST";
-            case "nulls_last" -> " NULLS LAST";
+            case NULLS_ORDER_FIRST -> " NULLS FIRST";
+            case NULLS_ORDER_LAST -> " NULLS LAST";
             default -> "";
         };
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultEntityQueryRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/DefaultEntityQueryRepository.java
@@ -322,6 +322,10 @@ public class DefaultEntityQueryRepository implements EntityQueryRepository {
     @Value("${sql.relations.max_level:50}")
     int maxLevelAllowed; //This value has to be reasonable small to prevent infinite recursion as early as possible
 
+    @Getter
+    @Value("${sql.entity_data_query_nulls_order_strategy:default}")
+    String nullsOrderStrategy;
+
     private final NamedParameterJdbcTemplate jdbcTemplate;
     private final TransactionTemplate transactionTemplate;
     private final DefaultQueryLogComponent queryLog;
@@ -502,11 +506,12 @@ public class DefaultEntityQueryRepository implements EntityQueryRepository {
                 if (sortOrderMappingOpt.isPresent()) {
                     EntityKeyMapping sortOrderMapping = sortOrderMappingOpt.get();
                     String direction = sortOrder.getDirection() == EntityDataSortOrder.Direction.ASC ? "asc" : "desc";
+                    String nullsOrder = resolveNullsOrder();
                     if (sortOrderMapping.getEntityKey().getType() == EntityKeyType.ENTITY_FIELD) {
-                        dataQuery = String.format("%s order by %s %s, result.id %s", dataQuery, sortOrderMapping.getValueAlias(), direction, direction);
+                        dataQuery = String.format("%s order by %s %s%s, result.id %s", dataQuery, sortOrderMapping.getValueAlias(), direction, nullsOrder, direction);
                     } else {
-                        dataQuery = String.format("%s order by %s %s, %s %s, result.id %s", dataQuery,
-                                sortOrderMapping.getSortOrderNumAlias(), direction, sortOrderMapping.getSortOrderStrAlias(), direction, direction);
+                        dataQuery = String.format("%s order by %s %s%s, %s %s, result.id %s", dataQuery,
+                                sortOrderMapping.getSortOrderNumAlias(), direction, nullsOrder, sortOrderMapping.getSortOrderStrAlias(), direction, direction);
                     }
                 }
             }
@@ -523,6 +528,14 @@ public class DefaultEntityQueryRepository implements EntityQueryRepository {
             }
             return EntityDataAdapter.createEntityData(pageLink, selectionMapping, rows, totalElements);
         });
+    }
+
+    private String resolveNullsOrder() {
+        return switch (nullsOrderStrategy) {
+            case "nulls_first" -> " NULLS FIRST";
+            case "nulls_last" -> " NULLS LAST";
+            default -> "";
+        };
     }
 
     private String buildEntityWhere(SqlQueryContext ctx, EntityFilter entityFilter, List<EntityKeyMapping> entityFieldsFilters) {

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/query/EntityKeyMapping.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/query/EntityKeyMapping.java
@@ -494,8 +494,8 @@ public class EntityKeyMapping {
             String attrNumAlias = getSortOrderNumAlias();
             String attrVarcharAlias = getSortOrderStrAlias();
             String attrSortOrderSelection =
-                    String.format("coalesce(%s.dbl_v, cast(%s.long_v as double precision), (case when %s.bool_v then 1 else 0 end)) %s," +
-                            "coalesce(%s.str_v, cast(%s.json_v as varchar), '') %s", alias, alias, alias, attrNumAlias, alias, alias, attrVarcharAlias);
+                    String.format("coalesce(%s.dbl_v, cast(%s.long_v as double precision), (case when %s.bool_v is null then null when %s.bool_v then 1 else 0 end)) %s," +
+                            "coalesce(%s.str_v, cast(%s.json_v as varchar), '') %s", alias, alias, alias, alias, attrNumAlias, alias, alias, attrVarcharAlias);
             return String.join(", ", attrValSelection, attrTsSelection, attrSortOrderSelection);
         } else {
             return String.join(", ", attrValSelection, attrTsSelection);

--- a/ui-ngx/src/app/shared/models/page/page-link.ts
+++ b/ui-ngx/src/app/shared/models/page/page-link.ts
@@ -84,11 +84,25 @@ export function sortItems(item1: any, item2: any, property: string, asc: boolean
       result = item1Value - item2Value;
     } else if (item1Type === 'string' && item2Type === 'string') {
       result = item1Value.localeCompare(item2Value);
-    } else if ((item1Type === 'boolean' && item2Type === 'boolean') || (item1Type !== item2Type)) {
-      if (item1Value && !item2Value) {
-        result = 1;
-      } else if (!item1Value && item2Value) {
-        result = -1;
+    } else if (item1Type === 'boolean' && item2Type === 'boolean') {
+      result = item1Value ? 1 : -1;
+    } else if (item1Type !== item2Type) {
+      const item1Empty = item1Value === null || item1Value === undefined || item1Value === '';
+      const item2Empty = item2Value === null || item2Value === undefined || item2Value === '';
+      if (!item1Empty && item2Empty) {
+        return asc ? 1 : -1;
+      } else if (item1Empty && !item2Empty) {
+        return asc ? -1 : 1;
+      } else if (!item1Empty && !item2Empty) {
+        const str1 = String(item1Value).trim();
+        const str2 = String(item2Value).trim();
+        const num1 = str1.length ? Number(str1) : NaN;
+        const num2 = str2.length ? Number(str2) : NaN;
+        if (!isNaN(num1) && !isNaN(num2)) {
+          result = num1 - num2;
+        } else {
+          result = String(item1Value).localeCompare(String(item2Value));
+        }
       }
     }
   }

--- a/ui-ngx/src/app/shared/models/page/page-link.ts
+++ b/ui-ngx/src/app/shared/models/page/page-link.ts
@@ -90,9 +90,9 @@ export function sortItems(item1: any, item2: any, property: string, asc: boolean
       const item1Empty = item1Value === null || item1Value === undefined || item1Value === '';
       const item2Empty = item2Value === null || item2Value === undefined || item2Value === '';
       if (!item1Empty && item2Empty) {
-        return asc ? 1 : -1;
+        result = 1;
       } else if (item1Empty && !item2Empty) {
-        return asc ? -1 : 1;
+        result = -1;
       } else if (!item1Empty && !item2Empty) {
         const str1 = String(item1Value).trim();
         const str2 = String(item2Value).trim();

--- a/ui-ngx/src/app/shared/models/page/page-link.ts
+++ b/ui-ngx/src/app/shared/models/page/page-link.ts
@@ -84,11 +84,23 @@ export function sortItems(item1: any, item2: any, property: string, asc: boolean
       result = item1Value - item2Value;
     } else if (item1Type === 'string' && item2Type === 'string') {
       result = item1Value.localeCompare(item2Value);
-    } else if ((item1Type === 'boolean' && item2Type === 'boolean') || (item1Type !== item2Type)) {
-      if (item1Value && !item2Value) {
+    } else if (item1Type === 'boolean' && item2Type === 'boolean') {
+      result = item1Value ? 1 : -1;
+    } else if (item1Type !== item2Type) {
+      const item1Empty = item1Value === null || item1Value === undefined || item1Value === '';
+      const item2Empty = item2Value === null || item2Value === undefined || item2Value === '';
+      if (!item1Empty && item2Empty) {
         result = 1;
-      } else if (!item1Value && item2Value) {
+      } else if (item1Empty && !item2Empty) {
         result = -1;
+      } else if (!item1Empty && !item2Empty) {
+        const num1 = Number(item1Value);
+        const num2 = Number(item2Value);
+        if (!isNaN(num1) && !isNaN(num2)) {
+          result = num1 - num2;
+        } else {
+          result = String(item1Value).localeCompare(String(item2Value));
+        }
       }
     }
   }


### PR DESCRIPTION
## Pull Request description

Previously, there were two issues:

1.) Backend: the PostgreSQL query handled rows with null values incorrectly, excepting null values as 0. Old query:

select * from (select entities.*, (coalesce(cast(alias5.bool_v as varchar), '') || coalesce(alias5.str_v, '') || coalesce(cast(alias5.long_v as varchar), '') || coalesce(cast(alias5.dbl_v as varchar), '') || coalesce(cast(alias5.json_v as varchar), '')) as alias5_value, alias5.ts as alias5_ts, coalesce(alias5.dbl_v, cast(alias5.long_v as double precision), **(case when alias5.bool_v then 1 else 0 end)**) alias5_value_so_num,coalesce(alias5.str_v, cast(alias5.json_v as varchar), '') alias5_value_so_varchar from (select e.id id, 'DEVICE' entity_type, cast(e.name as varchar) as alias2, cast(e.label as varchar) as alias3, cast(e.additional_info as varchar) as alias4 from device e where e.tenant_id=:permissions_tenant_id and (e.id in (:entity_filter_entity_ids))) entities left join ts_kv_latest alias5 ON alias5.entity_id=entities.id AND alias5.key = (select key_id from key_dictionary where key = :alias5_key_id)  ) result  order by alias5_value_so_num asc, alias5_value_so_varchar asc, result.id asc limit 10 offset 0

When both dbl_v and long_v are NULL (rows with no value), the **CASE WHEN alias5.bool_v THEN 1 ELSE 0 END** evaluates to 0 instead of NULL, because CASE WHEN NULL THEN 1 ELSE 0 END returns 0 in PostgreSQL.

2.) UI: incorrect sorting for empty values

3.) For SQL-backed entity data queries added a configurable nulls order strategy (default, nulls_first, nulls_last)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



