### PR TITLE
Prevented internal network access via Microsoft Teams notifications

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/notification/channels/MicrosoftTeamsNotificationChannel.java
+++ b/application/src/main/java/org/thingsboard/server/service/notification/channels/MicrosoftTeamsNotificationChannel.java
@@ -18,6 +18,7 @@ package org.thingsboard.server.service.notification.channels;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Strings;
+import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +47,7 @@ import org.thingsboard.server.common.data.notification.template.MicrosoftTeamsDe
 import org.thingsboard.server.service.notification.NotificationProcessingContext;
 import org.thingsboard.server.service.security.system.SystemSecurityService;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
@@ -63,21 +65,31 @@ public class MicrosoftTeamsNotificationChannel implements NotificationChannel<Mi
 
     private final SystemSecurityService systemSecurityService;
 
-    @Setter
-    private RestTemplate restTemplate = buildRestTemplate();
+    private final CloseableHttpClient httpClient = buildHttpClient();
 
-    private static RestTemplate buildRestTemplate() {
+    @Setter
+    private RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));
+
+    private static CloseableHttpClient buildHttpClient() {
         // Teams webhook endpoints (*.webhook.office.com, *.logic.azure.com) respond directly without 3xx redirects.
         // Disabling redirect handling prevents SSRF bypass via attacker-controlled 3xx -> internal host.
         RequestConfig requestConfig = RequestConfig.custom()
                 .setConnectTimeout(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
                 .setResponseTimeout(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
                 .build();
-        CloseableHttpClient httpClient = HttpClientBuilder.create()
+        return HttpClientBuilder.create()
                 .disableRedirectHandling()
                 .setDefaultRequestConfig(requestConfig)
                 .build();
-        return new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        try {
+            httpClient.close();
+        } catch (IOException e) {
+            log.warn("Failed to close Microsoft Teams HTTP client", e);
+        }
     }
 
     @Override
@@ -170,22 +182,24 @@ public class MicrosoftTeamsNotificationChannel implements NotificationChannel<Mi
         headers.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<String> request = new HttpEntity<>(JacksonUtil.toString(body), headers);
 
+        // Webhook URL contains a secret token in its path — log host only to keep credentials out of log aggregators.
+        String webhookHost = webhookUri.getHost();
         ResponseEntity<String> response;
         try {
             response = restTemplate.postForEntity(webhookUri, request, String.class);
         } catch (RestClientResponseException e) {
             log.warn("Microsoft Teams webhook returned non-success status {}", e.getStatusCode());
-            log.debug("Microsoft Teams webhook error response for [{}]", webhookUri, e);
+            log.debug("Microsoft Teams webhook error response from host [{}]", webhookHost, e);
             throw new RuntimeException(GENERIC_FAILURE_MESSAGE);
         } catch (RestClientException e) {
             log.warn("Microsoft Teams webhook is unreachable");
-            log.debug("Failed to send message to Microsoft Teams webhook [{}]", webhookUri, e);
+            log.debug("Failed to send message to Microsoft Teams webhook host [{}]", webhookHost, e);
             throw new RuntimeException(GENERIC_FAILURE_MESSAGE);
         }
         if (!response.getStatusCode().is2xxSuccessful()) {
             log.warn("Microsoft Teams webhook returned unexpected status {}", response.getStatusCode());
-            log.debug("Microsoft Teams webhook returned status {} for [{}], headers: {}",
-                    response.getStatusCode(), webhookUri, response.getHeaders());
+            log.debug("Microsoft Teams webhook returned status {} from host [{}]",
+                    response.getStatusCode(), webhookHost);
             throw new RuntimeException(GENERIC_FAILURE_MESSAGE);
         }
     }

--- a/application/src/main/java/org/thingsboard/server/service/notification/channels/MicrosoftTeamsNotificationChannel.java
+++ b/application/src/main/java/org/thingsboard/server/service/notification/channels/MicrosoftTeamsNotificationChannel.java
@@ -20,13 +20,20 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Strings;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import org.thingsboard.common.util.JacksonUtil;
 import org.thingsboard.common.util.SsrfProtectionValidator;
@@ -42,21 +49,36 @@ import org.thingsboard.server.service.security.system.SystemSecurityService;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MicrosoftTeamsNotificationChannel implements NotificationChannel<MicrosoftTeamsNotificationTargetConfig, MicrosoftTeamsDeliveryMethodNotificationTemplate> {
 
+    private static final Duration TIMEOUT = Duration.ofSeconds(15);
+    private static final String GENERIC_FAILURE_MESSAGE = "Failed to send message to Microsoft Teams";
+
     private final SystemSecurityService systemSecurityService;
 
     @Setter
-    private RestTemplate restTemplate = new RestTemplateBuilder()
-            .setConnectTimeout(Duration.of(15, ChronoUnit.SECONDS))
-            .setReadTimeout(Duration.of(15, ChronoUnit.SECONDS))
-            .build();
+    private RestTemplate restTemplate = buildRestTemplate();
+
+    private static RestTemplate buildRestTemplate() {
+        // Teams webhook endpoints (*.webhook.office.com, *.logic.azure.com) respond directly without 3xx redirects.
+        // Disabling redirect handling prevents SSRF bypass via attacker-controlled 3xx -> internal host.
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
+                .setResponseTimeout(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
+                .build();
+        CloseableHttpClient httpClient = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+        return new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));
+    }
 
     @Override
     public void sendNotification(MicrosoftTeamsNotificationTargetConfig targetConfig, MicrosoftTeamsDeliveryMethodNotificationTemplate processedTemplate, NotificationProcessingContext ctx) throws Exception {
@@ -110,13 +132,7 @@ public class MicrosoftTeamsNotificationChannel implements NotificationChannel<Mi
             adaptiveCard.getActions().add(actionOpenUrl);
         }
 
-        URI webhookUri = new URI(targetConfig.getWebhookUrl());
-        SsrfProtectionValidator.validateUri(webhookUri);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<String> request = new HttpEntity<>(JacksonUtil.toString(teamsAdaptiveCard), headers);
-        restTemplate.postForEntity(webhookUri, request, String.class);
+        post(targetConfig.getWebhookUrl(), teamsAdaptiveCard);
     }
 
     private void sendTeamsMessageCard(MicrosoftTeamsNotificationTargetConfig targetConfig, MicrosoftTeamsDeliveryMethodNotificationTemplate processedTemplate, NotificationProcessingContext ctx) throws JsonProcessingException, URISyntaxException {
@@ -143,13 +159,35 @@ public class MicrosoftTeamsNotificationChannel implements NotificationChannel<Mi
             teamsMessageCard.setPotentialAction(List.of(actionCard));
         }
 
-        URI webhookUri = new URI(targetConfig.getWebhookUrl());
+        post(targetConfig.getWebhookUrl(), teamsMessageCard);
+    }
+
+    private void post(String webhookUrl, Object body) throws URISyntaxException {
+        URI webhookUri = new URI(webhookUrl);
         SsrfProtectionValidator.validateUri(webhookUri);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<String> request = new HttpEntity<>(JacksonUtil.toString(teamsMessageCard), headers);
-        restTemplate.postForEntity(webhookUri, request, String.class);
+        HttpEntity<String> request = new HttpEntity<>(JacksonUtil.toString(body), headers);
+
+        ResponseEntity<String> response;
+        try {
+            response = restTemplate.postForEntity(webhookUri, request, String.class);
+        } catch (RestClientResponseException e) {
+            log.warn("Microsoft Teams webhook returned non-success status {}", e.getStatusCode());
+            log.debug("Microsoft Teams webhook error response for [{}]", webhookUri, e);
+            throw new RuntimeException(GENERIC_FAILURE_MESSAGE);
+        } catch (RestClientException e) {
+            log.warn("Microsoft Teams webhook is unreachable");
+            log.debug("Failed to send message to Microsoft Teams webhook [{}]", webhookUri, e);
+            throw new RuntimeException(GENERIC_FAILURE_MESSAGE);
+        }
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            log.warn("Microsoft Teams webhook returned unexpected status {}", response.getStatusCode());
+            log.debug("Microsoft Teams webhook returned status {} for [{}], headers: {}",
+                    response.getStatusCode(), webhookUri, response.getHeaders());
+            throw new RuntimeException(GENERIC_FAILURE_MESSAGE);
+        }
     }
 
     private String getButtonUri(MicrosoftTeamsDeliveryMethodNotificationTemplate processedTemplate, NotificationProcessingContext ctx) throws JsonProcessingException {

--- a/application/src/test/java/org/thingsboard/server/service/notification/channels/MicrosoftTeamsNotificationChannelTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/notification/channels/MicrosoftTeamsNotificationChannelTest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.notification.channels;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import org.thingsboard.server.common.data.notification.targets.MicrosoftTeamsNotificationTargetConfig;
+import org.thingsboard.server.common.data.notification.template.MicrosoftTeamsDeliveryMethodNotificationTemplate;
+import org.thingsboard.server.service.security.system.SystemSecurityService;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MicrosoftTeamsNotificationChannelTest {
+
+    private static final String GENERIC_FAILURE = "Failed to send message to Microsoft Teams";
+
+    @Mock
+    private RestTemplate restTemplate;
+    @Mock
+    private SystemSecurityService systemSecurityService;
+
+    private MicrosoftTeamsNotificationChannel channel;
+    private MicrosoftTeamsNotificationTargetConfig targetConfig;
+    private MicrosoftTeamsDeliveryMethodNotificationTemplate template;
+
+    @BeforeEach
+    void setUp() {
+        channel = new MicrosoftTeamsNotificationChannel(systemSecurityService);
+        channel.setRestTemplate(restTemplate);
+
+        targetConfig = new MicrosoftTeamsNotificationTargetConfig();
+        targetConfig.setWebhookUrl("https://example.webhook.office.com/hook");
+        targetConfig.setChannelName("test");
+        targetConfig.setUseOldApi(true);
+
+        template = new MicrosoftTeamsDeliveryMethodNotificationTemplate();
+        template.setBody("body");
+    }
+
+    @Test
+    void successfulPostDoesNotThrow() throws Exception {
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class)))
+                .thenReturn(new ResponseEntity<>("1", HttpStatus.OK));
+
+        assertThatCode(() -> channel.sendNotification(targetConfig, template, null))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void adaptiveCardPathSucceeds() throws Exception {
+        targetConfig.setUseOldApi(false);
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class)))
+                .thenReturn(new ResponseEntity<>("1", HttpStatus.OK));
+
+        assertThatCode(() -> channel.sendNotification(targetConfig, template, null))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void errorResponseStatusAndBodyAreNotLeaked() {
+        HttpClientErrorException upstream = HttpClientErrorException.create(
+                HttpStatus.NOT_FOUND, "Not Found",
+                HttpHeaders.EMPTY,
+                "<html>SECRET INTERNAL 404 PAGE</html>".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8);
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class))).thenThrow(upstream);
+
+        Throwable thrown = catchThrowable(() -> channel.sendNotification(targetConfig, template, null));
+
+        assertThat(thrown).isInstanceOf(RuntimeException.class);
+        assertThat(thrown.getMessage())
+                .isEqualTo(GENERIC_FAILURE)
+                .doesNotContain("404")
+                .doesNotContain("SECRET INTERNAL 404 PAGE");
+    }
+
+    @Test
+    void connectionErrorMessageDoesNotExposeTarget() {
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class)))
+                .thenThrow(new ResourceAccessException("I/O error on POST request for \"http://172.17.0.1:8181\": Connection refused"));
+
+        Throwable thrown = catchThrowable(() -> channel.sendNotification(targetConfig, template, null));
+
+        assertThat(thrown).isInstanceOf(RuntimeException.class);
+        assertThat(thrown.getMessage())
+                .isEqualTo(GENERIC_FAILURE)
+                .doesNotContain("172.17.0.1");
+    }
+
+    @Test
+    void redirectResponseIsRejectedWithoutLeak() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create("http://127.0.0.1/internal"));
+        ResponseEntity<String> redirect = new ResponseEntity<>("", headers, HttpStatus.FOUND);
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class))).thenReturn(redirect);
+
+        Throwable thrown = catchThrowable(() -> channel.sendNotification(targetConfig, template, null));
+
+        assertThat(thrown).isInstanceOf(RuntimeException.class);
+        assertThat(thrown.getMessage())
+                .isEqualTo(GENERIC_FAILURE)
+                .doesNotContain("127.0.0.1")
+                .doesNotContain("302")
+                .doesNotContain("redirect");
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/service/notification/channels/MicrosoftTeamsNotificationChannelTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/notification/channels/MicrosoftTeamsNotificationChannelTest.java
@@ -15,6 +15,7 @@
  */
 package org.thingsboard.server.service.notification.channels;
 
+import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,8 +31,10 @@ import org.thingsboard.server.common.data.notification.targets.MicrosoftTeamsNot
 import org.thingsboard.server.common.data.notification.template.MicrosoftTeamsDeliveryMethodNotificationTemplate;
 import org.thingsboard.server.service.security.system.SystemSecurityService;
 
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -133,6 +136,50 @@ class MicrosoftTeamsNotificationChannelTest {
                 .doesNotContain("127.0.0.1")
                 .doesNotContain("302")
                 .doesNotContain("redirect");
+    }
+
+    // Verifies that the RestTemplate built by the channel does not follow 3xx responses at the HTTP-client layer.
+    // The mocked-RestTemplate test above only exercises the response-status check; this one guards against a
+    // refactor that accidentally drops disableRedirectHandling() and reopens the SSRF bypass.
+    @Test
+    void disableRedirectHandlingPreventsFollowUpToInternalHost() throws Exception {
+        AtomicInteger redirectTargetHits = new AtomicInteger();
+        HttpServer redirectTarget = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        redirectTarget.createContext("/internal", exchange -> {
+            redirectTargetHits.incrementAndGet();
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        redirectTarget.start();
+
+        HttpServer redirector = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        redirector.createContext("/hook", exchange -> {
+            exchange.getResponseHeaders().add("Location",
+                    "http://127.0.0.1:" + redirectTarget.getAddress().getPort() + "/internal");
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+        redirector.start();
+
+        try {
+            // Use the channel's own RestTemplate (default-initialized via buildHttpClient()) — do NOT call setRestTemplate.
+            MicrosoftTeamsNotificationChannel realChannel = new MicrosoftTeamsNotificationChannel(systemSecurityService);
+            try {
+                targetConfig.setWebhookUrl("http://127.0.0.1:" + redirector.getAddress().getPort() + "/hook");
+
+                Throwable thrown = catchThrowable(() -> realChannel.sendNotification(targetConfig, template, null));
+                assertThat(thrown).isInstanceOf(RuntimeException.class);
+                assertThat(thrown.getMessage()).isEqualTo(GENERIC_FAILURE);
+                assertThat(redirectTargetHits.get())
+                        .as("HttpClient5 must not follow 3xx — disableRedirectHandling() regression?")
+                        .isZero();
+            } finally {
+                realChannel.shutdown();
+            }
+        } finally {
+            redirector.stop(0);
+            redirectTarget.stop(0);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- Disable HTTP redirect following in Microsoft Teams notification channel to prevent SSRF bypass via attacker-controlled 3xx redirects to internal hosts
- Sanitize all error paths to return a generic failure message without leaking status codes, response bodies, or target URLs
- Switch to `HttpComponentsClientHttpRequestFactory` with `HttpClientBuilder.disableRedirectHandling()` to keep HttpClient5 connection pooling while blocking redirects
- Extract shared `post()` method to ensure both Adaptive Card and Message Card paths go through the same validation and error handling

## Automated testing
- Successful POST (200) does not throw — both Message Card (`useOldApi=true`) and Adaptive Card (`useOldApi=false`) paths
- HTTP error response (e.g. 404) returns generic message, does not leak status code or response body
- Connection error returns generic message, does not leak internal IP/port
- Redirect response (302) is rejected with generic message, does not leak Location header or status code

## Manual testing
- **Info disclosure blocked** — Workflow URL pointing to internal server returning HTML body → generic error in UI, no URL/status/body leaked                                                               
  - **Redirect not followed** — Workflow URL pointing to server returning 302 to internal host → generic error in UI, internal server got no request
  
<img width="847" height="507" alt="Screenshot 2026-04-16 at 09 56 45" src="https://github.com/user-attachments/assets/9d22730a-634c-4457-a477-41ed081d634c" />
                                                          
  - **Happy path** — Workflow URL pointing to mock server returning 200 → sent successfully, both old and new API
  
<img width="847" height="507" alt="Screenshot 2026-04-16 at 10 02 02" src="https://github.com/user-attachments/assets/6028fd78-514d-4c47-9fe4-245eaa306583" />
