### PR TITLE
Fixed alarm rule crash on duration source change

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/calculatedField/CalculatedFieldEntityMessageProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/calculatedField/CalculatedFieldEntityMessageProcessor.java
@@ -485,7 +485,6 @@ public class CalculatedFieldEntityMessageProcessor extends AbstractContextAwareM
 
     private void initState(CalculatedFieldState state, CalculatedFieldCtx ctx) {
         state.setCtx(ctx, actorCtx);
-        state.init(false);
 
         if (ctx.getCfType() == CalculatedFieldType.GEOFENCING && ctx.isCfHasRelationPathQuerySource()) {
             GeofencingCalculatedFieldState geofencingState = (GeofencingCalculatedFieldState) state;
@@ -494,6 +493,7 @@ public class CalculatedFieldEntityMessageProcessor extends AbstractContextAwareM
 
         Map<String, ArgumentEntry> arguments = fetchArguments(ctx);
         state.update(arguments, ctx);
+        state.init(false);
 
         state.checkStateSize(new CalculatedFieldEntityCtxId(tenantId, ctx.getCfId(), entityId), ctx.getMaxStateSize());
         states.put(ctx.getCfId(), state);

--- a/application/src/test/java/org/thingsboard/server/cf/AlarmRulesTest.java
+++ b/application/src/test/java/org/thingsboard/server/cf/AlarmRulesTest.java
@@ -403,6 +403,54 @@ public class AlarmRulesTest extends AbstractControllerTest {
     }
 
     @Test
+    public void testChangeDurationConditionFromStaticToDynamic() throws Exception {
+        Argument temperatureArgument = new Argument();
+        temperatureArgument.setRefEntityKey(new ReferencedEntityKey("temperature", ArgumentType.TS_LATEST, null));
+        temperatureArgument.setDefaultValue("0");
+        Map<String, Argument> arguments = new HashMap<>(Map.of(
+                "temperature", temperatureArgument
+        ));
+
+        long staticDurationMs = 5000L;
+        Map<AlarmSeverity, Condition> createRules = Map.of(
+                AlarmSeverity.CRITICAL, new Condition("return temperature >= 50;", null, staticDurationMs)
+        );
+
+        CalculatedField calculatedField = createAlarmCf(deviceId, "High Temperature Alarm",
+                arguments, createRules, null);
+
+        // post telemetry to trigger condition, so that firstEventTs > 0 in AlarmRuleState
+        postTelemetry(deviceId, "{\"temperature\":50}");
+        Thread.sleep(1000);
+
+        // update CF: add attribute argument and switch duration from static to dynamic
+        AlarmCalculatedFieldConfiguration configuration =
+                (AlarmCalculatedFieldConfiguration) calculatedField.getConfiguration();
+
+        Argument durationArgument = new Argument();
+        durationArgument.setRefEntityKey(new ReferencedEntityKey("durationThreshold",
+                ArgumentType.ATTRIBUTE, AttributeScope.SERVER_SCOPE));
+        durationArgument.setDefaultValue("-1");
+        configuration.getArguments().put("durationThreshold", durationArgument);
+
+        DurationAlarmCondition durationCondition = (DurationAlarmCondition)
+                configuration.getCreateRules().get(AlarmSeverity.CRITICAL).getCondition();
+        durationCondition.setValue(new AlarmConditionValue<>(null, "durationThreshold"));
+
+        calculatedField = saveCalculatedField(calculatedField);
+
+        long dynamicDurationMs = 3000L;
+        postAttributes(deviceId, AttributeScope.SERVER_SCOPE,
+                "{\"durationThreshold\":" + dynamicDurationMs + "}");
+
+        checkAlarmResult(calculatedField, alarmResult -> {
+            assertThat(alarmResult.isCreated()).isTrue();
+            assertThat(alarmResult.getAlarm().getSeverity()).isEqualTo(AlarmSeverity.CRITICAL);
+            assertThat(alarmResult.getAlarm().getStatus()).isEqualTo(AlarmStatus.ACTIVE_UNACK);
+        });
+    }
+
+    @Test
     public void testCreateAlarm_currentOwnerArgument() throws Exception {
         Argument temperatureArgument = new Argument();
         temperatureArgument.setRefEntityKey(new ReferencedEntityKey("temperature", ArgumentType.TS_LATEST, null));

--- a/application/src/test/java/org/thingsboard/server/cf/AlarmRulesTest.java
+++ b/application/src/test/java/org/thingsboard/server/cf/AlarmRulesTest.java
@@ -407,9 +407,9 @@ public class AlarmRulesTest extends AbstractControllerTest {
         Argument temperatureArgument = new Argument();
         temperatureArgument.setRefEntityKey(new ReferencedEntityKey("temperature", ArgumentType.TS_LATEST, null));
         temperatureArgument.setDefaultValue("0");
-        Map<String, Argument> arguments = new HashMap<>(Map.of(
+        Map<String, Argument> arguments = Map.of(
                 "temperature", temperatureArgument
-        ));
+        );
 
         long staticDurationMs = 5000L;
         Map<AlarmSeverity, Condition> createRules = Map.of(
@@ -419,9 +419,13 @@ public class AlarmRulesTest extends AbstractControllerTest {
         CalculatedField calculatedField = createAlarmCf(deviceId, "High Temperature Alarm",
                 arguments, createRules, null);
 
-        // post telemetry to trigger condition, so that firstEventTs > 0 in AlarmRuleState
+        // post telemetry to trigger condition and wait for the static-phase eval to produce a debug event,
+        // which guarantees firstEventTs > 0 in AlarmRuleState before we trigger REINIT
         postTelemetry(deviceId, "{\"temperature\":50}");
-        Thread.sleep(1000);
+        CalculatedFieldId cfId = calculatedField.getId();
+        await().atMost(TIMEOUT, TimeUnit.SECONDS)
+                .until(() -> getDebugEvents(cfId, 1),
+                        events -> !events.isEmpty() && !events.get(0).getId().equals(latestEventId));
 
         // update CF: add attribute argument and switch duration from static to dynamic
         AlarmCalculatedFieldConfiguration configuration =


### PR DESCRIPTION
## Summary
- During REINIT, `init()` was called before `fetchArguments()`, so when a DURATION alarm rule with active tracking (`firstEventTs > 0`) tried to resolve a newly added dynamic argument, the arguments map was empty → `IllegalArgumentException: Argument 'X' is missing`
- Moved `fetchArguments()` + `state.update()` before `state.init(false)` in `initState()`

## Automated testing
- `testChangeDurationConditionFromStaticToDynamic` — create alarm with static duration → trigger condition so `firstEventTs > 0` → switch duration to dynamic with new attribute argument → verify alarm is created without "Argument is missing" error

## Manual testing
  - Created alarm rule with static duration (5s) on a device                                                                                                                                                  
  - Posted telemetry (temperature=50) to trigger condition and set firstEventTs > 0                                                                                                                           
  - Edited alarm rule: added server attribute argument durationThreshold, switched duration from static to dynamic                                                                                            
  - Saved — no Argument missing error in logs (this is where it crashed before the fix)                                                                                                                       
  - Posted server attribute durationThreshold=3000 — existing alarm preserved, no errors