### PR TITLE
Fixed app hanging on MQTT port conflict at startup

### DIFF
--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportService.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportService.java
@@ -78,9 +78,9 @@ public class MqttTransportService implements TbTransportService {
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.valueOf(leakDetectorLevel.toUpperCase()));
 
         log.info("Starting MQTT transport...");
-        bossGroup = new NioEventLoopGroup(bossGroupThreadCount);
-        workerGroup = new NioEventLoopGroup(workerGroupThreadCount);
         try {
+            bossGroup = new NioEventLoopGroup(bossGroupThreadCount);
+            workerGroup = new NioEventLoopGroup(workerGroupThreadCount);
             ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)
                     .channel(NioServerSocketChannel.class)
@@ -96,7 +96,7 @@ public class MqttTransportService implements TbTransportService {
                         .childOption(ChannelOption.SO_KEEPALIVE, keepAlive);
                 sslServerChannel = b.bind(sslHost, sslPort).sync().channel();
             }
-        } catch (Throwable e) {
+        } catch (Exception e) {
             log.error("Failed to start MQTT transport, releasing resources", e);
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
@@ -108,16 +108,17 @@ public class MqttTransportService implements TbTransportService {
                 if (sslServerChannel != null) {
                     sslServerChannel.close().sync();
                 }
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
+            } catch (Exception suppressed) {
+                e.addSuppressed(suppressed);
             } finally {
-                workerGroup.shutdownGracefully();
-                bossGroup.shutdownGracefully();
+                if (workerGroup != null) {
+                    workerGroup.shutdownGracefully();
+                }
+                if (bossGroup != null) {
+                    bossGroup.shutdownGracefully();
+                }
             }
-            if (e instanceof Exception) {
-                throw (Exception) e;
-            }
-            throw (Error) e;
+            throw e;
         }
         log.info("Mqtt transport started!");
     }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportService.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportService.java
@@ -96,17 +96,28 @@ public class MqttTransportService implements TbTransportService {
                         .childOption(ChannelOption.SO_KEEPALIVE, keepAlive);
                 sslServerChannel = b.bind(sslHost, sslPort).sync().channel();
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             log.error("Failed to start MQTT transport, releasing resources", e);
-            if (serverChannel != null) {
-                serverChannel.close();
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
             }
-            if (sslServerChannel != null) {
-                sslServerChannel.close();
+            try {
+                if (serverChannel != null) {
+                    serverChannel.close().sync();
+                }
+                if (sslServerChannel != null) {
+                    sslServerChannel.close().sync();
+                }
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            } finally {
+                workerGroup.shutdownGracefully();
+                bossGroup.shutdownGracefully();
             }
-            workerGroup.shutdownGracefully();
-            bossGroup.shutdownGracefully();
-            throw e;
+            if (e instanceof Exception) {
+                throw (Exception) e;
+            }
+            throw (Error) e;
         }
         log.info("Mqtt transport started!");
     }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportService.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportService.java
@@ -80,20 +80,33 @@ public class MqttTransportService implements TbTransportService {
         log.info("Starting MQTT transport...");
         bossGroup = new NioEventLoopGroup(bossGroupThreadCount);
         workerGroup = new NioEventLoopGroup(workerGroupThreadCount);
-        ServerBootstrap b = new ServerBootstrap();
-        b.group(bossGroup, workerGroup)
-                .channel(NioServerSocketChannel.class)
-                .childHandler(new MqttTransportServerInitializer(context, false))
-                .childOption(ChannelOption.SO_KEEPALIVE, keepAlive);
-
-        serverChannel = b.bind(host, port).sync().channel();
-        if (sslEnabled) {
-            b = new ServerBootstrap();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)
                     .channel(NioServerSocketChannel.class)
-                    .childHandler(new MqttTransportServerInitializer(context, true))
+                    .childHandler(new MqttTransportServerInitializer(context, false))
                     .childOption(ChannelOption.SO_KEEPALIVE, keepAlive);
-            sslServerChannel = b.bind(sslHost, sslPort).sync().channel();
+
+            serverChannel = b.bind(host, port).sync().channel();
+            if (sslEnabled) {
+                b = new ServerBootstrap();
+                b.group(bossGroup, workerGroup)
+                        .channel(NioServerSocketChannel.class)
+                        .childHandler(new MqttTransportServerInitializer(context, true))
+                        .childOption(ChannelOption.SO_KEEPALIVE, keepAlive);
+                sslServerChannel = b.bind(sslHost, sslPort).sync().channel();
+            }
+        } catch (Exception e) {
+            log.error("Failed to start MQTT transport, releasing resources", e);
+            if (serverChannel != null) {
+                serverChannel.close();
+            }
+            if (sslServerChannel != null) {
+                sslServerChannel.close();
+            }
+            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully();
+            throw e;
         }
         log.info("Mqtt transport started!");
     }

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportServiceTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportServiceTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.mqtt;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.net.BindException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+@ExtendWith(MockitoExtension.class)
+public class MqttTransportServiceTest {
+
+    private static final String HOST = "127.0.0.1";
+
+    @Mock
+    private MqttTransportContext context;
+
+    private MqttTransportService service;
+    private ServerSocket occupiedSocket;
+    private int occupiedPort;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        occupiedSocket = new ServerSocket(0, 50, InetAddress.getByName(HOST));
+        occupiedPort = occupiedSocket.getLocalPort();
+
+        service = new MqttTransportService();
+        ReflectionTestUtils.setField(service, "host", HOST);
+        ReflectionTestUtils.setField(service, "port", occupiedPort);
+        ReflectionTestUtils.setField(service, "sslEnabled", false);
+        ReflectionTestUtils.setField(service, "sslHost", HOST);
+        ReflectionTestUtils.setField(service, "sslPort", 0);
+        ReflectionTestUtils.setField(service, "leakDetectorLevel", "DISABLED");
+        ReflectionTestUtils.setField(service, "bossGroupThreadCount", 1);
+        ReflectionTestUtils.setField(service, "workerGroupThreadCount", 1);
+        ReflectionTestUtils.setField(service, "keepAlive", true);
+        ReflectionTestUtils.setField(service, "context", context);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (occupiedSocket != null && !occupiedSocket.isClosed()) {
+            occupiedSocket.close();
+        }
+    }
+
+    @Test
+    public void whenPlainBindFails_thenInitThrowsAndReleasesNettyResources() {
+        assertThatThrownBy(() -> service.init())
+                .isInstanceOf(BindException.class);
+
+        Channel serverChannel = (Channel) ReflectionTestUtils.getField(service, "serverChannel");
+        Channel sslServerChannel = (Channel) ReflectionTestUtils.getField(service, "sslServerChannel");
+        EventLoopGroup boss = (EventLoopGroup) ReflectionTestUtils.getField(service, "bossGroup");
+        EventLoopGroup worker = (EventLoopGroup) ReflectionTestUtils.getField(service, "workerGroup");
+
+        assertThat(serverChannel).isNull();
+        assertThat(sslServerChannel).isNull();
+        assertThat(boss).isNotNull();
+        assertThat(worker).isNotNull();
+        assertThat(boss.isShuttingDown()).isTrue();
+        assertThat(worker.isShuttingDown()).isTrue();
+
+        await().atMost(30, TimeUnit.SECONDS).until(boss::isTerminated);
+        await().atMost(30, TimeUnit.SECONDS).until(worker::isTerminated);
+    }
+
+    @Test
+    public void whenSslBindFailsAfterPlainBound_thenInitThrowsAndClosesPlainChannelAndReleasesNettyResources() {
+        ReflectionTestUtils.setField(service, "port", 0);
+        ReflectionTestUtils.setField(service, "sslEnabled", true);
+        ReflectionTestUtils.setField(service, "sslPort", occupiedPort);
+
+        assertThatThrownBy(() -> service.init())
+                .isInstanceOf(BindException.class);
+
+        Channel serverChannel = (Channel) ReflectionTestUtils.getField(service, "serverChannel");
+        Channel sslServerChannel = (Channel) ReflectionTestUtils.getField(service, "sslServerChannel");
+        EventLoopGroup boss = (EventLoopGroup) ReflectionTestUtils.getField(service, "bossGroup");
+        EventLoopGroup worker = (EventLoopGroup) ReflectionTestUtils.getField(service, "workerGroup");
+
+        assertThat(serverChannel).isNotNull();
+        assertThat(sslServerChannel).isNull();
+        assertThat(boss).isNotNull();
+        assertThat(worker).isNotNull();
+
+        await().atMost(10, TimeUnit.SECONDS).until(() -> !serverChannel.isOpen());
+
+        assertThat(boss.isShuttingDown()).isTrue();
+        assertThat(worker.isShuttingDown()).isTrue();
+        await().atMost(30, TimeUnit.SECONDS).until(boss::isTerminated);
+        await().atMost(30, TimeUnit.SECONDS).until(worker::isTerminated);
+    }
+}

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportServiceTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportServiceTest.java
@@ -20,9 +20,6 @@ import io.netty.channel.EventLoopGroup;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.net.BindException;
@@ -33,14 +30,11 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
 
-@ExtendWith(MockitoExtension.class)
 public class MqttTransportServiceTest {
 
     private static final String HOST = "127.0.0.1";
-
-    @Mock
-    private MqttTransportContext context;
 
     private MqttTransportService service;
     private ServerSocket occupiedSocket;
@@ -61,7 +55,7 @@ public class MqttTransportServiceTest {
         ReflectionTestUtils.setField(service, "bossGroupThreadCount", 1);
         ReflectionTestUtils.setField(service, "workerGroupThreadCount", 1);
         ReflectionTestUtils.setField(service, "keepAlive", true);
-        ReflectionTestUtils.setField(service, "context", context);
+        ReflectionTestUtils.setField(service, "context", mock(MqttTransportContext.class));
     }
 
     @AfterEach
@@ -76,13 +70,9 @@ public class MqttTransportServiceTest {
         assertThatThrownBy(() -> service.init())
                 .isInstanceOf(BindException.class);
 
-        Channel serverChannel = (Channel) ReflectionTestUtils.getField(service, "serverChannel");
-        Channel sslServerChannel = (Channel) ReflectionTestUtils.getField(service, "sslServerChannel");
         EventLoopGroup boss = (EventLoopGroup) ReflectionTestUtils.getField(service, "bossGroup");
         EventLoopGroup worker = (EventLoopGroup) ReflectionTestUtils.getField(service, "workerGroup");
 
-        assertThat(serverChannel).isNull();
-        assertThat(sslServerChannel).isNull();
         assertThat(boss).isNotNull();
         assertThat(worker).isNotNull();
         assertThat(boss.isShuttingDown()).isTrue();


### PR DESCRIPTION
## Summary

If the MQTT transport fails to start (for example, because `transport.mqtt.bind_port` is already in use), the JVM currently hangs instead of exiting. `MqttTransportService.init()` creates two `NioEventLoopGroup` instances before calling `bind(...).sync()`. When `bind` throws `BindException`, Spring treats the bean as failed and does not invoke the `@PreDestroy` `shutdown()` method, so the non-daemon Netty threads stay alive and prevent JVM termination. IDEA/systemd have to SIGKILL the process on timeout.

## Fix

Wrap the bootstrap/bind logic in `init()` in a `try/catch`. On any exception, close the plain and SSL server channels if they were bound, then gracefully shut down both worker and boss groups, and rethrow the original exception so Spring marks the bean as failed. `@PreDestroy` logic is unchanged (still handles the happy-path shutdown).

## Automated tests

New `MqttTransportServiceTest` with two unit tests that occupy a TCP port via `ServerSocket` and invoke `init()` via reflection:

- `whenPlainBindFails_thenInitThrowsAndReleasesNettyResources` — plain MQTT port is occupied. Verifies `BindException` is rethrown, both event loop groups enter `isShuttingDown()` and reach `isTerminated()`.
- `whenSslBindFailsAfterPlainBound_thenInitThrowsAndClosesPlainChannelAndReleasesNettyResources` — plain bind succeeds, SSL bind fails. Verifies the plain `serverChannel` is closed (`!isOpen()`) and both groups are shut down and terminated.

## Manual tests

- Normal start/stop: TB started and stopped cleanly (exit 130 on SIGINT).
- MQTT port 1883 occupied (via a helper script holding a dual-stack listener) — **before the fix**: TB printed `BindException` but JVM never exited; thread dumps showed the `nioEventLoopGroup-*` non-daemon thread alive, `DestroyJavaVM` waiting for it; the process had to be SIGKILL'd by the IDE/timeout. **After the fix**: same scenario prints `Failed to start MQTT transport, releasing resources` plus the `BindException`, and the JVM exits on its own with code 1 within seconds, no SIGKILL needed.