### PR TITLE
Ignore unknown properties when deserializing Redis cache entries

### DIFF
--- a/common/cache/src/main/java/org/thingsboard/server/cache/TbJsonRedisSerializer.java
+++ b/common/cache/src/main/java/org/thingsboard/server/cache/TbJsonRedisSerializer.java
@@ -18,6 +18,8 @@ package org.thingsboard.server.cache;
 import org.springframework.data.redis.serializer.SerializationException;
 import org.thingsboard.common.util.JacksonUtil;
 
+import java.io.IOException;
+
 public class TbJsonRedisSerializer<K, V> implements TbRedisSerializer<K, V> {
 
     private final Class<V> clazz;
@@ -33,6 +35,13 @@ public class TbJsonRedisSerializer<K, V> implements TbRedisSerializer<K, V> {
 
     @Override
     public V deserialize(K key, byte[] bytes) throws SerializationException {
-        return JacksonUtil.fromBytes(bytes, clazz);
+        if (bytes == null) {
+            return null;
+        }
+        try {
+            return JacksonUtil.IGNORE_UNKNOWN_PROPERTIES_JSON_MAPPER.readValue(bytes, clazz);
+        } catch (IOException e) {
+            throw new SerializationException("Failed to deserialize cached value", e);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `TbJsonRedisSerializer` now uses `JacksonUtil.IGNORE_UNKNOWN_PROPERTIES_JSON_MAPPER` to deserialize cached values, tolerating unknown JSON fields.
- Fixes a rolling-upgrade failure mode: if a newer node adds a field to a cached entity (e.g. `Role.excludedPermissions`) and writes it to Redis, older nodes previously failed the cache read with `UnrecognizedPropertyException` (bubbled up as `IllegalArgumentException` from `JacksonUtil.fromBytes`), since the shared `OBJECT_MAPPER` has Jackson's default `FAIL_ON_UNKNOWN_PROPERTIES = true`.
- Narrow scope: only the Redis cache serializer path is affected; `JacksonUtil.fromBytes` remains strict for all other callers.

## Notes

- This only addresses additive forward-compat (new field → old reader). Other incompatible schema changes (rename, type change, new enum constant) still require a cache key bump or eviction on deploy.