### PR TITLE
Fix flaky TbRestApiCallNodeTest via SsrfProtectionValidator ResourceLock

### DIFF
--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/rest/TbRestApiCallNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/rest/TbRestApiCallNodeTest.java
@@ -27,6 +27,7 @@ import org.apache.http.protocol.HttpRequestHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -70,6 +71,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
+@ResourceLock("SsrfProtectionValidator") // to avoid race conditions when modifying SsrfProtectionValidator's static configuration
 public class TbRestApiCallNodeTest extends AbstractRuleNodeUpgradeTest {
 
     static final long TIMEOUT = TimeUnit.SECONDS.toMillis(30);


### PR DESCRIPTION
## Summary
`TbRestApiCallNodeTest` flaked (~5–10%) in CI because it ran in parallel with `SsrfSafeAddressResolverGroupTest`, which toggles the static `SsrfProtectionValidator.enabled` flag in its `@BeforeEach`/`@AfterEach`. When the flag leaked into the REST test's async HTTP calls to `localhost`, SSRF rejected them and extra `tellFailure` invocations broke the Mockito verify count.

`TbHttpClientTest` and `SsrfSafeAddressResolverGroupTest` already declare `@ResourceLock("SsrfProtectionValidator")`; this PR applies the same lock to `TbRestApiCallNodeTest` so all three SSRF-sensitive tests in the `rest` package serialize.

No production code change — purely test isolation.

Fixes #15453

## Project-wide analysis

Surveyed every test class that reads or mutates `SsrfProtectionValidator`, cross-referenced against modules that enable JUnit Jupiter parallel execution:

| Module | Test class | Role vs SSRF static state | `@ResourceLock` |
|---|---|---|---|
| `common/util` | `SsrfProtectionValidatorTest` | mutates `setEnabled` / `setAdditionalBlockedHosts` / `setAllowedHosts` | already present |
| `rule-engine/rule-engine-components` | `SsrfSafeAddressResolverGroupTest` | mutates `setEnabled` / `setAllowedHosts` | already present |
| `rule-engine/rule-engine-components` | `TbHttpClientTest` | reads flag via HTTP path | already present |
| `rule-engine/rule-engine-components` | `TbRestApiCallNodeTest` | reads flag via HTTP path | **added in this PR** |

Both modules above enable `junit.jupiter.execution.parallel.enabled=true` in `src/test/resources/junit-platform.properties`, which is why the lock matters.

### Other modules intentionally not changed

Production code in `application/` (`ActorSystemContext`, `CustomOAuth2ClientMapper`, `MicrosoftTeamsNotificationChannel`) and `dao/` (`Oauth2ClientDataValidator`) also calls `SsrfProtectionValidator`, but:
- Neither `application/` nor `dao/` ships a `junit-platform.properties` enabling parallel execution;
- Neither pom configures surefire `parallel`/`forkCount` to share a JVM across concurrent tests;
- Tests in these modules run sequentially — no intra-JVM race is possible.

So the single-file change is sufficient repository-wide. No further lock additions are needed today.

### Long-term hardening (not in this PR)

The root issue is that `SsrfProtectionValidator.enabled` is global mutable state. A future change could move the configuration behind an instance-scoped or `ThreadLocal`-scoped mechanism so new tests do not need to remember the annotation. Short-term, the lock is the right minimal fix.

## Test plan
- [x] `mvn -pl rule-engine/rule-engine-components test -Dtest='org.thingsboard.rule.engine.rest.*Test'` runs clean locally — 32/32 passed (`TbHttpClientTest` 8, `TbRestApiCallNodeTest` 9, `SsrfSafeAddressResolverGroupTest` and the rest of the `rest` package).
- [ ] CI history on the affected test stops producing new failures.