### PR TITLE
Fixed CVE-2026-5588, CVE-2026-5598, CVE-2025-14813, CVE-2026-35554, CVE-2026-27314

### DIFF
--- a/common/message/src/main/java/org/thingsboard/server/common/msg/EncryptionUtil.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/EncryptionUtil.java
@@ -17,7 +17,7 @@ package org.thingsboard.server.common.msg;
 
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.crypto.digests.SHA3Digest;
-import org.bouncycastle.pqc.legacy.math.linearalgebra.ByteUtils;
+import org.bouncycastle.util.encoders.Hex;
 
 /**
  * @author Valerii Sosliuk
@@ -66,7 +66,7 @@ public class EncryptionUtil {
         md.update(dataBytes, 0, dataBytes.length);
         byte[] hashedBytes = new byte[256 / 8];
         md.doFinal(hashedBytes, 0);
-        String sha3Hash = ByteUtils.toHexString(hashedBytes);
+        String sha3Hash = Hex.toHexString(hashedBytes);
         return sha3Hash;
     }
 

--- a/common/queue/pom.xml
+++ b/common/queue/pom.xml
@@ -69,10 +69,6 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
-            <groupId>at.yawk.lz4</groupId>
-            <artifactId>lz4-java</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-pubsub</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <rat.version>0.10</rat.version> <!-- unused -->
         <cassandra.version>4.17.0</cassandra.version>
         <metrics.version>4.2.25</metrics.version>
-        <cassandra-all.version>5.0.4</cassandra-all.version> <!-- tools -->
+        <cassandra-all.version>5.0.7</cassandra-all.version> <!-- tools; 5.0.7 fixes CVE-2026-27314 -->
         <guava.version>33.1.0-jre</guava.version>
         <tomcat.version>10.1.54</tomcat.version> <!-- to fix CVE-2026-34487, CVE-2026-34486, CVE-2026-34483. TODO: remove when fixed in spring-boot-dependencies -->
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
@@ -102,7 +102,8 @@
         <swagger-annotations.version>2.2.30</swagger-annotations.version>
         <spatial4j.version>0.8</spatial4j.version>
         <jts.version>1.19.0</jts.version>
-        <bouncycastle.version>1.78.1</bouncycastle.version>
+        <bouncycastle.version>1.84</bouncycastle.version> <!-- 1.84 fixes CVE-2026-5588, CVE-2026-5598, CVE-2025-14813 -->
+        <thymeleaf.version>3.1.4.RELEASE</thymeleaf.version> <!-- to fix CVE-2026-40477, CVE-2026-40478. TODO: remove when fixed in spring-boot-dependencies -->
         <winsw.version>2.0.1</winsw.version>
         <sonar.exclusions>org/thingsboard/server/gen/**/*,
             org/thingsboard/server/extensions/core/plugin/telemetry/gen/**/*
@@ -112,8 +113,8 @@
         <!-- IMPORTANT: If you change the version of the kafka client, make sure to synchronize our overwritten implementation of the
         org.apache.kafka.common.network.NetworkReceive class in the application module. It addresses the issue https://issues.apache.org/jira/browse/KAFKA-4090.
         Here is the source to track https://github.com/apache/kafka/tree/trunk/clients/src/main/java/org/apache/kafka/common/network -->
-        <kafka.version>3.9.1</kafka.version>
-        <lz4.version>1.10.1</lz4.version> <!-- to fix CVE-2025-12183 and CVE-2025-66566 introduced through kafka-clients 3.9.1 TODO: remove when kafka-clients is bumped -->
+        <kafka.version>3.9.2</kafka.version> <!-- 3.9.2 fixes CVE-2026-35554 (race condition) -->
+        <lz4.version>1.10.1</lz4.version> <!-- to fix CVE-2025-12183 and CVE-2025-66566 introduced through kafka-clients; kafka 3.9.2 still ships older lz4, keep override -->
         <bucket4j.version>8.10.1</bucket4j.version>
         <antlr.version>3.5.3</antlr.version>
         <aws.sdk.version>1.12.701</aws.sdk.version>
@@ -1021,6 +1022,20 @@
                 <version>${tomcat.version}</version>
             </dependency>
             <!-- End of tomcat version override -->
+            <!-- Temporary thymeleaf version override to fix CVE-2026-40477, CVE-2026-40478 (Critical SSTI).
+                 Must be declared before the spring-boot-dependencies BOM import to take precedence.
+                 TODO: remove when fixed in spring-boot-dependencies -->
+            <dependency>
+                <groupId>org.thymeleaf</groupId>
+                <artifactId>thymeleaf</artifactId>
+                <version>${thymeleaf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.thymeleaf</groupId>
+                <artifactId>thymeleaf-spring6</artifactId>
+                <version>${thymeleaf.version}</version>
+            </dependency>
+            <!-- End of thymeleaf version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
         <pkg.unixLogFolder>/var/log/${pkg.name}</pkg.unixLogFolder>
         <pkg.installFolder>/usr/share/${pkg.name}</pkg.installFolder>
         <spring-boot.version>3.5.13</spring-boot.version>
+        <tomcat.version>10.1.54</tomcat.version> <!-- to fix CVE-2026-34487, CVE-2026-34486, CVE-2026-34483. TODO: remove when fixed in spring-boot-dependencies -->
+        <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -70,8 +72,6 @@
         <metrics.version>4.2.25</metrics.version>
         <cassandra-all.version>5.0.7</cassandra-all.version> <!-- tools; 5.0.7 fixes CVE-2026-27314 -->
         <guava.version>33.1.0-jre</guava.version>
-        <tomcat.version>10.1.54</tomcat.version> <!-- to fix CVE-2026-34487, CVE-2026-34486, CVE-2026-34483. TODO: remove when fixed in spring-boot-dependencies -->
-        <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <commons-io.version>2.16.1</commons-io.version>
         <commons-logging.version>1.3.1</commons-logging.version>
         <commons-csv.version>1.10.0</commons-csv.version>
@@ -103,7 +103,6 @@
         <spatial4j.version>0.8</spatial4j.version>
         <jts.version>1.19.0</jts.version>
         <bouncycastle.version>1.84</bouncycastle.version> <!-- 1.84 fixes CVE-2026-5588, CVE-2026-5598, CVE-2025-14813 -->
-        <thymeleaf.version>3.1.4.RELEASE</thymeleaf.version> <!-- to fix CVE-2026-40477, CVE-2026-40478. TODO: remove when fixed in spring-boot-dependencies -->
         <winsw.version>2.0.1</winsw.version>
         <sonar.exclusions>org/thingsboard/server/gen/**/*,
             org/thingsboard/server/extensions/core/plugin/telemetry/gen/**/*
@@ -113,8 +112,7 @@
         <!-- IMPORTANT: If you change the version of the kafka client, make sure to synchronize our overwritten implementation of the
         org.apache.kafka.common.network.NetworkReceive class in the application module. It addresses the issue https://issues.apache.org/jira/browse/KAFKA-4090.
         Here is the source to track https://github.com/apache/kafka/tree/trunk/clients/src/main/java/org/apache/kafka/common/network -->
-        <kafka.version>3.9.2</kafka.version> <!-- 3.9.2 fixes CVE-2026-35554 (race condition) -->
-        <lz4.version>1.10.1</lz4.version> <!-- to fix CVE-2025-12183 and CVE-2025-66566 introduced through kafka-clients; kafka 3.9.2 still ships older lz4, keep override -->
+        <kafka.version>3.9.2</kafka.version> <!-- to fix CVE-2026-35554 -->
         <bucket4j.version>8.10.1</bucket4j.version>
         <antlr.version>3.5.3</antlr.version>
         <aws.sdk.version>1.12.701</aws.sdk.version>
@@ -1022,20 +1020,6 @@
                 <version>${tomcat.version}</version>
             </dependency>
             <!-- End of tomcat version override -->
-            <!-- Temporary thymeleaf version override to fix CVE-2026-40477, CVE-2026-40478 (Critical SSTI).
-                 Must be declared before the spring-boot-dependencies BOM import to take precedence.
-                 TODO: remove when fixed in spring-boot-dependencies -->
-            <dependency>
-                <groupId>org.thymeleaf</groupId>
-                <artifactId>thymeleaf</artifactId>
-                <version>${thymeleaf.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.thymeleaf</groupId>
-                <artifactId>thymeleaf-spring6</artifactId>
-                <version>${thymeleaf.version}</version>
-            </dependency>
-            <!-- End of thymeleaf version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -1286,17 +1270,6 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.lz4</groupId>
-                        <artifactId>lz4-java</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>at.yawk.lz4</groupId>
-                <artifactId>lz4-java</artifactId>
-                <version>${lz4.version}</version> <!-- to fix CVE introduced through kafka-clients 3.9.1 -->
             </dependency>
             <dependency>
                 <groupId>com.github.springtestdbunit</groupId>
@@ -1572,12 +1545,6 @@
                 <groupId>org.apache.cassandra</groupId>
                 <artifactId>cassandra-all</artifactId>
                 <version>${cassandra-all.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.lz4</groupId>
-                        <artifactId>lz4-java</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>

--- a/rule-engine/rule-engine-components/pom.xml
+++ b/rule-engine/rule-engine-components/pom.xml
@@ -97,10 +97,6 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
-            <groupId>at.yawk.lz4</groupId>
-            <artifactId>lz4-java</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sns</artifactId>
         </dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -74,10 +74,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>at.yawk.lz4</groupId>
-            <artifactId>lz4-java</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>


### PR DESCRIPTION
## Context

Five high/critical vulnerabilities reported by the scheduled PE security scan ([#103565](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/103565)) that are in scope for CE — fixed by bumping the managed versions of three Java dependencies.

**Java (root `pom.xml`):**

- **CVE-2026-5588** (Critical) — BouncyCastle `bcpkix-jdk18on`: Improper Verification of Cryptographic Signature
- **CVE-2026-5598** (High) — BouncyCastle `bcprov-jdk18on`: Timing Attack
- **CVE-2025-14813** (High) — BouncyCastle `bcprov-jdk18on`: Use of a Broken or Risky Cryptographic Algorithm
- **CVE-2026-35554** (CVSS 8.7) — Apache Kafka client buffer-pool race: expired batches may be silently delivered to a wrong topic
- **CVE-2026-27314** (High) — Apache Cassandra `cassandra-all`: Privilege Defined With Unsafe Actions

## Fix

- **BouncyCastle**: bumped `bouncycastle.version` 1.78.1 → 1.84. All four artifacts (`bcprov-jdk18on`, `bcpkix-jdk18on`, `bcutil-jdk18on`, `bcprov-ext-jdk18on`) already reference `${bouncycastle.version}`.
- **Kafka**: bumped `kafka.version` 3.9.1 → 3.9.2.
- **Cassandra**: bumped `cassandra-all.version` 5.0.4 → 5.0.7.

### Cleanup: dropped lz4 override

The in-tree `<lz4.version>` property, managed `at.yawk.lz4:lz4-java` entry, exclusions on `kafka-clients` and `cassandra-all`, and the direct declarations in `tools/`, `common/queue/`, `rule-engine/rule-engine-components/` were all introduced in Dec 2025 (PRs #14479, #14530) as a workaround for CVE-2025-12183 / CVE-2025-66566 — with an explicit `TODO: remove when kafka-clients is bumped`. Kafka 3.9.2 now transitively ships `at.yawk.lz4:lz4-java:1.10.1`, and `cassandra-all` 5.0.7 declares the same artifact in its own pom. The workaround is obsolete and removed.

### Cleanup: grouped Spring Boot BOM overrides

`tomcat.version` and `commons-lang3.version` (overrides for artifacts managed by `spring-boot-dependencies`) are now placed immediately under `<spring-boot.version>` in `<properties>`, visually signalling they track the BOM.

## Kafka custom override

`application/src/main/java/org/apache/kafka/common/network/NetworkReceive.java` is our in-tree override of the upstream Kafka class (KAFKA-4090 workaround). Checked upstream diff between `kafka-clients` 3.9.1 and 3.9.2 — the file is **byte-identical** (`diff` returns empty, same MD5). No re-sync of the override is required for this bump.

```
diff <(curl -sL https://raw.githubusercontent.com/apache/kafka/3.9.1/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java) \
     <(curl -sL https://raw.githubusercontent.com/apache/kafka/3.9.2/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java)
# (empty)
```

## Result

```
mvn dependency:tree -pl common/util -am -Dincludes=org.bouncycastle:bcprov-jdk18on,org.apache.kafka:kafka-clients,org.apache.cassandra:cassandra-all
```
```
[INFO] +- org.bouncycastle:bcprov-jdk18on:jar:1.84:compile
[INFO] +- org.apache.kafka:kafka-clients:jar:3.9.2:compile
[INFO] +- org.apache.cassandra:cassandra-all:jar:5.0.7:compile
```

```
mvn dependency:tree -pl common/queue -am -Dincludes=at.yawk.lz4:lz4-java
```
```
[INFO]    \- at.yawk.lz4:lz4-java:jar:1.10.1:runtime
```
