### PR TITLE
Enforced exact dependency lockfile match for frontend builds

### DIFF
--- a/msa/js-executor/pom.xml
+++ b/msa/js-executor/pom.xml
@@ -80,7 +80,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
-                            <arguments>install --non-interactive --check-files --network-concurrency 4 --network-timeout 100000 --mutex network</arguments>
+                            <arguments>install --frozen-lockfile --non-interactive --check-files --network-concurrency 4 --network-timeout 100000 --mutex network</arguments>
                         </configuration>
                     </execution>
                     <execution>

--- a/msa/web-ui/pom.xml
+++ b/msa/web-ui/pom.xml
@@ -89,7 +89,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
-                            <arguments>install --non-interactive --check-files --network-concurrency 4 --network-timeout 100000 --mutex network</arguments>
+                            <arguments>install --frozen-lockfile --non-interactive --check-files --network-concurrency 4 --network-timeout 100000 --mutex network</arguments>
                         </configuration>
                     </execution>
                     <execution>

--- a/ui-ngx/pom.xml
+++ b/ui-ngx/pom.xml
@@ -66,7 +66,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
-                            <arguments>install --non-interactive --check-files --network-concurrency 4 --network-timeout 100000 --mutex network</arguments>
+                            <arguments>install --frozen-lockfile --non-interactive --check-files --network-concurrency 4 --network-timeout 100000 --mutex network</arguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary

Enforced `--frozen-lockfile` for `yarn install` in the three frontend modules: `ui-ngx/pom.xml`, `msa/web-ui/pom.xml`, `msa/js-executor/pom.xml`.

Without this flag, yarn silently regenerates `yarn.lock` when it drifts from `package.json`, so CI builds succeed even when the committed lockfile is stale. This hides cases where new `resolutions` are added to `package.json` but the lockfile is not updated — SBOM and security scanners continue to see the old, vulnerable versions (recent example: lodash resolutions in #15458). With `--frozen-lockfile`, yarn fails the build if the lockfile is out of sync, forcing drift to be resolved at PR time.

Dockerfile `yarn install --production` invocations (`msa/web-ui/docker/Dockerfile`, `msa/js-executor/docker/Dockerfile`) are left unchanged — they use a different dependency profile and can be addressed separately if needed.

## Test plan

- [x] `yarn install --frozen-lockfile --non-interactive --check-files --network-concurrency 4 --network-timeout 100000 --mutex network` exits 0 in `ui-ngx/`
- [x] same in `msa/web-ui/`
- [x] same in `msa/js-executor/`