### PR TITLE
Bump PostgreSQL test images to 18

### DIFF
--- a/dao/src/test/java/org/thingsboard/server/dao/TbTimescaleDBContainerProvider.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/TbTimescaleDBContainerProvider.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.dao;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.TimescaleDBContainerProvider;
+
+/**
+ * Extends the upstream {@link TimescaleDBContainerProvider} to disable the
+ * timescaledb-tune entrypoint script via NO_TS_TUNE=true.
+ *
+ * Works around a shell bug in /docker-entrypoint-initdb.d/001_timescaledb_tune.sh
+ * that crashes the container entrypoint on cgroup v2 hosts (including CI agents)
+ * when the kernel reports the 64-bit max for memory.max.
+ *
+ * Activated by the jdbc:tc:tbtimescaledb:&lt;tag&gt;:///... URL prefix
+ * registered via META-INF/services.
+ */
+public class TbTimescaleDBContainerProvider extends TimescaleDBContainerProvider {
+
+    private static final String NAME = "tbtimescaledb";
+
+    @Override
+    public boolean supports(String databaseType) {
+        return NAME.equals(databaseType);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance(String tag) {
+        JdbcDatabaseContainer container = super.newInstance(tag);
+        container.withEnv("NO_TS_TUNE", "true");
+        return container;
+    }
+}

--- a/dao/src/test/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
+++ b/dao/src/test/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
@@ -1,0 +1,1 @@
+org.thingsboard.server.dao.TbTimescaleDBContainerProvider

--- a/dao/src/test/resources/nosql-test.properties
+++ b/dao/src/test/resources/nosql-test.properties
@@ -13,6 +13,6 @@ spring.jpa.show-sql=false
 spring.jpa.hibernate.ddl-auto=none
 spring.datasource.username=postgres
 spring.datasource.password=postgres
-spring.datasource.url=jdbc:tc:postgresql:16.6:///thingsboard?TC_DAEMON=true&TC_TMPFS=/testtmpfs:rw&?TC_INITFUNCTION=org.thingsboard.server.dao.PostgreSqlInitializer::initDb
+spring.datasource.url=jdbc:tc:postgresql:18:///thingsboard?TC_DAEMON=true&TC_TMPFS=/testtmpfs:rw&?TC_INITFUNCTION=org.thingsboard.server.dao.PostgreSqlInitializer::initDb
 spring.datasource.driverClassName=org.testcontainers.jdbc.ContainerDatabaseDriver
 spring.datasource.hikari.maximumPoolSize=16

--- a/dao/src/test/resources/sql-test.properties
+++ b/dao/src/test/resources/sql-test.properties
@@ -14,7 +14,7 @@ spring.jpa.show-sql=false
 spring.jpa.hibernate.ddl-auto=none
 spring.datasource.username=postgres
 spring.datasource.password=postgres
-spring.datasource.url=jdbc:tc:postgresql:16.6:///thingsboard?TC_DAEMON=true&TC_TMPFS=/testtmpfs:rw&?TC_INITFUNCTION=org.thingsboard.server.dao.PostgreSqlInitializer::initDb
+spring.datasource.url=jdbc:tc:postgresql:18:///thingsboard?TC_DAEMON=true&TC_TMPFS=/testtmpfs:rw&?TC_INITFUNCTION=org.thingsboard.server.dao.PostgreSqlInitializer::initDb
 spring.datasource.driverClassName=org.testcontainers.jdbc.ContainerDatabaseDriver
 spring.datasource.hikari.maximumPoolSize=16
 

--- a/dao/src/test/resources/timescale-test.properties
+++ b/dao/src/test/resources/timescale-test.properties
@@ -13,6 +13,6 @@ spring.jpa.show-sql=false
 spring.jpa.hibernate.ddl-auto=none
 spring.datasource.username=postgres
 spring.datasource.password=postgres
-spring.datasource.url=jdbc:tc:timescaledb:latest-pg12:///thingsboard?TC_DAEMON=true&TC_TMPFS=/testtmpfs:rw&?TC_INITFUNCTION=org.thingsboard.server.dao.TimescaleSqlInitializer::initDb
+spring.datasource.url=jdbc:tc:tbtimescaledb:latest-pg18:///thingsboard?TC_DAEMON=true&TC_TMPFS=/testtmpfs:rw&?TC_INITFUNCTION=org.thingsboard.server.dao.TimescaleSqlInitializer::initDb
 spring.datasource.driverClassName=org.testcontainers.jdbc.ContainerDatabaseDriver
 spring.datasource.hikari.maximumPoolSize = 50


### PR DESCRIPTION
## Summary
Bump PostgreSQL-based test images pulled via the Testcontainers JDBC proxy, both to **PG18**:
- `postgres`: `16.6` → `18` (dao `sql-test.properties` / `nosql-test.properties`)
- `timescaledb`: `latest-pg12` → `latest-pg18` (dao `timescale-test.properties`)

PostgreSQL 12 reached **end-of-life on 2024-11-14**, and the vanilla `postgres` test image jumps straight to 18 to stay on a supported major.

## The TimescaleDB startup bug and how we work around it

Any recent `timescale/timescaledb:latest-pgNN` image (pg15 and newer) fails to start on cgroup v2 CI hosts (e.g. the TeamCity agents). The entrypoint script crashes:

```
/docker-entrypoint-initdb.d/001_timescaledb_tune.sh: line 50: [: -gt: unary operator expected
```

Root cause: the tune script reads `/sys/fs/cgroup/memory.max`, gets `"max"` (cgroup v2, no memory limit), blanks `TS_TUNE_MEMORY` to avoid bash's 64-bit-max overflow, and then immediately runs `[ ${TS_TUNE_MEMORY} -gt ${FREE_BYTES} ]` on the empty string — aborting the entrypoint with a non-zero exit. Postgres never starts, Testcontainers times out, and `getMappedPort()` bubbles up the misleading "Mapped port can only be obtained after the container is started" error.

The fix upstream is to pass `NO_TS_TUNE=true` to the container, but **the Testcontainers JDBC URL (`jdbc:tc:timescaledb:...`) has no hook for docker env vars** — only `TC_DAEMON` / `TC_TMPFS` / `TC_INITSCRIPT` / `TC_INITFUNCTION` / `TC_REUSABLE`. `TC_INITFUNCTION` runs *after* container startup, so it's too late.

**What this PR adds:** a tiny `JdbcDatabaseContainerProvider` that **extends** upstream's `TimescaleDBContainerProvider` — `TbTimescaleDBContainerProvider`. It claims a new database-type name `tbtimescaledb` and delegates container construction to `super.newInstance(tag)`, then tacks on `.withEnv("NO_TS_TUNE", "true")`. Registered via `META-INF/services`. If upstream fixes the tune-script bug or improves the provider, we ride along automatically — this class is a workaround for the docker image issue, nothing more.

Why `tbtimescaledb` (no hyphen): Testcontainers' URL regex for the database type is `[a-z0-9]+`.

The full class body:

```java
public class TbTimescaleDBContainerProvider extends TimescaleDBContainerProvider {

    private static final String NAME = "tbtimescaledb";

    @Override
    public boolean supports(String databaseType) {
        return NAME.equals(databaseType);
    }

    @Override
    public JdbcDatabaseContainer newInstance(String tag) {
        JdbcDatabaseContainer container = super.newInstance(tag);
        container.withEnv("NO_TS_TUNE", "true");
        return container;
    }
}
```

## How it works end-to-end

### 1. The Testcontainers JDBC proxy

Spring reads this in `timescale-test.properties`:

```properties
spring.datasource.driverClassName=org.testcontainers.jdbc.ContainerDatabaseDriver
spring.datasource.url=jdbc:tc:tbtimescaledb:latest-pg18:///thingsboard?TC_DAEMON=true&TC_TMPFS=/testtmpfs:rw&?TC_INITFUNCTION=org.thingsboard.server.dao.TimescaleSqlInitializer::initDb
```

When HikariCP asks the driver for a connection, `ContainerDatabaseDriver` intercepts and parses the URL with the regex:

```
jdbc:tc:(?<databaseType>[a-z0-9]+)(:(?<imageTag>[^:]+))?://...
```

→ `databaseType = "tbtimescaledb"`, `imageTag = "latest-pg18"`.

### 2. Service lookup via Java SPI

`ContainerDatabaseDriver` asks `ServiceLoader<JdbcDatabaseContainerProvider>` for every provider whose `supports("tbtimescaledb")` returns `true`. ServiceLoader walks every `META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider` file on the classpath and instantiates the listed classes.

The built-in `testcontainers-postgresql` jar registers:

```
PostgreSQLContainerProvider         (name "postgresql")
PostgisContainerProvider            (name "postgis")
TimescaleDBContainerProvider        (name "timescaledb")
PgVectorContainerProvider           (name "pgvector")
```

This PR adds `dao/src/test/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider` with:

```
org.thingsboard.server.dao.TbTimescaleDBContainerProvider   (name "tbtimescaledb")
```

Only our provider answers `supports("tbtimescaledb") == true`, so it wins. The inherited `timescaledb` name still belongs to the upstream provider — we don't override it.

### 3. Our provider creates the container

```java
public JdbcDatabaseContainer newInstance(String tag) {      // tag = "latest-pg18"
    JdbcDatabaseContainer container = super.newInstance(tag);  // upstream builds PostgreSQLContainer("timescale/timescaledb:<tag>")
    container.withEnv("NO_TS_TUNE", "true");                   // <-- the whole point of this class
    return container;
}
```

- Upstream's `TimescaleDBContainerProvider.newInstance(String)` already does the `DockerImageName.parse("timescale/timescaledb").asCompatibleSubstituteFor("postgres").withTag(tag)` dance. We delegate.
- `withEnv("NO_TS_TUNE", "true")` sets the docker env var that the timescaledb entrypoint checks first:
  ```bash
  NO_TS_TUNE=${NO_TS_TUNE:-""}
  ...
  if [ -z "${NO_TS_TUNE}" ]; then
      # ... the buggy memory-tuning block ...
  fi
  ```
  With it set, the whole broken `[ ${TS_TUNE_MEMORY} -gt ${FREE_BYTES} ]` branch is skipped. Postgres starts cleanly.

### 4. Testcontainers boots the container, then Spring uses it

- `ContainerDatabaseDriver` calls `container.start()` → Docker pulls the image, sets the env, runs the entrypoint, waits for DB ready.
- `TC_TMPFS=/testtmpfs:rw` maps `/testtmpfs` as a ramdisk in the container (speeds up writes).
- `TC_DAEMON=true` keeps the container alive across connection closes within the JVM.
- `TC_INITFUNCTION=org.thingsboard.server.dao.TimescaleSqlInitializer::initDb` tells the driver: **after the first real JDBC connection opens**, call that static method with the `Connection`. That's where we run `schema-timescale.sql`, `schema-entities.sql`, etc.
- From then on, every time Spring asks for a Hikari connection, the driver returns a connection to that same container. All `@DaoTimescaleTest`-annotated classes share it.

### 5. Why this is a one-class fix

The URL format `jdbc:tc:X:...` is purely a convention the Testcontainers driver uses to pick a provider. By inventing the name `tbtimescaledb` and owning its provider, we insert **one** bit of programmatic container configuration (`withEnv`) into an otherwise URL-driven setup — without touching `TimescaleSqlInitializer` or any test class, and without forking upstream's container construction logic.

## Changes
- `dao/src/test/resources/sql-test.properties` — `postgres:16.6` → `18`
- `dao/src/test/resources/nosql-test.properties` — `postgres:16.6` → `18`
- `dao/src/test/resources/timescale-test.properties` — `jdbc:tc:timescaledb:latest-pg12` → `jdbc:tc:tbtimescaledb:latest-pg18`
- `dao/src/test/java/org/thingsboard/server/dao/TbTimescaleDBContainerProvider.java` *(new)* — extends upstream provider, sets `NO_TS_TUNE=true`
- `dao/src/test/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider` *(new)* — SPI registration

Production docker-compose files and the `tb-postgres` image are untouched.

## Test plan
- [x] `mvn test -pl dao -Dtest='*Timescale*'` — 50 timescale tests pass against `timescale/timescaledb:latest-pg18`, container boots cleanly (no tune-script crash)
- [x] `mvn test -pl dao -Dparallel=packages -DforkCount=4` — full dao suite, 875 tests, 0 failures (on `postgres:18` + `timescaledb:latest-pg18`)
- [ ] CI (TeamCity) dao + smoke-logic suite green on `lts-4.2`