### PR TITLE
chore(build): silence ~200 lines of harmless warnings on lts-4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+        <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <springdoc-swagger.version>2.8.8TB</springdoc-swagger.version>
         <swagger-annotations.version>2.2.30</swagger-annotations.version>
         <spatial4j.version>0.8</spatial4j.version>
@@ -915,6 +916,12 @@
                             <exclude>**/resources/lwm2m/models/**</exclude>
                             <exclude>src/main/data/resources/**</exclude>
                             <exclude>.claude/**</exclude>
+                            <exclude>**/lombok.config</exclude>
+                            <exclude>**/eslint.config.mjs</exclude>
+                            <exclude>**/config.monitoring</exclude>
+                            <exclude>**/valkey-certs/**</exclude>
+                            <exclude>**/data/certs/**</exclude>
+                            <exclude>**/*.otf</exclude>
                         </excludes>
                         <mapping>
                             <proto>JAVADOC_STYLE</proto>
@@ -967,6 +974,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
+                <version>${maven-clean-plugin.version}</version>
                 <inherited>false</inherited>
                 <configuration>
                     <filesets>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -54,6 +54,24 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
+            <exclusions>
+                <!-- These sjk-* artifacts pull in com.jrockit.mc / com.oracle.jmc / jdk.org.netbeans
+                     system-scope dependencies with unresolved systemPath properties, which produces
+                     ERROR-level Maven warnings on every build. No ThingsBoard code imports from sjk,
+                     jmc, or netbeans profiler, so excluding them is safe. -->
+                <exclusion>
+                    <groupId>org.perfkit.sjk.parsers</groupId>
+                    <artifactId>sjk-jfr5</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.perfkit.sjk.parsers</groupId>
+                    <artifactId>sjk-jfr6</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.perfkit.sjk.parsers</groupId>
+                    <artifactId>sjk-nps</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>at.yawk.lz4</groupId>


### PR DESCRIPTION
## Pull Request description

Build-hygiene cleanup. Developers working on `lts-4.2` currently see **1040 `[WARNING]`** lines and **7 `[ERROR]`** lines on every `mvn clean install`, even though the build is green. This PR silences the ones that are pure noise (no code change, no behavior change), so the real warnings that deserve attention are actually visible.

Full categorization of every warning class and the tiered migration plan for the remaining ones is tracked in issue #15481. PE mirror is thingsboard/thingsboard-pe#4637.

### Measured impact

| Metric | Before | After |
|---|---:|---:|
| `[WARNING]` lines | 1040 | **843** |
| `[ERROR]` lines   |    7 | **0**   |

Baseline reproducible with the command from `TEST_FAST.md`:

```bash
MAVEN_OPTS="-Xmx1024m" mvn clean install -T6 -DskipTests -Dpkg.skip=true
```

### What changed (pom-only, no Java touched)

1. **`pom.xml`** — pin `maven-clean-plugin` to `3.5.0` (latest stable) via a `<maven-clean-plugin.version>` property (matching the convention already in use for surefire/install/deploy/jar). Kills the 55 `'build.plugins.plugin.version' for org.apache.maven.plugins:maven-clean-plugin is missing` warnings **plus** the cascading `Some problems were encountered while building the effective model for ...` lines that followed each one for every child module — ~197 lines total.

2. **`pom.xml`** — extend `license-maven-plugin` excludes for files that never carry a license header anyway: `**/lombok.config`, `**/eslint.config.mjs`, `**/config.monitoring`, `**/valkey-certs/**`, `**/data/certs/**`, `**/*.otf`. Directory-scoped patterns were chosen over broad extension globs (`**/*.crt`, `**/*.key`, `**/*.pem`) on purpose: a stray cert dropped outside these directories should still raise a warning for the contributor to notice.

3. **`tools/pom.xml`** — exclude `sjk-jfr5` / `sjk-jfr6` / `sjk-nps` transitive dependencies from `cassandra-all`. Their published POMs declare system-scope dependencies against unresolved `${jmc5.path}`, `${jmc6.path}`, `${visualvm.path}` properties, which is what produced the 7 `ERROR` lines. Verified no ThingsBoard source imports `sjk`, `jmc`, or `netbeans profiler` classes:

   ```bash
   grep -rn 'import.*sjk\|import.*jmc\.\|import.*jrockit\|import.*flightrecorder\|import.*netbeans.*profiler' \
     --include='*.java' .
   # (no matches)
   ```

### What is deliberately NOT in this PR

The remaining 843 warnings are **real deprecations** that need code migration, not build-config masking — see issue #15481 for the full Tier 2 / Tier 3 breakdown. Highlights:

- ~150 `@MockBean` / `@SpyBean` → `@MockitoBean` (Spring Boot 3.4)
- ~150 `unchecked` generics casts/conversions
- ~66 Spring Data Redis `DefaultedRedisConnection.*` method deprecations
- ~100 internal edge-protobuf message-type deprecations (kept intentionally for backcompat)
- Commons-lang3 deprecations, `TenantId(UUID)` ctor, `Validator.validateId`, Curator `PathChildrenCache`, testcontainers `CassandraContainer`, Lombok `@Builder` / `@EqualsAndHashCode` gaps, etc.

Each of these deserves its own focused PR/sweep — mixing them with build hygiene would bloat review scope.

### Crosslinks

- PE: thingsboard/thingsboard-pe#4637
- Tracking issue: #15481

## General checklist

- [x] Description contains human-readable scope of changes.
- [x] Description references the tracking issue (#15481).
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible (build-config only, pinned to the latest stable version of the plugin).
- [x] Similar PR is opened for PE version — crosslink above.

## Back-End feature checklist

- [x] No new Java code, no new REST endpoint, no new yml property. `mvn clean install -T6 -DskipTests -Dpkg.skip=true` still green.