### PR TITLE
Fix maven-assembly-plugin skipAssembly leaking into every execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -618,7 +618,6 @@
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-assembly-plugin</artifactId>
                             <configuration>
-                                <skipAssembly>${pkg.skip.zip}</skipAssembly>
                                 <finalName>${pkg.name}</finalName>
                                 <descriptors>
                                     <descriptor>${main.dir}/packaging/${pkg.type}/assembly/windows.xml</descriptor>
@@ -631,6 +630,9 @@
                                     <goals>
                                         <goal>single</goal>
                                     </goals>
+                                    <configuration>
+                                        <skipAssembly>${pkg.skip.zip}</skipAssembly>
+                                    </configuration>
                                 </execution>
                             </executions>
                         </plugin>


### PR DESCRIPTION
## Summary

- Move `<skipAssembly>${pkg.skip.zip}</skipAssembly>` out of the plugin-level `<configuration>` of `maven-assembly-plugin` and into the `assembly` execution's own `<configuration>`.
- Without this fix, Maven merges the plugin-level `<configuration>` into every execution of `maven-assembly-plugin` across the reactor, so `-Dpkg.skip.zip=true` (and the `-Dpkg.skip=true` alias that activates it) suppressed any `maven-assembly-plugin` execution anywhere — not only the intended Windows ZIP build.
- Introduced by `d2cde5ba941` ("Add per-format packaging skip flags (pkg.skip.bootjar/deb/rpm/zip)").

## Impact

- **CE `lts-4.2`/`lts-4.3`: latent.** No CE module declares a non-Windows-ZIP `maven-assembly-plugin` execution, so nothing consumes the leaked flag today. Purely a hygiene fix at the CE level.
- **Downstream forks: active.** For example, PE's `rule-engine-pe/rule-node-twilio-sms` declares its own `make-assembly` execution producing the classified `-rule-node.jar` that `application`'s `copy-pe-rule-nodes` step consumes. Under `-Dpkg.skip.zip=true` that assembly silently became a no-op and the classified artifact was never installed, breaking the downstream build. Fixing at the CE source lets the change flow downstream via normal merges rather than every fork carrying a local patch.

`tools/pom.xml` already sidesteps this via `<configuration combine.self="override">` on its own `<pluginManagement>` — earlier evidence the plugin-level placement was fragile.

## Verification

Ran on this branch in a worktree of `upstream/lts-4.2`:

| # | Command | Result | Windows ZIPs produced |
|---|---------|--------|-----------------------|
| 1 | `mvn clean install -T6 -DskipTests -Dpkg.skip=true` | BUILD SUCCESS (1:39) | none (all packaging skipped) |
| 2 | `mvn clean install -T6 -DskipTests` | BUILD SUCCESS (2:16) | monitoring, js-executor, vc-executor, mqtt/http transports, … |
| 3 | `mvn clean install -T6 -DskipTests -Dpkg.skip.zip=true` | BUILD SUCCESS (2:09) | none (ZIP execution skipped, other plugin executions unaffected) |

Also cross-checked with `mvn help:effective-pom` on `application/` under `-Dpkg.skip.zip=true`:

- **Before fix**: `<skipAssembly>true</skipAssembly>` appears at plugin-level `<configuration>` (leaks to any execution of the plugin).
- **After fix**: `<skipAssembly>true</skipAssembly>` appears only inside the `assembly` execution's own `<configuration>` — properly scoped.

## Test plan

- [x] Full packaging build (no skip flags) still produces Windows ZIPs for every declaring module
- [x] `-Dpkg.skip.zip=true` still skips the root Windows ZIP assembly
- [x] `-Dpkg.skip=true` still skips all packaging artifacts
- [x] Effective POM no longer carries `<skipAssembly>` at plugin-level