### PR TITLE
Updated PEM credentials to the non-deprecated certificate API

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/credentials/CertPemCredentials.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/credentials/CertPemCredentials.java
@@ -25,6 +25,7 @@ import org.thingsboard.server.common.data.StringUtils;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
+import javax.security.auth.x500.X500Principal;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.cert.CertPath;
@@ -77,7 +78,7 @@ public class CertPemCredentials implements ClientCredentials {
         KeyStore caKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
         caKeyStore.load(null, null);
         for (X509Certificate caCert : caCerts) {
-            caKeyStore.setCertificateEntry(CA_CERT_CERT_ALIAS_PREFIX + caCert.getSubjectDN().getName(), caCert);
+            caKeyStore.setCertificateEntry(CA_CERT_CERT_ALIAS_PREFIX + caCert.getSubjectX500Principal().getName(X500Principal.RFC1779), caCert);
         }
 
         TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
@@ -99,7 +100,7 @@ public class CertPemCredentials implements ClientCredentials {
         keyStore.load(null);
         List<X509Certificate> unique = certificates.stream().distinct().collect(Collectors.toList());
         for (X509Certificate cert : unique) {
-            keyStore.setCertificateEntry(CERT_ALIAS_PREFIX + cert.getSubjectDN().getName(), cert);
+            keyStore.setCertificateEntry(CERT_ALIAS_PREFIX + cert.getSubjectX500Principal().getName(X500Principal.RFC1779), cert);
         }
 
         if (privateKey != null) {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/credentials/CertPemCredentialsTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/credentials/CertPemCredentialsTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.thingsboard.common.util.SslUtil;
 
+import javax.security.auth.x500.X500Principal;
 import java.io.File;
 import java.io.IOException;
 import java.security.Key;
@@ -49,13 +50,13 @@ public class CertPemCredentialsTest {
 
         Assertions.assertEquals(4, x509Certificates.size());
         Assertions.assertEquals("CN=*.thingsboard.cloud, O=\"ThingsBoard, Inc.\", ST=New York, C=US",
-                x509Certificates.get(0).getSubjectDN().getName());
+                x509Certificates.get(0).getSubjectX500Principal().getName(X500Principal.RFC1779));
         Assertions.assertEquals("CN=Sectigo ECC Organization Validation Secure Server CA, O=Sectigo Limited, L=Salford, ST=Greater Manchester, C=GB",
-                x509Certificates.get(1).getSubjectDN().getName());
+                x509Certificates.get(1).getSubjectX500Principal().getName(X500Principal.RFC1779));
         Assertions.assertEquals("CN=USERTrust ECC Certification Authority, O=The USERTRUST Network, L=Jersey City, ST=New Jersey, C=US",
-                x509Certificates.get(2).getSubjectDN().getName());
+                x509Certificates.get(2).getSubjectX500Principal().getName(X500Principal.RFC1779));
         Assertions.assertEquals("CN=AAA Certificate Services, O=Comodo CA Limited, L=Salford, ST=Greater Manchester, C=GB",
-                x509Certificates.get(3).getSubjectDN().getName());
+                x509Certificates.get(3).getSubjectX500Principal().getName(X500Principal.RFC1779));
     }
 
     @Test
@@ -66,7 +67,7 @@ public class CertPemCredentialsTest {
 
         Assertions.assertEquals(1, x509Certificates.size());
         Assertions.assertEquals("CN=*.thingsboard.cloud, O=\"ThingsBoard, Inc.\", ST=New York, C=US",
-                x509Certificates.get(0).getSubjectDN().getName());
+                x509Certificates.get(0).getSubjectX500Principal().getName(X500Principal.RFC1779));
     }
 
     @Test
@@ -103,7 +104,7 @@ public class CertPemCredentialsTest {
 
         List<X509Certificate> certs = SslUtil.readCertFile(certContent);
         for (X509Certificate cert : certs) {
-            String alias = CERT_ALIAS_PREFIX + cert.getIssuerDN().getName();
+            String alias = CERT_ALIAS_PREFIX + cert.getIssuerX500Principal().getName(X500Principal.RFC1779);
             Certificate certificate = keyStore.getCertificate(alias);
             Assertions.assertNotNull(certificate);
             Assertions.assertEquals(new String(cert.getEncoded()), new String(certificate.getEncoded()));


### PR DESCRIPTION
## Pull Request description

Addresses the `X509Certificate.getSubjectDN() deprecated` row of #15481 (Tier 2). Safe, mechanical edits only — no new `@SuppressWarnings`, no changes to expected test strings, no runtime behavior change. Hygiene, not enforcement.

### Measured impact

| Metric | Before | After |
|---|---:|---:|
| `getSubjectDN()` warnings (rule-engine-components) | 7 | **0** |
| `getIssuerDN()` warnings (rule-engine-components) | 1 | **0** |
| `CertPemCredentialsTest`                            | 7/7 | 7/7 |
| `rule-engine-components` full `mvn test`            | 1464/1464 | 1464/1464 |

### What changed

- `CertPemCredentials` (production): keystore aliases in `createAndInitTrustManagerFactory` and `loadKeyStore` now derive from `getSubjectX500Principal().getName(X500Principal.RFC1779)` — 2 call sites.
- `CertPemCredentialsTest`: 5 assertions migrated to the same non-deprecated API. The adjacent `cert.getIssuerDN().getName()` lookup in `testLoadKeyStore` was migrated to `getIssuerX500Principal().getName(X500Principal.RFC1779)` in lock-step to keep alias symmetry with the production aliasing and to clear the last deprecation in the touched file.

### Why `RFC1779` (not the default `RFC2253`)

Empirically verified on all 6 PEM fixtures in `rule-engine-components/src/test/resources/pem/`: `getSubjectX500Principal().getName(X500Principal.RFC1779)` returns a string byte-identical to `getSubjectDN().getName()` for both subject and issuer, including the `"ThingsBoard, Inc."` quoted-comma RDN value. Default `getName()` (RFC 2253) differs (escaped commas, no spaces) and would require rewriting 5 hardcoded expected strings — outside the hygiene scope.

### What we explicitly did not touch

- Other Tier 2 / Tier 3 items in #15481.
- Expected DN format in test assertions — preserved as-is.
- Files outside the two that contain the target deprecations.
- No `@SuppressWarnings` added anywhere.

### Crosslinks

- Tracking issue: #15481

## General checklist

- [x] Description contains human-readable scope of changes.
- [x] Description references the tracking issue (#15481).
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible. Zero runtime behavior change (alias format byte-identical; verified empirically on repo PEM test fixtures).

## Back-End feature checklist

- [x] `rule-engine-components` full `mvn test` green (1464/1464).