### PR TITLE
Replaced deprecated string, number, and random-value helpers with modern equivalents

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/install/DefaultSystemDataLoaderService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/DefaultSystemDataLoaderService.java
@@ -330,7 +330,7 @@ public class DefaultSystemDataLoaderService implements SystemDataLoaderService {
 
     private String generateRandomKey() {
         return Base64.getEncoder().encodeToString(
-                RandomStringUtils.randomAlphanumeric(64).getBytes(StandardCharsets.UTF_8));
+                RandomStringUtils.secure().nextAlphanumeric(64).getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/server/service/security/auth/mfa/provider/impl/TotpTwoFaProvider.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/auth/mfa/provider/impl/TotpTwoFaProvider.java
@@ -62,7 +62,7 @@ public class TotpTwoFaProvider implements TwoFaProvider<TotpTwoFaProviderConfig,
     }
 
     private String generateSecretKey() {
-        return Base32.encode(RandomUtils.nextBytes(20));
+        return Base32.encode(RandomUtils.secure().randomBytes(20));
     }
 
 

--- a/application/src/main/java/org/thingsboard/server/service/ws/WebSocketSessionType.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/WebSocketSessionType.java
@@ -17,9 +17,9 @@ package org.thingsboard.server.service.ws;
 
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 @NoArgsConstructor
@@ -33,7 +33,7 @@ public enum WebSocketSessionType {
 
     public static Optional<WebSocketSessionType> forName(String name) {
         return Arrays.stream(values())
-                .filter(sessionType -> StringUtils.equals(sessionType.name, name))
+                .filter(sessionType -> Objects.equals(sessionType.name, name))
                 .findFirst();
     }
 

--- a/application/src/test/java/org/thingsboard/server/controller/AbstractWebTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/AbstractWebTest.java
@@ -1223,7 +1223,7 @@ public abstract class AbstractWebTest extends AbstractInMemoryStorageTest {
 
     protected NotificationTarget createNotificationTarget(UsersFilter usersFilter) {
         NotificationTarget notificationTarget = new NotificationTarget();
-        notificationTarget.setName(usersFilter.toString() + RandomStringUtils.randomNumeric(5));
+        notificationTarget.setName(usersFilter.toString() + RandomStringUtils.secure().nextNumeric(5));
         PlatformUsersNotificationTargetConfig targetConfig = new PlatformUsersNotificationTargetConfig();
         targetConfig.setUsersFilter(usersFilter);
         notificationTarget.setConfiguration(targetConfig);

--- a/application/src/test/java/org/thingsboard/server/service/notification/AbstractNotificationApiTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/notification/AbstractNotificationApiTest.java
@@ -155,7 +155,7 @@ public abstract class AbstractNotificationApiTest extends AbstractControllerTest
         User user = new User();
         user.setTenantId(tenantId);
         user.setAuthority(authority);
-        user.setEmail(RandomStringUtils.randomAlphabetic(20) + "@thingsboard.com");
+        user.setEmail(RandomStringUtils.secure().nextAlphabetic(20) + "@thingsboard.com");
         user = createUserAndLogin(user, "12345678");
         NotificationApiWsClient wsClient = buildAndConnectWebSocketClient();
         return Pair.of(user, wsClient);

--- a/application/src/test/java/org/thingsboard/server/service/notification/NotificationApiWsClient.java
+++ b/application/src/test/java/org/thingsboard/server/service/notification/NotificationApiWsClient.java
@@ -131,7 +131,7 @@ public class NotificationApiWsClient extends TbTestWebSocketClient {
     }
 
     private int newCmdId() {
-        return RandomUtils.nextInt(1, 1000);
+        return RandomUtils.secure().randomInt(1, 1000);
     }
 
 }

--- a/common/data/src/main/java/org/thingsboard/server/common/data/EntityType.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/EntityType.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
+import static org.thingsboard.server.common.data.StringUtils.removeStart;
+
 public enum EntityType {
     TENANT(1),
     CUSTOMER(2),
@@ -76,7 +78,7 @@ public enum EntityType {
     @Getter
     private final String tableName;
     @Getter
-    private final String normalName = StringUtils.capitalize(StringUtils.removeStart(name(), "TB_")
+    private final String normalName = StringUtils.capitalize(removeStart(name(), "TB_")
             .toLowerCase().replaceAll("_", " "));
 
     public static final List<String> NORMAL_NAMES = EnumSet.allOf(EntityType.class).stream()

--- a/common/data/src/main/java/org/thingsboard/server/common/data/StringUtils.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/StringUtils.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 import static org.apache.commons.lang3.StringUtils.repeat;
@@ -155,7 +156,7 @@ public class StringUtils {
     }
 
     public static boolean equals(String str1, String str2) {
-        return org.apache.commons.lang3.StringUtils.equals(str1, str2);
+        return Objects.equals(str1, str2);
     }
 
     public static boolean equalsAny(String string, String... otherStrings) {
@@ -210,23 +211,23 @@ public class StringUtils {
     }
 
     public static String randomNumeric(int length) {
-        return RandomStringUtils.randomNumeric(length);
+        return RandomStringUtils.secure().nextNumeric(length);
     }
 
     public static String random(int length) {
-        return RandomStringUtils.random(length);
+        return RandomStringUtils.secure().next(length);
     }
 
     public static String random(int length, String chars) {
-        return RandomStringUtils.random(length, chars);
+        return RandomStringUtils.secure().next(length, chars);
     }
 
     public static String randomAlphanumeric(int count) {
-        return RandomStringUtils.randomAlphanumeric(count);
+        return RandomStringUtils.secure().nextAlphanumeric(count);
     }
 
     public static String randomAlphabetic(int count) {
-        return RandomStringUtils.randomAlphabetic(count);
+        return RandomStringUtils.secure().nextAlphabetic(count);
     }
 
     public static String generateSafeToken(int length) {

--- a/common/data/src/main/java/org/thingsboard/server/common/data/util/TemplateUtils.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/util/TemplateUtils.java
@@ -23,7 +23,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Strings.nullToEmpty;
-import static org.apache.commons.lang3.StringUtils.removeStart;
+import static org.thingsboard.server.common.data.StringUtils.removeStart;
 
 public class TemplateUtils {
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/util/TypeCastUtil.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/util/TypeCastUtil.java
@@ -63,7 +63,7 @@ public class TypeCastUtil {
     }
 
     private static boolean isNumber(String value) {
-        return NumberUtils.isNumber(value.replace(',', '.'));
+        return NumberUtils.isCreatable(value.replace(',', '.'));
     }
 
     private static boolean isSimpleDouble(String valueAsString) {

--- a/common/version-control/src/main/java/org/thingsboard/server/service/sync/vc/GitRepository.java
+++ b/common/version-control/src/main/java/org/thingsboard/server/service/sync/vc/GitRepository.java
@@ -99,6 +99,7 @@ import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.REJECTED_NODELET
 import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.REJECTED_NONFASTFORWARD;
 import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.REJECTED_OTHER_REASON;
 import static org.eclipse.jgit.transport.RemoteRefUpdate.Status.REJECTED_REMOTE_CHANGED;
+import static org.thingsboard.server.common.data.StringUtils.removeStart;
 
 @Slf4j
 public class GitRepository {
@@ -448,7 +449,7 @@ public class GitRepository {
 
     private BranchInfo toBranchInfo(Ref ref) {
         String name = org.eclipse.jgit.lib.Repository.shortenRefName(ref.getName());
-        String branchName = StringUtils.removeStart(name, "origin/");
+        String branchName = removeStart(name, "origin/");
         boolean isDefault = this.headId != null && this.headId.equals(ref.getObjectId());
         return new BranchInfo(branchName, isDefault);
     }
@@ -465,7 +466,7 @@ public class GitRepository {
 
     private ObjectId resolve(String rev) throws IOException {
         if (settings.isLocalOnly()) {
-            rev = StringUtils.removeStart(rev, "origin/");
+            rev = removeStart(rev, "origin/");
         }
         ObjectId result = git.getRepository().resolve(rev);
         if (result == null) {

--- a/dao/src/main/java/org/thingsboard/server/dao/resource/BaseImageService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/resource/BaseImageService.java
@@ -173,7 +173,7 @@ public class BaseImageService extends BaseResourceService implements ImageServic
     }
 
     private String generatePublicResourceKey() {
-        return RandomStringUtils.randomAlphanumeric(32);
+        return RandomStringUtils.secure().nextAlphanumeric(32);
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/resource/BaseResourceService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/resource/BaseResourceService.java
@@ -74,6 +74,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -82,6 +83,7 @@ import java.util.function.UnaryOperator;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static org.thingsboard.server.common.data.StringUtils.isNotEmpty;
+import static org.thingsboard.server.common.data.StringUtils.removeStart;
 import static org.thingsboard.server.dao.device.DeviceServiceImpl.INCORRECT_TENANT_ID;
 import static org.thingsboard.server.dao.service.Validator.validateId;
 
@@ -588,7 +590,7 @@ public class BaseResourceService extends AbstractCachedEntityService<ResourceInf
             String resourceKey;
             TenantId resourceTenantId;
             try {
-                String[] parts = StringUtils.removeStart(link, "/api/resource/").split("/");
+                String[] parts = removeStart(link, "/api/resource/").split("/");
                 resourceType = ResourceType.valueOf(parts[0].toUpperCase());
                 String scope = parts[1];
                 resourceKey = parts[2];
@@ -611,7 +613,7 @@ public class BaseResourceService extends AbstractCachedEntityService<ResourceInf
 
     private String getResourceLink(String value) {
         if (StringUtils.startsWith(value, DataConstants.TB_RESOURCE_PREFIX + "/api/resource/")) {
-            return StringUtils.removeStart(value, DataConstants.TB_RESOURCE_PREFIX);
+            return removeStart(value, DataConstants.TB_RESOURCE_PREFIX);
         } else {
             return null;
         }
@@ -658,7 +660,7 @@ public class BaseResourceService extends AbstractCachedEntityService<ResourceInf
                 }
 
                 String newValue = processor.apply(value);
-                if (StringUtils.equals(value, newValue)) {
+                if (Objects.equals(value, newValue)) {
                     return value;
                 } else {
                     updated.set(true);

--- a/monitoring/src/main/java/org/thingsboard/monitoring/client/WsClient.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/client/WsClient.java
@@ -124,7 +124,7 @@ public class WsClient extends WebSocketClient implements AutoCloseable {
 
     public WsClient subscribeForTelemetry(List<UUID> devices, List<String> keys) {
         EntityDataCmd cmd = new EntityDataCmd();
-        cmd.setCmdId(RandomUtils.nextInt(0, 1000));
+        cmd.setCmdId(RandomUtils.secure().randomInt(0, 1000));
 
         EntityListFilter devicesFilter = new EntityListFilter();
         devicesFilter.setEntityType(EntityType.DEVICE);

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/MonitoringEntityService.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/MonitoringEntityService.java
@@ -162,7 +162,7 @@ public class MonitoringEntityService {
         device.setName(deviceName);
 
         DeviceCredentials credentials = new DeviceCredentials();
-        credentials.setCredentialsId(RandomStringUtils.randomAlphabetic(20));
+        credentials.setCredentialsId(RandomStringUtils.secure().nextAlphabetic(20));
         DeviceData deviceData = new DeviceData();
         deviceData.setConfiguration(new DefaultDeviceConfiguration());
 

--- a/tools/src/main/java/org/thingsboard/client/tools/migrator/PgCaMigrator.java
+++ b/tools/src/main/java/org/thingsboard/client/tools/migrator/PgCaMigrator.java
@@ -249,7 +249,7 @@ public class PgCaMigrator {
 
     private List<Object> castToNumericIfPossible(List<Object> values) {
         try {
-            if (values.get(6) != null && NumberUtils.isNumber(values.get(6).toString())) {
+            if (values.get(6) != null && NumberUtils.isCreatable(values.get(6).toString())) {
                 Double casted = NumberUtils.createDouble(values.get(6).toString());
                 List<Object> numeric = Lists.newArrayList();
                 numeric.addAll(values);


### PR DESCRIPTION
## Pull Request description

Build-hygiene cleanup. Continues the work from #15478. Replaces 24 deprecated commons-lang3 API calls with their non-deprecated equivalents — purely mechanical swaps, no behavior change. Tier 3 slice of the commons-lang3 group from tracking issue #15481.

### Measured impact

| Metric | Before | After |
|---|---:|---:|
| commons-lang3 deprecation `[WARNING]` lines | 45 | **21** |
| `[ERROR]` lines | 0 | **0** |

Baseline reproducible with:

```bash
MAVEN_OPTS="-Xmx1024m" mvn clean install -T6 -DskipTests -Dpkg.skip=true 2>&1 | tee /tmp/build.log
grep -E '^\[WARNING\].*commons\.lang' /tmp/build.log | wc -l
```

### What changed

All replacements verified against `commons-lang3-3.18.0.jar` (`javap` signatures). Zero behavior drift.

| Old API | New API | Count |
|---|---|---:|
| `RandomStringUtils.randomAlphanumeric(n)` | `RandomStringUtils.secure().nextAlphanumeric(n)` | 3 |
| `RandomStringUtils.randomAlphabetic(n)` | `RandomStringUtils.secure().nextAlphabetic(n)` | 3 |
| `RandomStringUtils.randomNumeric(n)` | `RandomStringUtils.secure().nextNumeric(n)` | 2 |
| `RandomStringUtils.random(n)` / `random(n, chars)` | `RandomStringUtils.secure().next(n)` / `next(n, chars)` | 2 |
| `RandomUtils.nextInt(a, b)` | `RandomUtils.secure().randomInt(a, b)` | 2 |
| `RandomUtils.nextBytes(n)` | `RandomUtils.secure().randomBytes(n)` | 1 |
| `NumberUtils.isNumber(s)` | `NumberUtils.isCreatable(s)` | 2 |
| `StringUtils.equals(a, b)` (String × String call sites) | `Objects.equals(a, b)` | 3 |
| `StringUtils.removeStart(s, r)` | `common.data.StringUtils.removeStart` wrapper (byte-identical impl) | 6 |

Deprecated statics in `RandomStringUtils` / `RandomUtils` in 3.16+ already delegate to `.secure()` internally, so `secure().nextX(…)` is exact drop-in with SecureRandom semantics. `NumberUtils.isNumber` is the renamed `isCreatable` since 3.5. `Objects.equals(a, b)` matches `StringUtils.equals(CharSequence, CharSequence)` for String × String by spec. TB's own `common.data.StringUtils.removeStart` is an inlined re-implementation of the commons-lang3 algorithm.

### Files touched (16)

- `common/data/.../StringUtils.java` — wrapper internal Random* + `equals`
- `common/data/.../EntityType.java`, `util/TemplateUtils.java` — `removeStart` import swap
- `common/data/.../util/TypeCastUtil.java` — `isNumber` → `isCreatable`
- `common/version-control/.../GitRepository.java` — 2× `removeStart`
- `dao/.../BaseResourceService.java` — 2× `removeStart` + 1× `equals`
- `dao/.../BaseImageService.java` — `randomAlphanumeric`
- `application/.../DefaultSystemDataLoaderService.java`, `TotpTwoFaProvider.java`, `WebSocketSessionType.java` — one swap each
- `application/src/test/.../AbstractWebTest.java`, `AbstractNotificationApiTest.java`, `NotificationApiWsClient.java` — test helpers
- `monitoring/.../WsClient.java`, `MonitoringEntityService.java` — one swap each
- `tools/.../PgCaMigrator.java` — `isNumber` → `isCreatable`

### What is deliberately NOT in this PR

21 commons-lang3 deprecation warnings remain; each needs inline logic, API widening, or a new dependency — none fit the "safe mechanical swap" bar of this PR:

- `StringUtils.containsAny` / `endsWithAny` (5) — require loop/stream inlines
- `StringUtils.startsWith` / `contains` (6) — require per-site null-check judgement
- `StringUtils.containsIgnoreCase` (2) — the candidate `indexOfIgnoreCase` in the same class is also deprecated in 3.18 (verified empirically — initial swap produced 2 new deprecation warnings; reverted)
- `StringUtils.endsWith` / `defaultString` / `compareIgnoreCase` (3) — wrapper-internal inlines, out of the scope of this sweep
- `StrSubstitutor` (4) — requires `commons-text` as an explicit dependency, version pinning has behavior implications
- `ObjectUtils.defaultIfNull` (1) — different class, not in the commons-lang3 group of #15481

Each would be a separate small PR.

### Testing

- `mvn -pl common/data test` — 39/39 pass (incl. `StringUtilsTest`, `EntityTypeTest`)
- `mvn -pl common/version-control test` — BUILD SUCCESS
- `mvn -pl monitoring test` — BUILD SUCCESS
- `mvn -pl tools test` — BUILD SUCCESS
- `mvn -pl application test -Dtest=TwoFactorAuthTest` — 11/11 pass (covers `TotpTwoFaProvider.generateSecretKey`)
- `mvn -pl dao test -Dtest=ResourceDataValidatorTest` — 1/1 pass

### Crosslink

- Tracking issue: #15481

## General checklist

- [x] Description contains human-readable scope of changes.
- [x] Description references the tracking issue (#15481).
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible (non-deprecated drop-in equivalents, verified behavior-preserving).

## Back-End feature checklist

- [x] No new REST endpoint, no new yml property. `mvn clean install -T6 -DskipTests -Dpkg.skip=true` still green.