### PR TITLE
Technical cleanup of TenantId construction in tests and production code

### DIFF
--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/session/GatewaySessionHandlerTest.java
@@ -75,7 +75,7 @@ public class GatewaySessionHandlerTest {
         ConcurrentHashMap<String, GatewayDeviceSessionContext> devices = new ConcurrentHashMap<>();
         TransportDeviceInfo deviceInfo = new TransportDeviceInfo();
         deviceInfo.setDeviceId(new DeviceId(UUID.randomUUID()));
-        deviceInfo.setTenantId(new TenantId(UUID.randomUUID()));
+        deviceInfo.setTenantId(TenantId.fromUUID(UUID.randomUUID()));
         deviceInfo.setCustomerId(new CustomerId(UUID.randomUUID()));
         deviceInfo.setDeviceName("device1");
         deviceInfo.setDeviceType("default");

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/cf/DefaultNativeCalculatedFieldRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/cf/DefaultNativeCalculatedFieldRepository.java
@@ -126,7 +126,7 @@ public class DefaultNativeCalculatedFieldRepository implements NativeCalculatedF
                 CalculatedFieldLink calculatedFieldLink = new CalculatedFieldLink();
                 calculatedFieldLink.setId(new CalculatedFieldLinkId(id));
                 calculatedFieldLink.setCreatedTime(createdTime);
-                calculatedFieldLink.setTenantId(new TenantId(tenantId));
+                calculatedFieldLink.setTenantId(TenantId.fromUUID(tenantId));
                 calculatedFieldLink.setEntityId(EntityIdFactory.getByTypeAndUuid(entityType, entityId));
                 calculatedFieldLink.setCalculatedFieldId(new CalculatedFieldId(calculatedFieldId));
 

--- a/dao/src/test/java/org/thingsboard/server/dao/sql/event/JpaBaseEventDaoTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/sql/event/JpaBaseEventDaoTest.java
@@ -132,7 +132,7 @@ public class JpaBaseEventDaoTest extends AbstractJpaDaoTest {
         StatisticsEvent.StatisticsEventBuilder event = StatisticsEvent.builder();
         event.id(eventId);
         event.ts(System.currentTimeMillis());
-        event.tenantId(new TenantId(tenantId));
+        event.tenantId(TenantId.fromUUID(tenantId));
         event.entityId(entityId);
         event.serviceId("server A");
         event.messagesProcessed(1);

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbAssignToCustomerNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbAssignToCustomerNodeTest.java
@@ -97,7 +97,7 @@ class TbAssignToCustomerNodeTest extends AbstractRuleNodeUpgradeTest {
     private final Edge EDGE = new Edge();
     private final Dashboard DASHBOARD = new Dashboard();
 
-    private final TenantId TENANT_ID = new TenantId(UUID.fromString("c818385f-e661-407f-8c52-daf2dddf406d"));
+    private final TenantId TENANT_ID = TenantId.fromUUID(UUID.fromString("c818385f-e661-407f-8c52-daf2dddf406d"));
     private final RuleNodeId RULE_NODE_ID = new RuleNodeId(UUID.fromString("c3570bd0-c0bc-4609-97a4-6f57d7c8b809"));
 
     private static Stream<Arguments> givenUnsupportedOriginatorType_whenOnMsg_thenVerifyExceptionThrown() {

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateRelationNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbCreateRelationNodeTest.java
@@ -111,7 +111,7 @@ public class TbCreateRelationNodeTest extends AbstractRuleNodeUpgradeTest {
         return supportedEntityTypes.stream().filter(entityType -> !entityType.equals(EntityType.TENANT)).map(Arguments::of);
     }
 
-    private static final TenantId tenantId = new TenantId(UUID.fromString("6fc86fc9-b25c-4893-b340-51cf4e101ab2"));
+    private static final TenantId tenantId = TenantId.fromUUID(UUID.fromString("6fc86fc9-b25c-4893-b340-51cf4e101ab2"));
     private static final DeviceId deviceId = new DeviceId(UUID.fromString("191ab124-1d8d-4749-97c6-fc84c113c1f5"));
     private static final AssetId assetId = new AssetId(UUID.fromString("a47a5867-deab-4333-b845-88cb1695990c"));
     private static final CustomerId customerId = new CustomerId(UUID.fromString("4af69229-273d-40de-9fba-f49f87373d23"));

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbDeleteRelationNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbDeleteRelationNodeTest.java
@@ -108,7 +108,7 @@ public class TbDeleteRelationNodeTest extends AbstractRuleNodeUpgradeTest {
         return supportedEntityTypes.stream().filter(entityType -> !entityType.equals(EntityType.TENANT)).map(Arguments::of);
     }
 
-    private static final TenantId tenantId = new TenantId(UUID.fromString("6fdb457d-0910-401c-8880-abc251e6a1e2"));
+    private static final TenantId tenantId = TenantId.fromUUID(UUID.fromString("6fdb457d-0910-401c-8880-abc251e6a1e2"));
     private static final DeviceId deviceId = new DeviceId(UUID.fromString("4eef91a7-8865-4c3c-837d-ed6f6577508b"));
     private static final AssetId assetId = new AssetId(UUID.fromString("f4fd3b10-3f36-4d46-a162-5e62050774cc"));
     private static final CustomerId customerId = new CustomerId(UUID.fromString("ab890af2-3622-41e0-ac94-14d50af84348"));

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbUnassignFromCustomerNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/action/TbUnassignFromCustomerNodeTest.java
@@ -98,7 +98,7 @@ class TbUnassignFromCustomerNodeTest extends AbstractRuleNodeUpgradeTest {
     private final Edge EDGE = new Edge();
     private final Dashboard DASHBOARD = new Dashboard();
 
-    private final TenantId TENANT_ID = new TenantId(UUID.fromString("06fcc15f-2677-436d-a1cb-7754bd0bcccf"));
+    private final TenantId TENANT_ID = TenantId.fromUUID(UUID.fromString("06fcc15f-2677-436d-a1cb-7754bd0bcccf"));
 
     private final ListeningExecutor DB_EXECUTOR = DirectListeningExecutor.INSTANCE;
 

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbAssetTypeSwitchNodeTest.java
@@ -58,7 +58,7 @@ class TbAssetTypeSwitchNodeTest {
 
     @BeforeEach
     void setUp() throws TbNodeException {
-        TenantId tenantId = new TenantId(UUID.randomUUID());
+        TenantId tenantId = TenantId.fromUUID(UUID.randomUUID());
         assetId = new AssetId(UUID.randomUUID());
         assetIdDeleted = new AssetId(UUID.randomUUID());
 

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbCheckAlarmStatusNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbCheckAlarmStatusNodeTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
 
 class TbCheckAlarmStatusNodeTest {
 
-    private static final TenantId TENANT_ID = new TenantId(UUID.randomUUID());
+    private static final TenantId TENANT_ID = TenantId.fromUUID(UUID.randomUUID());
     private static final DeviceId DEVICE_ID = new DeviceId(UUID.randomUUID());
     private static final AlarmId ALARM_ID = new AlarmId(UUID.randomUUID());
     private static final DirectListeningExecutor DB_EXECUTOR = DirectListeningExecutor.INSTANCE;

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbCheckRelationNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbCheckRelationNodeTest.java
@@ -63,7 +63,7 @@ import static org.mockito.Mockito.when;
 
 class TbCheckRelationNodeTest extends AbstractRuleNodeUpgradeTest {
 
-    private final TenantId TENANT_ID = new TenantId(UUID.randomUUID());
+    private final TenantId TENANT_ID = TenantId.fromUUID(UUID.randomUUID());
     private final DeviceId ORIGINATOR_ID = new DeviceId(UUID.randomUUID());
     private final DirectListeningExecutor DB_EXECUTOR = DirectListeningExecutor.INSTANCE;
     private final TbMsg EMPTY_POST_ATTRIBUTES_MSG = TbMsg.newMsg()

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/filter/TbDeviceTypeSwitchNodeTest.java
@@ -58,7 +58,7 @@ class TbDeviceTypeSwitchNodeTest {
 
     @BeforeEach
     void setUp() throws TbNodeException {
-        TenantId tenantId = new TenantId(UUID.randomUUID());
+        TenantId tenantId = TenantId.fromUUID(UUID.randomUUID());
         deviceId = new DeviceId(UUID.randomUUID());
         deviceIdDeleted = new DeviceId(UUID.randomUUID());
 

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/flow/TbRuleChainInputNodeTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class TbRuleChainInputNodeTest extends AbstractRuleNodeUpgradeTest {
 
-    private final TenantId TENANT_ID = new TenantId(UUID.fromString("4ba69ea5-6b27-42df-ab66-e7a727a67027"));
+    private final TenantId TENANT_ID = TenantId.fromUUID(UUID.fromString("4ba69ea5-6b27-42df-ab66-e7a727a67027"));
     private final DeviceId DEVICE_ID = new DeviceId(UUID.fromString("97731954-2147-4176-8f1a-d14f1b73e4e6"));
     private final AssetId ASSET_ID = new AssetId(UUID.fromString("841a47bd-4e8e-4ea5-88e6-420da0d70e51"));
     // A stable "current" rule chain ID: this node lives here. Must differ from any target used in tests.

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetCustomerDetailsNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetCustomerDetailsNodeTest.java
@@ -76,7 +76,7 @@ import static org.mockito.Mockito.when;
 public class TbGetCustomerDetailsNodeTest {
 
     private static final DeviceId DUMMY_DEVICE_ORIGINATOR = new DeviceId(UUID.randomUUID());
-    private static final TenantId TENANT_ID = new TenantId(UUID.randomUUID());
+    private static final TenantId TENANT_ID = TenantId.fromUUID(UUID.randomUUID());
     private static final ListeningExecutor DB_EXECUTOR = DirectListeningExecutor.INSTANCE;
     @Mock
     private TbContext ctxMock;

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetDeviceAttrNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetDeviceAttrNodeTest.java
@@ -60,7 +60,7 @@ import static org.mockito.BDDMockito.then;
 @ExtendWith(MockitoExtension.class)
 public class TbGetDeviceAttrNodeTest extends AbstractRuleNodeUpgradeTest {
 
-    private final TenantId TENANT_ID = new TenantId(UUID.fromString("5aea576c-66c4-4732-86b8-dc6bfcde7443"));
+    private final TenantId TENANT_ID = TenantId.fromUUID(UUID.fromString("5aea576c-66c4-4732-86b8-dc6bfcde7443"));
     private final DeviceId DEVICE_ID = new DeviceId(UUID.fromString("40b6b393-6ddf-47f9-973a-18550ca70384"));
     private final ListeningExecutor executor = DirectListeningExecutor.INSTANCE;
 

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetOriginatorFieldsNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetOriginatorFieldsNodeTest.java
@@ -59,7 +59,7 @@ import static org.mockito.Mockito.when;
 public class TbGetOriginatorFieldsNodeTest {
 
     private static final DeviceId DUMMY_DEVICE_ORIGINATOR = new DeviceId(UUID.randomUUID());
-    private static final TenantId DUMMY_TENANT_ID = new TenantId(UUID.randomUUID());
+    private static final TenantId DUMMY_TENANT_ID = TenantId.fromUUID(UUID.randomUUID());
     private static final ListeningExecutor DB_EXECUTOR = DirectListeningExecutor.INSTANCE;
     @Mock
     private TbContext ctxMock;

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetRelatedAttributeNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetRelatedAttributeNodeTest.java
@@ -91,7 +91,7 @@ import static org.mockito.Mockito.when;
 public class TbGetRelatedAttributeNodeTest {
 
     private static final EntityId DUMMY_DEVICE_ORIGINATOR = new DeviceId(UUID.randomUUID());
-    private static final TenantId TENANT_ID = new TenantId(UUID.randomUUID());
+    private static final TenantId TENANT_ID = TenantId.fromUUID(UUID.randomUUID());
     private static final ListeningExecutor DB_EXECUTOR = DirectListeningExecutor.INSTANCE;
     @Mock
     private TbContext ctxMock;
@@ -427,7 +427,7 @@ public class TbGetRelatedAttributeNodeTest {
     @Test
     public void givenFetchTelemetryToMetaData_whenOnMsg_thenShouldFetchTelemetryToMetaData() {
         // GIVEN
-        var tenant = new Tenant(new TenantId(UUID.randomUUID()));
+        var tenant = new Tenant(TenantId.fromUUID(UUID.randomUUID()));
         var device = new Device(new DeviceId(UUID.randomUUID()));
 
         prepareMsgAndConfig(TbMsgSource.METADATA, DataToFetch.LATEST_TELEMETRY, tenant.getId());

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetTenantAttributeNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetTenantAttributeNodeTest.java
@@ -70,7 +70,7 @@ import static org.mockito.Mockito.when;
 public class TbGetTenantAttributeNodeTest {
 
     private static final DeviceId DUMMY_DEVICE_ORIGINATOR = new DeviceId(UUID.randomUUID());
-    private static final TenantId TENANT_ID = new TenantId(UUID.randomUUID());
+    private static final TenantId TENANT_ID = TenantId.fromUUID(UUID.randomUUID());
     private static final DirectListeningExecutor DB_EXECUTOR = DirectListeningExecutor.INSTANCE;
     @Mock
     private TbContext ctxMock;

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetTenantDetailsNodeTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/metadata/TbGetTenantDetailsNodeTest.java
@@ -73,7 +73,7 @@ public class TbGetTenantDetailsNodeTest {
         config = new TbGetTenantDetailsNodeConfiguration().defaultConfiguration();
         nodeConfiguration = new TbNodeConfiguration(JacksonUtil.valueToTree(config));
         tenant = new Tenant();
-        tenant.setId(new TenantId(UUID.randomUUID()));
+        tenant.setId(TenantId.fromUUID(UUID.randomUUID()));
         tenant.setTitle("Tenant title");
         tenant.setCountry("Tenant country");
         tenant.setCity("Tenant city");

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/util/EntitiesFieldsAsyncLoaderTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/util/EntitiesFieldsAsyncLoaderTest.java
@@ -104,7 +104,7 @@ public class EntitiesFieldsAsyncLoaderTest {
     @BeforeAll
     public static void setup() {
         RANDOM_UUID = UUID.randomUUID();
-        TENANT_ID = new TenantId(UUID.randomUUID());
+        TENANT_ID = TenantId.fromUUID(UUID.randomUUID());
         SUPPORTED_ENTITY_TYPES = EnumSet.of(
                 EntityType.TENANT,
                 EntityType.CUSTOMER,
@@ -172,7 +172,7 @@ public class EntitiesFieldsAsyncLoaderTest {
     private void initMocks(EntityType entityType, boolean entityDoesNotExist) {
         switch (entityType) {
             case TENANT:
-                var tenant = Futures.immediateFuture(entityDoesNotExist ? null : new Tenant(new TenantId(RANDOM_UUID)));
+                var tenant = Futures.immediateFuture(entityDoesNotExist ? null : new Tenant(TenantId.fromUUID(RANDOM_UUID)));
 
                 when(ctxMock.getDbCallbackExecutor()).thenReturn(DB_EXECUTOR);
                 when(ctxMock.getTenantService()).thenReturn(tenantServiceMock);

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/util/EntitiesRelatedDeviceIdAsyncLoaderTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/util/EntitiesRelatedDeviceIdAsyncLoaderTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
 public class EntitiesRelatedDeviceIdAsyncLoaderTest {
 
     private static final EntityId DUMMY_ORIGINATOR = new DeviceId(UUID.randomUUID());
-    private static final TenantId TENANT_ID = new TenantId(UUID.randomUUID());
+    private static final TenantId TENANT_ID = TenantId.fromUUID(UUID.randomUUID());
     private static final ListeningExecutor DB_EXECUTOR = DirectListeningExecutor.INSTANCE;
     @Mock
     private TbContext ctxMock;

--- a/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/util/EntitiesRelatedEntityIdAsyncLoaderTest.java
+++ b/rule-engine/rule-engine-components/src/test/java/org/thingsboard/rule/engine/util/EntitiesRelatedEntityIdAsyncLoaderTest.java
@@ -55,7 +55,7 @@ import static org.thingsboard.common.util.DonAsynchron.withCallback;
 public class EntitiesRelatedEntityIdAsyncLoaderTest {
 
     private static final EntityId ASSET_ORIGINATOR_ID = new AssetId(UUID.randomUUID());
-    private static final TenantId TENANT_ID = new TenantId(UUID.randomUUID());
+    private static final TenantId TENANT_ID = TenantId.fromUUID(UUID.randomUUID());
     private static final ListeningExecutor DB_EXECUTOR = DirectListeningExecutor.INSTANCE;
 
     private TbContext ctxMock;


### PR DESCRIPTION
## Pull Request description

Follows up on the Tier 3 plan in issue #15481. Eliminates the `TenantId(UUID)` constructor deprecation warnings by migrating all call sites that actually emit `[WARNING]` in the default `mvn clean install -T6 -DskipTests -Dpkg.skip=true` build to the intended replacement `TenantId.fromUUID(UUID)` (introduced alongside the deprecation; canonicalizes instances via an internal SOFT-ref `ConcurrentReferenceHashMap<UUID, TenantId>`).

### Measured impact

| Metric | Before | After |
|---|---:|---:|
| `[WARNING]` lines                    | 843 | **821** |
| `TenantId(UUID)` ctor warnings       | 23  | **0**   |
| `[ERROR]` lines                      | 0   | 0       |

### What changed

Mechanical 1:1 substitution, 23 call sites across 21 files (23 insertions / 23 deletions):

1. `dao/` — 1 production file (`DefaultNativeCalculatedFieldRepository`) + 1 test file (`JpaBaseEventDaoTest`)
2. `common/transport/mqtt/` — 1 test file (`GatewaySessionHandlerTest`)
3. `rule-engine/rule-engine-components/` — 18 test files, 20 sites (`EntitiesFieldsAsyncLoaderTest` and `TbGetRelatedAttributeNodeTest` have 2 each)

**Per-file:** `new TenantId(X)` → `TenantId.fromUUID(X)` — argument untouched, no import or style changes.

### Behavioral compatibility

`TenantId.fromUUID(UUID)` returns interned instances; for every observable property — stored UUID, `equals`, `hashCode`, Jackson serialization — the two constructions are indistinguishable. Only `==` identity differs (new alloc vs interned), and a repo-wide grep confirms zero code uses `==`/`!=`/`assertSame`/`assertNotSame` between `TenantId` instances.

### Scope fence — intentionally NOT included

- 55 additional source-level `new TenantId(UUID)` sites in `application/src/test/**` and some `dao/src/test/**` whose modules do not emit the deprecation `[WARNING]` in the default build — fixing them yields zero log-noise reduction. Hygiene, not enforcement.
- `TenantId.java` itself — the constructor is `@Deprecated` intentionally per its javadoc ("still available due to possible usage in extensions"). No removal.
- Adjacent deprecations in the same files belong to other Tier 3 slices in #15481.

### Crosslinks

- Tracking issue: #15481

## General checklist

- [x] Description contains human-readable scope of changes.
- [x] Description references the tracking issue (#15481).
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible (identical observable behavior).

## Back-End feature checklist

- [x] No new REST endpoint, no new yml property. `mvn clean install -T6 -DskipTests -Dpkg.skip=true` still green. Targeted tests pass: `rule-engine/rule-engine-components` (1464/1464), `common/transport/mqtt:GatewaySessionHandlerTest` (3/3), `dao:JpaBaseEventDaoTest,*CalculatedField*` (9/9).