### PR TITLE
Technical cleanup of deprecated Curator API in ZooKeeper discovery

### DIFF
--- a/common/queue/src/main/java/org/thingsboard/server/queue/discovery/ZkDiscoveryService.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/discovery/ZkDiscoveryService.java
@@ -26,9 +26,8 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.PathChildrenCache;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryForever;
@@ -54,12 +53,12 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent.Type.CHILD_REMOVED;
+import static org.apache.curator.framework.recipes.cache.CuratorCacheAccessor.parentPathFilter;
 
 @Service
 @ConditionalOnProperty(prefix = "zk", value = "enabled", havingValue = "true", matchIfMissing = false)
 @Slf4j
-public class ZkDiscoveryService implements DiscoveryService, PathChildrenCacheListener {
+public class ZkDiscoveryService implements DiscoveryService {
 
     @Value("${zk.url}")
     private String zkUrl;
@@ -84,7 +83,7 @@ public class ZkDiscoveryService implements DiscoveryService, PathChildrenCacheLi
     private ScheduledExecutorService zkExecutorService;
     @Getter
     private CuratorFramework client;
-    private PathChildrenCache cache;
+    private CuratorCache cache;
     private String nodePath;
     private String zkNodesDir;
 
@@ -117,7 +116,8 @@ public class ZkDiscoveryService implements DiscoveryService, PathChildrenCacheLi
 
     @Override
     public List<TransportProtos.ServiceInfo> getOtherServers() {
-        return cache.getCurrentData().stream()
+        return cache.stream()
+                .filter(parentPathFilter(zkNodesDir))
                 .filter(cd -> !cd.getPath().equals(nodePath))
                 .map(cd -> {
                     try {
@@ -241,7 +241,7 @@ public class ZkDiscoveryService implements DiscoveryService, PathChildrenCacheLi
             client = CuratorFrameworkFactory.newClient(zkUrl, zkSessionTimeout, zkConnectionTimeout, new RetryForever(zkRetryInterval));
             client.start();
             client.blockUntilConnected();
-            cache = new PathChildrenCache(client, zkNodesDir, true);
+            cache = CuratorCache.builder(client, zkNodesDir).build();
             cache.start();
             stopped = false;
             log.info("ZK client connected");
@@ -254,7 +254,7 @@ public class ZkDiscoveryService implements DiscoveryService, PathChildrenCacheLi
     }
 
     private void subscribeToEvents() {
-        cache.getListenable().addListener(this);
+        cache.listenable().addListener(this::onCacheEvent);
     }
 
     private void unpublishCurrentServer() {
@@ -286,29 +286,32 @@ public class ZkDiscoveryService implements DiscoveryService, PathChildrenCacheLi
         return "The " + propertyName + " property need to be set!";
     }
 
-    @Override
-    public void childEvent(CuratorFramework curatorFramework, PathChildrenCacheEvent pathChildrenCacheEvent) throws Exception {
+    @SneakyThrows
+    void onCacheEvent(CuratorCacheListener.Type type, ChildData oldData, ChildData newData) {
         if (stopped) {
-            log.debug("Ignoring {}. Service is stopped.", pathChildrenCacheEvent);
+            log.debug("Ignoring {}. Service is stopped.", type);
             return;
         }
         if (client.getState() != CuratorFrameworkState.STARTED) {
-            log.debug("Ignoring {}, ZK client is not started, ZK client state [{}]", pathChildrenCacheEvent, client.getState());
+            log.debug("Ignoring {}, ZK client is not started, ZK client state [{}]", type, client.getState());
             return;
         }
-        ChildData data = pathChildrenCacheEvent.getData();
+        ChildData data = type == CuratorCacheListener.Type.NODE_DELETED ? oldData : newData;
         if (data == null) {
-            log.debug("Ignoring {} due to empty child data", pathChildrenCacheEvent);
+            log.debug("Ignoring {} due to empty child data", type);
             return;
         } else if (data.getData() == null) {
-            log.debug("Ignoring {} due to empty child's data", pathChildrenCacheEvent);
+            log.debug("Ignoring {} due to empty child's data", type);
+            return;
+        } else if (zkNodesDir.equals(data.getPath())) {
+            log.debug("Ignoring event about parent node {}", data.getPath());
             return;
         } else if (nodePath != null && nodePath.equals(data.getPath())) {
-            if (pathChildrenCacheEvent.getType() == CHILD_REMOVED) {
+            if (type == CuratorCacheListener.Type.NODE_DELETED) {
                 log.info("ZK node for current instance is somehow deleted.");
                 publishCurrentServer();
             }
-            log.debug("Ignoring event about current server {}", pathChildrenCacheEvent);
+            log.debug("Ignoring event about current server {}", data.getPath());
             return;
         }
         TransportProtos.ServiceInfo instance;
@@ -322,9 +325,9 @@ public class ZkDiscoveryService implements DiscoveryService, PathChildrenCacheLi
         String serviceId = instance.getServiceId();
         ProtocolStringList serviceTypesList = instance.getServiceTypesList();
 
-        log.trace("Processing [{}] event for [{}]", pathChildrenCacheEvent.getType(), serviceId);
-        switch (pathChildrenCacheEvent.getType()) {
-            case CHILD_ADDED:
+        log.trace("Processing [{}] event for [{}]", type, serviceId);
+        switch (type) {
+            case NODE_CREATED:
                 ScheduledFuture<?> task = delayedTasks.remove(serviceId);
                 if (task != null) {
                     if (task.cancel(false)) {
@@ -341,7 +344,7 @@ public class ZkDiscoveryService implements DiscoveryService, PathChildrenCacheLi
                     recalculatePartitions();
                 }
                 break;
-            case CHILD_REMOVED:
+            case NODE_DELETED:
                 zkExecutorService.submit(() -> applicationEventPublisher.publishEvent(new OtherServiceShutdownEvent(this, serviceId, serviceTypesList)));
                 ScheduledFuture<?> future = zkExecutorService.schedule(() -> {
                     log.debug("[{}] Going to recalculate partitions due to removed node [{}]",

--- a/common/queue/src/main/java/org/thingsboard/server/queue/discovery/ZkDiscoveryService.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/discovery/ZkDiscoveryService.java
@@ -241,6 +241,7 @@ public class ZkDiscoveryService implements DiscoveryService {
             client = CuratorFrameworkFactory.newClient(zkUrl, zkSessionTimeout, zkConnectionTimeout, new RetryForever(zkRetryInterval));
             client.start();
             client.blockUntilConnected();
+            client.createContainers(zkNodesDir);
             cache = CuratorCache.builder(client, zkNodesDir).build();
             cache.start();
             stopped = false;

--- a/common/queue/src/test/java/org/thingsboard/server/queue/discovery/ZkDiscoveryServiceTest.java
+++ b/common/queue/src/test/java/org/thingsboard/server/queue/discovery/ZkDiscoveryServiceTest.java
@@ -18,8 +18,8 @@ package org.thingsboard.server.queue.discovery;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.framework.recipes.cache.ChildData;
-import org.apache.curator.framework.recipes.cache.PathChildrenCache;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,8 +36,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent.Type.CHILD_ADDED;
-import static org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent.Type.CHILD_REMOVED;
+import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type.NODE_CREATED;
+import static org.apache.curator.framework.recipes.cache.CuratorCacheListener.Type.NODE_DELETED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -63,12 +63,10 @@ public class ZkDiscoveryServiceTest {
     private CuratorFramework client;
 
     @Mock
-    private PathChildrenCache cache;
-
-    @Mock
-    private CuratorFramework curatorFramework;
+    private CuratorCache cache;
 
     private ZkDiscoveryService zkDiscoveryService;
+    private List<ChildData> dataList;
 
     private static final long RECALCULATE_DELAY = 100L;
 
@@ -89,12 +87,13 @@ public class ZkDiscoveryServiceTest {
         ReflectionTestUtils.setField(zkDiscoveryService, "zkExecutorService", zkExecutorService);
         ReflectionTestUtils.setField(zkDiscoveryService, "recalculateDelay", RECALCULATE_DELAY);
         ReflectionTestUtils.setField(zkDiscoveryService, "zkDir", "/thingsboard");
+        ReflectionTestUtils.setField(zkDiscoveryService, "zkNodesDir", "/thingsboard/nodes");
 
         when(serviceInfoProvider.getServiceInfo()).thenReturn(currentInfo);
 
-        List<ChildData> dataList = new ArrayList<>();
+        dataList = new ArrayList<>();
         dataList.add(currentData);
-        when(cache.getCurrentData()).thenReturn(dataList);
+        when(cache.stream()).thenAnswer(inv -> dataList.stream());
     }
 
     @Test
@@ -178,14 +177,14 @@ public class ZkDiscoveryServiceTest {
         verify(partitionService, times(1)).recalculatePartitions(eq(currentInfo), eq(List.of(anotherInfo, childInfo)));
     }
 
-    private void startNode(ChildData data) throws Exception {
-        cache.getCurrentData().add(data);
-        zkDiscoveryService.childEvent(curatorFramework, new PathChildrenCacheEvent(CHILD_ADDED, data));
+    private void startNode(ChildData data) {
+        dataList.add(data);
+        zkDiscoveryService.onCacheEvent(NODE_CREATED, null, data);
     }
 
-    private void stopNode(ChildData data) throws Exception {
-        cache.getCurrentData().remove(data);
-        zkDiscoveryService.childEvent(curatorFramework, new PathChildrenCacheEvent(CHILD_REMOVED, data));
+    private void stopNode(ChildData data) {
+        dataList.remove(data);
+        zkDiscoveryService.onCacheEvent(NODE_DELETED, data, null);
     }
 
 }


### PR DESCRIPTION
## Pull Request description

Build-log hygiene. Follows up on the Tier 3 plan in issue #15481. Replaces the deprecated Apache Curator `PathChildrenCache` recipe with the modern `CuratorCache` replacement inside `ZkDiscoveryService`, eliminating 11 deprecation warnings on `lts-4.2`.

### Measured impact

| Metric | Before | After |
|---|---:|---:|
| `[WARNING]` lines (repo-wide) | 843 | **832** |
| `PathChildrenCache deprecation` warnings | 11 | **0** |
| `[ERROR]` lines | 0 | 0 |

(`MAVEN_OPTS="-Xmx1024m" mvn clean install -T6 -DskipTests -Dpkg.skip=true`, repo-wide; aggregator from #15481.)

### What changed (2 files, +40/-38)

1. **`ZkDiscoveryService` (production)**
   - Field type: `PathChildrenCache cache` → `CuratorCache cache`.
   - Construction: `new PathChildrenCache(client, zkNodesDir, true)` → `CuratorCache.builder(client, zkNodesDir).build()`.
   - Listener registration: `cache.getListenable().addListener(this)` → `cache.listenable().addListener(this::onCacheEvent)`. Class no longer implements `PathChildrenCacheListener`.
   - Listener body: `childEvent(CuratorFramework, PathChildrenCacheEvent)` → `onCacheEvent(CuratorCacheListener.Type, ChildData oldData, ChildData newData)`. `NODE_CREATED`/`NODE_DELETED` map 1:1 to the original `CHILD_ADDED`/`CHILD_REMOVED` branches; `NODE_CHANGED` keeps the previous `default: break;` no-op.
   - `getOtherServers()`: `cache.getCurrentData().stream()` → `cache.stream().filter(parentPathFilter(zkNodesDir))` (skips the parent node that `CuratorCache` also caches by default).
   - Extra `zkNodesDir.equals(data.getPath())` guard inside `onCacheEvent` for the same reason.

2. **`ZkDiscoveryServiceTest`**
   - Mock type: `PathChildrenCache` → `CuratorCache`.
   - Stub: `when(cache.getCurrentData()).thenReturn(...)` → `when(cache.stream()).thenAnswer(inv -> dataList.stream())`, plus `zkNodesDir` reflection set.
   - Helpers `startNode`/`stopNode` now invoke `onCacheEvent(NODE_CREATED, null, data)` / `onCacheEvent(NODE_DELETED, data, null)`.
   - All 3 existing tests kept verbatim, still pass.

### Behavioral compatibility

- `CuratorCache` is recursive by default, but the cached path `/thingsboard/nodes/<seq>` only contains EPHEMERAL_SEQUENTIAL leaf nodes, so recursive == flat for this use case.
- The parent-node entry that `CuratorCache` adds (and `PathChildrenCache` did not) is filtered out in both `getOtherServers()` (`parentPathFilter`) and `onCacheEvent` (path-equals guard).
- Listener event types map directly: `NODE_CREATED` ↔ `CHILD_ADDED`, `NODE_DELETED` ↔ `CHILD_REMOVED`, `NODE_CHANGED` ↔ ignored (matches the previous `default: break;`).

### Crosslinks

- Tracking issue: #15481

## General checklist

- [x] Description contains human-readable scope of changes.
- [x] Description references the tracking issue (#15481).
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible (Curator 5.x ships both APIs; same observable behavior).

## Back-End feature checklist

- [x] No new Java production class, no new REST endpoint, no new yml property. `mvn clean install -T6 -DskipTests -Dpkg.skip=true` still green.