### PR TITLE
Updated REST client timeout API to non-deprecated variants

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/notification/channels/MicrosoftTeamsNotificationChannel.java
+++ b/application/src/main/java/org/thingsboard/server/service/notification/channels/MicrosoftTeamsNotificationChannel.java
@@ -54,8 +54,8 @@ public class MicrosoftTeamsNotificationChannel implements NotificationChannel<Mi
 
     @Setter
     private RestTemplate restTemplate = new RestTemplateBuilder()
-            .setConnectTimeout(Duration.of(15, ChronoUnit.SECONDS))
-            .setReadTimeout(Duration.of(15, ChronoUnit.SECONDS))
+            .connectTimeout(Duration.of(15, ChronoUnit.SECONDS))
+            .readTimeout(Duration.of(15, ChronoUnit.SECONDS))
             .build();
 
     @Override

--- a/monitoring/src/main/java/org/thingsboard/monitoring/client/TbClient.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/client/TbClient.java
@@ -34,8 +34,8 @@ public class TbClient extends RestClient {
     public TbClient(@Value("${monitoring.rest.base_url}") String baseUrl,
                     @Value("${monitoring.rest.request_timeout_ms}") int requestTimeoutMs) {
         super(new RestTemplateBuilder()
-                .setConnectTimeout(Duration.ofMillis(requestTimeoutMs))
-                .setReadTimeout(Duration.ofMillis(requestTimeoutMs))
+                .connectTimeout(Duration.ofMillis(requestTimeoutMs))
+                .readTimeout(Duration.ofMillis(requestTimeoutMs))
                 .build(), baseUrl);
     }
 

--- a/monitoring/src/main/java/org/thingsboard/monitoring/notification/channels/impl/SlackNotificationChannel.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/notification/channels/impl/SlackNotificationChannel.java
@@ -40,8 +40,8 @@ public class SlackNotificationChannel implements NotificationChannel {
     @PostConstruct
     private void init() {
         restTemplate = new RestTemplateBuilder()
-                .setConnectTimeout(Duration.ofSeconds(5))
-                .setReadTimeout(Duration.ofSeconds(2))
+                .connectTimeout(Duration.ofSeconds(5))
+                .readTimeout(Duration.ofSeconds(2))
                 .build();
     }
 

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/transport/impl/HttpTransportHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/transport/impl/HttpTransportHealthChecker.java
@@ -43,8 +43,8 @@ public class HttpTransportHealthChecker extends TransportHealthChecker<HttpTrans
     protected void initClient() throws Exception {
         if (restTemplate == null) {
             restTemplate = new RestTemplateBuilder()
-                    .setConnectTimeout(Duration.ofMillis(config.getRequestTimeoutMs()))
-                    .setReadTimeout(Duration.ofMillis(config.getRequestTimeoutMs()))
+                    .connectTimeout(Duration.ofMillis(config.getRequestTimeoutMs()))
+                    .readTimeout(Duration.ofMillis(config.getRequestTimeoutMs()))
                     .build();
             log.debug("Initialized HTTP client");
         }


### PR DESCRIPTION
## Pull Request description

Production-code cleanup. Follows up on the hygiene plan in issue #15481. Eliminates the 8 `RestTemplateBuilder.setConnectTimeout(Duration)` / `setReadTimeout(Duration)` deprecation warnings that Spring Boot 3.5 emits by switching to the non-deprecated replacements `connectTimeout(Duration)` / `readTimeout(Duration)`.

### Measured impact

`MAVEN_OPTS="-Xmx1024m" mvn clean install -T1 -DskipTests -Dpkg.skip=true`

| Metric | Before | After |
|---|---:|---:|
| `[WARNING]` total | 843 | 837 |
| `setConnectTimeout(Duration)` matches | 4 | **0** |
| `setReadTimeout(Duration)` matches | 4 | **0** |

The −6 (rather than the expected −8) total drop is a benign `javac` re-bucketing artefact: with the source modified, the compiler chose to emit two pre-existing deprecation warnings (`ProtoUtils.getTbMsgProto` in `SequentialByOriginatorIdTbRuleEngineSubmitStrategy.java`, `TelemetryCmdsWrapper` in `TbWebSocketHandler.java`) as detailed `[WARNING]` lines instead of collapsing them into the per-file `[INFO]` "Some input files additionally use or override a deprecated API" summaries. The aggregate count of `[INFO]` deprecation summaries is unchanged at 6 in both runs, and no new deprecated API was introduced.

### What changed (production code only, no test code touched)

4 files, 8 method-call renames:

| File | Lines | Change |
|---|---|---|
| `application/src/main/java/.../MicrosoftTeamsNotificationChannel.java` | 57–58 | `setConnectTimeout` → `connectTimeout`, `setReadTimeout` → `readTimeout` |
| `monitoring/src/main/java/.../SlackNotificationChannel.java` | 43–44 | same |
| `monitoring/src/main/java/.../HttpTransportHealthChecker.java` | 46–47 | same |
| `monitoring/src/main/java/.../TbClient.java` | 37–38 | same |

### Behavioral compatibility

Spring Boot 3.5.13 ships `setConnectTimeout(Duration)` and `setReadTimeout(Duration)` as thin shims that delegate to their non-`set` counterparts. Verified by inspecting the bytecode of `RestTemplateBuilder.class` — the deprecated method body is literally:

```
0: aload_0
1: aload_1
2: invokevirtual #173 // connectTimeout:(Ljava/time/Duration;)Lorg/springframework/boot/web/client/RestTemplateBuilder;
5: areturn
```

Zero behavior delta — pure rename.

### Crosslinks

- Tracking issue: #15481

## General checklist

- [x] Description contains human-readable scope of changes.
- [x] Description references the tracking issue (#15481).
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible (behavior-equivalent rename, verified by bytecode).

## Back-End feature checklist

- [x] No new Java production code, no new REST endpoint, no new yml property. `mvn clean install -T1 -DskipTests -Dpkg.skip=true` still green.