### PR TITLE
Fix tb-cassandra docker build: dpkg conffile prompt blocks openjdk-17-jre-headless upgrade

### DIFF
--- a/msa/tb/docker-cassandra/Dockerfile
+++ b/msa/tb/docker-cassandra/Dockerfile
@@ -42,6 +42,10 @@ ENV CASSANDRA_LOG=/var/log/cassandra
 
 COPY logback.xml ${pkg.name}.conf start-db.sh stop-db.sh start-tb.sh upgrade-tb.sh install-tb.sh ${pkg.name}.deb /tmp/
 
+# Keep base image's customized conffiles (e.g. /etc/java-17-openjdk/security/java.security)
+# when apt upgrades openjdk-17-jre-headless transitively as cassandra's java11-runtime provider;
+# without this dpkg blocks on a non-interactive conffile prompt and the build fails.
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends wget nmap procps gnupg2 \
     && echo "deb http://apt.postgresql.org/pub/repos/apt/ $(. /etc/os-release && echo -n $VERSION_CODENAME)-pgdg main" | tee --append /etc/apt/sources.list.d/pgdg.list > /dev/null \
@@ -49,7 +53,9 @@ RUN apt-get update \
     && echo "deb https://debian.cassandra.apache.org 40x main" | tee -a /etc/apt/sources.list.d/cassandra.sources.list > /dev/null \
     && wget -q https://downloads.apache.org/cassandra/KEYS -O- | apt-key add - \
     && apt-get update \
-    && apt-get install -y --no-install-recommends cassandra cassandra-tools postgresql-${PG_MAJOR} \
+    && apt-get install -y --no-install-recommends \
+         -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+         cassandra cassandra-tools postgresql-${PG_MAJOR} \
     && rm -rf /var/lib/apt/lists/* \
     && update-rc.d cassandra disable \
     && update-rc.d postgresql disable \


### PR DESCRIPTION
## Summary

The `tb-cassandra` docker image build fails on `lts-4.2` (and the same Dockerfile on `rc`/`master`) when apt-get pulls in a newer `openjdk-17-jre-headless` to satisfy cassandra's `java11-runtime` dependency. The base image `thingsboard/openjdk17:bookworm-slim` ships a customized `/etc/java-17-openjdk/security/java.security`; on upgrade dpkg detects the modified conffile and prompts:

```
Configuration file '/etc/java-17-openjdk/security/java.security'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
     Y or I  : install the package maintainer's version
     N or O  : keep your currently-installed version
       D     : show the differences between the versions
       Z     : start a shell to examine the situation
*** java.security (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package
  openjdk-17-jre-headless:amd64 (--configure):
  end of file on stdin at conffile prompt
```

Because there is no stdin in the docker build, dpkg fails. `openjdk-17-jre-headless` ends up unconfigured, which cascades into the misleading downstream error `cassandra depends on openjdk-11-jre-headless | openjdk-8-jre-headless | java11-runtime | java8-runtime` and the build aborts.

Setting `DEBIAN_FRONTEND=noninteractive` alone does **not** fix this — that env var only suppresses *debconf* prompts, not *dpkg conffile* prompts, which are a separate mechanism.

## Fix

Pass `-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"` to both `apt-get install` invocations so dpkg silently keeps the base image's customized conffile. Also set `DEBIAN_FRONTEND=noninteractive` for completeness.

The choice of `--force-confold` (keep installed/customized version) over `--force-confnew` is deliberate — the modified `java.security` is part of the ThingsBoard base image's hardening and we want to preserve it.

Reference failing build: [TestBlackBoxMicroservices #1213 / build 106476](https://builds.thingsboard.io/buildConfiguration/ThingsBoard_TestBlackBoxMicroservices/106476).

## Test plan

- [x] **Reproduce on bare base image (no fix)**: minimal Dockerfile with the same apt-get sequence on `thingsboard/openjdk17:bookworm-slim` (linux/amd64) fails at the exact same `*** java.security (Y/I/N/O/D/Z) [default=N] ?` line, exit code 100. Matches CI build 106476 line-for-line.
- [x] **Verify fix works**: same minimal Dockerfile with the proposed change builds clean — dpkg now logs `==> Keeping old config file as default.` and proceeds to `Setting up openjdk-17-jre-headless` → `Setting up postgresql-16` → `Setting up cassandra (4.0.20)` → `Setting up cassandra-tools (4.0.20)` → image exported.
- [ ] CI: TestBlackBoxMicroservices on this branch is the real test.

## Notes / follow-ups

The same one-line Dockerfile is identical on `rc` and `master`. Once this lands on `lts-4.2`, the same fix should be ported there (or applied centrally in the `thingsboard/openjdk*` base image via `/etc/apt/apt.conf.d/90-noninteractive` so every consumer inherits it).