### PR TITLE
Prevent consumer busy-wait when partition assignment is empty

### DIFF
--- a/common/queue/src/main/java/org/thingsboard/server/queue/common/AbstractTbQueueConsumerTemplate.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/common/AbstractTbQueueConsumerTemplate.java
@@ -98,7 +98,10 @@ public abstract class AbstractTbQueueConsumerTemplate<R, T extends TbQueueMsg> i
                 doSubscribe(partitions);
                 subscribed = true;
             }
-            records = partitions.isEmpty() ? emptyList() : doPoll(durationInMillis);
+            if (partitions.isEmpty()) {
+                return sleepAndReturnEmpty(startNanos, durationInMillis);
+            }
+            records = doPoll(durationInMillis);
         } finally {
             consumerLock.unlock();
         }

--- a/common/queue/src/test/java/org/thingsboard/server/queue/common/AbstractTbQueueConsumerTemplateTest.java
+++ b/common/queue/src/test/java/org/thingsboard/server/queue/common/AbstractTbQueueConsumerTemplateTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.queue.common;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
+import org.thingsboard.server.queue.TbQueueMsg;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.spy;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+public class AbstractTbQueueConsumerTemplateTest {
+
+    private static final long POLL_DURATION_MS = 100L;
+    private static final long SLEEP_TOLERANCE_MS = 20L;
+
+    @Test
+    public void givenEmptyPartitionsAndLongPollingSupported_whenPoll_thenSleepsAndDoesNotCallDoPoll() {
+        // Regression: with empty partitions AND isLongPollingSupported()==true (e.g. Kafka),
+        // poll() previously returned instantly with no sleep, causing the consumer loop to busy-spin.
+        TestConsumer consumer = spy(new TestConsumer("test-topic", true));
+        consumer.subscribe(Collections.emptySet());
+
+        long startNs = System.nanoTime();
+        List<TbQueueMsg> result = consumer.poll(POLL_DURATION_MS);
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
+
+        assertThat(result, is(empty()));
+        verify(consumer, never()).doPoll(anyLong());
+        assertThat("poll() must sleep ~durationInMillis when partitions are empty (no busy-wait)",
+                elapsedMs, greaterThanOrEqualTo(POLL_DURATION_MS - SLEEP_TOLERANCE_MS));
+    }
+
+    @Test
+    public void givenEmptyPartitionsAndNoLongPolling_whenPoll_thenSleepsAndDoesNotCallDoPoll() {
+        TestConsumer consumer = spy(new TestConsumer("test-topic", false));
+        consumer.subscribe(Collections.emptySet());
+
+        long startNs = System.nanoTime();
+        List<TbQueueMsg> result = consumer.poll(POLL_DURATION_MS);
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
+
+        assertThat(result, is(empty()));
+        verify(consumer, never()).doPoll(anyLong());
+        assertThat(elapsedMs, greaterThanOrEqualTo(POLL_DURATION_MS - SLEEP_TOLERANCE_MS));
+    }
+
+    @Test
+    public void givenNonEmptyPartitions_whenPoll_thenCallsDoPoll() {
+        TestConsumer consumer = spy(new TestConsumer("test-topic", true));
+        consumer.subscribe(Collections.singleton(new TopicPartitionInfo("test-topic", null, 0, true)));
+
+        List<TbQueueMsg> result = consumer.poll(POLL_DURATION_MS);
+
+        assertThat(result, is(empty()));
+        verify(consumer, times(1)).doPoll(POLL_DURATION_MS);
+    }
+
+    @Test
+    public void givenPartitionsBecomeEmptyAfterRebalance_whenPollAgain_thenStopsCallingDoPoll() {
+        // Reproduces the observed trigger: a rebalance leaves the consumer with an empty
+        // partition assignment. Subsequent poll() calls must not busy-spin or call doPoll().
+        TestConsumer consumer = spy(new TestConsumer("test-topic", true));
+        consumer.subscribe(Collections.singleton(new TopicPartitionInfo("test-topic", null, 0, true)));
+        consumer.poll(POLL_DURATION_MS);
+        verify(consumer, times(1)).doPoll(POLL_DURATION_MS);
+
+        consumer.subscribe(Collections.emptySet());
+
+        long startNs = System.nanoTime();
+        List<TbQueueMsg> result = consumer.poll(POLL_DURATION_MS);
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
+
+        assertThat(result, is(empty()));
+        verify(consumer, times(1)).doPoll(anyLong());
+        assertThat(elapsedMs, greaterThanOrEqualTo(POLL_DURATION_MS - SLEEP_TOLERANCE_MS));
+    }
+
+    static class TestConsumer extends AbstractTbQueueConsumerTemplate<Object, TbQueueMsg> {
+
+        private final boolean longPollingSupported;
+
+        TestConsumer(String topic, boolean longPollingSupported) {
+            super(topic);
+            this.longPollingSupported = longPollingSupported;
+        }
+
+        @Override
+        protected List<Object> doPoll(long durationInMillis) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        protected TbQueueMsg decode(Object record) {
+            return null;
+        }
+
+        @Override
+        protected void doSubscribe(Set<TopicPartitionInfo> partitions) {
+        }
+
+        @Override
+        protected void doCommit() {
+        }
+
+        @Override
+        protected void doUnsubscribe() {
+        }
+
+        @Override
+        protected boolean isLongPollingSupported() {
+            return longPollingSupported;
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
Fixes a CPU busy-wait in `AbstractTbQueueConsumerTemplate.poll()` that triggered on Kafka-backed consumers (`ie-downlink-consumer`, notification consumers, and any other loop on `TbKafkaConsumerTemplate`) once their partition assignment became empty after a rebalance.

## Root cause
Two reasonable-in-isolation behaviors combined into a bug:

1. `poll()` short-circuited `doPoll()` whenever `partitions.isEmpty()`:
   ```java
   records = partitions.isEmpty() ? emptyList() : doPoll(durationInMillis);
   ```
2. The fallback sleep is only entered when `!isLongPollingSupported()`, which is `false` for Kafka (the assumption being that `doPoll()` itself will block).

Together: empty `partitions` + Kafka backend ⇒ `poll()` returns instantly with no sleep, the outer `consumerLoop` `continue`s, and the thread spins forever. Observed in production: 26 affected `ie-downlink-consumer` threads at `consumerLock.unlock()` consuming ~244% CPU for nearly an hour with `doPoll()` never invoked.

The trigger was a 450k-device DB scan that caused a rule-engine consumer to be kicked from the Kafka group; the resulting cascade of `recalculatePartitions()` calls left the consumer with an empty assignment that no later event corrected.

## Fix
Route the empty-partition path through `sleepAndReturnEmpty()` so `durationInMillis` is honored regardless of whether the backend supports long polling:

```java
if (partitions.isEmpty()) {
    return sleepAndReturnEmpty(startNanos, durationInMillis);
}
records = doPoll(durationInMillis);
```

## Tests
New `AbstractTbQueueConsumerTemplateTest` (4 cases):
- Empty partitions + `isLongPollingSupported()==true` → `poll()` sleeps ≈ `durationInMillis` and never calls `doPoll()` (the Kafka regression).
- Empty partitions + `isLongPollingSupported()==false` → same behavior preserved.
- Non-empty partitions → `doPoll()` is invoked.
- Rebalance scenario: subscribe with one partition (poll calls `doPoll`), then re-subscribe to `emptySet()` → next poll sleeps and does not call `doPoll`.

Confirmed the new tests fail against the pre-fix code (elapsed = 0–7 ms instead of ≥ 80 ms) and pass against the fix.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).
