### PR TITLE
Fixed CVE-2026-40975, CVE-2026-40973, CVE-2026-22740, CVE-2026-42198

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <pkg.implementationTitle>${project.name}</pkg.implementationTitle>
         <pkg.unixLogFolder>/var/log/${pkg.name}</pkg.unixLogFolder>
         <pkg.installFolder>/usr/share/${pkg.name}</pkg.installFolder>
-        <spring-boot.version>3.5.13</spring-boot.version>
+        <spring-boot.version>3.5.14</spring-boot.version>
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -70,8 +70,8 @@
         <metrics.version>4.2.25</metrics.version>
         <cassandra-all.version>5.0.4</cassandra-all.version> <!-- tools -->
         <guava.version>33.1.0-jre</guava.version>
-        <tomcat.version>10.1.54</tomcat.version> <!-- to fix CVE-2026-34487, CVE-2026-34486, CVE-2026-34483. TODO: remove when fixed in spring-boot-dependencies -->
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
+        <postgresql.version>42.7.11</postgresql.version> <!-- to fix CVE-2026-42198. TODO: remove when fixed in spring-boot-dependencies -->
         <commons-io.version>2.16.1</commons-io.version>
         <commons-logging.version>1.3.1</commons-logging.version>
         <commons-csv.version>1.10.0</commons-csv.version>
@@ -89,7 +89,7 @@
         <protobuf.version>3.25.5</protobuf.version> <!-- A Major v4 does not support by the pubsub yet-->
         <grpc.version>1.76.0</grpc.version>
         <tbel.version>1.2.9</tbel.version>
-        <lombok.version>1.18.44</lombok.version> <!-- must be in sync with spring-boot-dependencies; needed for maven-compiler-plugin annotationProcessorPaths -->
+        <lombok.version>1.18.46</lombok.version> <!-- must be in sync with spring-boot-dependencies; needed for maven-compiler-plugin annotationProcessorPaths -->
         <paho.client.version>1.2.5</paho.client.version>
         <paho.mqttv5.client.version>1.2.5</paho.mqttv5.client.version>
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
@@ -1002,25 +1002,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Temporary tomcat version override to fix CVE-2026-34487, CVE-2026-34486, CVE-2026-34483.
-                 Must be declared before the spring-boot-dependencies BOM import to take precedence.
-                 TODO: remove when fixed in spring-boot-dependencies -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-el</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <!-- End of tomcat version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -1355,6 +1336,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
         <pkg.unixLogFolder>/var/log/${pkg.name}</pkg.unixLogFolder>
         <pkg.installFolder>/usr/share/${pkg.name}</pkg.installFolder>
         <spring-boot.version>3.5.14</spring-boot.version>
+        <!-- TODO: remove spring-boot-test.version override and the matching dependencyManagement entries below
+             once Spring Boot 3.5.15+ is released with a fix for the ImportsContextCustomizer regression in 3.5.14
+             that causes "Duplicate spy definition" failures on legacy @SpyBean fields (see PR #15557). -->
+        <spring-boot-test.version>3.5.13</spring-boot-test.version>
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -1247,6 +1251,19 @@
                         <artifactId>android-json</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!-- TODO: remove these two pins once Spring Boot 3.5.15+ ships the fix for the
+                 ImportsContextCustomizer regression in 3.5.14 (see PR #15557). Test artifacts are not
+                 packaged in the runtime image, so pinning them does not affect the CVE fixes. -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-test</artifactId>
+                <version>${spring-boot-test.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-test-autoconfigure</artifactId>
+                <version>${spring-boot-test.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
## Context

Four high-severity vulnerabilities reported by the scheduled PE security scan ([#106974](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/106974)) that are in scope for CE — fixed by bumping Spring Boot and overriding the PostgreSQL JDBC driver.

**Java (root `pom.xml`):**

- **CVE-2026-40975** (High) — Spring Boot 3.5.13
- **CVE-2026-40973** (High) — Spring Boot 3.5.13
- **CVE-2026-22740** (High, CVSS 7.1) — Spring Web 6.2.17
- **CVE-2026-42198** (High, CVSS 8.7) — PostgreSQL JDBC driver 42.7.10

## Fix

- **Spring Boot**: bumped `spring-boot.version` 3.5.13 → 3.5.14. This transitively brings spring-framework 6.2.18 (covers CVE-2026-22740 in spring-web), spring-security 6.5.10, spring-data 3.5.11, micrometer 1.15.11, hibernate-core 6.6.49.Final, and other patch-level updates from the BOM.
- **PostgreSQL**: added `<postgresql.version>42.7.11</postgresql.version>` with an explicit `<dependencyManagement>` entry next to `commons-lang3`. Spring Boot 3.5.14 BOM still ships `postgresql 42.7.10`, and a property-only override does not propagate without a matching dep mgmt entry — verified empirically (see Result below).
- **Lombok**: bumped `lombok.version` 1.18.44 → 1.18.46 to match the Spring Boot 3.5.14 BOM, per the existing inline comment requiring sync (used by `maven-compiler-plugin` `annotationProcessorPaths`; runtime tree picks BOM's value, the property must follow to keep annotation processing in sync).

### Cleanup: dropped tomcat.version override

The in-tree `<tomcat.version>10.1.54</tomcat.version>` property and the matching `tomcat-embed-core / -el / -websocket` entries in `<dependencyManagement>` (introduced in #15417 with the explicit `TODO: remove when fixed in spring-boot-dependencies`) are obsolete — Spring Boot 3.5.14 BOM ships `tomcat 10.1.54` natively. The workaround is removed; the resolved runtime version is unchanged.

## Spring class override sync

`application/src/main/java/org/springframework/http/converter/xml/MappingJackson2XmlHttpMessageConverter.java` is our in-tree override of the upstream Spring class. Checked upstream diff between `spring-framework` 6.2.17 and 6.2.18 — the file is **byte-identical** (`diff` returns empty). No re-sync of the override is required for this bump.

```
diff <(curl -sL https://raw.githubusercontent.com/spring-projects/spring-framework/v6.2.17/spring-web/src/main/java/org/springframework/http/converter/xml/MappingJackson2XmlHttpMessageConverter.java) \
     <(curl -sL https://raw.githubusercontent.com/spring-projects/spring-framework/v6.2.18/spring-web/src/main/java/org/springframework/http/converter/xml/MappingJackson2XmlHttpMessageConverter.java)
# (empty)
```

## Result

```
mvn dependency:tree -pl application -am -Dincludes=org.springframework.boot:spring-boot,org.springframework:spring-web,org.postgresql:postgresql,org.apache.tomcat.embed:tomcat-embed-core,org.apache.commons:commons-lang3
```
```
[INFO]    \- org.springframework.boot:spring-boot:jar:3.5.14:compile
[INFO]    +- org.springframework:spring-web:jar:6.2.18:compile
[INFO]    +- org.postgresql:postgresql:jar:42.7.11:compile
[INFO]    +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.54:compile
[INFO]    +- org.apache.commons:commons-lang3:jar:3.18.0:compile
```