### PR TITLE
Fixed MAX aggregation for mixed double and long telemetry values

### DIFF
--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbelCfTsRollingArg.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbelCfTsRollingArg.java
@@ -73,7 +73,7 @@ public class TbelCfTsRollingArg implements TbelCfArg, Iterable<TbelCfTsDoubleVal
             throw new IllegalArgumentException("Rolling argument values are empty.");
         }
 
-        double max = Double.MIN_VALUE;
+        double max = -Double.MAX_VALUE;
         for (TbelCfTsDoubleVal value : values) {
             double val = value.getValue();
             if (!ignoreNaN && Double.isNaN(val)) {

--- a/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbelCfTsRollingArgTest.java
+++ b/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbelCfTsRollingArgTest.java
@@ -58,6 +58,19 @@ public class TbelCfTsRollingArgTest {
     }
 
     @Test
+    void testMaxOverAllNegativeValues() {
+        TbelCfTsRollingArg negativeArg = new TbelCfTsRollingArg(
+                new TbTimeWindow(ts - 30000, ts - 10),
+                List.of(
+                        new TbelCfTsDoubleVal(ts - 10, -50.0),
+                        new TbelCfTsDoubleVal(ts - 20, -100.0),
+                        new TbelCfTsDoubleVal(ts - 30, -75.0)
+                )
+        );
+        assertThat(negativeArg.max()).isEqualTo(-50.0);
+    }
+
+    @Test
     void testMin() {
         assertThat(rollingArg.min()).isEqualTo(2.0);
         assertThat(rollingArg.min(false)).isNaN();

--- a/dao/src/main/java/org/thingsboard/server/dao/sqlts/ts/TsKvRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sqlts/ts/TsKvRepository.java
@@ -61,8 +61,10 @@ public interface TsKvRepository extends JpaRepository<TsKvEntity, TsKvCompositeK
                              @Param("startTs") long startTs,
                              @Param("endTs") long endTs);
 
+    // -1.7976931348623157E308 = -Double.MAX_VALUE — the most negative finite double, used as a "less than any value" sentinel for MAX.
+    // Double.MIN_VALUE is +4.9E-324 (smallest positive), which would beat any negative real value and corrupt MAX.
     @Query("SELECT new TsKvEntity(MAX(COALESCE(tskv.longValue, -9223372036854775807)), " +
-            "MAX(COALESCE(tskv.doubleValue, java.lang.Double.MIN_VALUE)), " +
+            "MAX(COALESCE(tskv.doubleValue, -1.7976931348623157E308)), " +
             "SUM(CASE WHEN tskv.longValue IS NULL THEN 0 ELSE 1 END), " +
             "SUM(CASE WHEN tskv.doubleValue IS NULL THEN 0 ELSE 1 END), " +
             "'MAX', MAX(tskv.ts)) FROM TsKvEntity tskv " +

--- a/dao/src/main/java/org/thingsboard/server/dao/timeseries/AggregatePartitionsFunction.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/timeseries/AggregatePartitionsFunction.java
@@ -277,7 +277,7 @@ public class AggregatePartitionsFunction implements com.google.common.util.concu
     private Optional<TsKvEntry> processMinOrMaxResult(AggregationResult aggResult) {
         if (aggResult.dataType == DataType.DOUBLE || aggResult.dataType == DataType.LONG) {
             if (aggResult.hasDouble) {
-                double currentD = aggregation == Aggregation.MIN ? Optional.ofNullable(aggResult.dValue).orElse(Double.MAX_VALUE) : Optional.ofNullable(aggResult.dValue).orElse(Double.MIN_VALUE);
+                double currentD = aggregation == Aggregation.MIN ? Optional.ofNullable(aggResult.dValue).orElse(Double.MAX_VALUE) : Optional.ofNullable(aggResult.dValue).orElse(-Double.MAX_VALUE);
                 double currentL = aggregation == Aggregation.MIN ? Optional.ofNullable(aggResult.lValue).orElse(Long.MAX_VALUE) : Optional.ofNullable(aggResult.lValue).orElse(Long.MIN_VALUE);
                 return Optional.of(new BasicTsKvEntry(ts, new DoubleDataEntry(key, aggregation == Aggregation.MIN ? Math.min(currentD, currentL) : Math.max(currentD, currentL))));
             } else {

--- a/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
@@ -723,6 +723,19 @@ public abstract class BaseTimeseriesServiceTest extends AbstractServiceTest {
     }
 
     @Test
+    public void testFindDeviceMaxAggregationOverAllNegativeDoubleTsData() throws Exception {
+        save(deviceId, 5000, -50.0);
+        save(deviceId, 15000, -100.0);
+        save(deviceId, 25000, -75.0);
+
+        List<TsKvEntry> list = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
+                60000, 60000, 1, Aggregation.MAX))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+
+        assertEquals(1, list.size());
+        assertEquals(java.util.Optional.of(-50.0), list.get(0).getDoubleValue());
+    }
+
+    @Test
     public void testSaveTs_RemoveTs_AndSaveTsAgain() throws Exception {
         save(deviceId, 2000000L, 95);
         save(deviceId, 4000000L, 100);

--- a/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/timeseries/BaseTimeseriesServiceTest.java
@@ -711,6 +711,18 @@ public abstract class BaseTimeseriesServiceTest extends AbstractServiceTest {
     }
 
     @Test
+    public void testFindDeviceMaxAggregationOverNegativeMixedLongAndDoubleTsData() throws Exception {
+        save(deviceId, 5000, -100L);
+        save(deviceId, 15000, -50.0);
+
+        List<TsKvEntry> list = tsService.findAll(tenantId, deviceId, Collections.singletonList(new BaseReadTsKvQuery(LONG_KEY, 0,
+                60000, 60000, 1, Aggregation.MAX))).get(MAX_TIMEOUT, TimeUnit.SECONDS);
+
+        assertEquals(1, list.size());
+        assertEquals(java.util.Optional.of(-50.0), list.get(0).getDoubleValue());
+    }
+
+    @Test
     public void testSaveTs_RemoveTs_AndSaveTsAgain() throws Exception {
         save(deviceId, 2000000L, 95);
         save(deviceId, 4000000L, 100);


### PR DESCRIPTION
## Pull Request description

For devices with negative telemetry keys that store telemetry in both long and double format, the max value was ~4.9E-324 instead of real.
Three locations were fixed: SQL aggregation, Cassandra aggregation, and the TBEL rollingArg.max() used in calculated fields. 

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



