### PR TITLE
Fix intermittent `tsc: not found` under `mvn -T`: serialize msa yarn modules

### DIFF
--- a/msa/js-executor/pom.xml
+++ b/msa/js-executor/pom.xml
@@ -52,6 +52,29 @@
             <type>exe</type>
             <scope>provided</scope>
         </dependency>
+        <!--
+            Reactor-only ordering dep (NOT a real classpath dependency).
+            Forces `mvn -T<n>` to serialize this module after web-ui so that
+            no two `yarn install` / `yarn run pkg` invocations can overlap on
+            the same agent. Concurrent yarn 1.x processes share ~/.cache/yarn
+            and have intermittently produced `tsc: not found` failures during
+            yarn pkg (incomplete typescript extraction in node_modules).
+            The chain is: ui-ngx -> msa/web-ui -> msa/js-executor.
+            type=pom + provided + wildcard exclusions keep nothing on the classpath.
+        -->
+        <dependency>
+            <groupId>org.thingsboard.msa</groupId>
+            <artifactId>web-ui</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -90,7 +113,7 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <arguments>run pkg</arguments>
+                            <arguments>--mutex network run pkg</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/msa/pom.xml
+++ b/msa/pom.xml
@@ -44,7 +44,16 @@
     </properties>
 
     <modules>
-        <!--Modules order is important to speedup parallel build and avoid yarn pgk parallel execution-->
+        <!--
+            Module order below is informational only. Yarn-using modules
+            (web-ui, js-executor) are serialized via reactor-only
+            <dependency> entries in their own poms, forming the chain
+            ui-ngx -> web-ui -> js-executor. This prevents
+            concurrent yarn install / yarn run pkg invocations under `mvn -T<n>`,
+            which previously caused intermittent `tsc: not found` failures
+            (incomplete typescript extraction in node_modules from racing
+            yarn 1.x processes against the shared ~/.cache/yarn).
+        -->
         <module>tb</module>
         <module>web-ui</module>
         <module>vc-executor</module>

--- a/msa/web-ui/pom.xml
+++ b/msa/web-ui/pom.xml
@@ -99,7 +99,7 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <arguments>run pkg</arguments>
+                            <arguments>--mutex network run pkg</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/ui-ngx/pom.xml
+++ b/ui-ngx/pom.xml
@@ -106,7 +106,7 @@
                                     <goal>yarn</goal>
                                 </goals>
                                 <configuration>
-                                    <arguments>run build:prod</arguments>
+                                    <arguments>--mutex network run build:prod</arguments>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
## Summary

Under `mvn -T<n>` with the three yarn-using modules (`ui-ngx`, `msa/web-ui`, `msa/js-executor`), concurrent yarn 1.x processes contend on the shared `~/.cache/yarn`. The existing `--mutex network` flag was applied only to `yarn install`, so `yarn run pkg` could overlap with another module's install. Intermittent CI failures observed:

```
/bin/sh: 1: tsc: not found
```

during `yarn run pkg`, caused by incomplete `typescript` extraction into per-module `node_modules` while another yarn process raced against the cache.

Fix at two layers:

### 1. Maven reactor chain (primary)
Add a reactor-only `<dependency>` entry (`type=pom`, `scope=provided`, wildcard exclusions) to form
```
ui-ngx -> msa/web-ui -> msa/js-executor
```
so `MultiThreadedBuilder` schedules these three modules **strictly serial**, regardless of `-T` thread count. `msa/web-ui` already has a real dependency on `ui-ngx`, so only one new fake link was needed (in `msa/js-executor`). The fake dependency carries an inline comment explaining why it exists.

### 2. Yarn-level mutex (defense in depth)
Add `--mutex network` to:
- `yarn run pkg` in `msa/web-ui`, `msa/js-executor`
- `yarn run build:prod` in `ui-ngx`

so single-module invocations outside the reactor chain (e.g. `mvn -pl msa/js-executor install`) still serialize against any other yarn process on the agent.

### Cleanup
The "Modules order is important to speedup parallel build and avoid yarn pgk parallel execution" comment in `msa/pom.xml` was misleading - module order in the reactor does **not** enforce serialization under `-T`; only dependency edges do. Comment rewritten to point at the real serialization mechanism.

## Test plan

- [x] `mvn validate -pl ui-ngx,msa/web-ui,msa/js-executor -am` reactor build order confirms `ui-ngx -> web-ui -> js-executor` chain holds under both `-T1` and `-T6`.
- [x] `mvn -T6 clean install -pl ui-ngx,msa/web-ui,msa/js-executor -am -DskipTests -Dpkg.skip=true` (local) — **BUILD SUCCESS in 1:40**, no race conditions.
  - Maven confirmed parallel mode: `Using the MultiThreadedBuilder implementation with a thread count of 6`.
  - Module build order: `[2/5] ui-ngx` -> `[4/5] web-ui` -> `[5/5] js-executor` (`[1/5]` / `[3/5]` are no-op aggregator poms).
  - Every `Running 'yarn ...'` line is followed by its `Done in Xs.` line **before** the next yarn starts — zero interleaving across the six yarn invocations:

    | # | Module             | Command                                  | Duration |
    |---|--------------------|------------------------------------------|----------|
    | 1 | `ui-ngx`           | `yarn install ... --mutex network`       | 13.32 s  |
    | 2 | `ui-ngx`           | `yarn --mutex network run build:prod`    | 39.38 s  |
    | 3 | `msa/web-ui`       | `yarn install ... --mutex network`       |  0.90 s  |
    | 4 | `msa/web-ui`       | `yarn --mutex network run pkg`           | 10.94 s  |
    | 5 | `msa/js-executor`  | `yarn install ... --mutex network`       |  0.71 s  |
    | 6 | `msa/js-executor`  | `yarn --mutex network run pkg`           | 10.51 s  |

  - Total wall clock matches the sum of yarn legs (~75 s) plus per-module install/copy overhead — exactly the strictly-serial profile intended. No `tsc: not found`, no concurrent yarn cache contention.
- [ ] Run full CE black-box microservices suite to confirm `tsc: not found` no longer reproduces.

## Notes for reviewer

- Trade-off: building `msa/js-executor` with `-am` from a clean state will now also build `ui-ngx` and `msa/web-ui`. After local m2 cache is warm, `mvn -pl msa/js-executor install` (without `-am`) works as before since the fake dep is a tiny POM artifact.
- Fake dep uses `type=pom` + wildcard `<exclusions>` so nothing leaks onto anyone's classpath.