### PR TITLE
Fixed stale duration check future warning on alarm rule REINIT

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/alarm/AlarmCalculatedFieldState.java
+++ b/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/alarm/AlarmCalculatedFieldState.java
@@ -179,6 +179,7 @@ public class AlarmCalculatedFieldState extends BaseCalculatedFieldState {
             ruleState.setActive(null);
             AlarmCondition condition = rule.getCondition();
             if (condition.hasSchedule() || (condition.getType() == AlarmConditionType.DURATION && !ruleState.isEmpty())) {
+                ruleState.cancelDurationCheckFuture();
                 reevalNeeded.set(true);
             }
         }

--- a/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/alarm/AlarmRuleState.java
+++ b/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/alarm/AlarmRuleState.java
@@ -256,10 +256,7 @@ public class AlarmRuleState {
         firstEventTs = 0L;
         lastCheckTs = 0L;
         duration = 0L;
-        if (durationCheckFuture != null) {
-            durationCheckFuture.cancel(true);
-            durationCheckFuture = null;
-        }
+        cancelDurationCheckFuture();
     }
 
     public void setDurationCheckFuture(ScheduledFuture<?> durationCheckFuture) {

--- a/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/alarm/AlarmRuleState.java
+++ b/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/alarm/AlarmRuleState.java
@@ -270,6 +270,13 @@ public class AlarmRuleState {
         this.durationCheckFuture = durationCheckFuture;
     }
 
+    public void cancelDurationCheckFuture() {
+        if (durationCheckFuture != null) {
+            durationCheckFuture.cancel(true);
+            durationCheckFuture = null;
+        }
+    }
+
     public boolean isEmpty() {
         return eventCount == 0L && firstEventTs == 0L && lastCheckTs == 0L && durationCheckFuture == null;
     }


### PR DESCRIPTION
## Summary
- After PR #15439 made REINIT during an active DURATION countdown actually succeed, the existing `durationCheckFuture` from the previous configuration was preserved through `initRuleState`. The next matching event (or scheduled re-eval) called `setDurationCheckFuture`, which logs a WARN with synthetic stacktrace and silently replaces the future.
- Added `AlarmRuleState#cancelDurationCheckFuture()` that cancels and nulls only the future (without touching `firstEventTs`/`lastCheckTs`/`duration`) and call it from `AlarmCalculatedFieldState#initRuleState` before signaling `reevalNeeded`.

## Automated testing
- `AlarmRulesTest#testChangeDurationConditionFromStaticToDynamic` (added in #15439) — passes, and the WARN `Setting new duration check future while previous is not null` no longer appears in the test output.
