### PR TITLE
Fixed CSV import not unescaping double quotes in unquoted fields

### DIFF
--- a/ui-ngx/src/app/shared/import-export/import-export.models.ts
+++ b/ui-ngx/src/app/shared/import-export/import-export.models.ts
@@ -210,7 +210,7 @@ function splitCSV(str: string, sep: string): string[] {
         foo = foo.shift().split(sep).concat(foo);
       }
     } else {
-      foo[x].replace(/""/g, '"');
+      foo[x] = foo[x].replace(/""/g, '"');
     }
   }
   return foo;


### PR DESCRIPTION
  ## Summary                                                                                                                                                     
            
  - CSV fields containing escaped double quotes (`""`) were not converted to a single `"` during import
  - Affected fields that were not wrapped in quotes, e.g. `say""hello` was imported as `say""hello` instead of `say"hello"`   