### PR TITLE
Fixed SSRF and file access vulnerabilities in TBEL script sandbox

### DIFF
--- a/application/src/test/java/org/thingsboard/server/service/script/TbelInvokeServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/script/TbelInvokeServiceTest.java
@@ -217,6 +217,90 @@ class TbelInvokeServiceTest extends AbstractTbelInvokeTest {
         assertThat(compiledScriptsCache.getIfPresent(scriptIdToHash.get(scriptRemovedFromCache))).isNotNull();
     }
 
+    @Test
+    void givenForbiddenSocketHandler_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.logging.SocketHandler(\"127.0.0.1\", 9999)");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.logging.SocketHandler");
+                });
+    }
+
+    @Test
+    void givenForbiddenZipFile_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.zip.ZipFile(\"/tmp/test.zip\")");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.zip.ZipFile");
+                });
+    }
+
+    @Test
+    void givenForbiddenFileHandler_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.logging.FileHandler(\"/tmp/test.log\")");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.logging.FileHandler");
+                });
+    }
+
+    @Test
+    void givenForbiddenJarFile_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.jar.JarFile(\"/tmp/test.jar\")");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.jar.JarFile");
+                });
+    }
+
+    @Test
+    void givenForbiddenPreferences_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("java.util.prefs.Preferences.userRoot()");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getMessage()).contains("unresolvable property or identifier: java");
+                });
+    }
+
+    @Test
+    void givenForbiddenLocaleServiceProvider_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.spi.LocaleServiceProvider()");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.spi.LocaleServiceProvider");
+                });
+    }
+
     private void assertThatScriptIsBlocked(UUID scriptId) {
         assertThatThrownBy(() -> {
             invokeScriptResultString(scriptId, "{}");

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <zookeeper.version>3.9.5</zookeeper.version> <!-- to fix CVE-2026-24308 and CVE-2026-24281. TODO: remove override when fixed in curator-client -->
         <protobuf.version>3.25.5</protobuf.version> <!-- A Major v4 does not support by the pubsub yet-->
         <grpc.version>1.76.0</grpc.version>
-        <tbel.version>1.2.9</tbel.version>
+        <tbel.version>1.2.10</tbel.version>
         <lombok.version>1.18.46</lombok.version> <!-- must be in sync with spring-boot-dependencies; needed for maven-compiler-plugin annotationProcessorPaths -->
         <paho.client.version>1.2.5</paho.client.version>
         <paho.mqttv5.client.version>1.2.5</paho.mqttv5.client.version>


### PR DESCRIPTION
Backport of #15364 to `lts-4.2`.

## Summary
- Bump `tbel` dependency 1.2.9 → 1.2.10 (see thingsboard/tbel#48)
- Add 6 integration tests in `TbelInvokeServiceTest` verifying sandbox blocks dangerous `java.util` subpackage classes

## Problem
The TBEL sandbox `allowedPackages` entry `"java.util"` uses `startsWith` prefix matching, which inadvertently permits all subpackages. This allows a Tenant Admin to:
1. **SSRF** via `java.util.logging.SocketHandler`
2. **Arbitrary file read** via `java.util.zip.ZipFile` / `java.util.jar.JarFile`
3. **Arbitrary file write** via `java.util.logging.FileHandler`

## Fix
tbel 1.2.10 adds `java.util.logging`, `java.util.zip`, `java.util.jar`, `java.util.prefs`, `java.util.spi` to `forbiddenPackages` in `SandboxedClassLoader`, following the existing pattern used for `java.util.concurrent`. `java.util.prefs` and `java.util.spi` are not part of the documented TBEL API and are blocked as a precaution — user scripts should not have access to system preferences or service provider loading.

## Test plan
Automated tests in `TbelInvokeServiceTest`:
- `givenForbiddenSocketHandler_whenInvoking_thenThrowsRuntimeError`
- `givenForbiddenZipFile_whenInvoking_thenThrowsRuntimeError`
- `givenForbiddenFileHandler_whenInvoking_thenThrowsRuntimeError`
- `givenForbiddenJarFile_whenInvoking_thenThrowsRuntimeError`
- `givenForbiddenPreferences_whenInvoking_thenThrowsRuntimeError`
- `givenForbiddenLocaleServiceProvider_whenInvoking_thenThrowsRuntimeError`

Note: CI will pass once tbel 1.2.10 is released to Maven (depends on thingsboard/tbel#48 being merged).