### PR TITLE
Fixed CVE-2026-40682, CVE-2026-42027

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
         <antisamy.version>1.7.5</antisamy.version>
         <snmp4j.version>3.8.0</snmp4j.version>
         <langchain4j.version>1.8.0-TB</langchain4j.version>
+        <opennlp-tools.version>2.5.9</opennlp-tools.version> <!-- to fix CVE-2026-40682, CVE-2026-42027 in transitive dep via langchain4j-bom (which still pins 2.5.4). TODO: remove when langchain4j fork ships opennlp-tools >= 2.5.9 -->
         <error_prone_annotations.version>2.38.0</error_prone_annotations.version>
         <animal-sniffer-annotations.version>1.24</animal-sniffer-annotations.version>
         <auto-value-annotations.version>1.11.0</auto-value-annotations.version>
@@ -1346,6 +1347,11 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.opennlp</groupId>
+                <artifactId>opennlp-tools</artifactId>
+                <version>${opennlp-tools.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
## Context

Two high-severity vulnerabilities reported by the scheduled PE security scan ([#108009](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/108009)) — both in `org.apache.opennlp:opennlp-tools 2.5.4`, pulled in transitively through `org.thingsboard.langchain4j:langchain4j-bom 1.8.0-TB` into `rule-engine-api` and `rule-engine-components`:

- **CVE-2026-40682** (High) — XML External Entity (XXE) Injection
- **CVE-2026-42027** (High) — Unsafe Reflection

Both fixed upstream in `opennlp-tools` 2.5.9.

## Fix

Pinned `opennlp-tools` to `2.5.9` via a `<opennlp-tools.version>` property and a matching `<dependencyManagement>` entry in root `pom.xml`. The langchain4j fork still pins `opennlp-tools 2.5.4` in its parent pom (verified for `1.8.0-TB`, `1.13.0-TB1`), so a langchain4j bump alone would not close these CVEs — a direct override here is required.

## Result

```
mvn -pl rule-engine/rule-engine-components -am -DskipTests dependency:tree -Dincludes=org.apache.opennlp:opennlp-tools
```
```
[INFO] \- org.thingsboard.langchain4j:langchain4j:jar:1.8.0-TB:compile
[INFO]    \- org.apache.opennlp:opennlp-tools:jar:2.5.9:compile
```