### PR TITLE
Fixed CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <spring-boot-test.version>3.5.13</spring-boot-test.version>
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <postgresql.version>42.7.11</postgresql.version> <!-- to fix CVE-2026-42198. TODO: remove when fixed in spring-boot-dependencies -->
+        <netty.version>4.1.133.Final</netty.version> <!-- to fix CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -1006,6 +1007,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Temporary netty-bom version override -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- End of netty-bom version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Summary

Bumps `io.netty:netty-bom` from `4.1.132.Final` to `4.1.133.Final` to remediate four high-severity CVEs flagged by the [security scan #108293](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/108293) (snyk + scout) on `lts-4.2`.

A single property bump (`netty.version`) plus an explicit `netty-bom` import declared **before** the `spring-boot-dependencies` BOM in `<dependencyManagement>` is required: a property override on its own is insufficient because `spring-boot-dependencies` re-imports `netty-bom` with its own internal `${netty.version}` value, which would otherwise win.

## CVEs fixed

- **CVE-2026-42579** (high) — Improper Input Validation in `io.netty:netty-codec-dns` — was 4.1.132.Final, now 4.1.133.Final
- **CVE-2026-42583** (high) — Allocation of Resources Without Limits or Throttling / Uncontrolled Resource Consumption in `io.netty:netty-codec` — was 4.1.132.Final, now 4.1.133.Final
- **CVE-2026-42584** (high) — Inconsistent Interpretation of HTTP Requests (HTTP Request/Response Smuggling) in `io.netty:netty-codec-http` — was 4.1.132.Final, now 4.1.133.Final
- **CVE-2026-42587** (high) — Improper Handling of Highly Compressed Data (Data Amplification) / Uncontrolled Resource Consumption in `io.netty:netty-codec`, `io.netty:netty-codec-http`, `io.netty:netty-codec-http2` — was 4.1.132.Final, now 4.1.133.Final

## Commits

- Bump io.netty:netty-bom from 4.1.132.Final to 4.1.133.Final to fix CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, and CVE-2026-42587

## `mvn dependency:tree` evidence

Command run from the worktree root: `mvn dependency:tree -Dincludes=io.netty` (full reactor, no `-pl`). Filtered to the affected artifacts.

```text
[INFO]                   +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.133.Final:compile
[INFO]                   +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.133.Final:provided
[INFO]                   |  \- io.netty:netty-codec:jar:4.1.133.Final:compile
[INFO]                   |  \- io.netty:netty-codec:jar:4.1.133.Final:provided
[INFO]                +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.133.Final:compile
[INFO]                |  \- io.netty:netty-codec:jar:4.1.133.Final:compile
[INFO]             +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.133.Final:compile
[INFO]             |  \- io.netty:netty-codec:jar:4.1.133.Final:compile
[INFO]    +- io.netty:netty-codec:jar:4.1.133.Final:compile
[INFO]    +- io.netty:netty-codec-dns:jar:4.1.133.Final:compile
[INFO]    +- io.netty:netty-codec-http:jar:4.1.133.Final:compile
[INFO]    +- io.netty:netty-codec-http2:jar:4.1.133.Final:compile
[INFO]    +- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.133.Final:compile
[INFO] \- io.netty:netty-codec:jar:4.1.133.Final:compile
[INFO] \- io.netty:netty-codec:jar:4.1.133.Final:provided
[INFO] \- io.netty:netty-codec:jar:4.1.133.Final:test
[INFO] \- io.netty:netty-codec-mqtt:jar:4.1.132.Final:compile (org.thingsboard:netty-mqtt internal vendored fork — NOT vulnerable)
```

All five netty CVE artifacts (`netty-codec`, `netty-codec-http`, `netty-codec-http2`, `netty-codec-dns`, `netty-transport-native-epoll`) now resolve to `4.1.133.Final` across the full reactor.

## Unfixable / Debian

The same scan surfaced findings the skill could not auto-resolve. They are reported here once for the `lts-4.2` PR; the `lts-4.3` PR carries the same fixes and is not duplicating this section.

### Maven CVEs not fixed in this PR

- **CVE-2026-42577** (high) — Missing Release of Resource after Effective Lifetime in `io.netty:netty-transport-native-epoll`. Only fixed in netty `4.2.13.Final`. Migrating from netty 4.1.x to 4.2.x is a major-version jump with API changes and is out of scope for a CVE patch PR.
- **CVE-2023-26919** (high) — Sandbox Bypass in `org.javadelight:delight-nashorn-sandbox` `0.4.5`. The upstream project has no patched release; the library has been unmaintained since 2023. Replacing or removing this dependency requires a separate refactor.

### Debian / base-image CVEs (not auto-fixed by this skill)

The scan reports these are present in the runtime container's Debian packages, not in the Java dependency graph. They require a base-image bump in the Dockerfile, which is intentionally out of scope for this Maven-only PR:

- CVE-2026-33846, CVE-2026-33845 — `gnutls28` `3.7.9-2+deb12u6` (lts-4.2 base image, Debian 12) — no upstream patch yet
- CVE-2026-6772, CVE-2026-6766 — `nss` `2:3.87.1-1+deb12u2` (lts-4.2 base image, Debian 12) — no upstream patch yet

Recommendation: track upstream Debian advisories; no base-image bump action is currently available for `lts-4.2`.