### PR TITLE
DeviceStateService: swallow TenantNotFoundException in async device-added callback

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -358,16 +358,26 @@ public class DefaultDeviceStateService extends AbstractPartitionBasedService<Dev
                         Futures.addCallback(fetchDeviceState(device), new FutureCallback<>() {
                             @Override
                             public void onSuccess(DeviceStateData state) {
-                                TopicPartitionInfo tpi = partitionService.resolve(ServiceType.TB_CORE, tenantId, device.getId());
-                                Set<DeviceId> deviceIds = partitionedEntities.get(tpi);
-                                boolean isMyPartition = deviceIds != null;
-                                if (isMyPartition) {
-                                    deviceIds.add(state.getDeviceId());
-                                    initializeActivityState(deviceId, state);
+                                try {
+                                    TopicPartitionInfo tpi = partitionService.resolve(ServiceType.TB_CORE, tenantId, device.getId());
+                                    Set<DeviceId> deviceIds = partitionedEntities.get(tpi);
+                                    boolean isMyPartition = deviceIds != null;
+                                    if (isMyPartition) {
+                                        deviceIds.add(state.getDeviceId());
+                                        initializeActivityState(deviceId, state);
+                                        callback.onSuccess();
+                                    } else {
+                                        log.debug("[{}][{}] Device belongs to external partition. Probably rebalancing is in progress. Topic: {}", tenantId, deviceId, tpi.getFullTopicName());
+                                        callback.onFailure(new RuntimeException("Device belongs to external partition " + tpi.getFullTopicName() + "!"));
+                                    }
+                                } catch (TenantNotFoundException e) {
+                                    // Tenant was removed (e.g. during shutdown / test tearDown) between fetchDeviceState completing
+                                    // and partition resolution. Device-state registration is moot in that case.
+                                    log.debug("[{}][{}] Tenant not found while registering device to the state service; skipping.", tenantId, deviceId);
                                     callback.onSuccess();
-                                } else {
-                                    log.debug("[{}][{}] Device belongs to external partition. Probably rebalancing is in progress. Topic: {}", tenantId, deviceId, tpi.getFullTopicName());
-                                    callback.onFailure(new RuntimeException("Device belongs to external partition " + tpi.getFullTopicName() + "!"));
+                                } catch (Throwable t) {
+                                    log.warn("[{}][{}] Failed to register device to the state service", tenantId, deviceId, t);
+                                    callback.onFailure(t);
                                 }
                             }
 


### PR DESCRIPTION
## Summary

Fixes a long‑standing flake (e.g. `PskLwm2mIntegrationTest.testWithPskConnectLwm2mBadPskKeyByLength_BAD_REQUEST`, currently muted in TeamCity) caused by an unhandled `TenantNotFoundException` escaping the `Futures.addCallback` `onSuccess` in `DefaultDeviceStateService.onQueueMsg(...)`.

### Root cause

`onQueueMsg` schedules an asynchronous follow‑up after `fetchDeviceState`:

```java
Futures.addCallback(fetchDeviceState(device), new FutureCallback<>() {
    @Override
    public void onSuccess(DeviceStateData state) {
        TopicPartitionInfo tpi = partitionService.resolve(ServiceType.TB_CORE, tenantId, device.getId());
        ...
    }
    ...
}, deviceStateCallbackExecutor);
```

`partitionService.resolve` → `HashPartitionService.getRoutingInfo` → `DefaultTenantRoutingInfoService.getRoutingInfo` throws `TenantNotFoundException` if the tenant profile cache no longer holds the tenant — which happens during shutdown, test tearDown, or while rebalancing right after a `POST /api/device`.

Guava's `Futures.CallbackListener.run` does **not** wrap `onSuccess` in `try/catch`, so the exception escapes to the `ForkJoinPool` worker thread. Surefire then attaches the stack trace to whichever test method was last writing to that thread's stdout buffer, producing flaky `<<< ERROR!` reports with no test code in the stack:

```
TenantNotFoundException: Tenant with id 46d13ed0-… not found
  at DefaultTenantRoutingInfoService.getRoutingInfo(:45)
  at HashPartitionService.resolve(:333/:349)
  at DefaultDeviceStateService$1.onSuccess(DefaultDeviceStateService.java:361)
  at Futures$CallbackListener.run
  at ForkJoinWorkerThread.run
```

The outer `onQueueMsg` already has a `catch (Exception e) { callback.onFailure(e); }` for this exact reason; the inner `addCallback.onSuccess` was missing the same protection.

### Fix

Wrap the `onSuccess` body in `try/catch`. `TenantNotFoundException` is treated as a no‑op (`log.debug` + `callback.onSuccess()`) — once the tenant is gone, registering the device into the state service is moot. Any other unexpected `Throwable` is routed through `callback.onFailure(...)` to preserve the existing failure semantics.

## Test plan

- [ ] `mvn test -pl application -Dtest='org.thingsboard.server.transport.lwm2m.security.sql.PskLwm2mIntegrationTest'` — verify previously muted `testWithPskConnectLwm2mBadPskKeyByLength_BAD_REQUEST` passes consistently
- [ ] CI: full `test transports` suite is green
- [ ] No regression in existing `DeviceStateService` tests

## Follow-up (separate PR)

The test is currently muted in TeamCity for this very symptom. Once this fix is merged and the test runs green, unmute it (`PskLwm2mIntegrationTest.testWithPskConnectLwm2mBadPskKeyByLength_BAD_REQUEST`).