### PR TITLE
Prevented integer overflow in calculated field SUM output

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/SimpleCalculatedFieldState.java
+++ b/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/SimpleCalculatedFieldState.java
@@ -85,7 +85,7 @@ public class SimpleCalculatedFieldState extends BaseCalculatedFieldState {
             return expressionResult;
         }
         if (decimals.equals(0)) {
-            return TbUtils.toInt(expressionResult);
+            return TbUtils.toLong(expressionResult);
         }
         return TbUtils.toFixed(expressionResult, decimals);
     }
@@ -96,6 +96,8 @@ public class SimpleCalculatedFieldState extends BaseCalculatedFieldState {
         ObjectNode valuesNode = JacksonUtil.newObjectNode();
         if (result instanceof Double doubleValue) {
             valuesNode.put(outputName, doubleValue);
+        } else if (result instanceof Long longValue) {
+            valuesNode.put(outputName, longValue);
         } else if (result instanceof Integer integerValue) {
             valuesNode.put(outputName, integerValue);
         } else {

--- a/application/src/test/java/org/thingsboard/server/service/cf/ctx/state/SimpleCalculatedFieldStateTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/cf/ctx/state/SimpleCalculatedFieldStateTest.java
@@ -140,7 +140,7 @@ public class SimpleCalculatedFieldStateTest {
         Output output = getCalculatedFieldConfig().getOutput();
         assertThat(result.getType()).isEqualTo(output.getType());
         assertThat(result.getScope()).isEqualTo(output.getScope());
-        assertThat(result.getResult()).isEqualTo(JacksonUtil.valueToTree(Map.of("output", 49)));
+        assertThat(result.getResult()).isEqualTo(JacksonUtil.valueToTree(Map.of("output", 49L)));
     }
 
     @Test
@@ -170,7 +170,7 @@ public class SimpleCalculatedFieldStateTest {
         Output output = getCalculatedFieldConfig().getOutput();
         assertThat(result.getType()).isEqualTo(output.getType());
         assertThat(result.getScope()).isEqualTo(output.getScope());
-        assertThat(result.getResult()).isEqualTo(JacksonUtil.valueToTree(Map.of("output", 35)));
+        assertThat(result.getResult()).isEqualTo(JacksonUtil.valueToTree(Map.of("output", 35L)));
     }
 
     @Test

--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbUtils.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/tbel/TbUtils.java
@@ -1186,6 +1186,10 @@ public class TbUtils {
         return BigDecimal.valueOf(value).setScale(0, RoundingMode.HALF_UP).intValue();
     }
 
+    public static long toLong(double value) {
+        return BigDecimal.valueOf(value).setScale(0, RoundingMode.HALF_UP).longValue();
+    }
+
     public static boolean isNaN(double value) {
         return Double.isNaN(value);
     }

--- a/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
+++ b/common/script/script-api/src/test/java/org/thingsboard/script/api/tbel/TbUtilsTest.java
@@ -1250,6 +1250,14 @@ public class TbUtilsTest {
     }
 
     @Test
+    public void toLong() {
+        Assertions.assertEquals(1729L, TbUtils.toLong(doubleVal));
+        Assertions.assertEquals(13L, TbUtils.toLong(12.8));
+        Assertions.assertEquals(28L, TbUtils.toLong(28.0));
+        Assertions.assertEquals(3_980_173_734L, TbUtils.toLong(3_980_173_734.0));
+    }
+
+    @Test
     public void isNaN() {
         assertFalse(TbUtils.isNaN(doubleVal));
         assertTrue(TbUtils.isNaN(Double.NaN));


### PR DESCRIPTION
  `SimpleCalculatedFieldState` rounded the `double` result down to `int` via `NumberUtils.toInt` when "Decimals by default" was `0` (the UI default). `BigDecimal.intValue()` returns only the low-order 32 bits, so a SUM above ~2.1B wrapped to a
  negative number (e.g. `3,980,173,734` → `-314,793,562`).

  ### Changes
  - `NumberUtils`: add `toLong(double)` alongside the existing `toInt(double)` (`toInt` is left untouched to preserve other callers).
  - `NumberUtils.roundResult`: switch the `precision == 0` branch from `toInt` to `toLong`.
  - `SimpleCalculatedFieldState.createResultJson`: add a `Long` branch so the JSON node is emitted as a numeric long (the aggregation path already routes through `JacksonUtil.toString`, which handles `Long` transparently).
  - Tests: extend `NumberUtilsTest` to cover values above `Integer.MAX_VALUE`; update `SimpleCalculatedFieldStateTest` to assert the new `Long` output.

  Note: 4.2 introduced `TbUtils.toLong` for the same fix, but 4.3 routes CF rounding through `NumberUtils` only, so the `TbUtils` change is not needed here.

  ## General checklist

  - [x] You have reviewed the guidelines document.
  - [x] Labels that classify your pull request have been added.
  - [x] The milestone is specified and corresponds to fix version.
  - [x] Description references specific issue.
  - [x] Description contains human-readable scope of changes.
  - [x] Description contains brief notes about what needs to be added to the documentation.
  - [x] No merge conflicts, commented blocks of code, code formatting issues.
  - [x] Changes are backward compatible or upgrade script is provided.
  - [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added.

  ## Back-End feature checklist

  - [x] Added corresponding unit and/or integration test(s).
  - [x] If new dependency was added: the dependency tree is checked for conflicts. (N/A)
  - [x] If new service was added: the service is marked with corresponding @TbCoreComponent, etc. (N/A)
  - [x] If new REST API was added: the RestClient.java was updated. (N/A)
  - [x] If new yml property was added: make sure a description is added. (N/A)