### PR TITLE
Fixed CVE-2026-41284, CVE-2026-43512

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <postgresql.version>42.7.11</postgresql.version> <!-- to fix CVE-2026-42198. TODO: remove when fixed in spring-boot-dependencies -->
         <netty.version>4.1.133.Final</netty.version> <!-- to fix CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587. TODO: remove when fixed in spring-boot-dependencies -->
+        <tomcat.version>10.1.55</tomcat.version> <!-- to fix CVE-2026-41284, CVE-2026-43512. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -1016,6 +1017,23 @@
                 <scope>import</scope>
             </dependency>
             <!-- End of netty-bom version override -->
+            <!-- Temporary tomcat-embed version override -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <!-- End of tomcat-embed version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Summary

Fixes 2 CVEs in the embedded Tomcat servlet container shipped via Spring Boot 3.5.14. Bumps `tomcat.version` from 10.1.54 (Spring Boot default) to 10.1.55 and adds explicit `dependencyManagement` overrides for `tomcat-embed-core`, `tomcat-embed-el`, and `tomcat-embed-websocket` before the `spring-boot-dependencies` BOM import (Spring Boot's `tomcat.version` property is not honored when the BOM is imported rather than inherited).

Source: TeamCity security scan https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/109919

## CVEs fixed

- **CVE-2026-41284** (high) — Unbounded read in WebDAV LOCK and PROPFIND handling — `org.apache.tomcat.embed:tomcat-embed-core` was 10.1.54, now 10.1.55
- **CVE-2026-43512** (critical) — Digest authenticator will authenticate any unknown user with password "null" — `org.apache.tomcat.embed:tomcat-embed-core` was 10.1.54, now 10.1.55

Both CVEs are also fixed in `tomcat-embed-el` and `tomcat-embed-websocket` 10.1.55 via the same release.

## Commits

- Bump tomcat.version from 10.1.54 to 10.1.55 to fix CVE-2026-41284 and CVE-2026-43512

## `mvn dependency:tree` evidence

Command: `mvn -f pom.xml dependency:tree -Dincludes=org.apache.tomcat.embed`

```text
[INFO]       +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.55:provided
[INFO]       +- org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.55:provided
[INFO]       \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.55:provided
[INFO]       +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.55:provided
[INFO]       +- org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.55:provided
[INFO]       \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.55:provided
[INFO]          +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.55:compile
[INFO]          +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.55:provided
[INFO]          +- org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.55:compile
[INFO]          +- org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.55:provided
[INFO]          \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.55:compile
[INFO]          \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.55:provided
[INFO]             +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.55:provided
[INFO]             +- org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.55:provided
[INFO]             \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.55:provided
```

(Reactor-wide build, all modules `BUILD SUCCESS`.)

## Unfixable / Debian

### Unfixable Maven CVEs

- **CVE-2023-26919** (high) — Sandbox Bypass via `loadWithNewGlobal` in `org.javadelight:delight-nashorn-sandbox` 0.4.5 — no upstream fix available; the library has no patched release. Tracked separately for replacement / removal.

### Debian / base-image CVEs (NOT auto-fixed by this PR)

The TeamCity Docker Scout findings are against the Debian base image used in `${docker.base.image}`. They are reported here for visibility; the recommended action is a base-image bump rather than a Maven change.

**lts-4.2 (Debian 12):**

| CVE             | Package    | Current               | Fixed              | Recommendation                       |
|-----------------|------------|-----------------------|--------------------|--------------------------------------|
| CVE-2026-0861   | glibc      | 2.36-9+deb12u13       | 2.36-9+deb12u14    | Rebuild from latest debian:12 image  |
| CVE-2026-4437   | glibc      | 2.36-9+deb12u13       | 2.36-9+deb12u14    | Rebuild from latest debian:12 image  |
| CVE-2026-4046   | glibc      | 2.36-9+deb12u13       | 2.36-9+deb12u14    | Rebuild from latest debian:12 image  |
| CVE-2026-0915   | glibc      | 2.36-9+deb12u13       | 2.36-9+deb12u14    | Rebuild from latest debian:12 image  |
| CVE-2025-15281  | glibc      | 2.36-9+deb12u13       | 2.36-9+deb12u14    | Rebuild from latest debian:12 image  |
| CVE-2026-33846  | gnutls28   | 3.7.9-2+deb12u6       | no upstream fix    | Track upstream                       |
| CVE-2026-33845  | gnutls28   | 3.7.9-2+deb12u6       | no upstream fix    | Track upstream                       |
| CVE-2026-42011  | gnutls28   | 3.7.9-2+deb12u6       | no upstream fix    | Track upstream                       |
| CVE-2026-42010  | gnutls28   | 3.7.9-2+deb12u6       | no upstream fix    | Track upstream                       |
| CVE-2026-6772   | nss        | 2:3.87.1-1+deb12u2    | no upstream fix    | Track upstream                       |
| CVE-2026-6766   | nss        | 2:3.87.1-1+deb12u2    | no upstream fix    | Track upstream                       |
| CVE-2025-6297   | dpkg       | 1.21.22               | 1.21.23            | Rebuild from latest debian:12 image  |
