### PR TITLE
Fixed CVE-2026-41284, CVE-2026-43512

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <postgresql.version>42.7.11</postgresql.version> <!-- to fix CVE-2026-42198. TODO: remove when fixed in spring-boot-dependencies -->
         <netty.version>4.1.133.Final</netty.version> <!-- to fix CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587. TODO: remove when fixed in spring-boot-dependencies -->
+        <tomcat.version>10.1.55</tomcat.version> <!-- to fix CVE-2026-41284, CVE-2026-43512. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -1016,6 +1017,23 @@
                 <scope>import</scope>
             </dependency>
             <!-- End of netty-bom version override -->
+            <!-- Temporary tomcat-embed version override -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <!-- End of tomcat-embed version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Summary

Forward-merge of the embedded Tomcat 10.1.55 bump from `fix/cves-lts-4.2` into the `lts-4.3` line. Fixes the same 2 CVEs in `tomcat-embed-core`. No additional bumps were required on `lts-4.3` — the merge alone brought the override across.

Source: TeamCity security scan https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/109920

## CVEs fixed

- **CVE-2026-41284** (high) — Unbounded read in WebDAV LOCK and PROPFIND handling — `org.apache.tomcat.embed:tomcat-embed-core` was 10.1.54, now 10.1.55
- **CVE-2026-43512** (critical) — Digest authenticator will authenticate any unknown user with password "null" — `org.apache.tomcat.embed:tomcat-embed-core` was 10.1.54, now 10.1.55

## Commits

- Merge fix/cves-lts-4.2 into fix/cves-lts-4.3
- Bump tomcat.version from 10.1.54 to 10.1.55 to fix CVE-2026-41284 and CVE-2026-43512 (forward-merged from lts-4.2)

## `mvn dependency:tree` evidence

Command: `mvn -f pom.xml dependency:tree -Dincludes=org.apache.tomcat.embed`

```text
[INFO]       +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.55:provided
[INFO]       +- org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.55:provided
[INFO]       \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.55:provided
[INFO]          +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.55:compile
[INFO]          +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.55:provided
[INFO]          +- org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.55:compile
[INFO]          +- org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.55:provided
[INFO]          \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.55:compile
[INFO]          \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.55:provided
```

(Reactor-wide build, all modules `BUILD SUCCESS`.)

Companion CE 4.2 PR: https://github.com/thingsboard/thingsboard/pull/15649
