### PR TITLE
Fixed app hanging on transport port conflict at startup

### DIFF
--- a/common/coap-server/src/main/java/org/thingsboard/server/coapserver/DefaultCoapServerService.java
+++ b/common/coap-server/src/main/java/org/thingsboard/server/coapserver/DefaultCoapServerService.java
@@ -106,26 +106,46 @@ public class DefaultCoapServerService implements CoapServerService, SmartInitial
     private CoapServer createCoapServer() throws UnknownHostException {
         Configuration networkConfig = createNetworkConfiguration();
         server = new CoapServer(networkConfig);
+        try {
+            CoapEndpoint.Builder noSecCoapEndpointBuilder = new CoapEndpoint.Builder();
+            InetAddress addr = InetAddress.getByName(coapServerContext.getHost());
+            InetSocketAddress sockAddr = new InetSocketAddress(addr, coapServerContext.getPort());
+            noSecCoapEndpointBuilder.setInetSocketAddress(sockAddr);
 
-        CoapEndpoint.Builder noSecCoapEndpointBuilder = new CoapEndpoint.Builder();
-        InetAddress addr = InetAddress.getByName(coapServerContext.getHost());
-        InetSocketAddress sockAddr = new InetSocketAddress(addr, coapServerContext.getPort());
-        noSecCoapEndpointBuilder.setInetSocketAddress(sockAddr);
+            noSecCoapEndpointBuilder.setConfiguration(networkConfig);
+            CoapEndpoint noSecCoapEndpoint = noSecCoapEndpointBuilder.build();
+            server.addEndpoint(noSecCoapEndpoint);
+            if (isDtlsEnabled()) {
+                createDtlsEndpoint(networkConfig);
+                dtlsSessionsExecutor = ThingsBoardExecutors.newSingleThreadScheduledExecutor(getClass().getSimpleName());
+                dtlsSessionsExecutor.scheduleAtFixedRate(this::evictTimeoutSessions, new Random().nextInt((int) getDtlsSessionReportTimeout()), getDtlsSessionReportTimeout(), TimeUnit.MILLISECONDS);
+            }
+            Resource root = server.getRoot();
+            TbCoapServerMessageDeliverer messageDeliverer = new TbCoapServerMessageDeliverer(root);
+            server.setMessageDeliverer(messageDeliverer);
 
-        noSecCoapEndpointBuilder.setConfiguration(networkConfig);
-        CoapEndpoint noSecCoapEndpoint = noSecCoapEndpointBuilder.build();
-        server.addEndpoint(noSecCoapEndpoint);
-        if (isDtlsEnabled()) {
-            createDtlsEndpoint(networkConfig);
-            dtlsSessionsExecutor = ThingsBoardExecutors.newSingleThreadScheduledExecutor(getClass().getSimpleName());
-            dtlsSessionsExecutor.scheduleAtFixedRate(this::evictTimeoutSessions, new Random().nextInt((int) getDtlsSessionReportTimeout()), getDtlsSessionReportTimeout(), TimeUnit.MILLISECONDS);
+            server.start();
+            return server;
+        } catch (RuntimeException | UnknownHostException e) {
+            log.error("Failed to start CoAP server, releasing resources", e);
+            try {
+                if (dtlsSessionsExecutor != null) {
+                    dtlsSessionsExecutor.shutdownNow();
+                }
+                if (server != null) {
+                    server.destroy();
+                }
+            } catch (Exception suppressed) {
+                e.addSuppressed(suppressed);
+            } finally {
+                server = null;
+                dtlsSessionsExecutor = null;
+                dtlsConnector = null;
+                dtlsCoapEndpoint = null;
+                tbDtlsCertificateVerifier = null;
+            }
+            throw e;
         }
-        Resource root = server.getRoot();
-        TbCoapServerMessageDeliverer messageDeliverer = new TbCoapServerMessageDeliverer(root);
-        server.setMessageDeliverer(messageDeliverer);
-
-        server.start();
-        return server;
     }
 
     private boolean isDtlsEnabled() {

--- a/common/coap-server/src/main/java/org/thingsboard/server/coapserver/DefaultCoapServerService.java
+++ b/common/coap-server/src/main/java/org/thingsboard/server/coapserver/DefaultCoapServerService.java
@@ -85,7 +85,9 @@ public class DefaultCoapServerService implements CoapServerService, SmartInitial
             dtlsSessionsExecutor.shutdownNow();
         }
         log.info("Stopping CoAP server!");
-        server.destroy();
+        if (server != null) {
+            server.destroy();
+        }
         log.info("CoAP server stopped!");
     }
 
@@ -105,8 +107,8 @@ public class DefaultCoapServerService implements CoapServerService, SmartInitial
 
     private CoapServer createCoapServer() throws UnknownHostException {
         Configuration networkConfig = createNetworkConfiguration();
-        server = new CoapServer(networkConfig);
         try {
+            server = new CoapServer(networkConfig);
             CoapEndpoint.Builder noSecCoapEndpointBuilder = new CoapEndpoint.Builder();
             InetAddress addr = InetAddress.getByName(coapServerContext.getHost());
             InetSocketAddress sockAddr = new InetSocketAddress(addr, coapServerContext.getPort());

--- a/common/coap-server/src/test/java/org/thingsboard/server/coapserver/DefaultCoapServerServiceTest.java
+++ b/common/coap-server/src/test/java/org/thingsboard/server/coapserver/DefaultCoapServerServiceTest.java
@@ -15,20 +15,36 @@
  */
 package org.thingsboard.server.coapserver;
 
+import org.eclipse.californium.core.CoapServer;
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.server.resources.Resource;
+import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.common.util.ThingsBoardExecutors;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -68,6 +84,56 @@ public class DefaultCoapServerServiceTest {
         assertThatThrownBy(() -> service.init())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("None of the server endpoints could be started");
+
+        assertThat(ReflectionTestUtils.getField(service, "server")).isNull();
+        assertThat(ReflectionTestUtils.getField(service, "dtlsSessionsExecutor")).isNull();
+        assertThat(ReflectionTestUtils.getField(service, "dtlsConnector")).isNull();
+        assertThat(ReflectionTestUtils.getField(service, "dtlsCoapEndpoint")).isNull();
+        assertThat(ReflectionTestUtils.getField(service, "tbDtlsCertificateVerifier")).isNull();
+    }
+
+    @Test
+    public void whenDtlsEnabledAndStartFails_thenInitShutsDownDtlsExecutorAndReleasesCoapServer() throws Exception {
+        // DTLS enabled: the DTLS endpoint is created and dtlsSessionsExecutor is scheduled before server.start().
+        // This exercises the catch's dtlsSessionsExecutor.shutdownNow() branch, which the plain-bind test does not.
+        TbCoapDtlsSettings mockDtlsSettings = mock(TbCoapDtlsSettings.class);
+        when(mockCoapServerContext.getDtlsSettings()).thenReturn(mockDtlsSettings);
+
+        DtlsConnectorConfig mockDtlsConfig = mock(DtlsConnectorConfig.class);
+        when(mockDtlsConfig.getAddress()).thenReturn(new InetSocketAddress(InetAddress.getByName(HOST), occupiedPort + 1));
+        TbCoapDtlsCertificateVerifier mockVerifier = mock(TbCoapDtlsCertificateVerifier.class);
+        when(mockVerifier.getDtlsSessionReportTimeout()).thenReturn(1800000L);
+        when(mockDtlsConfig.getAdvancedCertificateVerifier()).thenReturn(mockVerifier);
+        when(mockDtlsSettings.dtlsConnectorConfig(any())).thenReturn(mockDtlsConfig);
+
+        ScheduledExecutorService mockExecutor = mock(ScheduledExecutorService.class);
+        Resource mockRoot = mock(Resource.class);
+
+        try (MockedStatic<ThingsBoardExecutors> executorsStatic = mockStatic(ThingsBoardExecutors.class);
+             MockedConstruction<CoapServer> serverMock = mockConstruction(CoapServer.class, (server, ctx) -> {
+                 when(server.getRoot()).thenReturn(mockRoot);
+                 doThrow(new IllegalStateException("None of the server endpoints could be started")).when(server).start();
+             });
+             MockedConstruction<DTLSConnector> dtlsMock = mockConstruction(DTLSConnector.class);
+             MockedConstruction<CoapEndpoint.Builder> builderMock = mockConstruction(CoapEndpoint.Builder.class, (builder, ctx) -> {
+                 when(builder.setInetSocketAddress(any())).thenReturn(builder);
+                 when(builder.setConfiguration(any())).thenReturn(builder);
+                 when(builder.setConnector(any(DTLSConnector.class))).thenReturn(builder);
+                 when(builder.build()).thenReturn(mock(CoapEndpoint.class));
+             })) {
+
+            executorsStatic.when(() -> ThingsBoardExecutors.newSingleThreadScheduledExecutor(anyString())).thenReturn(mockExecutor);
+
+            assertThatThrownBy(() -> service.init())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("None of the server endpoints could be started");
+
+            // DTLS branch was actually entered and the executor was created...
+            verify(mockDtlsSettings).dtlsConnectorConfig(any());
+            // ...and the cleanup branch shut it down and destroyed the server.
+            verify(mockExecutor).shutdownNow();
+            verify(serverMock.constructed().get(0)).destroy();
+        }
 
         assertThat(ReflectionTestUtils.getField(service, "server")).isNull();
         assertThat(ReflectionTestUtils.getField(service, "dtlsSessionsExecutor")).isNull();

--- a/common/coap-server/src/test/java/org/thingsboard/server/coapserver/DefaultCoapServerServiceTest.java
+++ b/common/coap-server/src/test/java/org/thingsboard/server/coapserver/DefaultCoapServerServiceTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.coapserver;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultCoapServerServiceTest {
+
+    private static final String HOST = "127.0.0.1";
+
+    @Mock
+    private CoapServerContext mockCoapServerContext;
+
+    private DefaultCoapServerService service;
+    private DatagramSocket occupiedSocket;
+    private int occupiedPort;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        occupiedSocket = new DatagramSocket(new InetSocketAddress(InetAddress.getByName(HOST), 0));
+        occupiedPort = occupiedSocket.getLocalPort();
+
+        service = new DefaultCoapServerService();
+        ReflectionTestUtils.setField(service, "coapServerContext", mockCoapServerContext);
+
+        when(mockCoapServerContext.getHost()).thenReturn(HOST);
+        when(mockCoapServerContext.getPort()).thenReturn(occupiedPort);
+        when(mockCoapServerContext.getDtlsSettings()).thenReturn(null);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (occupiedSocket != null && !occupiedSocket.isClosed()) {
+            occupiedSocket.close();
+        }
+    }
+
+    @Test
+    public void whenPlainBindFails_thenInitThrowsAndReleasesCoapServer() {
+        assertThatThrownBy(() -> service.init())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("None of the server endpoints could be started");
+
+        assertThat(ReflectionTestUtils.getField(service, "server")).isNull();
+        assertThat(ReflectionTestUtils.getField(service, "dtlsSessionsExecutor")).isNull();
+        assertThat(ReflectionTestUtils.getField(service, "dtlsConnector")).isNull();
+        assertThat(ReflectionTestUtils.getField(service, "dtlsCoapEndpoint")).isNull();
+        assertThat(ReflectionTestUtils.getField(service, "tbDtlsCertificateVerifier")).isNull();
+    }
+
+}

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapService.java
@@ -82,15 +82,18 @@ public class LwM2MTransportBootstrapService implements SmartInitializingSingleto
     @PostConstruct
     public void init() {
         log.info("Starting LwM2M transport bootstrap server...");
-        LeshanBootstrapServer bootstrapServer = getLhBootstrapServer();
+        LeshanBootstrapServer bootstrapServer = null;
         try {
+            bootstrapServer = getLhBootstrapServer();
             this.server = bootstrapServer;
             bootstrapServer.start();
             log.info("Started LwM2M transport bootstrap server.");
         } catch (RuntimeException e) {
             log.error("Failed to start LwM2M transport bootstrap server, releasing resources", e);
             try {
-                bootstrapServer.destroy();
+                if (bootstrapServer != null) {
+                    bootstrapServer.destroy();
+                }
             } catch (Exception suppressed) {
                 e.addSuppressed(suppressed);
             } finally {

--- a/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapService.java
+++ b/common/transport/lwm2m/src/main/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapService.java
@@ -82,13 +82,29 @@ public class LwM2MTransportBootstrapService implements SmartInitializingSingleto
     @PostConstruct
     public void init() {
         log.info("Starting LwM2M transport bootstrap server...");
-        this.server = getLhBootstrapServer();
-        this.server.start();
-        log.info("Started LwM2M transport bootstrap server.");
+        LeshanBootstrapServer bootstrapServer = getLhBootstrapServer();
+        try {
+            this.server = bootstrapServer;
+            bootstrapServer.start();
+            log.info("Started LwM2M transport bootstrap server.");
+        } catch (RuntimeException e) {
+            log.error("Failed to start LwM2M transport bootstrap server, releasing resources", e);
+            try {
+                bootstrapServer.destroy();
+            } catch (Exception suppressed) {
+                e.addSuppressed(suppressed);
+            } finally {
+                this.server = null;
+            }
+            throw e;
+        }
     }
 
     @PreDestroy
     public void shutdown() {
+        if (server == null) {
+            return;
+        }
         try {
             log.info("Stopping LwM2M transport bootstrap server!");
             server.destroy();

--- a/common/transport/lwm2m/src/test/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapServiceTest.java
+++ b/common/transport/lwm2m/src/test/java/org/thingsboard/server/transport/lwm2m/bootstrap/LwM2MTransportBootstrapServiceTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.lwm2m.bootstrap;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.server.common.transport.TransportService;
+import org.thingsboard.server.transport.lwm2m.bootstrap.secure.TbLwM2MDtlsBootstrapCertificateVerifier;
+import org.thingsboard.server.transport.lwm2m.bootstrap.store.LwM2MBootstrapSecurityStore;
+import org.thingsboard.server.transport.lwm2m.bootstrap.store.LwM2MInMemoryBootstrapConfigStore;
+import org.thingsboard.server.transport.lwm2m.config.LwM2MTransportBootstrapConfig;
+import org.thingsboard.server.transport.lwm2m.config.LwM2MTransportServerConfig;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class LwM2MTransportBootstrapServiceTest {
+
+    private static final String HOST = "127.0.0.1";
+
+    @Mock
+    private LwM2MTransportServerConfig serverConfig;
+
+    @Mock
+    private LwM2MTransportBootstrapConfig bootstrapConfig;
+
+    @Mock
+    private LwM2MBootstrapSecurityStore lwM2MBootstrapSecurityStore;
+
+    @Mock
+    private LwM2MInMemoryBootstrapConfigStore lwM2MInMemoryBootstrapConfigStore;
+
+    @Mock
+    private TransportService transportService;
+
+    @Mock
+    private TbLwM2MDtlsBootstrapCertificateVerifier certificateVerifier;
+
+    private LwM2MTransportBootstrapService service;
+    private DatagramSocket occupiedPlain;
+    private DatagramSocket occupiedSecure;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        occupiedPlain = new DatagramSocket(new InetSocketAddress(InetAddress.getByName(HOST), 0));
+        occupiedSecure = new DatagramSocket(new InetSocketAddress(InetAddress.getByName(HOST), 0));
+
+        when(bootstrapConfig.getHost()).thenReturn(HOST);
+        when(bootstrapConfig.getPort()).thenReturn(occupiedPlain.getLocalPort());
+        when(bootstrapConfig.getSecureHost()).thenReturn(HOST);
+        when(bootstrapConfig.getSecurePort()).thenReturn(occupiedSecure.getLocalPort());
+        when(bootstrapConfig.getSslCredentials()).thenReturn(null);
+
+        when(serverConfig.isRecommendedCiphers()).thenReturn(false);
+        when(serverConfig.isRecommendedSupportedGroups()).thenReturn(false);
+        when(serverConfig.getDtlsRetransmissionTimeout()).thenReturn(9000);
+        when(serverConfig.getDtlsCidLength()).thenReturn(null);
+
+        service = new LwM2MTransportBootstrapService(
+                serverConfig,
+                bootstrapConfig,
+                lwM2MBootstrapSecurityStore,
+                lwM2MInMemoryBootstrapConfigStore,
+                transportService,
+                certificateVerifier
+        );
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (occupiedPlain != null && !occupiedPlain.isClosed()) {
+            occupiedPlain.close();
+        }
+        if (occupiedSecure != null && !occupiedSecure.isClosed()) {
+            occupiedSecure.close();
+        }
+    }
+
+    @Test
+    public void whenEndpointsFailToStart_thenInitThrowsAndReleasesBootstrapServer() {
+        assertThatThrownBy(() -> service.init())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("None of the server endpoints could be started");
+
+        assertThat(ReflectionTestUtils.getField(service, "server")).isNull();
+    }
+
+}


### PR DESCRIPTION
This PR fixes two cases where ThingsBoard's JVM hangs after a transport bind failure at startup because non-daemon Californium threads survive a failed `init()`. Both transports are addressed with the same pattern: release Californium resources in a `try/catch` so the bean fails cleanly and the JVM exits with code 1.

## CoAP transport

### Symptom

If the CoAP transport fails to start (for example, because `coap.bind_port` is already in use), the JVM hangs instead of exiting. `DefaultCoapServerService.createCoapServer()` creates a `CoapServer` and adds endpoints before calling `server.start()`. When the only endpoint fails to bind, Californium throws `IllegalStateException("None of the server endpoints could be started")`, but the underlying partial state plus protocol-stage executor leave non-daemon Californium threads alive. Spring treats the bean as failed and does not invoke the `@PreDestroy` `shutdown()` method, so the process stays up after the failure.

### Fix

Wrap the endpoint/build/`server.start()` logic in `createCoapServer()` in a `try/catch`. On any `RuntimeException` or `UnknownHostException`: shut down `dtlsSessionsExecutor` if it was created, call `server.destroy()` to close any partially-bound endpoint and release Californium executors, null out instance fields, and rethrow the original exception so Spring marks the bean as failed.

### Automated tests

New `DefaultCoapServerServiceTest` with one unit test that occupies a UDP port via `DatagramSocket` and invokes `init()`:

- `whenPlainBindFails_thenInitThrowsAndReleasesCoapServer` — plain CoAP port is occupied. Verifies `IllegalStateException` is rethrown and the `server`, `dtlsSessionsExecutor`, `dtlsConnector`, `dtlsCoapEndpoint`, `tbDtlsCertificateVerifier` instance fields are all nulled.

### Manual tests

- CoAP port 5683 occupied (`nc -6 -u -l 5683`). **Before the fix**: TB hangs after `BindException` / `Application run failed`; non-daemon Californium threads keep JVM alive, requires SIGKILL. **After the fix**: process exits on its own with `Process finished with exit code 1`.

## LwM2M bootstrap transport

### Symptom

The LwM2M bootstrap transport (`transport.lwm2m.bootstrap.bind_port` / `secure.bind_port`, default UDP 5687/5688) has the same hang on init failure. `LwM2MTransportBootstrapService.init()` runs in `@PostConstruct`, so a failure during Spring `refresh()` does not invoke `@PreDestroy shutdown()`. The Californium `CoapServer` created inside `LeshanBootstrapServer` spawns non-daemon protocol-stage executor threads (`CoapServer(main)#N`, `CoapServer(secondary)#N`) in its constructor — before `start()`. When both UDP endpoints fail to bind, Leshan rethrows `IllegalStateException("None of the server endpoints could be started")` but the executors stay alive and keep the JVM up.

The main LwM2M transport (`DefaultLwM2mTransportService`, UDP 5685/5686) does not need a fix: it runs in `@AfterStartUp` (an `ApplicationReadyEvent` listener), so its failure propagates back through `EventPublishingRunListener.ready()` to `SpringApplication.run()`, which calls `handleRunFailure(context)` → `context.close()` → the bean's existing `@PreDestroy` runs and releases Californium resources cleanly.

### Fix

Wrap `getLhBootstrapServer()` + `bootstrapServer.start()` in `LwM2MTransportBootstrapService.init()` in a `try/catch`. On any `RuntimeException`: call `bootstrapServer.destroy()` to release the Californium `CoapServer` executors, null the `server` field, suppress any cleanup exception via `addSuppressed`, and rethrow the original. Add a `server != null` null-check to `@PreDestroy shutdown()` in case it ever runs after a failed init.

### Automated tests

New `LwM2MTransportBootstrapServiceTest` with one unit test that occupies both UDP ports via `DatagramSocket` and invokes `init()`:

- `whenEndpointsFailToStart_thenInitThrowsAndReleasesBootstrapServer` — both plain and secure ports are occupied. Verifies `IllegalStateException` with `"None of the server endpoints could be started"` is rethrown and the `server` instance field is nulled.

### Manual tests

- LwM2M bootstrap UDP ports 5687 + 5688 occupied (`nc -6 -u -l 5687` and `nc -6 -u -l 5688` in two terminals). **Before the fix**: TB prints `IllegalStateException` / `Application run failed`, JVM stays up; `jcmd <pid> Thread.print | grep -v daemon` shows 3 × `CoapServer(main)#N` + 2 × `CoapServer(secondary)#N` non-daemon threads holding `DestroyJavaVM`. **After the fix**: process exits on its own with `Process finished with exit code 1`, no leaked threads.
- Sanity: occupy only main LwM2M ports 5685 + 5686 → unchanged (TB already exits cleanly on its own, since the main service runs in `@AfterStartUp`).
- Sanity: normal start with no occupied ports → unchanged behaviour.