### PR TITLE
Fixed RPC call request rule node returning null body

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbCoreConsumerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbCoreConsumerService.java
@@ -465,8 +465,8 @@ public class DefaultTbCoreConsumerService extends AbstractConsumerService<ToCore
         return firmwareStateService.process(msg.getValue());
     }
 
-    private void forwardToCoreRpcService(FromDeviceRPCResponseProto proto, TbCallback callback) {
-        RpcError error = proto.getError() >= 0 ? RpcError.values()[proto.getError()] : null;
+    void forwardToCoreRpcService(FromDeviceRPCResponseProto proto, TbCallback callback) {
+        RpcError error = RpcError.fromProtoErrorCode(proto.getError());
         FromDeviceRpcResponse response = new FromDeviceRpcResponse(new UUID(proto.getRequestIdMSB(), proto.getRequestIdLSB())
                 , proto.hasResponse() ? proto.getResponse() : null, error);
         tbCoreDeviceRpcService.processRpcResponseFromRuleEngine(response);

--- a/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbCoreConsumerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbCoreConsumerService.java
@@ -466,9 +466,9 @@ public class DefaultTbCoreConsumerService extends AbstractConsumerService<ToCore
     }
 
     private void forwardToCoreRpcService(FromDeviceRPCResponseProto proto, TbCallback callback) {
-        RpcError error = proto.getError() > 0 ? RpcError.values()[proto.getError()] : null;
+        RpcError error = proto.getError() >= 0 ? RpcError.values()[proto.getError()] : null;
         FromDeviceRpcResponse response = new FromDeviceRpcResponse(new UUID(proto.getRequestIdMSB(), proto.getRequestIdLSB())
-                , proto.getResponse(), error);
+                , proto.hasResponse() ? proto.getResponse() : null, error);
         tbCoreDeviceRpcService.processRpcResponseFromRuleEngine(response);
         callback.onSuccess();
     }

--- a/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbRuleEngineConsumerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbRuleEngineConsumerService.java
@@ -180,9 +180,9 @@ public class DefaultTbRuleEngineConsumerService extends AbstractPartitionBasedCo
             callback.onSuccess();
         } else if (nfMsg.hasFromDeviceRpcResponse()) {
             TransportProtos.FromDeviceRPCResponseProto proto = nfMsg.getFromDeviceRpcResponse();
-            RpcError error = proto.getError() > 0 ? RpcError.values()[proto.getError()] : null;
+            RpcError error = proto.getError() >= 0 ? RpcError.values()[proto.getError()] : null;
             FromDeviceRpcResponse response = new FromDeviceRpcResponse(new UUID(proto.getRequestIdMSB(), proto.getRequestIdLSB())
-                    , proto.getResponse(), error);
+                    , proto.hasResponse() ? proto.getResponse() : null, error);
             tbDeviceRpcService.processRpcResponseFromDevice(response);
             callback.onSuccess();
         } else if (nfMsg.getQueueUpdateMsgsCount() > 0) {

--- a/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbRuleEngineConsumerService.java
+++ b/application/src/main/java/org/thingsboard/server/service/queue/DefaultTbRuleEngineConsumerService.java
@@ -180,7 +180,7 @@ public class DefaultTbRuleEngineConsumerService extends AbstractPartitionBasedCo
             callback.onSuccess();
         } else if (nfMsg.hasFromDeviceRpcResponse()) {
             TransportProtos.FromDeviceRPCResponseProto proto = nfMsg.getFromDeviceRpcResponse();
-            RpcError error = proto.getError() >= 0 ? RpcError.values()[proto.getError()] : null;
+            RpcError error = RpcError.fromProtoErrorCode(proto.getError());
             FromDeviceRpcResponse response = new FromDeviceRpcResponse(new UUID(proto.getRequestIdMSB(), proto.getRequestIdLSB())
                     , proto.hasResponse() ? proto.getResponse() : null, error);
             tbDeviceRpcService.processRpcResponseFromDevice(response);

--- a/application/src/test/java/org/thingsboard/server/service/queue/DefaultTbCoreConsumerServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/queue/DefaultTbCoreConsumerServiceTest.java
@@ -27,8 +27,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.rpc.RpcError;
 import org.thingsboard.server.common.msg.queue.TbCallback;
+import org.thingsboard.server.common.msg.rpc.FromDeviceRpcResponse;
 import org.thingsboard.server.gen.transport.TransportProtos;
+import org.thingsboard.server.service.rpc.TbCoreDeviceRpcService;
 import org.thingsboard.server.service.ruleengine.RuleEngineCallService;
 import org.thingsboard.server.service.state.DeviceStateService;
 
@@ -51,6 +54,8 @@ public class DefaultTbCoreConsumerServiceTest {
     private TbCoreConsumerStats statsMock;
     @Mock
     private RuleEngineCallService ruleEngineCallServiceMock;
+    @Mock
+    private TbCoreDeviceRpcService tbCoreDeviceRpcServiceMock;
 
     @Mock
     private TbCallback tbCallbackMock;
@@ -636,6 +641,33 @@ public class DefaultTbCoreConsumerServiceTest {
 
         // THEN
         then(ruleEngineCallServiceMock).should().onQueueMsg(restApiCallResponseMsgProto, tbCallbackMock);
+    }
+
+    @Test
+    public void givenNotFoundErrorAndNoResponse_whenForwardToCoreRpcService_thenNotFoundAndNullResponseAreRecovered() {
+        // GIVEN
+        ReflectionTestUtils.setField(defaultTbCoreConsumerServiceMock, "tbCoreDeviceRpcService", tbCoreDeviceRpcServiceMock);
+        var requestId = UUID.randomUUID();
+        // error = NOT_FOUND.ordinal() (0) and response left unset: the previously broken combination
+        // ('error > 0' dropped NOT_FOUND, proto3 default collapsed a null response to "").
+        var proto = TransportProtos.FromDeviceRPCResponseProto.newBuilder()
+                .setRequestIdMSB(requestId.getMostSignificantBits())
+                .setRequestIdLSB(requestId.getLeastSignificantBits())
+                .setError(RpcError.NOT_FOUND.ordinal())
+                .build();
+        doCallRealMethod().when(defaultTbCoreConsumerServiceMock).forwardToCoreRpcService(proto, tbCallbackMock);
+
+        // WHEN
+        defaultTbCoreConsumerServiceMock.forwardToCoreRpcService(proto, tbCallbackMock);
+
+        // THEN
+        var responseCaptor = ArgumentCaptor.forClass(FromDeviceRpcResponse.class);
+        then(tbCoreDeviceRpcServiceMock).should().processRpcResponseFromRuleEngine(responseCaptor.capture());
+        var response = responseCaptor.getValue();
+        assertThat(response.getId()).isEqualTo(requestId);
+        assertThat(response.getError()).contains(RpcError.NOT_FOUND);
+        assertThat(response.getResponse()).isEmpty();
+        then(tbCallbackMock).should().onSuccess();
     }
 
 }

--- a/application/src/test/java/org/thingsboard/server/service/queue/DefaultTbRuleEngineConsumerServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/queue/DefaultTbRuleEngineConsumerServiceTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.queue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.server.common.data.rpc.RpcError;
+import org.thingsboard.server.common.msg.queue.TbCallback;
+import org.thingsboard.server.common.msg.rpc.FromDeviceRpcResponse;
+import org.thingsboard.server.gen.transport.TransportProtos;
+import org.thingsboard.server.gen.transport.TransportProtos.ToRuleEngineNotificationMsg;
+import org.thingsboard.server.queue.common.TbProtoQueueMsg;
+import org.thingsboard.server.service.rpc.TbRuleEngineDeviceRpcService;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doCallRealMethod;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultTbRuleEngineConsumerServiceTest {
+
+    @Mock
+    private TbRuleEngineDeviceRpcService tbDeviceRpcServiceMock;
+    @Mock
+    private TbCallback tbCallbackMock;
+
+    @Mock
+    private DefaultTbRuleEngineConsumerService defaultTbRuleEngineConsumerServiceMock;
+
+    @Test
+    public void givenNotFoundErrorAndNoResponse_whenHandleFromDeviceRpcResponse_thenNotFoundAndNullResponseAreRecovered() {
+        // GIVEN
+        ReflectionTestUtils.setField(defaultTbRuleEngineConsumerServiceMock, "tbDeviceRpcService", tbDeviceRpcServiceMock);
+        var requestId = UUID.randomUUID();
+        // error = NOT_FOUND.ordinal() (0) and response left unset: the previously broken combination
+        // ('error > 0' dropped NOT_FOUND, proto3 default collapsed a null response to "").
+        var proto = TransportProtos.FromDeviceRPCResponseProto.newBuilder()
+                .setRequestIdMSB(requestId.getMostSignificantBits())
+                .setRequestIdLSB(requestId.getLeastSignificantBits())
+                .setError(RpcError.NOT_FOUND.ordinal())
+                .build();
+        var nfMsg = ToRuleEngineNotificationMsg.newBuilder().setFromDeviceRpcResponse(proto).build();
+        var queueMsg = new TbProtoQueueMsg<>(requestId, nfMsg);
+        doCallRealMethod().when(defaultTbRuleEngineConsumerServiceMock).handleNotification(requestId, queueMsg, tbCallbackMock);
+
+        // WHEN
+        defaultTbRuleEngineConsumerServiceMock.handleNotification(requestId, queueMsg, tbCallbackMock);
+
+        // THEN
+        var responseCaptor = ArgumentCaptor.forClass(FromDeviceRpcResponse.class);
+        then(tbDeviceRpcServiceMock).should().processRpcResponseFromDevice(responseCaptor.capture());
+        var response = responseCaptor.getValue();
+        assertThat(response.getId()).isEqualTo(requestId);
+        assertThat(response.getError()).contains(RpcError.NOT_FOUND);
+        assertThat(response.getResponse()).isEmpty();
+        then(tbCallbackMock).should().onSuccess();
+    }
+
+}

--- a/common/data/src/main/java/org/thingsboard/server/common/data/rpc/RpcError.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/rpc/RpcError.java
@@ -20,4 +20,16 @@ package org.thingsboard.server.common.data.rpc;
  */
 public enum RpcError {
     NOT_FOUND, FORBIDDEN, NO_ACTIVE_CONNECTION, TIMEOUT, INTERNAL;
+
+    private static final RpcError[] VALUES = values();
+
+    /**
+     * Resolves an {@link RpcError} from the proto {@code error} ordinal.
+     * Returns {@code null} both for the "no error" sentinel (negative value) and for unknown ordinals
+     * that a newer node in a mixed-version cluster might emit, so callers never hit an
+     * {@link ArrayIndexOutOfBoundsException}.
+     */
+    public static RpcError fromProtoErrorCode(int errorCode) {
+        return errorCode >= 0 && errorCode < VALUES.length ? VALUES[errorCode] : null;
+    }
 }

--- a/common/proto/src/main/java/org/thingsboard/server/common/util/ProtoUtils.java
+++ b/common/proto/src/main/java/org/thingsboard/server/common/util/ProtoUtils.java
@@ -587,7 +587,7 @@ public class ProtoUtils {
         FromDeviceRpcResponse fromDeviceRpcResponse = new FromDeviceRpcResponse(
                 new UUID(rpcResponse.getRequestIdMSB(), rpcResponse.getRequestIdLSB()),
                 rpcResponse.hasResponse() ? rpcResponse.getResponse() : null,
-                rpcResponse.getError() >= 0 ? RpcError.values()[rpcResponse.getError()] : null);
+                RpcError.fromProtoErrorCode(rpcResponse.getError()));
         return new FromDeviceRpcResponseActorMsg(
                 proto.getRequestId(),
                 TenantId.fromUUID(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),

--- a/common/proto/src/main/java/org/thingsboard/server/common/util/ProtoUtils.java
+++ b/common/proto/src/main/java/org/thingsboard/server/common/util/ProtoUtils.java
@@ -583,10 +583,11 @@ public class ProtoUtils {
     }
 
     private static ToDeviceActorNotificationMsg fromProto(TransportProtos.FromDeviceRpcResponseActorMsgProto proto) {
+        TransportProtos.FromDeviceRPCResponseProto rpcResponse = proto.getRpcResponse();
         FromDeviceRpcResponse fromDeviceRpcResponse = new FromDeviceRpcResponse(
-                new UUID(proto.getRpcResponse().getRequestIdMSB(), proto.getRpcResponse().getRequestIdLSB()),
-                proto.getRpcResponse().getResponse(),
-                proto.getRpcResponse().getError() >= 0 ? RpcError.values()[proto.getRpcResponse().getError()] : null);
+                new UUID(rpcResponse.getRequestIdMSB(), rpcResponse.getRequestIdLSB()),
+                rpcResponse.hasResponse() ? rpcResponse.getResponse() : null,
+                rpcResponse.getError() >= 0 ? RpcError.values()[rpcResponse.getError()] : null);
         return new FromDeviceRpcResponseActorMsg(
                 proto.getRequestId(),
                 TenantId.fromUUID(new UUID(proto.getTenantIdMSB(), proto.getTenantIdLSB())),

--- a/common/proto/src/main/proto/queue.proto
+++ b/common/proto/src/main/proto/queue.proto
@@ -1238,7 +1238,7 @@ message LocalSubscriptionServiceMsgProto {
 message FromDeviceRPCResponseProto {
   int64 requestIdMSB = 1;
   int64 requestIdLSB = 2;
-  string response = 3;
+  optional string response = 3;
   int32 error = 4;
 }
 

--- a/common/proto/src/test/java/org/thingsboard/server/common/util/ProtoUtilsTest.java
+++ b/common/proto/src/test/java/org/thingsboard/server/common/util/ProtoUtilsTest.java
@@ -227,6 +227,17 @@ class ProtoUtilsTest {
     }
 
     @Test
+    void protoFromDeviceRpcResponseOnewaySerialization() {
+        // Oneway RPC success: response and error are both null. Relies on the proto
+        // 'optional string response' presence bit so the receiver round-trips null
+        // rather than seeing the proto3 default "".
+        FromDeviceRpcResponseActorMsg msg = new FromDeviceRpcResponseActorMsg(23, tenantId, deviceId, new FromDeviceRpcResponse(id, null, null));
+        TransportProtos.ToDeviceActorNotificationMsgProto serializedMsg = ProtoUtils.toProto(msg);
+        Assertions.assertNotNull(serializedMsg);
+        assertThat(ProtoUtils.fromProto(serializedMsg)).as("deserialized").isEqualTo(msg);
+    }
+
+    @Test
     void protoRemoveRpcActorSerialization() {
         RemoveRpcActorMsg msg = new RemoveRpcActorMsg(tenantId, deviceId, id);
         TransportProtos.ToDeviceActorNotificationMsgProto serializedMsg = ProtoUtils.toProto(msg);


### PR DESCRIPTION
## Pull Request description

Initial issue: TbSendRPCRequestNode produces empty string as data instead of empty JSON in cluster mode. After investigation, the issue was found in handling FromDeviceRpcResponse.response.

- queue.proto: string response → optional string response (wire-compatible; only adds a presence bit to the API)
- 3 receivers (ProtoUtils, DefaultTbCoreConsumerService, DefaultTbRuleEngineConsumerService): use proto.hasResponse() ? proto.getResponse() : null to round-trip null correctly
- 2 receivers (the two consumer services): error check fixed from > 0 to >= 0 so RpcError.NOT_FOUND (ordinal 0) isn't silently dropped
- Regression test added: protoFromDeviceRpcResponseOnewaySerialization round-trips FromDeviceRpcResponse(id, null, null)

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



