### PR TITLE
Fix queue prefix handling for rule engine topics

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/entitiy/queue/DefaultTbQueueService.java
+++ b/application/src/main/java/org/thingsboard/server/service/entitiy/queue/DefaultTbQueueService.java
@@ -27,6 +27,7 @@ import org.thingsboard.server.common.data.tenant.profile.TenantProfileQueueConfi
 import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
 import org.thingsboard.server.dao.queue.QueueService;
 import org.thingsboard.server.queue.TbQueueAdmin;
+import org.thingsboard.server.queue.discovery.TopicService;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 import org.thingsboard.server.service.entitiy.AbstractTbEntityService;
 
@@ -45,6 +46,7 @@ public class DefaultTbQueueService extends AbstractTbEntityService implements Tb
     private final QueueService queueService;
     private final TbClusterService tbClusterService;
     private final TbQueueAdmin tbQueueAdmin;
+    private final TopicService topicService;
 
     @Override
     public Queue saveQueue(Queue queue) {
@@ -173,9 +175,10 @@ public class DefaultTbQueueService extends AbstractTbEntityService implements Tb
     private void createTopicsIfNeeded(Queue queue, Queue oldQueue) {
         int newPartitions = queue.getPartitions();
         int oldPartitions = oldQueue != null ? oldQueue.getPartitions() : 0;
+        String topic = topicService.buildTopicName(queue.getTopic());
         for (int i = oldPartitions; i < newPartitions; i++) {
             tbQueueAdmin.createTopicIfNotExists(
-                    new TopicPartitionInfo(queue.getTopic(), queue.getTenantId(), i, false).getFullTopicName(),
+                    new TopicPartitionInfo(topic, queue.getTenantId(), i, false).getFullTopicName(),
                     queue.getCustomProperties(),
                     true); // forcing topic creation because the topic may still be cached on some nodes
         }

--- a/application/src/test/java/org/thingsboard/server/service/entitiy/queue/DefaultTbQueueServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/entitiy/queue/DefaultTbQueueServiceTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.entitiy.queue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thingsboard.server.cluster.TbClusterService;
+import org.thingsboard.server.common.data.id.QueueId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.queue.Queue;
+import org.thingsboard.server.dao.queue.QueueService;
+import org.thingsboard.server.queue.TbQueueAdmin;
+import org.thingsboard.server.queue.discovery.TopicService;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultTbQueueServiceTest {
+
+    @Mock
+    private QueueService queueService;
+    @Mock
+    private TbClusterService tbClusterService;
+    @Mock
+    private TbQueueAdmin tbQueueAdmin;
+    @Mock
+    private TopicService topicService;
+
+    private DefaultTbQueueService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DefaultTbQueueService(queueService, tbClusterService, tbQueueAdmin, topicService);
+    }
+
+    @Test
+    void saveQueueCreatesPrefixedKafkaTopicsWhenQueuePrefixIsConfigured() {
+        Queue queue = queue("tb_rule_engine.testQueue", 2);
+        when(queueService.saveQueue(queue)).thenReturn(queue);
+        when(topicService.buildTopicName("tb_rule_engine.testQueue")).thenReturn("thingsboard.tb_rule_engine.testQueue");
+
+        service.saveQueue(queue);
+
+        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.0"), eq(null), eq(true));
+        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.1"), eq(null), eq(true));
+        verify(tbQueueAdmin, never()).createTopicIfNotExists(eq("tb_rule_engine.testQueue.0"), eq(null), eq(true));
+        verify(tbClusterService).onQueuesUpdate(List.of(queue));
+    }
+
+    @Test
+    void saveQueueCreatesOnlyNewPrefixedPartitionsWhenPartitionCountIncreases() {
+        QueueId queueId = new QueueId(UUID.randomUUID());
+        Queue oldQueue = queue("tb_rule_engine.testQueue", 1);
+        oldQueue.setId(queueId);
+        Queue queue = queue("tb_rule_engine.testQueue", 3);
+        queue.setId(queueId);
+
+        when(queueService.findQueueById(queue.getTenantId(), queueId)).thenReturn(oldQueue);
+        when(queueService.saveQueue(queue)).thenReturn(queue);
+        when(topicService.buildTopicName("tb_rule_engine.testQueue")).thenReturn("thingsboard.tb_rule_engine.testQueue");
+
+        service.saveQueue(queue);
+
+        verify(tbQueueAdmin, never()).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.0"), eq(null), eq(true));
+        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.1"), eq(null), eq(true));
+        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.2"), eq(null), eq(true));
+        verify(tbClusterService).onQueuesUpdate(List.of(queue));
+    }
+
+    private Queue queue(String topic, int partitions) {
+        Queue queue = new Queue();
+        queue.setName("testQueue");
+        queue.setTopic(topic);
+        queue.setTenantId(TenantId.SYS_TENANT_ID);
+        queue.setPartitions(partitions);
+        return queue;
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/service/entitiy/queue/DefaultTbQueueServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/entitiy/queue/DefaultTbQueueServiceTest.java
@@ -31,9 +31,12 @@ import org.thingsboard.server.queue.discovery.TopicService;
 import java.util.List;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -63,9 +66,9 @@ class DefaultTbQueueServiceTest {
 
         service.saveQueue(queue);
 
-        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.0"), eq(null), eq(true));
-        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.1"), eq(null), eq(true));
-        verify(tbQueueAdmin, never()).createTopicIfNotExists(eq("tb_rule_engine.testQueue.0"), eq(null), eq(true));
+        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.0"), isNull(), eq(true));
+        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.1"), isNull(), eq(true));
+        verify(tbQueueAdmin, never()).createTopicIfNotExists(eq("tb_rule_engine.testQueue.0"), isNull(), eq(true));
         verify(tbClusterService).onQueuesUpdate(List.of(queue));
     }
 
@@ -83,9 +86,40 @@ class DefaultTbQueueServiceTest {
 
         service.saveQueue(queue);
 
-        verify(tbQueueAdmin, never()).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.0"), eq(null), eq(true));
-        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.1"), eq(null), eq(true));
-        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.2"), eq(null), eq(true));
+        verify(tbQueueAdmin, never()).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.0"), isNull(), eq(true));
+        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.1"), isNull(), eq(true));
+        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.2"), isNull(), eq(true));
+        verify(tbClusterService).onQueuesUpdate(List.of(queue));
+    }
+
+    @Test
+    void saveQueueDoesNotCreateKafkaTopicsWhenPartitionCountIsUnchanged() {
+        QueueId queueId = new QueueId(UUID.randomUUID());
+        Queue oldQueue = queue("tb_rule_engine.testQueue", 2);
+        oldQueue.setId(queueId);
+        Queue queue = queue("tb_rule_engine.testQueue", 2);
+        queue.setId(queueId);
+
+        when(queueService.findQueueById(queue.getTenantId(), queueId)).thenReturn(oldQueue);
+        when(queueService.saveQueue(queue)).thenReturn(queue);
+        when(topicService.buildTopicName("tb_rule_engine.testQueue")).thenReturn("thingsboard.tb_rule_engine.testQueue");
+
+        service.saveQueue(queue);
+
+        verifyNoInteractions(tbQueueAdmin);
+        verify(tbClusterService).onQueuesUpdate(List.of(queue));
+    }
+
+    @Test
+    void saveQueueDoesNotPersistQueuePrefixIntoQueueTopic() {
+        Queue queue = queue("tb_rule_engine.testQueue", 1);
+        when(queueService.saveQueue(queue)).thenReturn(queue);
+        when(topicService.buildTopicName("tb_rule_engine.testQueue")).thenReturn("thingsboard.tb_rule_engine.testQueue");
+
+        service.saveQueue(queue);
+
+        assertEquals("tb_rule_engine.testQueue", queue.getTopic());
+        verify(tbQueueAdmin).createTopicIfNotExists(eq("thingsboard.tb_rule_engine.testQueue.0"), isNull(), eq(true));
         verify(tbClusterService).onQueuesUpdate(List.of(queue));
     }
 


### PR DESCRIPTION
## Pull Request description

Fixes #15642.

When a queue prefix is configured, rule engine Kafka consumers use `TopicService.buildTopicName(...)`, but queue topic creation used the raw queue topic. As a result, saving a queue could create unprefixed Kafka topics while the runtime used prefixed topics, leaving redundant topics behind.

This change applies the configured topic prefix before creating queue partition topics in `DefaultTbQueueService`, aligning topic creation with the existing Kafka consumer/delete path. The stored `Queue.topic` value remains unchanged.

Documentation notes: no documentation changes are required. This is a backend bug fix that makes topic creation follow the already documented queue prefix behavior.

Validation:

- Added unit coverage for prefixed topic creation, partition-count increases, unchanged partition counts, and ensuring the prefix is not persisted back into `Queue.topic`.
- Attempted targeted Maven validation with JDK 25. The backend reactor reached dependent modules, but the `application -am` path also triggers `ui-ngx:yarn install`; available Maven skip flags did not bypass the frontend plugin. The run was stopped before completion to avoid treating unrelated frontend dependency installation as backend test evidence.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added. N/A: external contributors cannot add labels in this repository.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version. N/A: external contributors cannot set milestones in this repository.
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. N/A: required for internal contributors only.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. N/A: backend-only Kafka topic lifecycle fix, no UI change.
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present. N/A: no widget or frontend API change.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help). N/A: no frontend API change.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts. N/A: no new dependency.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc. N/A: no new service.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created. N/A: no REST API change.
- [x] If new yml property was added: make sure a description is added (above or near the property). N/A: no yml property change.
