### PR TITLE
refactor: extract validateMaxDashboardsPerTenant in DashboardDataValidator

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/service/validator/DashboardDataValidator.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/service/validator/DashboardDataValidator.java
@@ -32,6 +32,10 @@ public class DashboardDataValidator extends DataValidator<Dashboard> {
 
     @Override
     protected void validateCreate(TenantId tenantId, Dashboard data) {
+        validateMaxDashboardsPerTenant(tenantId);
+    }
+
+    public void validateMaxDashboardsPerTenant(TenantId tenantId) {
         validateNumberOfEntitiesPerTenant(tenantId, EntityType.DASHBOARD);
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/validator/DashboardDataValidatorTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/validator/DashboardDataValidatorTest.java
@@ -21,11 +21,19 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.thingsboard.server.common.data.Dashboard;
+import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.dao.tenant.TenantService;
+import org.thingsboard.server.dao.usagerecord.ApiLimitService;
+import org.thingsboard.server.exception.EntitiesLimitExceededException;
 
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.verify;
 
@@ -34,6 +42,8 @@ class DashboardDataValidatorTest {
 
     @MockBean
     TenantService tenantService;
+    @MockBean
+    ApiLimitService apiLimitService;
     @SpyBean
     DashboardDataValidator validator;
     TenantId tenantId = TenantId.fromUUID(UUID.fromString("9ef79cdf-37a8-4119-b682-2e7ed4e018da"));
@@ -51,6 +61,27 @@ class DashboardDataValidatorTest {
 
         validator.validateDataImpl(tenantId, dashboard);
         verify(validator).validateString("Dashboard title", dashboard.getTitle());
+    }
+
+    @Test
+    void validateMaxDashboardsPerTenant_doesNotThrow_whenLimitNotReached() {
+        willReturn(true).given(apiLimitService).checkEntitiesLimit(tenantId, EntityType.DASHBOARD);
+
+        assertThatNoException().isThrownBy(() -> validator.validateMaxDashboardsPerTenant(tenantId));
+    }
+
+    @Test
+    void validateMaxDashboardsPerTenant_throwsEntitiesLimitExceeded_whenLimitReached() {
+        long limit = 5;
+        willReturn(false).given(apiLimitService).checkEntitiesLimit(tenantId, EntityType.DASHBOARD);
+        willReturn(limit).given(apiLimitService).getLimit(eq(tenantId), any());
+
+        assertThatThrownBy(() -> validator.validateMaxDashboardsPerTenant(tenantId))
+                .isInstanceOfSatisfying(EntitiesLimitExceededException.class, ex -> {
+                    assertThat(ex.getTenantId()).isEqualTo(tenantId);
+                    assertThat(ex.getEntityType()).isEqualTo(EntityType.DASHBOARD);
+                    assertThat(ex.getLimit()).isEqualTo(limit);
+                });
     }
 
 }


### PR DESCRIPTION
## Summary

- Extracted the dashboard entities-limit check from `DashboardDataValidator.validateCreate` into a new public method `validateMaxDashboardsPerTenant(TenantId)`.
- Allows callers outside the validator (e.g. controllers that need to enforce the dashboard limit before constructing a `Dashboard`) to reuse the same logic without duplicating `apiLimitService.checkEntitiesLimit` / `getLimit` calls.
- Added unit tests covering both the limit-not-reached and limit-reached paths.