### PR TITLE
Fixed default dashboard not opening after OAuth2 login

### DIFF
--- a/ui-ngx/src/app/app.component.ts
+++ b/ui-ngx/src/app/app.component.ts
@@ -92,6 +92,14 @@ export class AppComponent {
   }
 
   setupAuth() {
+    // URL-token login (OAuth2 redirect to root) emits selectUserReady once;
+    // skip(1) would swallow it and gotoDefaultPlace would never fire.
+    const params = new URLSearchParams(window.location.search);
+    const hasRootUrlAuth = window.location.pathname === '/' && (
+      !!params.get('accessToken') ||
+      (!!params.get('username') && !!params.get('password'))
+    );
+
     this.store.select(selectUserReady).pipe(
       filter((data) => data.isUserLoaded),
       tap((data) => {
@@ -102,7 +110,7 @@ export class AppComponent {
         }
         this.notifyUserLang(userLang);
       }),
-      skip(1),
+      skip(hasRootUrlAuth ? 0 : 1),
     ).subscribe((data) => {
       this.authService.gotoDefaultPlace(data.isAuthenticated);
     });

--- a/ui-ngx/src/app/app.component.ts
+++ b/ui-ngx/src/app/app.component.ts
@@ -92,14 +92,6 @@ export class AppComponent {
   }
 
   setupAuth() {
-    // URL-token login (OAuth2 redirect to root) emits selectUserReady once;
-    // skip(1) would swallow it and gotoDefaultPlace would never fire.
-    const params = new URLSearchParams(window.location.search);
-    const hasRootUrlAuth = window.location.pathname === '/' && (
-      !!params.get('accessToken') ||
-      (!!params.get('username') && !!params.get('password'))
-    );
-
     this.store.select(selectUserReady).pipe(
       filter((data) => data.isUserLoaded),
       tap((data) => {
@@ -110,7 +102,7 @@ export class AppComponent {
         }
         this.notifyUserLang(userLang);
       }),
-      skip(hasRootUrlAuth ? 0 : 1),
+      skip(1),
     ).subscribe((data) => {
       this.authService.gotoDefaultPlace(data.isAuthenticated);
     });

--- a/ui-ngx/src/app/core/auth/auth.service.ts
+++ b/ui-ngx/src/app/core/auth/auth.service.ts
@@ -73,6 +73,12 @@ export class AuthService {
   private refreshTokenSubject: ReplaySubject<LoginResponse> = null;
   private jwtHelper = new JwtHelperService();
 
+  // Set in loadUser when the user arrives via a root-URL login (OAuth2 redirect,
+  // or username/password/publicId in the query). Such logins resolve during
+  // bootstrap and produce a single selectUserReady emission, so gotoDefaultPlace
+  // is driven here rather than from the app.component subscription.
+  private urlAuthRedirect = false;
+
   private static _storeGet(key) {
     return localStorage.getItem(key);
   }
@@ -102,10 +108,18 @@ export class AuthService {
       (authPayload) => {
         this.notifyAuthenticated(authPayload);
         this.notifyUserLoaded(true);
+        if (this.urlAuthRedirect) {
+          this.urlAuthRedirect = false;
+          this.gotoDefaultPlace(true);
+        }
       },
       () => {
         this.notifyUnauthenticated();
         this.notifyUserLoaded(true);
+        if (this.urlAuthRedirect) {
+          this.urlAuthRedirect = false;
+          this.gotoDefaultPlace(false);
+        }
       }
     );
   }
@@ -303,6 +317,9 @@ export class AuthService {
       const username = this.utils.getQueryParam('username');
       const password = this.utils.getQueryParam('password');
       const loginError = this.utils.getQueryParam('loginError');
+      // Deep links (pathname !== '/') must open the requested page, not the default dashboard.
+      this.urlAuthRedirect = window.location.pathname === '/' &&
+        !!(publicId || accessToken || (username && password));
       if (publicId) {
         return this.publicLogin(publicId).pipe(
           mergeMap((response) => {


### PR DESCRIPTION
## Summary
- OAuth2 redirect to root URL (`/?accessToken=…&refreshToken=…`) was not navigating the user to their configured default dashboard; they landed on `/home` instead.
- Same bug applied to `/?username=…&password=…` URL logins.
- Root cause: the post-login `gotoDefaultPlace` is driven by the second emission of `selectUserReady` in `app.component.setupAuth` (`skip(1)`). The standard login flow produces two emissions (initial unauthenticated state → authenticated state); URL-token logins produce only one, so `skip(1)` swallows it and `gotoDefaultPlace` never fires.
- Fix detects root-URL token logins at setup time and uses `skip(0)` instead, so the single authenticated emission goes through.
- Deep-link OAuth2 (when `prev_uri` cookie redirects the user back to a specific URL like `/dashboards/abc/?accessToken=…`) is preserved unchanged via the `pathname === '/'` guard — those continue to land on the deep link.

## Test plan
Tested manually in Chrome (regular mode; Safari Private has unrelated localStorage/URL quirks).

### Baseline (must still work)
- [x] Logout → /login → enter credentials → lands on default dashboard.
- [x] Logged-in user reloads a deep link like `/dashboards/<id>` → stays on that deep link (does not jump to default dashboard).

### Bug reproduction without setting up a real OAuth2 provider
The frontend cannot distinguish tokens delivered by a real OAuth2 redirect from tokens we put into the URL ourselves — same `loadUser` `accessToken` branch handles both. Backend's `Oauth2AuthenticationSuccessHandler#getRedirectUrl` produces exactly `<baseUrl>/?accessToken=<JWT>&refreshToken=<JWT>`.

Steps:
1. Log in as a customer-user that has **Default dashboard** set on the user profile and **Always fullscreen OFF** (any non-fullscreen tenant-admin / customer-user with a default dashboard works).
2. Open DevTools → Console.
3. Paste and run:
   ```js
   const at = localStorage.getItem('jwt_token');
   const rt = localStorage.getItem('refresh_token');
   const url = `${location.origin}/?accessToken=${at}&refreshToken=${rt}`;
   localStorage.clear();
   window.location.href = url;
   ```
4. Page reloads — wait 2–3 seconds.

**Before this PR:** address bar shows `/home`, default dashboard is not opened.
**After this PR:** address bar shows `/dashboards/<default-dashboard-id>`, dashboard opens.

- [x] Bug reproduction shows `/dashboards/<id>` after the fix.

### Deep-link OAuth2 regression check
- [x] Pasting `<host>/dashboards/<id>/?accessToken=…&refreshToken=…` directly into the address bar lands on `/dashboards/<id>` (NOT the default dashboard) — guarded by `pathname === '/'`.