### PR TITLE
Bump Netty to 4.1.134.Final to fix MQTT decoder regression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <spring-boot-test.version>3.5.13</spring-boot-test.version>
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <postgresql.version>42.7.11</postgresql.version> <!-- to fix CVE-2026-42198. TODO: remove when fixed in spring-boot-dependencies -->
-        <netty.version>4.1.133.Final</netty.version> <!-- to fix CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587. TODO: remove when fixed in spring-boot-dependencies -->
+        <netty.version>4.1.134.Final</netty.version> <!-- to fix CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587, and MQTT decoder regression introduced in 4.1.133 by the CVE-2026-44248 fix. TODO: remove when fixed in spring-boot-dependencies -->
         <tomcat.version>10.1.55</tomcat.version> <!-- to fix CVE-2026-41284, CVE-2026-43512. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>


### PR DESCRIPTION
## Summary

Bumps `netty.version` from `4.1.133.Final` to `4.1.134.Final` to fix an MQTT decoder regression introduced by the CVE-2026-44248 fix in 4.1.133.

## Symptom

After upgrading to 4.1.133, MQTT transport logs explode with errors like:

```
o.t.s.t.mqtt.MqttTransportHandler [nioEventLoopGroup-3-9] ERROR [..] Message decoding failed: message length exceeds 65536: 101
```

The printed number (`101` above) is small — far below the 65536 limit. The exception is `io.netty.handler.codec.TooLongFrameException` thrown from `MqttDecoder.decode()` (the `READ_VARIABLE_HEADER` state).

## Root cause

In 4.1.133, `MqttDecoder` decides whether to swallow a `Signal.REPLAY` from `decodeVariableHeader()` by comparing `initialAvailableBytes = buffer.readableBytes()` (the **total** cumulation) to `maxBytesInMessage`. When multiple MQTT packets sit in the same buffer, later packets' bytes can make a current in-limit packet look oversized, so the decoder bails out and throws `TooLongFrameException`. The printed second number is the current packet's `bytesRemainingBeforeVariableHeader` (small), not the actual cumulation size (≥ 65536) — which is why the error message reads as nonsense.

## Upstream fix

- Issue: [netty/netty#16776](https://github.com/netty/netty/issues/16776) — _"The fix for CVE-2026-44248 breaks MQTT decoding"_
- PR: [netty/netty#16787](https://github.com/netty/netty/pull/16787) — _"Fix MQTT decoder size check after variable header replay"_ (merged 2026-05-20 into `4.2`)
- 4.1 auto-port commit: [`30f8f284db`](https://github.com/netty/netty/commit/30f8f284db) (_"Auto-port 4.1: Fix MQTT decoder size check after variable header replay (#16838)"_)
- Released as: [`netty-4.1.134.Final`](https://github.com/netty/netty/releases/tag/netty-4.1.134.Final) on 2026-05-20

## Proof the fix is in 4.1.134.Final

1. **Tag source confirms.** `MqttDecoder.java` at tag `netty-4.1.134.Final` no longer references `initialAvailableBytes`; the `Signal` handling now compares per-packet `bytesRemainingBeforeVariableHeader` against `maxBytesInMessage`:

   ```java
   case READ_VARIABLE_HEADER:  try {
       int bytesRemainingBeforeVariableHeader = bytesRemainingInVariablePart;
       boolean bailOut = false;
       try {
           variableHeader = decodeVariableHeader(ctx, buffer, mqttFixedHeader);
       } catch (Signal signal) {
           if (bytesRemainingBeforeVariableHeader > maxBytesInMessage) {
               bailOut = true;
           } else {
               throw signal;
           }
       }
   ```
   Source: https://github.com/netty/netty/blob/netty-4.1.134.Final/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java

2. **Commit is in the 4.1.133 → 4.1.134 delta.**

   ```
   $ gh api 'repos/netty/netty/compare/netty-4.1.133.Final...netty-4.1.134.Final' \
       --jq '.commits[] | {sha: .sha[0:10], msg: (.commit.message | split("\n")[0])}' | grep -i mqtt
   {"sha":"30f8f284db","msg":"Auto-port 4.1: Fix MQTT decoder size check after variable header replay (#16838)"}
   ```

3. **Git ancestry confirms.** `30f8f284db` is a direct ancestor of `netty-4.1.134.Final`:

   ```
   $ gh api 'repos/netty/netty/compare/30f8f284db...netty-4.1.134.Final' --jq '{ahead_by, behind_by, status}'
   {"ahead_by": 1, "behind_by": 0, "status": "ahead"}
   ```

## Notes

- 4.1.134.Final retains all CVE fixes from 4.1.133 (CVE-2026-42579 / -42583 / -42584 / -42587 / -44248). Comment in `pom.xml` updated to reflect the additional regression fix.
- This is the only change in this PR.