### PR TITLE
fix: release DirectByteBuffer after MQTT SSL auth to prevent native memory leak

### DIFF
--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -150,7 +150,6 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     protected final MqttTransportContext context;
     private final TransportService transportService;
     private final SchedulerComponent scheduler;
-    private final boolean ssl;
     private volatile SslHandler sslHandler;
     private final ConcurrentMap<MqttTopicMatcher, Integer> mqttQoSMap;
 
@@ -173,7 +172,6 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         this.context = context;
         this.transportService = context.getTransportService();
         this.scheduler = context.getScheduler();
-        this.ssl = sslHandler != null;
         this.sslHandler = sslHandler;
         this.mqttQoSMap = new ConcurrentHashMap<>();
         this.deviceSessionCtx = new DeviceSessionCtx(sessionId, mqttQoSMap, context);

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -150,7 +150,8 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     protected final MqttTransportContext context;
     private final TransportService transportService;
     private final SchedulerComponent scheduler;
-    private final SslHandler sslHandler;
+    private final boolean ssl;
+    private volatile SslHandler sslHandler;
     private final ConcurrentMap<MqttTopicMatcher, Integer> mqttQoSMap;
 
     final DeviceSessionCtx deviceSessionCtx;
@@ -172,6 +173,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         this.context = context;
         this.transportService = context.getTransportService();
         this.scheduler = context.getScheduler();
+        this.ssl = sslHandler != null;
         this.sslHandler = sslHandler;
         this.mqttQoSMap = new ConcurrentHashMap<>();
         this.deviceSessionCtx = new DeviceSessionCtx(sessionId, mqttQoSMap, context);
@@ -1373,6 +1375,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                 }
             });
         }
+        this.sslHandler = null;
     }
 
     @Override


### PR DESCRIPTION
## Pull Request description

Holding sslHandler as a final field kept SSLEngine and its JNI-allocated DirectByteBuffers alive for the full session lifetime. On rapid reconnect loops this caused linear native memory growth, eventually hitting OOM.

Null the reference at the end of onValidateDeviceResponse() so SslHandler becomes eligible for Young GC immediately after authentication completes. Add boolean ssl flag to preserve isSSL semantics after the field is cleared.

## Root Cause

### What happens

On every MQTT SSL connection Netty creates an `SslHandler` wrapping a JDK `SSLEngine`
(JSSE, not OpenSSL). During the TLS handshake, `SSLEngine` allocates `DirectByteBuffer`
memory via native JNI code. This memory is tracked by JMX as
`java.nio:type=BufferPool,name=direct`.

`MqttTransportHandler` held `sslHandler` as a `final` field — the reference was kept
for the entire lifetime of the handler (from connect to disconnect).

### Why buffers were never freed

`DirectByteBuffer` is released through a `Cleaner` — a `PhantomReference` that calls
`Unsafe.freeMemory()` when the object is garbage collected. But two things prevented this:

1. **GC never collected Old Gen.** Heap was only ~20% occupied, and G1GC only starts Mixed GC
   at `InitiatingHeapOccupancyPercent=45%` (default). That threshold was never reached.

2. **Netty does not close JDK `SSLEngine` on pipeline removal.**
   `SslHandler.handlerRemoved0()` releases the engine only if it is `instanceof ReferenceCounted`.
   `JdkSslEngine` is **not** `ReferenceCounted` — so the engine and its DirectByteBuffers
   stay alive as long as `MqttTransportHandler` is in memory.

After channel close, all external references to `MqttTransportHandler` are cleared
(pipeline, closeFuture, sessions map), but the handler sat in Old Gen uncollected.


### Code fix (MqttTransportHandler.java)

File: `common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java`

`sslHandler` is used **only** during CONNECT packet processing:
- `processConnect()` — extracts the client X509 certificate
- `onValidateDeviceResponse()` — checks the certificate on auth failure

After `onValidateDeviceResponse()` completes, `sslHandler` is **never used again**,
but was previously held as a `final` field until the end of the session.

## Expected Result

### Misbehaving device (200ms reconnect loop)

Before fix:
- Each SSL handshake → `SslHandler` → `SSLEngine` → DirectByteBuffer (~150 KB)
- `sslHandler` held by `final` field → object promoted to Old Gen
- Old Gen never collected (heap 20% < IHOP 45%)
- Memory grows linearly: OOM in 2–3 days

After fix:
- `sslHandler = null` immediately after auth → object eligible for **Young GC**
- `SSLEngine` and its DirectByteBuffer collected on the next Minor GC, never reach Old Gen
- Cleaner runs, `Unsafe.freeMemory()` called — native memory returned to OS


## Why It Works

`DirectByteBuffer` lives as long as `SSLEngine` is alive. `SSLEngine` lives as long as
`SslHandler` is alive. `SslHandler` lived as long as `MqttTransportHandler` because of
the `final` field reference. `MqttTransportHandler` is a long-lived Netty `ChannelHandler`
that exists for the full duration of the TCP connection.

Setting `this.sslHandler = null` breaks this chain immediately after auth.
`SslHandler` has no more strong references from the handler → becomes unreachable →
GC triggers the `Cleaner` → `Unsafe.freeMemory()` → native memory returned to OS.

The key insight: `SslHandler` is not needed after authentication. All subsequent TLS
encrypt/decrypt work is done automatically by the Netty pipeline. `MqttTransportHandler`
only handles MQTT application logic — it never touches TLS directly after the CONNECT phase.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



