### PR TITLE
Document LZ4 native-addon vs --allow-addons trade-off for js-executor compression

### DIFF
--- a/msa/js-executor/config/custom-environment-variables.yml
+++ b/msa/js-executor/config/custom-environment-variables.yml
@@ -34,6 +34,9 @@ kafka:
   partitions_consumed_concurrently: "TB_KAFKA_PARTITIONS_CONSUMED_CONCURRENTLY" # (EXPERIMENTAL) increase this value if you are planning to handle more than one partition (scale up, scale down) - this will decrease the latency
   requestTimeout: "TB_QUEUE_KAFKA_REQUEST_TIMEOUT_MS"
   connectionTimeout: "TB_KAFKA_CONNECTION_TIMEOUT_MS"
+  # Kafka producer compression: none, gzip or lz4.
+  # none/gzip require no native addon (gzip uses Node's built-in zlib); lz4 is backed
+  # by the native lz4-napi addon and therefore needs --allow-addons under --permission.
   compression: "TB_QUEUE_KAFKA_COMPRESSION" # gzip, lz4 or none
   topic_properties: "TB_QUEUE_KAFKA_JE_TOPIC_PROPERTIES"
   use_confluent_cloud: "TB_QUEUE_KAFKA_USE_CONFLUENT_CLOUD"

--- a/msa/js-executor/config/default.yml
+++ b/msa/js-executor/config/default.yml
@@ -34,6 +34,10 @@ kafka:
   partitions_consumed_concurrently: "1" # (EXPERIMENTAL) increase this value if you are planning to handle more than one partition (scale up, scale down) - this will decrease the latency
   requestTimeout: "30000" # The default value in kafkajs is: 30000
   connectionTimeout: "1000" # The default value in kafkajs is: 1000
+  # Kafka producer compression: none, gzip or lz4.
+  # none/gzip require no native addon (gzip uses Node's built-in zlib); lz4 is backed
+  # by the native lz4-napi addon and therefore needs --allow-addons when the executor
+  # runs under Node's --permission model.
   compression: "none" # gzip, lz4 or none
   topic_properties: "retention.ms:604800000;segment.bytes:52428800;retention.bytes:104857600;partitions:100;min.insync.replicas:1"
   use_confluent_cloud: false

--- a/msa/js-executor/queue/kafkaTemplate.ts
+++ b/msa/js-executor/queue/kafkaTemplate.ts
@@ -58,6 +58,17 @@ export class KafkaTemplate implements IQueue {
                 // dependency on the lz4-napi native binary (e.g. inside pkg-built executables).
                 // The package re-assigns module.exports = LZ4Codec, which wipes the __esModule
                 // flag and the .default property — so accept either shape.
+                //
+                // Permission model note: LZ4 is backed by the native lz4-napi addon. Under
+                // Node's --permission model, loading any native addon (process.dlopen) is
+                // blocked unless --allow-addons is granted. That flag is global — Node has no
+                // per-addon allowlist and no build-time grant — so there is no way to permit
+                // only this addon. Operators who want to run under --permission WITHOUT
+                // --allow-addons should use kafka.compression=gzip (Node's built-in zlib, no
+                // native addon) or none. Where --allow-addons is granted, it is safe under a
+                // hardened runtime (read-only root filesystem, no writable mounts, dropped
+                // capabilities, read access scoped to the app dir): no attacker-controlled
+                // .node can be introduced, so the grant only permits the build-baked binary.
                 const lz4Module = require('@2l/kafkajs-lz4');
                 const LZ4Codec = lz4Module.default || lz4Module;
                 CompressionCodecs[CompressionTypes.LZ4] = new LZ4Codec().codec;


### PR DESCRIPTION
## What

Documentation-only change to the ThingsBoard JavaScript Executor. It documents the
native-addon / Node permission-model trade-off of each `kafka.compression` value, in
the three places an operator encounters it:

- `msa/js-executor/queue/kafkaTemplate.ts` — the `lz4` branch of `resolveCompressionType()`
- `msa/js-executor/config/default.yml` — the `compression` setting
- `msa/js-executor/config/custom-environment-variables.yml` — the `TB_QUEUE_KAFKA_COMPRESSION` mapping

No codec, dependency, or default behavior change. The default stays `none`.

## Why

`kafka.compression` supports `none` / `gzip` / `lz4`. `lz4` is backed by the native
`lz4-napi` addon (via `@2l/kafkajs-lz4`). When the executor runs under Node's
`--permission` model, loading any native addon (`process.dlopen`) is blocked unless
`--allow-addons` is granted.

That flag is **global**: Node has no per-addon allowlist and no build-time grant, so
there is no way to permit only this one addon. Operators hardening the executor under
`--permission` had no in-tree pointer to the addon-free path. This change records it:

- `none` / `gzip` need **no** native addon — `gzip` uses Node's built-in `zlib`, so
  both run under `--permission` with no `--allow-addons`.
- `lz4` requires `--allow-addons` under `--permission`.
- Where `--allow-addons` is granted, it is safe under a hardened runtime (read-only
  root filesystem, no writable mounts, dropped capabilities, read access scoped to the
  app dir): no attacker-controlled `.node` can be introduced, so the grant only permits
  the build-baked binary.

## Testing

- `mvn license:check -pl msa/js-executor` — BUILD SUCCESS.
- Comment-only / config-comment-only; the executor behaves identically.
