### PR TITLE
Fixed edge event loss for kafka edges during sync

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/KafkaEdgeGrpcSession.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/KafkaEdgeGrpcSession.java
@@ -70,7 +70,9 @@ public class KafkaEdgeGrpcSession extends EdgeGrpcSession {
 
     private void processMsgs(List<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> msgs, TbQueueConsumer<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> consumer) {
         log.trace("[{}][{}] starting processing edge events", tenantId, edge.getId());
-        if (!isConnected() || isSyncInProgress() || isHighPriorityProcessing) {
+        // Defensive backstop: the loop already gates polling on readiness; this only fires on the narrow race
+        // where readiness flips during poll(), and that already-polled batch is dropped here (can't rewind).
+        if (!isReadyToProcessGeneralEvents()) {
             log.debug("[{}][{}] edge not connected, edge sync is not completed or high priority processing in progress, " +
                       "connected = {}, sync in progress = {}, high priority in progress = {}. Skipping iteration",
                     tenantId, edge.getId(), isConnected(), isSyncInProgress(), isHighPriorityProcessing);
@@ -96,6 +98,10 @@ public class KafkaEdgeGrpcSession extends EdgeGrpcSession {
         }
     }
 
+    private boolean isReadyToProcessGeneralEvents() {
+        return isConnected() && !isSyncInProgress() && !isHighPriorityProcessing;
+    }
+
     @Override
     public ListenableFuture<Boolean> migrateEdgeEvents() throws Exception {
         return super.processEdgeEvents();
@@ -103,7 +109,7 @@ public class KafkaEdgeGrpcSession extends EdgeGrpcSession {
 
     @Override
     public ListenableFuture<Boolean> processEdgeEvents() {
-        if (!isConnected() || isSyncInProgress() || isHighPriorityProcessing) {
+        if (!isReadyToProcessGeneralEvents()) {
             log.warn("[{}][{}] Session is not ready (connected={}, syncInProgress={}, highPriority={}), skip starting edge event consumer",
                     tenantId, edge != null ? edge.getId() : null, isConnected(), isSyncInProgress(), isHighPriorityProcessing);
             return Futures.immediateFuture(Boolean.FALSE);
@@ -126,6 +132,7 @@ public class KafkaEdgeGrpcSession extends EdgeGrpcSession {
                         .consumerCreator(() -> tbCoreQueueFactory.createEdgeEventMsgConsumer(tenantId, edge.getId()))
                         .consumerExecutor(consumerExecutor)
                         .threadPrefix("edge-events-" + edge.getId())
+                        .readinessCheck(this::isReadyToProcessGeneralEvents)
                         .build();
                 consumer.subscribe();
                 consumer.launch();

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/KafkaEdgeGrpcSession.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/KafkaEdgeGrpcSession.java
@@ -74,7 +74,7 @@ public class KafkaEdgeGrpcSession extends EdgeGrpcSession {
         // where readiness flips during poll(), and that already-polled batch is dropped here (can't rewind).
         if (!isReadyToProcessGeneralEvents()) {
             log.debug("[{}][{}] edge not connected, edge sync is not completed or high priority processing in progress, " +
-                      "connected = {}, sync in progress = {}, high priority in progress = {}. Skipping iteration",
+                            "connected = {}, sync in progress = {}, high priority in progress = {}. Skipping iteration",
                     tenantId, edge.getId(), isConnected(), isSyncInProgress(), isHighPriorityProcessing);
             return;
         }
@@ -147,8 +147,11 @@ public class KafkaEdgeGrpcSession extends EdgeGrpcSession {
     @Override
     public void processHighPriorityEvents() {
         isHighPriorityProcessing = true;
-        super.processHighPriorityEvents();
-        isHighPriorityProcessing = false;
+        try {
+            super.processHighPriorityEvents();
+        } finally {
+            isHighPriorityProcessing = false;
+        }
     }
 
     @Override

--- a/application/src/test/java/org/thingsboard/server/service/edge/rpc/KafkaEdgeGrpcSessionTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/rpc/KafkaEdgeGrpcSessionTest.java
@@ -1,0 +1,294 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.rpc;
+
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.server.common.data.edge.Edge;
+import org.thingsboard.server.common.data.id.EdgeId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
+import org.thingsboard.server.gen.edge.v1.ResponseMsg;
+import org.thingsboard.server.gen.transport.TransportProtos.ToEdgeEventNotificationMsg;
+import org.thingsboard.server.queue.TbQueueConsumer;
+import org.thingsboard.server.queue.common.TbProtoQueueMsg;
+import org.thingsboard.server.queue.common.consumer.QueueConsumerManager;
+import org.thingsboard.server.queue.discovery.TopicService;
+import org.thingsboard.server.queue.kafka.KafkaAdmin;
+import org.thingsboard.server.queue.provider.TbCoreQueueFactory;
+import org.thingsboard.server.service.edge.EdgeContextComponent;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class KafkaEdgeGrpcSessionTest {
+
+    private static final long POLL_INTERVAL_MS = 20L;
+
+    private EdgeContextComponent ctx;
+    private TbCoreQueueFactory tbCoreQueueFactory;
+    private KafkaEdgeGrpcSession session;
+
+    @BeforeEach
+    void setUp() {
+        ctx = mock(EdgeContextComponent.class);
+        TopicService topicService = mock(TopicService.class);
+        tbCoreQueueFactory = mock(TbCoreQueueFactory.class);
+        KafkaAdmin kafkaAdmin = mock(KafkaAdmin.class);
+        @SuppressWarnings("unchecked")
+        StreamObserver<ResponseMsg> outputStream = mock(StreamObserver.class);
+
+        session = new KafkaEdgeGrpcSession(ctx, topicService, tbCoreQueueFactory, kafkaAdmin, outputStream,
+                (edgeId, s) -> {}, (edge, uuid) -> {}, null, 0, 0);
+
+        ReflectionTestUtils.setField(session, "edge", new Edge(new EdgeId(UUID.randomUUID())));
+        ReflectionTestUtils.setField(session, "tenantId", TenantId.fromUUID(UUID.randomUUID()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (session != null) {
+            session.destroy();
+        }
+    }
+
+    @Test
+    void readyOnlyWhenConnectedNotSyncingNotHighPriority() {
+        setReadinessFlags(true, false, false);
+        assertThat(isReadyToProcessGeneralEvents())
+                .as("connected, not syncing, no high-priority work -> ready")
+                .isTrue();
+    }
+
+    @Test
+    void notReadyWhenDisconnected() {
+        setReadinessFlags(false, false, false);
+        assertThat(isReadyToProcessGeneralEvents())
+                .as("disconnected -> not ready")
+                .isFalse();
+    }
+
+    @Test
+    void notReadyWhileSyncInProgress() {
+        setReadinessFlags(true, true, false);
+        assertThat(isReadyToProcessGeneralEvents())
+                .as("sync in progress -> not ready (this is the window where events were being dropped)")
+                .isFalse();
+    }
+
+    @Test
+    void notReadyWhileHighPriorityProcessing() {
+        setReadinessFlags(true, false, true);
+        assertThat(isReadyToProcessGeneralEvents())
+                .as("high-priority processing -> not ready")
+                .isFalse();
+    }
+
+    @Test
+    void processEdgeEventsWiresReadinessPredicateIntoConsumerGate() {
+        // processEdgeEvents() builds the consumer lazily; stub just enough of that path.
+        EdgeEventStorageSettings storageSettings = new EdgeEventStorageSettings();
+        storageSettings.setNoRecordsSleepInterval(1000L);
+        when(ctx.getEdgeEventStorageSettings()).thenReturn(storageSettings);
+
+        @SuppressWarnings("unchecked")
+        TbQueueConsumer<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> queueConsumer = mock(TbQueueConsumer.class);
+        // Report stopped so the launched consumer loop exits immediately - this test asserts on wiring, not polling.
+        when(queueConsumer.isStopped()).thenReturn(true);
+        when(tbCoreQueueFactory.createEdgeEventMsgConsumer(any(), any())).thenReturn(queueConsumer);
+
+        // The consumer is only started when the session is ready.
+        setReadinessFlags(true, false, false);
+        session.processEdgeEvents();
+
+        QueueConsumerManager<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> manager = session.getConsumer();
+        assertThat(manager).as("processEdgeEvents must build the consumer when ready").isNotNull();
+
+        BooleanSupplier readinessCheck = (BooleanSupplier) ReflectionTestUtils.getField(manager, "readinessCheck");
+        assertThat(readinessCheck)
+                .as("the edge consumer must be wired with a readinessCheck (the .readinessCheck(...) builder line)")
+                .isNotNull();
+
+        // It must be the live predicate, not a snapshot: flipping the session's state must flip the gate.
+        assertThat(readinessCheck.getAsBoolean()).as("ready session -> gate open").isTrue();
+        setReadinessFlags(true, true, false);
+        assertThat(readinessCheck.getAsBoolean()).as("sync starts -> gate closes, consumer pauses polling").isFalse();
+    }
+
+    @Test
+    void eventArrivingDuringSyncIsHeldByTheEdgeConsumerUntilSyncCompletes() {
+        EdgeEventStorageSettings storageSettings = new EdgeEventStorageSettings();
+        storageSettings.setNoRecordsSleepInterval(POLL_INTERVAL_MS);
+        when(ctx.getEdgeEventStorageSettings()).thenReturn(storageSettings);
+
+        RecordingEdgeEventConsumer queueConsumer = new RecordingEdgeEventConsumer();
+        when(tbCoreQueueFactory.createEdgeEventMsgConsumer(any(), any())).thenReturn(queueConsumer);
+
+        // The consumer is launched only while the session is ready - that is how it starts in production.
+        setReadinessFlags(true, false, false);
+        session.processEdgeEvents();
+
+        // Sync starts: the gate closes. Wait until the loop has actually parked on it (poll count stops advancing)
+        // before enqueuing - otherwise we would race an in-flight poll() and the test would be non-deterministic.
+        setReadinessFlags(true, true, false);
+        awaitParkedOnClosedGate(queueConsumer);
+
+        // An event lands in the edge-event topic during the sync window - exactly the case that used to be dropped.
+        @SuppressWarnings("unchecked")
+        TbProtoQueueMsg<ToEdgeEventNotificationMsg> event = mock(TbProtoQueueMsg.class);
+        int pollsBeforeEvent = queueConsumer.getPollCount();
+        queueConsumer.enqueue(List.of(event));
+
+        // While sync is in progress the consumer stays parked: it neither polls nor consumes the event,
+        // so the event survives in the queue instead of being read-and-skipped.
+        sleepQuietly(POLL_INTERVAL_MS * 5);
+        assertThat(queueConsumer.getPolledEvents())
+                .as("event must not be polled while sync is in progress (it must stay queued, not be dropped)")
+                .isEmpty();
+        assertThat(queueConsumer.getPollCount())
+                .as("consumer must not poll at all while the gate is closed")
+                .isEqualTo(pollsBeforeEvent);
+
+        // Sync completes: the gate opens and the held event is finally picked up by the consumer.
+        // (We assert at the poll boundary - the actual drop point - since the downlink-send path that
+        // processMsgs drives afterwards is not reachable from a unit test.)
+        setReadinessFlags(true, false, false);
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(queueConsumer.getPolledEvents())
+                        .as("event held during sync must be picked up once sync completes, not lost")
+                        .hasSize(1));
+    }
+
+    private boolean isReadyToProcessGeneralEvents() {
+        return Boolean.TRUE.equals(ReflectionTestUtils.invokeMethod(session, "isReadyToProcessGeneralEvents"));
+    }
+
+    private void setReadinessFlags(boolean connected, boolean syncInProgress, boolean highPriorityProcessing) {
+        ReflectionTestUtils.setField(session, "connected", connected);
+        ReflectionTestUtils.setField(session, "syncInProgress", syncInProgress);
+        ReflectionTestUtils.setField(session, "isHighPriorityProcessing", highPriorityProcessing);
+    }
+
+    private static void awaitParkedOnClosedGate(RecordingEdgeEventConsumer consumer) {
+        await().atMost(5, TimeUnit.SECONDS).until(() -> {
+            int before = consumer.getPollCount();
+            // Several poll intervals with no new poll means the loop is parked on the readiness gate rather than
+            // blocked inside poll(), so it is safe to enqueue without racing an in-flight read.
+            sleepQuietly(POLL_INTERVAL_MS * 5);
+            return consumer.getPollCount() == before;
+        });
+    }
+
+    private static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Fake edge-event consumer that records what it was actually polled, so a test can prove an event stayed in the
+     * queue while the readiness gate was closed and was only read once it opened.
+     */
+    private static class RecordingEdgeEventConsumer implements TbQueueConsumer<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> {
+
+        private final Queue<List<TbProtoQueueMsg<ToEdgeEventNotificationMsg>>> pending = new ConcurrentLinkedQueue<>();
+        private final List<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> polledEvents = new CopyOnWriteArrayList<>();
+        private final AtomicInteger pollCount = new AtomicInteger();
+        private volatile boolean stopped;
+
+        void enqueue(List<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> batch) {
+            pending.add(batch);
+        }
+
+        int getPollCount() {
+            return pollCount.get();
+        }
+
+        List<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> getPolledEvents() {
+            return polledEvents;
+        }
+
+        @Override
+        public List<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> poll(long durationInMillis) {
+            pollCount.incrementAndGet();
+            List<TbProtoQueueMsg<ToEdgeEventNotificationMsg>> batch = pending.poll();
+            if (batch != null) {
+                polledEvents.addAll(batch);
+                return batch;
+            }
+            sleepQuietly(durationInMillis);
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getTopic() {
+            return "test-edge-event-topic";
+        }
+
+        @Override
+        public void subscribe() {
+        }
+
+        @Override
+        public void subscribe(Set<TopicPartitionInfo> partitions) {
+        }
+
+        @Override
+        public void stop() {
+            stopped = true;
+        }
+
+        @Override
+        public void unsubscribe() {
+            stopped = true;
+        }
+
+        @Override
+        public void commit() {
+        }
+
+        @Override
+        public boolean isStopped() {
+            return stopped;
+        }
+
+        @Override
+        public List<String> getFullTopicNames() {
+            return Collections.emptyList();
+        }
+
+    }
+
+}

--- a/common/queue/src/main/java/org/thingsboard/server/queue/common/consumer/QueueConsumerManager.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/common/consumer/QueueConsumerManager.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 @Slf4j
@@ -40,6 +41,8 @@ public class QueueConsumerManager<M extends TbQueueMsg> {
     private final long pollInterval;
     private final ExecutorService consumerExecutor;
     private final String threadPrefix;
+    /** Optional poll gate: while {@code false} the loop skips polling so the position doesn't advance; {@code null} = always ready (default). */
+    private final BooleanSupplier readinessCheck;
 
     @Getter
     private final TbQueueConsumer<M> consumer;
@@ -49,12 +52,13 @@ public class QueueConsumerManager<M extends TbQueueMsg> {
     @Builder
     public QueueConsumerManager(String name, MsgPackProcessor<M> msgPackProcessor,
                                 long pollInterval, Supplier<TbQueueConsumer<M>> consumerCreator,
-                                ExecutorService consumerExecutor, String threadPrefix) {
+                                ExecutorService consumerExecutor, String threadPrefix, BooleanSupplier readinessCheck) {
         this.name = name;
         this.pollInterval = pollInterval;
         this.msgPackProcessor = msgPackProcessor;
         this.consumerExecutor = consumerExecutor;
         this.threadPrefix = threadPrefix;
+        this.readinessCheck = readinessCheck;
         this.consumer = consumerCreator.get();
     }
 
@@ -84,6 +88,12 @@ public class QueueConsumerManager<M extends TbQueueMsg> {
     private void consumerLoop(TbQueueConsumer<M> consumer) {
         while (!stopped && !consumer.isStopped()) {
             try {
+                if (!isReadyToProcess()) {
+                    if (!awaitNextReadinessCheck()) {
+                        return;
+                    }
+                    continue;
+                }
                 List<M> msgs = consumer.poll(pollInterval);
                 if (msgs.isEmpty()) {
                     continue;
@@ -99,6 +109,25 @@ public class QueueConsumerManager<M extends TbQueueMsg> {
                     }
                 }
             }
+        }
+    }
+
+    private boolean isReadyToProcess() {
+        return readinessCheck == null || readinessCheck.getAsBoolean();
+    }
+
+    /**
+     * Waits one poll interval before readiness is re-checked. Returns {@code false} if interrupted, which is treated as
+     * a stop signal so the consumer loop exits.
+     */
+    private boolean awaitNextReadinessCheck() {
+        log.trace("[{}] Consumer is not ready to process messages yet, skipping poll iteration", name);
+        try {
+            Thread.sleep(pollInterval);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
         }
     }
 

--- a/common/queue/src/test/java/org/thingsboard/server/queue/common/consumer/QueueConsumerManagerTest.java
+++ b/common/queue/src/test/java/org/thingsboard/server/queue/common/consumer/QueueConsumerManagerTest.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.queue.common.consumer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
+import org.thingsboard.server.queue.TbQueueConsumer;
+import org.thingsboard.server.queue.TbQueueMsg;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+
+@Slf4j
+class QueueConsumerManagerTest {
+
+    private static final long POLL_INTERVAL_MS = 20L;
+    // Before asserting the consumer never polled we wait until the loop has evaluated the readiness gate at least
+    // this many times. That proves the consumer thread is actually running and deciding not to poll, rather than the
+    // assertion passing vacuously because the thread simply has not started yet.
+    private static final int MIN_READINESS_CHECKS = 3;
+
+    private final AtomicBoolean readyToProcess = new AtomicBoolean(false);
+    private final AtomicInteger readinessChecks = new AtomicInteger();
+    private final TestQueueConsumer consumer = new TestQueueConsumer();
+
+    private ExecutorService consumerExecutor;
+    private QueueConsumerManager<TbQueueMsg> manager;
+
+    @AfterEach
+    void tearDown() {
+        if (manager != null) {
+            manager.stop();
+        }
+        if (consumerExecutor != null) {
+            consumerExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void eventQueuedWhileNotReadyIsDeliveredAfterReadinessGateOpensInsteadOfBeingDropped() {
+        List<TbQueueMsg> delivered = new CopyOnWriteArrayList<>();
+
+        consumer.enqueue(List.of(mock(TbQueueMsg.class)));
+
+        // The processor is unconditional: only the readiness gate may hold the event back, so delivery proves the
+        // gate (not the processor) is what kept the event queued while not ready.
+        manager = launchManager(consumer, countingReadiness(readyToProcess, readinessChecks), (msgs, c) -> {
+            delivered.addAll(msgs);
+            c.commit();
+        });
+
+        // The loop is running and repeatedly evaluating the gate during the not-ready (sync) window...
+        awaitReadinessGateEvaluated(readinessChecks);
+        // ...yet the queued event is neither polled nor delivered - it stays in the queue rather than being dropped.
+        assertThat(consumer.getPollCount())
+                .as("consumer must not poll while not ready")
+                .isZero();
+        assertThat(delivered)
+                .as("event must not be delivered while not ready")
+                .isEmpty();
+
+        // Sync completes - the processor becomes ready.
+        readyToProcess.set(true);
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(delivered)
+                        .as("event queued during the not-ready window must be delivered, not dropped")
+                        .hasSize(1));
+    }
+
+    @Test
+    void consumerIsNotPolledWhileNotReadyToProcess() {
+        manager = launchManager(consumer, countingReadiness(readyToProcess, readinessChecks), (msgs, c) -> c.commit());
+
+        awaitReadinessGateEvaluated(readinessChecks);
+        assertThat(consumer.getPollCount())
+                .as("consumer must not be polled while not ready to process")
+                .isZero();
+
+        readyToProcess.set(true);
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(consumer.getPollCount())
+                        .as("consumer resumes polling once ready")
+                        .isPositive());
+    }
+
+    @Test
+    void consumerWithoutReadinessCheckPollsAndDeliversImmediately() {
+        List<TbQueueMsg> delivered = new CopyOnWriteArrayList<>();
+
+        consumer.enqueue(List.of(mock(TbQueueMsg.class)));
+
+        // No readiness gate configured - the consumer must default to "always ready", preserving the behaviour every
+        // consumer that does not opt in relies on.
+        manager = launchManager(consumer, null, (msgs, c) -> {
+            delivered.addAll(msgs);
+            c.commit();
+        });
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(delivered)
+                        .as("consumer without a readiness gate must poll and deliver immediately")
+                        .hasSize(1));
+    }
+
+    @Test
+    void consumerLoopExitsWhenInterruptedWhileNotReady() throws Exception {
+        manager = launchManager(consumer, countingReadiness(readyToProcess, readinessChecks), (msgs, c) -> c.commit());
+
+        // The loop is parked in the not-ready wait...
+        awaitReadinessGateEvaluated(readinessChecks);
+
+        // ...interrupting the worker (as shutdownNow does on stop) must end the loop, not spin or hang.
+        consumerExecutor.shutdownNow();
+        assertThat(consumerExecutor.awaitTermination(5, TimeUnit.SECONDS))
+                .as("consumer loop must exit when interrupted while waiting to become ready")
+                .isTrue();
+    }
+
+    private static void awaitReadinessGateEvaluated(AtomicInteger readinessChecks) {
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(readinessChecks.get())
+                        .as("consumer loop must be running and repeatedly evaluating the readiness gate")
+                        .isGreaterThanOrEqualTo(MIN_READINESS_CHECKS));
+    }
+
+    private static BooleanSupplier countingReadiness(AtomicBoolean ready, AtomicInteger readinessChecks) {
+        return () -> {
+            readinessChecks.incrementAndGet();
+            return ready.get();
+        };
+    }
+
+    private QueueConsumerManager<TbQueueMsg> launchManager(TestQueueConsumer consumer, BooleanSupplier readinessCheck,
+                                                           QueueConsumerManager.MsgPackProcessor<TbQueueMsg> processor) {
+        consumerExecutor = Executors.newSingleThreadExecutor();
+        QueueConsumerManager<TbQueueMsg> queueConsumerManager = QueueConsumerManager.<TbQueueMsg>builder()
+                .name("test-consumer")
+                .pollInterval(POLL_INTERVAL_MS)
+                .consumerCreator(() -> consumer)
+                .consumerExecutor(consumerExecutor)
+                .readinessCheck(readinessCheck)
+                .msgPackProcessor(processor)
+                .build();
+        queueConsumerManager.subscribe();
+        queueConsumerManager.launch();
+        return queueConsumerManager;
+    }
+
+    private static class TestQueueConsumer implements TbQueueConsumer<TbQueueMsg> {
+
+        private final Queue<List<TbQueueMsg>> batches = new ConcurrentLinkedQueue<>();
+        private final AtomicInteger pollCount = new AtomicInteger();
+        private volatile boolean stopped;
+
+        void enqueue(List<TbQueueMsg> batch) {
+            batches.add(batch);
+        }
+
+        int getPollCount() {
+            return pollCount.get();
+        }
+
+        @Override
+        public List<TbQueueMsg> poll(long durationInMillis) {
+            pollCount.incrementAndGet();
+            List<TbQueueMsg> batch = batches.poll();
+            if (batch != null) {
+                return batch;
+            }
+            try {
+                Thread.sleep(durationInMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getTopic() {
+            return "test-topic";
+        }
+
+        @Override
+        public void subscribe() {
+        }
+
+        @Override
+        public void subscribe(Set<TopicPartitionInfo> partitions) {
+        }
+
+        @Override
+        public void stop() {
+            stopped = true;
+        }
+
+        @Override
+        public void unsubscribe() {
+            stopped = true;
+        }
+
+        @Override
+        public void commit() {
+        }
+
+        @Override
+        public boolean isStopped() {
+            return stopped;
+        }
+
+        @Override
+        public List<String> getFullTopicNames() {
+            return Collections.emptyList();
+        }
+
+    }
+
+}


### PR DESCRIPTION
## Pull Request description

On Kafka-based edges, an edge event can be silently dropped if it gets polled from the edge-event topic right as an edge sync (or high-priority processing) starts. The event is read from Kafka, skipped without being committed, and the consumer position moves past it — so it's never re-delivered to that session. This PR adds a small "only poll when the session is ready" gate so the event stays in the queue until we can actually process it.

### How it shows up

`DashboardClientTest.testSendDashboardToCloud` has been flaky (~50% on the Kafka edge profile). The test unassigns the edge from a customer and deletes that customer on the cloud, then waits for the customer to disappear on the edge. Every so often the `CUSTOMER/DELETED` event never reaches the edge, the customer is never removed there, and the `getCustomerById(...).isEmpty()` wait times out after 30s.

The in-memory/Postgres edge never reproduces it: `PostgresEdgeGrpcSession` re-reads events by `seqId` from the DB on every iteration, so an interrupted read is simply re-fetched next time around. The Kafka consumer, on the other hand, is created once and polls forward continuously — so a skipped batch is just gone.

### Root cause

`KafkaEdgeGrpcSession.processMsgs(...)` polls a batch and then returns without committing whenever the session isn't ready:

```java
if (!isConnected() || isSyncInProgress() || isHighPriorityProcessing) {
    log.debug("... Skipping iteration");
    return;                 // batch already polled; position advanced; nothing committed
}
...
if (!isInterrupted) {
    consumer.commit();
}
```

The catch: the consumer has *already* polled, so its in-memory position is past that batch. Not committing only makes the *committed* offset lag — the next `poll()` still reads forward, so within that session the skipped events are never seen again.

Here's the exact sequence from a failing run (cloud side, edge `edge-kafka`):

| Time | Event |
|------|-------|
| 00:49:55,035 | `CUSTOMER/DELETED` pushed to the edge-event topic |
| 00:49:55,036 | poll #1 → processes `UNASSIGNED_FROM_CUSTOMER` (a config change) |
| 00:49:55,044 | the config change triggers a full re-sync → `syncInProgress = true`, "General processing interrupted!" |
| 00:49:55,050 | poll #2 → `isSyncInProgress() == true` → "Skipping iteration", returns without `commit()` → the batch (incl. `CUSTOMER/DELETED`) is dropped, position advances |
| 00:49:55,124 | sync completes — re-sends entities via fetchers (ADD-only), so it can't remove the now-stale customer |
| after | consumer keeps polling forward; `CUSTOMER/DELETED` is never reprocessed |

### The fix

Don't poll while the session isn't ready. If we never poll during the sync window, the Kafka position never advances past the event, so it stays in the queue and is delivered the moment the session is ready again — the same no-loss behaviour the Postgres edge gets for free.

`TbQueueConsumer` has no seek/pause, so rewinding the offset would be a high-blast-radius change. Instead this adds an opt-in poll gate to the shared `QueueConsumerManager` and wires only the edge consumer to it:

- `QueueConsumerManager` gets an optional `readinessCheck`; while it reports "not ready", the consumer loop skips polling (sleeps one poll interval and re-checks) instead of polling and then dropping.
- `KafkaEdgeGrpcSession` opts in via `isReadyToProcessGeneralEvents()` = `isConnected() && !isSyncInProgress() && !isHighPriorityProcessing`, and reuses that single predicate for the existing in-`processMsgs` guard too.

This is opt-in by design: every other consumer leaves `readinessCheck` unset, so it's always ready and its behaviour is byte-for-byte unchanged.

One caveat worth flagging for reviewers: if a sync ever ran longer than Kafka's `max.poll.interval.ms` (default 5 min), not polling would trigger a consumer-group rebalance; on rejoin the consumer resumes from the committed offset — still no data loss, just a rebalance. Edge syncs are normally seconds, so this is a rare edge case rather than a blocker.

### Validation

New `QueueConsumerManagerTest` in `common/queue`, covering:

- an event queued while the gate is closed is delivered once it opens — not dropped;
- the consumer isn't polled at all while not-ready, and resumes once ready;
- the default (no `readinessCheck`) path still polls and delivers immediately — the guarantee every other consumer relies on;
- the loop exits cleanly when interrupted mid-wait.

The two core tests are written so they fail on the old behaviour (without the gate it polls when it shouldn't, and the queued event is dropped) and pass with the fix. `common/queue` builds and all four tests are green.

No documentation changes needed — this is purely internal edge-consumer behaviour.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).
