### PR TITLE
Fixed CVE-2026-45799

### DIFF
--- a/common/data/pom.xml
+++ b/common/data/pom.xml
@@ -84,8 +84,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- wire-schema-jvm (not wire-schema): from Wire 4.x the plain wire-schema artifact is an empty
+                 Kotlin-Multiplatform pointer whose Maven pom carries no classes, so the -jvm variant must be
+                 referenced explicitly. It transitively pulls wire-runtime-jvm. See CVE-2026-45799 fix. -->
             <groupId>com.squareup.wire</groupId>
-            <artifactId>wire-schema</artifactId>
+            <artifactId>wire-schema-jvm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.thingsboard</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-collections.version>4.4</commons-collections.version>
         <protobuf-dynamic.version>1.0.4TB</protobuf-dynamic.version>
-        <wire-schema.version>3.7.1</wire-schema.version>
+        <wire-schema.version>6.3.0</wire-schema.version> <!-- to fix CVE-2026-45799 (transitive wire-runtime). TODO: remove pin when upstream bundles >= 6.3.0 -->
         <twilio.version>10.1.3</twilio.version>
         <hypersistence-utils.version>3.7.4</hypersistence-utils.version> <!-- artifact name should be updated with hibernate-core version -->
         <jakarta.el.version>4.0.2</jakarta.el.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,11 @@
         <pkg.unixLogFolder>/var/log/${pkg.name}</pkg.unixLogFolder>
         <pkg.installFolder>/usr/share/${pkg.name}</pkg.installFolder>
         <spring-boot.version>3.5.15</spring-boot.version>
-        <!-- TODO: remove spring-boot-test.version override and the matching dependencyManagement entries below
-             once Spring Boot 3.5.15+ is released with a fix for the ImportsContextCustomizer regression in 3.5.14
-             that causes "Duplicate spy definition" failures on legacy @SpyBean fields (see PR #15557). -->
+        <!-- Pins spring-boot-test to 3.5.13: the ImportsContextCustomizer change in 3.5.14 causes "Duplicate spy
+             definition" failures on legacy @SpyBean fields (see PR #15557). Spring declined to restore the prior
+             behavior (spring-projects/spring-boot#50230, closed NOT_PLANNED), so no 3.5.x release fixes this — the
+             bump to 3.5.15 in this PR does not. TODO: remove this override and the matching dependencyManagement
+             entries below once TB migrates its tests off the deprecated @SpyBean/@MockBean to @MockitoSpyBean/@MockitoBean. -->
         <spring-boot-test.version>3.5.13</spring-boot-test.version>
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <netty.version>4.1.134.Final</netty.version> <!-- to fix CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587, and MQTT decoder regression introduced in 4.1.133 by the CVE-2026-44248 fix. TODO: remove when fixed in spring-boot-dependencies -->
@@ -134,7 +136,7 @@
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <commons-collections.version>4.4</commons-collections.version>
         <protobuf-dynamic.version>1.0.4TB</protobuf-dynamic.version>
-        <wire-schema.version>6.3.0</wire-schema.version> <!-- to fix CVE-2026-45799 (transitive wire-runtime). TODO: remove pin when upstream bundles >= 6.3.0 -->
+        <wire-schema.version>6.3.0</wire-schema.version> <!-- to fix CVE-2026-45799 (transitive wire-runtime). Not managed by the Spring Boot BOM — this pin is the sole source of the wire version, nothing to defer to. TODO: remove only once a TB dependency pulls wire >= 6.3.0 transitively, making the explicit pin redundant. -->
         <twilio.version>10.1.3</twilio.version>
         <hypersistence-utils.version>3.7.4</hypersistence-utils.version> <!-- artifact name should be updated with hibernate-core version -->
         <jakarta.el.version>4.0.2</jakarta.el.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1770,7 +1770,7 @@
             </dependency>
             <dependency>
                 <groupId>com.squareup.wire</groupId>
-                <artifactId>wire-schema</artifactId>
+                <artifactId>wire-schema-jvm</artifactId>
                 <version>${wire-schema.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,15 +62,13 @@
         <pkg.implementationTitle>${project.name}</pkg.implementationTitle>
         <pkg.unixLogFolder>/var/log/${pkg.name}</pkg.unixLogFolder>
         <pkg.installFolder>/usr/share/${pkg.name}</pkg.installFolder>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>3.5.15</spring-boot.version>
         <!-- TODO: remove spring-boot-test.version override and the matching dependencyManagement entries below
              once Spring Boot 3.5.15+ is released with a fix for the ImportsContextCustomizer regression in 3.5.14
              that causes "Duplicate spy definition" failures on legacy @SpyBean fields (see PR #15557). -->
         <spring-boot-test.version>3.5.13</spring-boot-test.version>
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
-        <postgresql.version>42.7.11</postgresql.version> <!-- to fix CVE-2026-42198. TODO: remove when fixed in spring-boot-dependencies -->
         <netty.version>4.1.134.Final</netty.version> <!-- to fix CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587, and MQTT decoder regression introduced in 4.1.133 by the CVE-2026-44248 fix. TODO: remove when fixed in spring-boot-dependencies -->
-        <tomcat.version>10.1.55</tomcat.version> <!-- to fix CVE-2026-41284, CVE-2026-43512. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -1015,23 +1013,6 @@
                 <scope>import</scope>
             </dependency>
             <!-- End of netty-bom version override -->
-            <!-- Temporary tomcat-embed version override -->
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-el</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <!-- End of tomcat-embed version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -1368,11 +1349,6 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
-                <version>${postgresql.version}</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
## Summary

Fixes **1 high-severity CVE** (CVE-2026-45799) flagged by the security scan, plus housekeeping of the Spring Boot CVE-override cluster. `com.squareup.wire:wire-schema` is bumped 3.7.1 → 6.3.0, which transitively raises the vulnerable `wire-runtime` to 6.3.0. Spring Boot is bumped 3.5.14 → 3.5.15; its BOM now ships `postgresql 42.7.11` and `tomcat 10.1.55`, so the local `postgresql.version` / `tomcat.version` overrides (and the `tomcat-embed` `dependencyManagement` block) are removed — CVE coverage for CVE-2026-42198, CVE-2026-41284 and CVE-2026-43512 is preserved by the BOM.

Source scan: https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/113400

## CVEs fixed

- **CVE-2026-45799** (high) — Improper Validation of Array Index (DoS) in `com.squareup.wire:wire-runtime` — was 3.7.1 (transitive via `com.squareup.wire:wire-schema`), now 6.3.0.

## Note on the Wire 6.x coordinate

From Wire 4.x the plain `com.squareup.wire:wire-schema` artifact is an **empty Kotlin-Multiplatform pointer** (its Maven jar contains no classes and its pom does not pull the `-jvm` variant). `common/data` therefore now depends on **`wire-schema-jvm`** explicitly, which carries the schema/parser classes and transitively pulls `wire-runtime-jvm:6.3.0` (which provides `com.squareup.wire.Syntax`). The `ProtoParser(Location, char[])` / `readProtoFile()` / `Location` / `Field.Label` API used by `DynamicProtoUtils` is unchanged between 3.7.1 and 6.3.0.

## Commits

- Bump com.squareup.wire:wire-schema from 3.7.1 to 6.3.0 to fix CVE-2026-45799
- Bump spring-boot from 3.5.14 to 3.5.15 and drop redundant postgresql and tomcat version overrides now provided by the BOM
- Use wire-schema-jvm coordinate so wire 6.3.0 resolves under Maven

## Build verification

`common/data` (which is the only module using Wire) compiles and its Wire-dependent unit test passes against 6.3.0:

```text
mvn -pl common/data -am test -Dtest=DynamicProtoUtilsTest
...
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- in org.thingsboard.server.common.data.DynamicProtoUtilsTest
BUILD SUCCESS
```

Downstream coverage: `mvn -pl application -am test-compile` also builds clean against 6.3.0. The CoAP/MQTT `*ProtoIntegrationTest` classes that import `com.squareup.wire.schema.internal.parser.ProtoFileElement` directly compile without changes, confirming the three-major Wire bump is source-compatible across all of TB's usage of the `internal.parser` surface.

Resolved versions after the changes (postgresql/tomcat now come from the Spring Boot 3.5.15 BOM):

```text
com.squareup.wire:wire-runtime:jar:6.3.0
com.squareup.wire:wire-schema-jvm:jar:6.3.0
org.postgresql:postgresql:jar:42.7.11
org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.55
org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.55
org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.55
```

## Unfixable / out-of-scope from this scan

These were flagged by the scan but are not fixed here:

- **CVE-2023-26919** (high) — `org.javadelight:delight-nashorn-sandbox` 0.4.5 — no upstream fix available.
- **CVE-2026-45799** residual on the **PE** side only — `wire-runtime-jvm` 4.3.0 is pulled by `com.amazonaws:amazon-kinesis-producer` → AWS Glue `schema-registry-serde` 1.1.18, which was built against wire 4.3.0. Force-pinning 6.x there risks runtime incompatibility; it needs a KPL / Glue-serde upgrade tracked separately. (Not applicable to CE — CE has no kinesis dependency.)
- **CVE-2026-44705** (high) — npm `tmp` 0.2.5 → 0.2.6 — UI/JS dependency, not a Maven artifact; out of scope for this pom-only flow.

### Debian / base-image CVEs (no upstream fix yet — track, no action)

- **CVE-2026-48959**, **CVE-2026-48962** — `perl` — no fixed version available.
- **CVE-2026-6772**, **CVE-2026-6766** — `nss` — no fixed version available.

> Note: the `spring-boot-test.version` override (3.5.13) is intentionally left in place. Spring Boot 3.5.15 does **not** fix the ImportsContextCustomizer / "Duplicate spy definition" regression — Spring declined to restore the prior behavior (spring-projects/spring-boot#50230, closed `NOT_PLANNED`). Removing the pin requires migrating TB's tests off the deprecated `@SpyBean`/`@MockBean`, tracked separately.
