### PR TITLE
Fix typos: 'resereved' -> 'reserved' and fix protobuf comment grammar

### DIFF
--- a/common/data/src/main/java/org/thingsboard/server/common/data/security/DeviceCredentialsFilter.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/security/DeviceCredentialsFilter.java
@@ -16,7 +16,7 @@
 package org.thingsboard.server.common.data.security;
 
 /**
- * TODO: This is a temporary name. DeviceCredentialsId is resereved in dao layer
+ * TODO: This is a temporary name. DeviceCredentialsId is reserved in dao layer
  */
 public interface DeviceCredentialsFilter {
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <mail.version>2.0.1</mail.version>
         <curator.version>5.6.0</curator.version>
         <zookeeper.version>3.9.5</zookeeper.version> <!-- to fix CVE-2026-24308 and CVE-2026-24281. TODO: remove override when fixed in curator-client -->
-        <protobuf.version>3.25.5</protobuf.version> <!-- A Major v4 does not support by the pubsub yet-->
+        <protobuf.version>3.25.5</protobuf.version> <!-- Protobuf v4 is not yet supported by the pubsub -->
         <grpc.version>1.76.0</grpc.version>
         <tbel.version>1.2.10</tbel.version>
         <lombok.version>1.18.46</lombok.version> <!-- must be in sync with spring-boot-dependencies; needed for maven-compiler-plugin annotationProcessorPaths -->


### PR DESCRIPTION
## Description

Simple typo fix in two files:

1. **DeviceCredentialsFilter.java**: Fixed `resereved` → `reserved` in Javadoc comment
2. **pom.xml**: Fixed grammar in Protobuf version comment from "A Major v4 does not support by the pubsub yet" → "Protobuf v4 is not yet supported by the pubsub"

## General checklist

- [x] No merge conflicts or commented code

## Back-End feature checklist

- [x] No new dependencies added
- [x] No new REST API added