### PR TITLE
Remove unused null keyFilters variables with TODO comments

### DIFF
--- a/common/data/src/main/java/org/thingsboard/server/common/data/security/DeviceCredentialsFilter.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/security/DeviceCredentialsFilter.java
@@ -16,7 +16,7 @@
 package org.thingsboard.server.common.data.security;
 
 /**
- * TODO: This is a temporary name. DeviceCredentialsId is resereved in dao layer
+ * TODO: This is a temporary name. DeviceCredentialsId is reserved in dao layer
  */
 public interface DeviceCredentialsFilter {
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <mail.version>2.0.1</mail.version>
         <curator.version>5.6.0</curator.version>
         <zookeeper.version>3.9.5</zookeeper.version> <!-- to fix CVE-2026-24308 and CVE-2026-24281. TODO: remove override when fixed in curator-client -->
-        <protobuf.version>3.25.5</protobuf.version> <!-- A Major v4 does not support by the pubsub yet-->
+        <protobuf.version>3.25.5</protobuf.version> <!-- Protobuf v4 is not yet supported by the pubsub -->
         <grpc.version>1.76.0</grpc.version>
         <tbel.version>1.2.10</tbel.version>
         <lombok.version>1.18.46</lombok.version> <!-- must be in sync with spring-boot-dependencies; needed for maven-compiler-plugin annotationProcessorPaths -->

--- a/ui-ngx/src/app/modules/home/components/widget/lib/alarm/alarms-table-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/alarm/alarms-table-widget.component.ts
@@ -727,8 +727,7 @@ export class AlarmsTableWidgetComponent extends PageComponent implements OnInit,
       ? (key.type === EntityKeyType.ENTITY_FIELD || key.type === EntityKeyType.ALARM_FIELD ? 'entityField'
          : key.type === EntityKeyType.TIME_SERIES ? 'timeseries' : 'attribute')
       : 'entityField';
-    const keyFilters: KeyFilter[] = null; // TODO:
-    this.alarmsDatasource.loadAlarms(this.pageLink, sortOrderLabel, sortColumnType, keyFilters);
+    this.alarmsDatasource.loadAlarms(this.pageLink, sortOrderLabel, sortColumnType, null);
     this.ctx.detectChanges();
   }
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/entity/entities-table-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/entity/entities-table-widget.component.ts
@@ -621,8 +621,7 @@ export class EntitiesTableWidgetComponent extends PageComponent implements OnIni
       ? (key.type === EntityKeyType.ENTITY_FIELD ? 'entityField'
          : key.type === EntityKeyType.TIME_SERIES ? 'timeseries' : 'attribute')
       : 'entityField';
-    const keyFilters: KeyFilter[] = null; // TODO:
-    this.entityDatasource.loadEntities(this.pageLink, sortOrderLabel, sortColumnType, keyFilters);
+    this.entityDatasource.loadEntities(this.pageLink, sortOrderLabel, sortColumnType, null);
     this.ctx.detectChanges();
   }
 


### PR DESCRIPTION
## Description

Removed unused `const keyFilters: KeyFilter[] = null; // TODO:` variables in two TypeScript widget files. These variables were always `null` and had an empty TODO comment. Inlined `null` directly in the method call instead.

### Files changed:
- **alarms-table-widget.component.ts**: Removed unused `keyFilters` null variable
- **entities-table-widget.component.ts**: Removed unused `keyFilters` null variable

## General checklist

- [x] No merge conflicts or commented code

## Front-End feature checklist

- [x] No API changes or breaking changes