### PR TITLE
Remove stale TODO comments in AlarmController for error codes

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/AlarmController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/AlarmController.java
@@ -170,7 +170,6 @@ public class AlarmController extends BaseController {
         checkParameter(ALARM_ID, strAlarmId);
         AlarmId alarmId = new AlarmId(toUUID(strAlarmId));
         Alarm alarm = checkAlarmId(alarmId, Operation.WRITE);
-        //TODO: return correct error code if the alarm is not found or already cleared
         return tbAlarmService.ack(alarm, getCurrentUser());
     }
 
@@ -185,7 +184,6 @@ public class AlarmController extends BaseController {
         checkParameter(ALARM_ID, strAlarmId);
         AlarmId alarmId = new AlarmId(toUUID(strAlarmId));
         Alarm alarm = checkAlarmId(alarmId, Operation.WRITE);
-        //TODO: return correct error code if the alarm is not found or already cleared
         return tbAlarmService.clear(alarm, getCurrentUser());
     }
 

--- a/common/data/src/main/java/org/thingsboard/server/common/data/security/DeviceCredentialsFilter.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/security/DeviceCredentialsFilter.java
@@ -16,7 +16,7 @@
 package org.thingsboard.server.common.data.security;
 
 /**
- * TODO: This is a temporary name. DeviceCredentialsId is resereved in dao layer
+ * TODO: This is a temporary name. DeviceCredentialsId is reserved in dao layer
  */
 public interface DeviceCredentialsFilter {
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <mail.version>2.0.1</mail.version>
         <curator.version>5.6.0</curator.version>
         <zookeeper.version>3.9.5</zookeeper.version> <!-- to fix CVE-2026-24308 and CVE-2026-24281. TODO: remove override when fixed in curator-client -->
-        <protobuf.version>3.25.5</protobuf.version> <!-- A Major v4 does not support by the pubsub yet-->
+        <protobuf.version>3.25.5</protobuf.version> <!-- Protobuf v4 is not yet supported by the pubsub -->
         <grpc.version>1.76.0</grpc.version>
         <tbel.version>1.2.10</tbel.version>
         <lombok.version>1.18.46</lombok.version> <!-- must be in sync with spring-boot-dependencies; needed for maven-compiler-plugin annotationProcessorPaths -->


### PR DESCRIPTION
**Describe the change**
Removed two stale TODO comments in AlarmController (ackAlarm at line 173 and clearAlarm at line 188) that requested returning correct error codes when the alarm is not found or already acknowledged/cleared.

**Why this is safe**
Both scenarios were already fully handled:
- ITEM_NOT_FOUND (32) is thrown via checkAlarmId() in BaseController before the service is reached
- BAD_REQUEST_PARAMS (31) with descriptive messages is thrown in DefaultTbAlarmService.ack() / clear() for already acknowledged/cleared cases

**Related issue**
N/A — code cleanup.