### PR TITLE
Fix zombie edge event consumer on session handover

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/session/manager/KafkaBasedEdgeGrpcSessionManager.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/session/manager/KafkaBasedEdgeGrpcSessionManager.java
@@ -99,6 +99,15 @@ public class KafkaBasedEdgeGrpcSessionManager extends AbstractEdgeGrpcSessionMan
     public boolean destroy() {
         cancelHighPriorityProcessing();
         EdgeSessionState state = getState();
+        // Unblock the consumer loop first: processMsgs() may be parked on the send-downlink
+        // future of a batch that the (now gone) edge will never acknowledge. Completing it as
+        // interrupted lets the loop observe the stop flag instead of stalling consumer.stop().
+        if (state.getSendDownlinkMsgsFuture() != null && !state.getSendDownlinkMsgsFuture().isDone()) {
+            state.getSendDownlinkMsgsFuture().set(true);
+        }
+        if (state.getScheduledSendDownlinkTask() != null) {
+            state.getScheduledSendDownlinkTask().cancel(true);
+        }
         try {
             if (consumer != null) {
                 log.info("[{}][{}] Stopping edge event consumer...", state.getTenantId(), state.getEdgeId());

--- a/common/queue/src/main/java/org/thingsboard/server/queue/common/consumer/QueueConsumerManager.java
+++ b/common/queue/src/main/java/org/thingsboard/server/queue/common/consumer/QueueConsumerManager.java
@@ -25,6 +25,7 @@ import org.thingsboard.server.queue.TbQueueMsg;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -36,6 +37,8 @@ import java.util.function.Supplier;
 @Slf4j
 public class QueueConsumerManager<M extends TbQueueMsg> {
 
+    public static final long DEFAULT_STOP_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(10);
+
     private final String name;
     private final MsgPackProcessor<M> msgPackProcessor;
     private final long pollInterval;
@@ -43,6 +46,7 @@ public class QueueConsumerManager<M extends TbQueueMsg> {
     private final String threadPrefix;
     /** Optional poll gate: while {@code false} the loop skips polling so the position doesn't advance; {@code null} = always ready (default). */
     private final BooleanSupplier readinessCheck;
+    private final long stopTimeoutMs;
 
     @Getter
     private final TbQueueConsumer<M> consumer;
@@ -52,13 +56,15 @@ public class QueueConsumerManager<M extends TbQueueMsg> {
     @Builder
     public QueueConsumerManager(String name, MsgPackProcessor<M> msgPackProcessor,
                                 long pollInterval, Supplier<TbQueueConsumer<M>> consumerCreator,
-                                ExecutorService consumerExecutor, String threadPrefix, BooleanSupplier readinessCheck) {
+                                ExecutorService consumerExecutor, String threadPrefix,
+                                BooleanSupplier readinessCheck, Long stopTimeoutMs) {
         this.name = name;
         this.pollInterval = pollInterval;
         this.msgPackProcessor = msgPackProcessor;
         this.consumerExecutor = consumerExecutor;
         this.threadPrefix = threadPrefix;
         this.readinessCheck = readinessCheck;
+        this.stopTimeoutMs = stopTimeoutMs != null ? stopTimeoutMs : DEFAULT_STOP_TIMEOUT_MS;
         this.consumer = consumerCreator.get();
     }
 
@@ -135,11 +141,22 @@ public class QueueConsumerManager<M extends TbQueueMsg> {
         log.debug("[{}] Stopping consumer", name);
         stopped = true;
         consumer.unsubscribe();
+        if (consumerTask == null) {
+            return;
+        }
         try {
-            if (consumerTask != null) {
-                consumerTask.get(10, TimeUnit.SECONDS);
-            }
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            consumerTask.get(stopTimeoutMs, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            // The loop did not finish in time: it is most likely blocked inside the message pack
+            // processor (e.g. waiting for a downlink delivery that will never be acknowledged).
+            // A leftover consumer keeps its group membership alive via heartbeats and thereby
+            // blocks a replacement consumer of the same group from getting partitions assigned,
+            // so we must interrupt it instead of abandoning it.
+            log.warn("[{}] Consumer loop did not stop in {} ms, interrupting it", name, stopTimeoutMs);
+            consumerTask.cancel(true);
+        } catch (CancellationException e) {
+            log.debug("[{}] Consumer loop was already cancelled", name);
+        } catch (InterruptedException | ExecutionException e) {
             log.error("[{}] Failed to await consumer loop stop", name, e);
         }
     }

--- a/common/queue/src/test/java/org/thingsboard/server/queue/common/consumer/QueueConsumerManagerTest.java
+++ b/common/queue/src/test/java/org/thingsboard/server/queue/common/consumer/QueueConsumerManagerTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
@@ -145,6 +146,98 @@ class QueueConsumerManagerTest {
                 .isTrue();
     }
 
+    // --- stop() behaviour ---------------------------------------------------
+    // Stopping must work both while the loop is idle and while it is blocked inside the
+    // msg pack processor. A stop that cannot terminate the loop leaves a zombie consumer
+    // behind, which (for kafka) keeps its group membership alive via heartbeats and blocks
+    // the next consumer of the same group from getting partitions assigned (see edge
+    // downlink starvation after session handover).
+
+    private static final long SHORT_STOP_TIMEOUT_MS = 200;
+
+    @Test
+    void stopShouldCompleteGracefullyWhenConsumerLoopIsIdle() {
+        manager = launchManager(consumer, null, (msgs, c) -> c.commit());
+
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(consumer.getPollCount()).isPositive());
+
+        manager.stop();
+
+        assertThat(consumerLoopHasExited()).as("consumer loop thread released").isTrue();
+    }
+
+    @Test
+    void stopShouldInterruptConsumerLoopThatIsBlockedInProcessing() throws Exception {
+        CountDownLatch processingStarted = new CountDownLatch(1);
+        CountDownLatch neverReleased = new CountDownLatch(1);
+        consumer.enqueue(List.of(mock(TbQueueMsg.class)));
+        manager = launchManager(consumer, null, (msgs, c) -> {
+            processingStarted.countDown();
+            // simulates waiting for a downlink delivery that will never be acknowledged
+            neverReleased.await();
+        }, SHORT_STOP_TIMEOUT_MS);
+        assertThat(processingStarted.await(5, TimeUnit.SECONDS))
+                .as("processor entered its blocking section").isTrue();
+
+        long stopStarted = System.currentTimeMillis();
+        manager.stop();
+
+        assertThat(System.currentTimeMillis() - stopStarted)
+                .as("stop() must not hang much longer than the configured stop timeout")
+                .isLessThan(SHORT_STOP_TIMEOUT_MS + 3000);
+        assertThat(consumerLoopHasExited())
+                .as("blocked consumer loop must be interrupted, not abandoned").isTrue();
+    }
+
+    @Test
+    void stopShouldReturnImmediatelyWhenConsumerWasNeverLaunched() {
+        consumerExecutor = Executors.newSingleThreadExecutor();
+        manager = QueueConsumerManager.<TbQueueMsg>builder()
+                .name("test-consumer")
+                .pollInterval(POLL_INTERVAL_MS)
+                .consumerCreator(() -> consumer)
+                .consumerExecutor(consumerExecutor)
+                .msgPackProcessor((msgs, c) -> c.commit())
+                .build();
+
+        manager.stop();
+
+        assertThat(consumer.isStopped()).isTrue();
+    }
+
+    @Test
+    void consumerLoopShouldSurviveProcessorFailuresAndKeepPolling() {
+        AtomicInteger processedBatches = new AtomicInteger();
+        consumer.enqueue(List.of(mock(TbQueueMsg.class)));
+        consumer.enqueue(List.of(mock(TbQueueMsg.class)));
+        manager = launchManager(consumer, null, (msgs, c) -> {
+            if (processedBatches.incrementAndGet() == 1) {
+                throw new RuntimeException("transient failure on the first batch");
+            }
+            c.commit();
+        });
+
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
+                assertThat(processedBatches.get())
+                        .as("loop keeps processing after a processor failure")
+                        .isGreaterThanOrEqualTo(2));
+    }
+
+    /**
+     * The single-threaded consumer executor can only run this probe task once the
+     * consumer loop has actually finished - a hung loop keeps the thread forever.
+     */
+    private boolean consumerLoopHasExited() {
+        try {
+            consumerExecutor.submit(() -> {
+            }).get(5, TimeUnit.SECONDS);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     private static void awaitReadinessGateEvaluated(AtomicInteger readinessChecks) {
         await().atMost(5, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertThat(readinessChecks.get())
@@ -161,6 +254,12 @@ class QueueConsumerManagerTest {
 
     private QueueConsumerManager<TbQueueMsg> launchManager(TestQueueConsumer consumer, BooleanSupplier readinessCheck,
                                                            QueueConsumerManager.MsgPackProcessor<TbQueueMsg> processor) {
+        return launchManager(consumer, readinessCheck, processor, null);
+    }
+
+    private QueueConsumerManager<TbQueueMsg> launchManager(TestQueueConsumer consumer, BooleanSupplier readinessCheck,
+                                                           QueueConsumerManager.MsgPackProcessor<TbQueueMsg> processor,
+                                                           Long stopTimeoutMs) {
         consumerExecutor = Executors.newSingleThreadExecutor();
         QueueConsumerManager<TbQueueMsg> queueConsumerManager = QueueConsumerManager.<TbQueueMsg>builder()
                 .name("test-consumer")
@@ -168,6 +267,7 @@ class QueueConsumerManagerTest {
                 .consumerCreator(() -> consumer)
                 .consumerExecutor(consumerExecutor)
                 .readinessCheck(readinessCheck)
+                .stopTimeoutMs(stopTimeoutMs)
                 .msgPackProcessor(processor)
                 .build();
         queueConsumerManager.subscribe();


### PR DESCRIPTION
## Pull Request description

When stopping the Thingsboard server for a longer time (e.g. 1h), and then bringing it up again, 
the connected edge instances are not receiving downstream messages, via GRPC, till the edge instances are getting  restarted.

I created a LLM assisted testsetup (https://github.com/arminfelder/thingsboard-debug) using first TB 4.3 (branch v4.3), and conducted the automated tests for around an hour., after confirmation, another test run has been conducted against the master branch

As a result the following issue has been identified:
consumerTasks can get get abandoned, and therfor block the edge instance, till restart:
currently in case a loop misses the 10s limit there is just a warning log "Failed to await consumer loop stop" 

therefor this contribution adds:
+            log.warn("[{}] Consumer loop did not stop in {} ms, interrupting it", name, stopTimeoutMs);
+            consumerTask.cancel(true);

to force close the consumer

an LLM written analysis of the issue is also available here: https://github.com/arminfelder/thingsboard-debug/blob/master/docs/edge-sync-bugs-and-fixes-master.md


## General checklist

- [x ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



