### PR TITLE
fix(iot-hub): include webp in device package image extensions

### DIFF
--- a/ui-ngx/src/app/modules/home/components/iot-hub/device-install-dialog/device-install-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/iot-hub/device-install-dialog/device-install-dialog.component.ts
@@ -143,7 +143,7 @@ export class TbDeviceInstallDialogComponent extends DialogComponent<TbDeviceInst
       ));
       const JSZip = (await import('jszip')).default;
       const zip = await JSZip.loadAsync(zipData);
-      const imageExtensions = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg']);
+      const imageExtensions = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp']);
       for (const [path, entry] of Object.entries(zip.files) as [string, any][]) {
         if (!entry.dir) {
           const ext = path.split('.').pop()?.toLowerCase();


### PR DESCRIPTION
## Summary

Add `webp` to the set of recognized image extensions when extracting images from a device package zip in the install dialog. Previously `webp` images bundled in the package were silently skipped.

Changed `imageExtensions` in `device-install-dialog.component.ts` from `['png', 'jpg', 'jpeg', 'gif', 'svg']` to also include `'webp'`.