### PR TITLE
Fixed CVE-2026-44249, CVE-2026-44250, CVE-2026-44890, CVE-2026-44893, CVE-2026-45292, CVE-2026-45416, CVE-2026-45674, CVE-2026-46340, CVE-2026-47691, CVE-2026-48006, CVE-2026-48059, CVE-2026-50010, CVE-2026-50011

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
              entries below once TB migrates its tests off the deprecated @SpyBean/@MockBean to @MockitoSpyBean/@MockitoBean. -->
         <spring-boot-test.version>3.5.13</spring-boot-test.version>
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
-        <netty.version>4.1.134.Final</netty.version> <!-- to fix CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587, and MQTT decoder regression introduced in 4.1.133 by the CVE-2026-44248 fix. TODO: remove when fixed in spring-boot-dependencies -->
+        <netty.version>4.1.135.Final</netty.version> <!-- to fix CVE-2026-44249, CVE-2026-44250, CVE-2026-44890, CVE-2026-44893, CVE-2026-45416, CVE-2026-45674, CVE-2026-46340, CVE-2026-47691, CVE-2026-48006, CVE-2026-48059, CVE-2026-50010, CVE-2026-50011 (supersedes earlier netty CVE pins; also retains the 4.1.134 MQTT decoder regression fix). TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->


### PR DESCRIPTION
## Summary

Fixes **12 high/critical CVEs** reported by the security scan against the `lts-4.2` image by bumping the **Netty** family from `4.1.134.Final` to `4.1.135.Final` (a single `netty.version` property change, applied across the whole family via the existing `netty-bom` override). One dependency bump, one commit.

Source scan: https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/115494 (branch `lts-4.2`).

## CVEs fixed

- CVE-2026-44249 (critical) — Incorrect Comparison / IPv6 subnet-filter bypass — was 4.1.134.Final in io.netty:netty-handler, now 4.1.135.Final
- CVE-2026-45416 (high) — Allocation of Resources Without Limits or Throttling (SNI handler) — was 4.1.134.Final in io.netty:netty-handler, now 4.1.135.Final
- CVE-2026-50010 (high) — Improper Verification of Cryptographic Signature — was 4.1.134.Final in io.netty:netty-handler, now 4.1.135.Final
- CVE-2026-47691 (high) — Insufficient Verification of Data Authenticity — was 4.1.134.Final in io.netty:netty-resolver-dns, now 4.1.135.Final
- CVE-2026-45674 (high) — Insufficient Verification of Data Authenticity — was 4.1.134.Final in io.netty:netty-resolver-dns, now 4.1.135.Final
- CVE-2026-44893 (high) — Missing Release of Resource after Effective Lifetime — was 4.1.134.Final in io.netty:netty-codec-haproxy, now 4.1.135.Final
- CVE-2026-48059 (high) — Missing Release of Memory after Effective Lifetime — was 4.1.134.Final in io.netty:netty-codec-haproxy, now 4.1.135.Final
- CVE-2026-44890 (high) — Allocation of Resources Without Limits or Throttling — was 4.1.134.Final in io.netty:netty-codec-redis, now 4.1.135.Final
- CVE-2026-44250 (high) — Denial of Service (DoS) — was 4.1.134.Final in io.netty:netty-codec-redis, now 4.1.135.Final
- CVE-2026-48006 (high) — Missing Release of Memory after Effective Lifetime — was 4.1.134.Final in io.netty:netty-codec-redis, now 4.1.135.Final
- CVE-2026-50011 (high) — Allocation of Resources Without Limits or Throttling — was 4.1.134.Final in io.netty:netty-codec-redis, now 4.1.135.Final
- CVE-2026-46340 (high) — Allocation of Resources Without Limits or Throttling — was 4.1.134.Final in io.netty:netty-transport-sctp, now 4.1.135.Final

## Commits

- Bump io.netty:netty-bom from 4.1.134.Final to 4.1.135.Final to fix CVE-2026-44249, CVE-2026-44250, and 10 others

## `mvn dependency:tree` evidence

Command (run on the full reactor from the branch worktree):

```text
mvn dependency:tree -Dincludes=io.netty,com.squareup.wire
```

All CVE-listed Netty artifacts resolve to `4.1.135.Final`:

```text
io.netty:netty-handler:jar:4.1.135.Final
io.netty:netty-resolver-dns:jar:4.1.135.Final
io.netty:netty-codec-haproxy:jar:4.1.135.Final
io.netty:netty-codec-redis:jar:4.1.135.Final
io.netty:netty-transport-sctp:jar:4.1.135.Final
```

(`io.netty:netty-tcnative` remains at its independent `2.0.77.Final` line and is not in scope of these CVEs.)

## Not fixed in this PR

### Already fixed — wire (CVE-2026-45799)

The scan flagged `com.squareup.wire:wire-runtime` 4.3.0 (CVE-2026-45799), but `dependency:tree` shows wire already resolves to the patched KMP coordinates at branch HEAD — `wire-runtime-jvm:6.3.0` and `wire-schema-jvm:6.3.0` (pinned by the existing `wire-schema.version=6.3.0` override). No `wire-runtime:4.3.0` is present. The scan reflected an image built before that pin landed; no change required.

### Unfixable Maven CVEs

- CVE-2023-26919 (high) — Sandbox Bypass — `org.javadelight:delight-nashorn-sandbox` 0.4.5 — no upstream fix available (0.4.5 is the latest release; scanner reports no fix version).

### Debian / base-image CVEs (not fixed here — base-image team)

- CVE-2026-45447, CVE-2026-7383, CVE-2026-9076, CVE-2026-34180 (high) — `openssl` — 3.0.20-1~deb12u1 → 3.0.20-1~deb12u2 (fix available; resolved by a base-image bump).
- CVE-2026-6772, CVE-2026-6766 (high) — `nss` — 2:3.87.1-1+deb12u2 → no fix yet (track upstream).
- CVE-2026-48959, CVE-2026-48962 (high) — `perl` — 5.36.0-7+deb12u3 → no fix yet (track upstream).

### UI / npm CVEs (not fixed here — frontend team's responsibility)

- CVE-2026-44705 (high) — `tmp` 0.2.5 → 0.2.6 — reported only; hand off to the frontend team.
- CVE-2026-49982 (high) — `tmp` 0.2.5 → 0.2.7 — reported only; hand off to the frontend team.