### PR TITLE
Fixed CVE-2026-44249, CVE-2026-44250, CVE-2026-44890, CVE-2026-44893, CVE-2026-45292, CVE-2026-45416, CVE-2026-45674, CVE-2026-46340, CVE-2026-47691, CVE-2026-48006, CVE-2026-48059, CVE-2026-50010, CVE-2026-50011

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
              entries below once TB migrates its tests off the deprecated @SpyBean/@MockBean to @MockitoSpyBean/@MockitoBean. -->
         <spring-boot-test.version>3.5.13</spring-boot-test.version>
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
-        <netty.version>4.1.134.Final</netty.version> <!-- to fix CVE-2026-42579, CVE-2026-42583, CVE-2026-42584, CVE-2026-42587, and MQTT decoder regression introduced in 4.1.133 by the CVE-2026-44248 fix. TODO: remove when fixed in spring-boot-dependencies -->
+        <netty.version>4.1.135.Final</netty.version> <!-- to fix CVE-2026-44249, CVE-2026-44250, CVE-2026-44890, CVE-2026-44893, CVE-2026-45416, CVE-2026-45674, CVE-2026-46340, CVE-2026-47691, CVE-2026-48006, CVE-2026-48059, CVE-2026-50010, CVE-2026-50011 (supersedes earlier netty CVE pins; also retains the 4.1.134 MQTT decoder regression fix). TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->


### PR DESCRIPTION
## Summary

Carries the Netty CVE fix onto `master` via merge of `fix/cves-lts-4.3`. The merge bumps the **Netty** family from `4.1.134.Final` to `4.1.135.Final` (single `netty.version` property change applied family-wide via the existing `netty-bom` override). No additional `master`-specific bumps were needed — a post-merge re-scan of the `master` reactor confirmed all flagged artifacts resolve to the patched versions.

Source scans (LTS security scan): https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/115494 (lts-4.2) and https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/115495 (lts-4.3).

## CVEs fixed

- CVE-2026-44249 (critical) — Incorrect Comparison / IPv6 subnet-filter bypass — was 4.1.134.Final in io.netty:netty-handler, now 4.1.135.Final
- CVE-2026-45416 (high) — Allocation of Resources Without Limits or Throttling (SNI handler) — was 4.1.134.Final in io.netty:netty-handler, now 4.1.135.Final
- CVE-2026-50010 (high) — Improper Verification of Cryptographic Signature — was 4.1.134.Final in io.netty:netty-handler, now 4.1.135.Final
- CVE-2026-47691 (high) — Insufficient Verification of Data Authenticity — was 4.1.134.Final in io.netty:netty-resolver-dns, now 4.1.135.Final
- CVE-2026-45674 (high) — Insufficient Verification of Data Authenticity — was 4.1.134.Final in io.netty:netty-resolver-dns, now 4.1.135.Final
- CVE-2026-44893 (high) — Missing Release of Resource after Effective Lifetime — was 4.1.134.Final in io.netty:netty-codec-haproxy, now 4.1.135.Final
- CVE-2026-48059 (high) — Missing Release of Memory after Effective Lifetime — was 4.1.134.Final in io.netty:netty-codec-haproxy, now 4.1.135.Final
- CVE-2026-44890 (high) — Allocation of Resources Without Limits or Throttling — was 4.1.134.Final in io.netty:netty-codec-redis, now 4.1.135.Final
- CVE-2026-44250 (high) — Denial of Service (DoS) — was 4.1.134.Final in io.netty:netty-codec-redis, now 4.1.135.Final
- CVE-2026-48006 (high) — Missing Release of Memory after Effective Lifetime — was 4.1.134.Final in io.netty:netty-codec-redis, now 4.1.135.Final
- CVE-2026-50011 (high) — Allocation of Resources Without Limits or Throttling — was 4.1.134.Final in io.netty:netty-codec-redis, now 4.1.135.Final
- CVE-2026-46340 (high) — Allocation of Resources Without Limits or Throttling — was 4.1.134.Final in io.netty:netty-transport-sctp, now 4.1.135.Final

## Commits

- Merge fix/cves-lts-4.3 into fix/cves-master (carries: Bump io.netty:netty-bom from 4.1.134.Final to 4.1.135.Final)

## `mvn dependency:tree` evidence

Command (run on the full `master` reactor from the branch worktree):

```text
mvn dependency:tree -Dincludes=io.netty,com.squareup.wire
```

All CVE-listed Netty artifacts resolve to `4.1.135.Final`:

```text
io.netty:netty-handler:jar:4.1.135.Final
io.netty:netty-resolver-dns:jar:4.1.135.Final
io.netty:netty-codec-haproxy:jar:4.1.135.Final
io.netty:netty-codec-redis:jar:4.1.135.Final
io.netty:netty-transport-sctp:jar:4.1.135.Final
```

Wire already resolves to the patched KMP coordinates (`wire-runtime-jvm:6.3.0`, `wire-schema-jvm:6.3.0`), so CVE-2026-45799 needs no change on `master` either.

## Related

- LTS counterparts: thingsboard/thingsboard#15795 (lts-4.2), thingsboard/thingsboard#15796 (lts-4.3).