### PR TITLE
Reserve dynamic ports for OpenAPI spec generation to avoid port conflicts

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -508,11 +508,30 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Reserve free ephemeral ports so concurrent openapi-spec builds (and orphaned
+                                 forks from prior failed builds) on the same CI agent don't collide on fixed ports. -->
+                            <execution>
+                                <id>reserve-openapi-ports</id>
+                                <phase>initialize</phase>
+                                <goals><goal>reserve-network-port</goal></goals>
+                                <configuration>
+                                    <portNames>
+                                        <portName>jmx.port</portName>
+                                        <portName>http.port</portName>
+                                    </portNames>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
                             <mainClass>org.thingsboard.server.ThingsboardServerApplication</mainClass>
-                            <jmxPort>9001</jmxPort>
+                            <jmxPort>${jmx.port}</jmxPort>
                         </configuration>
                         <executions>
                             <execution>
@@ -532,6 +551,7 @@
                                     <arguments>
                                         <argument>--spring.config.name=thingsboard</argument>
                                         <argument>--spring.profiles.active=openapi</argument>
+                                        <argument>--server.port=${http.port}</argument>
                                     </arguments>
                                     <maxAttempts>180</maxAttempts>
                                     <wait>2000</wait>
@@ -557,7 +577,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <apiDocsUrl>http://localhost:8080/v3/api-docs/thingsboard</apiDocsUrl>
+                            <apiDocsUrl>http://localhost:${http.port}/v3/api-docs/thingsboard</apiDocsUrl>
                             <outputFileName>openapi.json</outputFileName>
                             <outputDir>${project.build.directory}</outputDir>
                         </configuration>


### PR DESCRIPTION
### Problem

The `openapi-spec` profile pins the `spring-boot-maven-plugin` JMX port to a hardcoded `9001` and the springdoc HTTP port to a hardcoded `8080`. The OpenAPI spec generation on CI occasionally fails with:

```
Error: Exception thrown by the agent : java.rmi.server.ExportException: Port already in use: 9001;
  nested exception is: java.net.BindException: Address already in use
...
Failed to execute goal org.springframework.boot:spring-boot-maven-plugin:start (openapi-start)
  on project application: Failed to connect to MBean server at port 9001
```

`spring-boot:start` forks a detached JVM whose JMX/RMI server is killed only by the matching `stop` goal. If a previous build is cancelled/timed-out (or its `start` hangs) between `start` (`pre-integration-test`) and `stop` (`post-integration-test`), that forked JVM is orphaned and keeps holding `9001`, so every later build on the same agent fails to bind it. The 6-minute gap in the failing log is the `start` goal waiting `maxAttempts (180) × wait (2000ms)` for an MBean server that never appears because the fresh fork died on the bind error. The HTTP port `8080` is exposed to the same class of conflict; the JMX agent simply attaches first and masks it.

### Fix

Reserve two free ephemeral ports via `build-helper-maven-plugin:reserve-network-port` (already available, version managed in the root pom) at the `initialize` phase and use them for the JMX port, the app's `--server.port`, and the springdoc `apiDocsUrl`. Each build now gets its own ports, so a leaked fork or any other process on `9001`/`8080` can no longer block spec generation.

All changes are scoped to the `openapi-spec` profile; normal builds are unaffected.

### Verification

`mvn clean verify -Popenapi-spec -DskipTests --projects application --also-make` → BUILD SUCCESS, with:

```
[INFO] --- build-helper:1.12:reserve-network-port (reserve-openapi-ports) @ application ---
[INFO] Reserved port 56958 for jmx.port
[INFO] Reserved port 56959 for http.port
```

`spring-boot:start`/`stop` succeeded over the reserved JMX port, springdoc fetched the spec from the reserved HTTP port, and `application/target/openapi.json` was generated (enforcer `RequireFilesExist` passed). No `9001`/`8080` anywhere in the log.
