### PR TITLE
Emit DELIVERED for gateway persistent RPC on PUBACK (lts-4.3)

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -614,6 +614,13 @@ actors:
     #   <ul><li> QoS level 0: This feature does not apply, as no acknowledgment is expected, and therefore no timeout is triggered.</li>
     #   <li> QoS level 1: This feature applies, as an acknowledgment is expected.</li>
     #   <li> QoS level 2: Unsupported.</li></ul></li>
+    # <li> For MQTT Gateway (connected sub-devices): the same QoS rules as MQTT transport apply
+    #   (only a QoS level 1 PUBACK triggers a delivery timeout). However, the gateway's own transport
+    #   session is never closed, so the gateway connection and its other sub-devices stay unaffected.
+    #   Only the sub-device session is deregistered and the RPC is reverted to the queued state. It is
+    #   redelivered automatically once the sub-device session is re-registered, which happens on the next
+    #   gateway message for that device (connect, telemetry, or attribute publish): the RPC subscription
+    #   is reapplied and the queued RPC is resent. Until then the RPC remains queued.</li>
     # <li> For CoAP transport:
     #   <ul><li> Confirmable requests: This feature applies, as delivery confirmation is expected.</li>
     #   <li> Non-confirmable requests: This feature does not apply, as no delivery acknowledgment is expected.</li></ul></li>

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/AbstractMqttServerSideRpcIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/AbstractMqttServerSideRpcIntegrationTest.java
@@ -333,7 +333,34 @@ public abstract class AbstractMqttServerSideRpcIntegrationTest extends AbstractM
     }
 
     protected void validateGatewayPersistentRpcDelivered(String deviceName) throws Exception {
+        GatewayRpcSession session = connectGatewayAndSubscribeForRpc(deviceName, false);
+
+        long expirationTime = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);
+        String rpcRequest = "{\"method\":\"toggle_gpio\",\"params\":{\"pin\":1},\"persistent\":true,\"expirationTime\":" + expirationTime + "}";
+        String response = doPostAsync("/api/rpc/twoway/" + session.device().getId().getId().toString(), rpcRequest, String.class, status().isOk());
+        String rpcId = JacksonUtil.toJsonNode(response).get("rpcId").asText();
+
+        session.callback().getSubscribeLatch().await(DEFAULT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        // Confirm the downlink arrived at QoS1 — otherwise no PUBACK is produced and the test could
+        // pass for the wrong reason if a regression downgraded the gateway RPC to QoS0.
+        assertEquals(MqttQoS.AT_LEAST_ONCE.value(), session.callback().getMessageArrivedQoS());
+
+        awaitRpcStatus(rpcId, RpcStatus.DELIVERED, 200, 100);
+
+        session.client().disconnect();
+    }
+
+    /**
+     * Connects a gateway, provisions the sub-device via CONNECT, and subscribes to the gateway RPC topic
+     * at QoS1. Two-step subscribe (client.subscribeAndWait + awaitForDeviceActorToReceiveSubscription, 1)
+     * rather than the 5-arg subscribeAndWait, which waits for subscription count+1 — the gateway CONNECT
+     * already registered one RPC subscription, so it would hang.
+     */
+    protected GatewayRpcSession connectGatewayAndSubscribeForRpc(String deviceName, boolean manualAcks) throws Exception {
         MqttTestClient client = new MqttTestClient();
+        if (manualAcks) {
+            client.enableManualAcks();
+        }
         client.connectAndWait(gatewayAccessToken);
 
         String connectPayload = "{\"device\": \"" + deviceName + "\", \"type\": \"" + TransportPayloadType.JSON.name() + "\"}";
@@ -344,33 +371,22 @@ public abstract class AbstractMqttServerSideRpcIntegrationTest extends AbstractM
 
         MqttTestCallback callback = new MqttTestSubscribeOnTopicCallback(GATEWAY_RPC_TOPIC);
         client.setCallback(callback);
-        // Subscribe at QoS1 so the downlink publish is QoS1 and Paho auto-PUBACKs (-> DELIVERED).
-        // Two-step subscribe (client.subscribeAndWait + awaitForDeviceActorToReceiveSubscription, 1)
-        // rather than subscribeAndWait(client, topic, deviceId, featureType, qos): the latter waits for
-        // count+1, but the gateway CONNECT already registered one RPC subscription, so it would hang.
         client.subscribeAndWait(GATEWAY_RPC_TOPIC, MqttQoS.AT_LEAST_ONCE);
         awaitForDeviceActorToReceiveSubscription(device.getId(), FeatureType.RPC, 1);
+        return new GatewayRpcSession(client, device, callback);
+    }
 
-        long expirationTime = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);
-        String rpcRequest = "{\"method\":\"toggle_gpio\",\"params\":{\"pin\":1},\"persistent\":true,\"expirationTime\":" + expirationTime + "}";
-        String response = doPostAsync("/api/rpc/twoway/" + device.getId().getId().toString(), rpcRequest, String.class, status().isOk());
-        String rpcId = JacksonUtil.toJsonNode(response).get("rpcId").asText();
-
-        callback.getSubscribeLatch().await(DEFAULT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        // Confirm the downlink arrived at QoS1 — otherwise no PUBACK is produced and the test could
-        // pass for the wrong reason if a regression downgraded the gateway RPC to QoS0.
-        assertEquals(MqttQoS.AT_LEAST_ONCE.value(), callback.getMessageArrivedQoS());
-
-        // Poll the persisted status until DELIVERED (200 x 100ms = 20s window).
+    protected Rpc awaitRpcStatus(String rpcId, RpcStatus expectedStatus, int retries, int intervalMs) throws Exception {
         Rpc rpc = doExecuteWithRetriesAndInterval(() -> {
             Rpc current = doGet("/api/rpc/persistent/" + rpcId, Rpc.class);
-            return RpcStatus.DELIVERED.equals(current.getStatus()) ? current : null;
-        }, 200, 100);
+            return expectedStatus.equals(current.getStatus()) ? current : null;
+        }, retries, intervalMs);
         assertNotNull(rpc);
-        assertEquals(RpcStatus.DELIVERED, rpc.getStatus());
-
-        client.disconnect();
+        assertEquals(expectedStatus, rpc.getStatus());
+        return rpc;
     }
+
+    protected record GatewayRpcSession(MqttTestClient client, Device device, MqttTestCallback callback) {}
 
     protected void validateProtoTwoWayRpcGatewayResponse(String deviceName, MqttTestClient client, byte[] connectPayloadBytes) throws Exception {
         client.publish(GATEWAY_CONNECT_TOPIC, connectPayloadBytes);

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/AbstractMqttServerSideRpcIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/AbstractMqttServerSideRpcIntegrationTest.java
@@ -38,6 +38,7 @@ import org.thingsboard.server.common.data.device.profile.MqttDeviceProfileTransp
 import org.thingsboard.server.common.data.device.profile.ProtoTransportPayloadConfiguration;
 import org.thingsboard.server.common.data.device.profile.TransportPayloadTypeConfiguration;
 import org.thingsboard.server.common.data.rpc.Rpc;
+import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.common.msg.session.FeatureType;
 import org.thingsboard.server.gen.transport.TransportApiProtos;
 import org.thingsboard.server.transport.mqtt.AbstractMqttIntegrationTest;
@@ -331,6 +332,46 @@ public abstract class AbstractMqttServerSideRpcIntegrationTest extends AbstractM
         assertEquals(MqttQoS.AT_MOST_ONCE.value(), callback.getMessageArrivedQoS());
     }
 
+    protected void validateGatewayPersistentRpcDelivered(String deviceName) throws Exception {
+        MqttTestClient client = new MqttTestClient();
+        client.connectAndWait(gatewayAccessToken);
+
+        String connectPayload = "{\"device\": \"" + deviceName + "\", \"type\": \"" + TransportPayloadType.JSON.name() + "\"}";
+        client.publish(GATEWAY_CONNECT_TOPIC, connectPayload.getBytes());
+
+        Device device = doExecuteWithRetriesAndInterval(() -> getDeviceByName(deviceName), 20, 100);
+        assertNotNull(device);
+
+        MqttTestCallback callback = new MqttTestSubscribeOnTopicCallback(GATEWAY_RPC_TOPIC);
+        client.setCallback(callback);
+        // Subscribe at QoS1 so the downlink publish is QoS1 and Paho auto-PUBACKs (-> DELIVERED).
+        // Two-step subscribe (client.subscribeAndWait + awaitForDeviceActorToReceiveSubscription, 1)
+        // rather than subscribeAndWait(client, topic, deviceId, featureType, qos): the latter waits for
+        // count+1, but the gateway CONNECT already registered one RPC subscription, so it would hang.
+        client.subscribeAndWait(GATEWAY_RPC_TOPIC, MqttQoS.AT_LEAST_ONCE);
+        awaitForDeviceActorToReceiveSubscription(device.getId(), FeatureType.RPC, 1);
+
+        long expirationTime = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);
+        String rpcRequest = "{\"method\":\"toggle_gpio\",\"params\":{\"pin\":1},\"persistent\":true,\"expirationTime\":" + expirationTime + "}";
+        String response = doPostAsync("/api/rpc/twoway/" + device.getId().getId().toString(), rpcRequest, String.class, status().isOk());
+        String rpcId = JacksonUtil.toJsonNode(response).get("rpcId").asText();
+
+        callback.getSubscribeLatch().await(DEFAULT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        // Confirm the downlink arrived at QoS1 — otherwise no PUBACK is produced and the test could
+        // pass for the wrong reason if a regression downgraded the gateway RPC to QoS0.
+        assertEquals(MqttQoS.AT_LEAST_ONCE.value(), callback.getMessageArrivedQoS());
+
+        // Poll the persisted status until DELIVERED (200 x 100ms = 20s window).
+        Rpc rpc = doExecuteWithRetriesAndInterval(() -> {
+            Rpc current = doGet("/api/rpc/persistent/" + rpcId, Rpc.class);
+            return RpcStatus.DELIVERED.equals(current.getStatus()) ? current : null;
+        }, 200, 100);
+        assertNotNull(rpc);
+        assertEquals(RpcStatus.DELIVERED, rpc.getStatus());
+
+        client.disconnect();
+    }
+
     protected void validateProtoTwoWayRpcGatewayResponse(String deviceName, MqttTestClient client, byte[] connectPayloadBytes) throws Exception {
         client.publish(GATEWAY_CONNECT_TOPIC, connectPayloadBytes);
 
@@ -353,7 +394,7 @@ public abstract class AbstractMqttServerSideRpcIntegrationTest extends AbstractM
         assertEquals(MqttQoS.AT_MOST_ONCE.value(), callback.getMessageArrivedQoS());
     }
 
-    private Device getDeviceByName(String deviceName) throws Exception {
+    protected Device getDeviceByName(String deviceName) throws Exception {
         return doGet("/api/tenant/devices?deviceName=" + deviceName, Device.class);
     }
 

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest.java
@@ -21,24 +21,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
 import org.thingsboard.common.util.JacksonUtil;
-import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.TransportPayloadType;
-import org.thingsboard.server.common.data.rpc.Rpc;
 import org.thingsboard.server.common.data.rpc.RpcStatus;
-import org.thingsboard.server.common.msg.session.FeatureType;
 import org.thingsboard.server.dao.service.DaoSqlTest;
 import org.thingsboard.server.transport.mqtt.MqttTestConfigProperties;
-import org.thingsboard.server.transport.mqtt.mqttv3.MqttTestCallback;
-import org.thingsboard.server.transport.mqtt.mqttv3.MqttTestClient;
-import org.thingsboard.server.transport.mqtt.mqttv3.MqttTestSubscribeOnTopicCallback;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.thingsboard.server.common.data.device.profile.MqttTopics.GATEWAY_CONNECT_TOPIC;
-import static org.thingsboard.server.common.data.device.profile.MqttTopics.GATEWAY_RPC_TOPIC;
 
 @Slf4j
 @DaoSqlTest
@@ -60,47 +51,25 @@ public class MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest extends Abst
 
     @Test
     public void testGatewayPersistentRpcTimeoutWhenNoPuback() throws Exception {
-        MqttTestClient client = new MqttTestClient();
-        client.enableManualAcks();
-        client.connectAndWait(gatewayAccessToken);
-
-        String deviceName = "Gateway Device Persistent RPC Timeout Json";
-        String connectPayload = "{\"device\": \"" + deviceName + "\", \"type\": \"" + TransportPayloadType.JSON.name() + "\"}";
-        client.publish(GATEWAY_CONNECT_TOPIC, connectPayload.getBytes());
-
-        Device device = doExecuteWithRetriesAndInterval(() -> getDeviceByName(deviceName), 20, 100);
-        assertNotNull(device);
-
-        MqttTestCallback callback = new MqttTestSubscribeOnTopicCallback(GATEWAY_RPC_TOPIC);
-        client.setCallback(callback);
-        // QoS1 downlink so the gateway would need to PUBACK — but manual acks withhold it.
-        // Use the two-step form (client.subscribeAndWait + awaitForDeviceActorToReceiveSubscription)
-        // rather than subscribeAndWait(client, topic, deviceId, featureType, qos) because the gateway
-        // device actor already has one RPC subscription entry created when the CONNECT message was
-        // processed above, so subscribeAndWait (which waits for count+1) would wait for 2 forever.
-        client.subscribeAndWait(GATEWAY_RPC_TOPIC, MqttQoS.AT_LEAST_ONCE);
-        awaitForDeviceActorToReceiveSubscription(device.getId(), FeatureType.RPC, 1);
+        // manualAcks = true → the gateway client never PUBACKs the QoS1 downlink.
+        GatewayRpcSession session = connectGatewayAndSubscribeForRpc("Gateway Device Persistent RPC Timeout Json", true);
 
         long expirationTime = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);
         String rpcRequest = "{\"method\":\"toggle_gpio\",\"params\":{\"pin\":1},\"persistent\":true,\"retries\":0,\"expirationTime\":" + expirationTime + "}";
-        String response = doPostAsync("/api/rpc/twoway/" + device.getId().getId().toString(), rpcRequest, String.class, status().isOk());
+        String response = doPostAsync("/api/rpc/twoway/" + session.device().getId().getId().toString(), rpcRequest, String.class, status().isOk());
         String rpcId = JacksonUtil.toJsonNode(response).get("rpcId").asText();
 
-        callback.getSubscribeLatch().await(DEFAULT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        session.callback().getSubscribeLatch().await(DEFAULT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         // Confirm the downlink arrived at QoS1 — a QoS0 downlink would produce no PUBACK path at all,
         // so the timeout would fire for the wrong reason and mask a regression.
-        assertEquals(MqttQoS.AT_LEAST_ONCE.value(), callback.getMessageArrivedQoS());
+        assertEquals(MqttQoS.AT_LEAST_ONCE.value(), session.callback().getMessageArrivedQoS());
 
         // No PUBACK is ever sent. The gateway awaiting-ack scheduler emits TIMEOUT after
-        // transport.mqtt.timeout (100 ms); the server re-queues the RPC to QUEUED.
-        Rpc rpc = doExecuteWithRetriesAndInterval(() -> {
-            Rpc current = doGet("/api/rpc/persistent/" + rpcId, Rpc.class);
-            return RpcStatus.QUEUED.equals(current.getStatus()) ? current : null;
-        }, 50, 100);
-        assertNotNull(rpc);
-        assertEquals(RpcStatus.QUEUED, rpc.getStatus());
+        // transport.mqtt.timeout (100 ms); the RPC status reverts to QUEUED (re-queued via the
+        // close_session_on_rpc_delivery_timeout path).
+        awaitRpcStatus(rpcId, RpcStatus.QUEUED, 50, 100);
 
-        client.disconnect();
+        session.client().disconnect();
     }
 
 }

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest.java
@@ -87,6 +87,9 @@ public class MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest extends Abst
         String rpcId = JacksonUtil.toJsonNode(response).get("rpcId").asText();
 
         callback.getSubscribeLatch().await(DEFAULT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        // Confirm the downlink arrived at QoS1 — a QoS0 downlink would produce no PUBACK path at all,
+        // so the timeout would fire for the wrong reason and mask a regression.
+        assertEquals(MqttQoS.AT_LEAST_ONCE.value(), callback.getMessageArrivedQoS());
 
         // No PUBACK is ever sent. The gateway awaiting-ack scheduler emits TIMEOUT after
         // transport.mqtt.timeout (100 ms); the server re-queues the RPC to QUEUED.
@@ -98,10 +101,6 @@ public class MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest extends Abst
         assertEquals(RpcStatus.QUEUED, rpc.getStatus());
 
         client.disconnect();
-    }
-
-    private Device getDeviceByName(String deviceName) throws Exception {
-        return doGet("/api/tenant/devices?deviceName=" + deviceName, Device.class);
     }
 
 }

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.mqtt.mqttv3.rpc;
+
+import io.netty.handler.codec.mqtt.MqttQoS;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.context.TestPropertySource;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.TransportPayloadType;
+import org.thingsboard.server.common.data.rpc.Rpc;
+import org.thingsboard.server.common.data.rpc.RpcStatus;
+import org.thingsboard.server.common.msg.session.FeatureType;
+import org.thingsboard.server.dao.service.DaoSqlTest;
+import org.thingsboard.server.transport.mqtt.MqttTestConfigProperties;
+import org.thingsboard.server.transport.mqtt.mqttv3.MqttTestCallback;
+import org.thingsboard.server.transport.mqtt.mqttv3.MqttTestClient;
+import org.thingsboard.server.transport.mqtt.mqttv3.MqttTestSubscribeOnTopicCallback;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.thingsboard.server.common.data.device.profile.MqttTopics.GATEWAY_CONNECT_TOPIC;
+import static org.thingsboard.server.common.data.device.profile.MqttTopics.GATEWAY_RPC_TOPIC;
+
+@Slf4j
+@DaoSqlTest
+@TestPropertySource(properties = {
+        "actors.rpc.close_session_on_rpc_delivery_timeout=true",
+        "transport.mqtt.timeout=100",
+})
+public class MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest extends AbstractMqttServerSideRpcIntegrationTest {
+
+    @Before
+    public void beforeTest() throws Exception {
+        MqttTestConfigProperties configProperties = MqttTestConfigProperties.builder()
+                .deviceName("RPC timeout test device")
+                .gatewayName("RPC timeout test gateway")
+                .transportPayloadType(TransportPayloadType.JSON)
+                .build();
+        processBeforeTest(configProperties);
+    }
+
+    @Test
+    public void testGatewayPersistentRpcTimeoutWhenNoPuback() throws Exception {
+        MqttTestClient client = new MqttTestClient();
+        client.enableManualAcks();
+        client.connectAndWait(gatewayAccessToken);
+
+        String deviceName = "Gateway Device Persistent RPC Timeout Json";
+        String connectPayload = "{\"device\": \"" + deviceName + "\", \"type\": \"" + TransportPayloadType.JSON.name() + "\"}";
+        client.publish(GATEWAY_CONNECT_TOPIC, connectPayload.getBytes());
+
+        Device device = doExecuteWithRetriesAndInterval(() -> getDeviceByName(deviceName), 20, 100);
+        assertNotNull(device);
+
+        MqttTestCallback callback = new MqttTestSubscribeOnTopicCallback(GATEWAY_RPC_TOPIC);
+        client.setCallback(callback);
+        // QoS1 downlink so the gateway would need to PUBACK — but manual acks withhold it.
+        // Use the two-step form (client.subscribeAndWait + awaitForDeviceActorToReceiveSubscription)
+        // rather than subscribeAndWait(client, topic, deviceId, featureType, qos) because the gateway
+        // device actor already has one RPC subscription entry created when the CONNECT message was
+        // processed above, so subscribeAndWait (which waits for count+1) would wait for 2 forever.
+        client.subscribeAndWait(GATEWAY_RPC_TOPIC, MqttQoS.AT_LEAST_ONCE);
+        awaitForDeviceActorToReceiveSubscription(device.getId(), FeatureType.RPC, 1);
+
+        long expirationTime = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);
+        String rpcRequest = "{\"method\":\"toggle_gpio\",\"params\":{\"pin\":1},\"persistent\":true,\"retries\":0,\"expirationTime\":" + expirationTime + "}";
+        String response = doPostAsync("/api/rpc/twoway/" + device.getId().getId().toString(), rpcRequest, String.class, status().isOk());
+        String rpcId = JacksonUtil.toJsonNode(response).get("rpcId").asText();
+
+        callback.getSubscribeLatch().await(DEFAULT_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        // No PUBACK is ever sent. The gateway awaiting-ack scheduler emits TIMEOUT after
+        // transport.mqtt.timeout (100 ms); the server re-queues the RPC to QUEUED.
+        Rpc rpc = doExecuteWithRetriesAndInterval(() -> {
+            Rpc current = doGet("/api/rpc/persistent/" + rpcId, Rpc.class);
+            return RpcStatus.QUEUED.equals(current.getStatus()) ? current : null;
+        }, 50, 100);
+        assertNotNull(rpc);
+        assertEquals(RpcStatus.QUEUED, rpc.getStatus());
+
+        client.disconnect();
+    }
+
+    private Device getDeviceByName(String deviceName) throws Exception {
+        return doGet("/api/tenant/devices?deviceName=" + deviceName, Device.class);
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/MqttServerSideRpcJsonIntegrationTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/mqttv3/rpc/MqttServerSideRpcJsonIntegrationTest.java
@@ -81,6 +81,11 @@ public class MqttServerSideRpcJsonIntegrationTest extends AbstractMqttServerSide
         processJsonTwoWayRpcTestGateway("Gateway Device TwoWay RPC Json");
     }
 
+    @Test
+    public void testGatewayServerMqttPersistentRpcDeliveredOnPuback() throws Exception {
+        validateGatewayPersistentRpcDelivered("Gateway Device Persistent RPC Json");
+    }
+
     protected void processJsonOneWayRpcTestGateway(String deviceName) throws Exception {
         MqttTestClient client = new MqttTestClient();
         client.connectAndWait(gatewayAccessToken);

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -1525,7 +1525,11 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     public void sendToDeviceRpcRequest(MqttMessage payload, TransportProtos.ToDeviceRpcRequestMsg rpcRequest, TransportProtos.SessionInfoProto sessionInfo) {
         int msgId = ((MqttPublishMessage) payload).variableHeader().packetId();
         int requestId = rpcRequest.getRequestId();
-        if (isAckExpected(payload)) {
+        // Non-persistent one-way RPCs self-complete on send (DeviceActorMessageProcessor) and are never
+        // in the pending map, so a delivery status for them only yields a benign "already removed from
+        // pending map" WARN. Track/emit delivery status only for the rest.
+        boolean oneWayNonPersisted = rpcRequest.getOneway() && !rpcRequest.getPersisted();
+        if (!oneWayNonPersisted && isAckExpected(payload)) {
             rpcAwaitingAck.put(msgId, rpcRequest);
             context.getScheduler().schedule(() -> {
                 TransportProtos.ToDeviceRpcRequestMsg msg = rpcAwaitingAck.remove(msgId);
@@ -1545,8 +1549,10 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                 return;
             }
             if (!isAckExpected(payload)) {
-                log.trace("[{}][{}][{}] Going to send to device actor RPC request DELIVERED status update ...", deviceSessionCtx.getDeviceId(), sessionId, requestId);
-                transportService.process(sessionInfo, rpcRequest, RpcStatus.DELIVERED, TransportServiceCallback.EMPTY);
+                if (!oneWayNonPersisted) {
+                    log.trace("[{}][{}][{}] Going to send to device actor RPC request DELIVERED status update ...", deviceSessionCtx.getDeviceId(), sessionId, requestId);
+                    transportService.process(sessionInfo, rpcRequest, RpcStatus.DELIVERED, TransportServiceCallback.EMPTY);
+                }
             } else if (rpcRequest.getPersisted()) {
                 log.trace("[{}][{}][{}] Going to send to device actor RPC request SENT status update ...", deviceSessionCtx.getDeviceId(), sessionId, requestId);
                 transportService.process(sessionInfo, rpcRequest, RpcStatus.SENT, TransportServiceCallback.EMPTY);

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -88,6 +88,7 @@ import org.thingsboard.server.transport.mqtt.session.GatewaySessionHandler;
 import org.thingsboard.server.transport.mqtt.session.MqttTopicMatcher;
 import org.thingsboard.server.transport.mqtt.session.SparkplugDeviceSessionContext;
 import org.thingsboard.server.transport.mqtt.session.SparkplugNodeSessionHandler;
+import org.thingsboard.server.transport.mqtt.util.MqttRpcStatusUtil;
 import org.thingsboard.server.transport.mqtt.util.ReturnCodeResolver;
 import org.thingsboard.server.transport.mqtt.util.sparkplug.SparkplugMessageType;
 import org.thingsboard.server.transport.mqtt.util.sparkplug.SparkplugRpcRequestHeader;
@@ -1525,11 +1526,8 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     public void sendToDeviceRpcRequest(MqttMessage payload, TransportProtos.ToDeviceRpcRequestMsg rpcRequest, TransportProtos.SessionInfoProto sessionInfo) {
         int msgId = ((MqttPublishMessage) payload).variableHeader().packetId();
         int requestId = rpcRequest.getRequestId();
-        // Non-persistent one-way RPCs self-complete on send (DeviceActorMessageProcessor) and are never
-        // in the pending map, so a delivery status for them only yields a benign "already removed from
-        // pending map" WARN. Track/emit delivery status only for the rest.
-        boolean oneWayNonPersisted = rpcRequest.getOneway() && !rpcRequest.getPersisted();
-        if (!oneWayNonPersisted && isAckExpected(payload)) {
+        boolean requireDeliveryTracking = MqttRpcStatusUtil.requireDeliveryTracking(rpcRequest);
+        if (requireDeliveryTracking && isAckExpected(payload)) {
             rpcAwaitingAck.put(msgId, rpcRequest);
             context.getScheduler().schedule(() -> {
                 TransportProtos.ToDeviceRpcRequestMsg msg = rpcAwaitingAck.remove(msgId);
@@ -1549,7 +1547,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                 return;
             }
             if (!isAckExpected(payload)) {
-                if (!oneWayNonPersisted) {
+                if (requireDeliveryTracking) {
                     log.trace("[{}][{}][{}] Going to send to device actor RPC request DELIVERED status update ...", deviceSessionCtx.getDeviceId(), sessionId, requestId);
                     transportService.process(sessionInfo, rpcRequest, RpcStatus.DELIVERED, TransportServiceCallback.EMPTY);
                 }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -1524,10 +1524,11 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     }
 
     public void sendToDeviceRpcRequest(MqttMessage payload, TransportProtos.ToDeviceRpcRequestMsg rpcRequest, TransportProtos.SessionInfoProto sessionInfo) {
-        int msgId = ((MqttPublishMessage) payload).variableHeader().packetId();
+        MqttPublishMessage publishMsg = (MqttPublishMessage) payload;
+        int msgId = publishMsg.variableHeader().packetId();
         int requestId = rpcRequest.getRequestId();
         boolean requireDeliveryTracking = MqttRpcStatusUtil.requireDeliveryTracking(rpcRequest);
-        if (requireDeliveryTracking && isAckExpected(payload)) {
+        if (requireDeliveryTracking && isAckExpected(publishMsg)) {
             rpcAwaitingAck.put(msgId, rpcRequest);
             context.getScheduler().schedule(() -> {
                 TransportProtos.ToDeviceRpcRequestMsg msg = rpcAwaitingAck.remove(msgId);
@@ -1537,7 +1538,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                 }
             }, Math.max(0, Math.min(deviceSessionCtx.getContext().getTimeout(), rpcRequest.getExpirationTime() - System.currentTimeMillis())), TimeUnit.MILLISECONDS);
         }
-        var cf = publish(payload, deviceSessionCtx);
+        var cf = publish(publishMsg, deviceSessionCtx);
         cf.addListener(result -> {
             Throwable throwable = result.cause();
             if (throwable != null) {
@@ -1546,7 +1547,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                         ThingsboardErrorCode.INVALID_ARGUMENTS, " Failed send To Device Rpc Request: " + rpcRequest.getMethodName());
                 return;
             }
-            if (!isAckExpected(payload)) {
+            if (!isAckExpected(publishMsg)) {
                 if (requireDeliveryTracking) {
                     log.trace("[{}][{}][{}] Going to send to device actor RPC request DELIVERED status update ...", deviceSessionCtx.getDeviceId(), sessionId, requestId);
                     transportService.process(sessionInfo, rpcRequest, RpcStatus.DELIVERED, TransportServiceCallback.EMPTY);

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -385,6 +385,8 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                 TransportProtos.ToDeviceRpcRequestMsg rpcRequest = rpcAwaitingAck.remove(msgId);
                 if (rpcRequest != null) {
                     transportService.process(deviceSessionCtx.getSessionInfo(), rpcRequest, RpcStatus.DELIVERED, true, TransportServiceCallback.EMPTY);
+                } else if (gatewaySessionHandler != null) {
+                    gatewaySessionHandler.onPubAck(msgId);
                 }
                 break;
             default:

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/AbstractGatewayDeviceSessionContext.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/AbstractGatewayDeviceSessionContext.java
@@ -17,6 +17,7 @@ package org.thingsboard.server.transport.mqtt.session;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -106,19 +107,20 @@ public abstract class AbstractGatewayDeviceSessionContext<T extends AbstractGate
         try {
             parent.getPayloadAdaptor().convertToGatewayPublish(this, getDeviceInfo().getDeviceName(), request).ifPresent(
                     payload -> {
-                        ChannelFuture channelFuture = parent.writeAndFlush(payload);
-                        if (request.getPersisted()) {
-                            channelFuture.addListener(result -> {
-                                if (result.cause() == null) {
-                                    if (!isAckExpected(payload)) {
-                                        transportService.process(getSessionInfo(), request, RpcStatus.DELIVERED, TransportServiceCallback.EMPTY);
-                                    } else if (request.getPersisted()) {
-                                        transportService.process(getSessionInfo(), request, RpcStatus.SENT, TransportServiceCallback.EMPTY);
-
-                                    }
-                                }
-                            });
+                        if (isAckExpected(payload)) {
+                            int msgId = ((MqttPublishMessage) payload).variableHeader().packetId();
+                            parent.registerRpcAwaitingAck(msgId, getSessionInfo(), request);
                         }
+                        ChannelFuture channelFuture = parent.writeAndFlush(payload);
+                        channelFuture.addListener(result -> {
+                            if (result.cause() == null) {
+                                if (!isAckExpected(payload)) {
+                                    transportService.process(getSessionInfo(), request, RpcStatus.DELIVERED, TransportServiceCallback.EMPTY);
+                                } else if (request.getPersisted()) {
+                                    transportService.process(getSessionInfo(), request, RpcStatus.SENT, TransportServiceCallback.EMPTY);
+                                }
+                            }
+                        });
                     }
             );
         } catch (Exception e) {

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/AbstractGatewayDeviceSessionContext.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/AbstractGatewayDeviceSessionContext.java
@@ -30,6 +30,7 @@ import org.thingsboard.server.common.transport.TransportServiceCallback;
 import org.thingsboard.server.common.transport.auth.TransportDeviceInfo;
 import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.gen.transport.TransportProtos.SessionInfoProto;
+import org.thingsboard.server.transport.mqtt.util.MqttRpcStatusUtil;
 
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
@@ -107,19 +108,16 @@ public abstract class AbstractGatewayDeviceSessionContext<T extends AbstractGate
         try {
             parent.getPayloadAdaptor().convertToGatewayPublish(this, getDeviceInfo().getDeviceName(), request).ifPresent(
                     payload -> {
-                        // Non-persistent one-way RPCs self-complete on send; a delivery status for them
-                        // only yields a benign "already removed from pending map" WARN. Skip those
-                        // (mirrors MqttTransportHandler#sendToDeviceRpcRequest).
-                        boolean oneWayNonPersisted = request.getOneway() && !request.getPersisted();
-                        if (!oneWayNonPersisted && isAckExpected(payload)) {
-                            int msgId = ((MqttPublishMessage) payload).variableHeader().packetId();
-                            parent.registerRpcAwaitingAck(msgId, getSessionInfo(), request);
+                        MqttPublishMessage publishMsg = (MqttPublishMessage) payload;
+                        boolean requireDeliveryTracking = MqttRpcStatusUtil.requireDeliveryTracking(request);
+                        if (requireDeliveryTracking && isAckExpected(publishMsg)) {
+                            parent.registerRpcAwaitingAck(publishMsg.variableHeader().packetId(), getSessionInfo(), request);
                         }
-                        ChannelFuture channelFuture = parent.writeAndFlush(payload);
+                        ChannelFuture channelFuture = parent.writeAndFlush(publishMsg);
                         channelFuture.addListener(result -> {
                             if (result.cause() == null) {
-                                if (!isAckExpected(payload)) {
-                                    if (!oneWayNonPersisted) {
+                                if (!isAckExpected(publishMsg)) {
+                                    if (requireDeliveryTracking) {
                                         transportService.process(getSessionInfo(), request, RpcStatus.DELIVERED, TransportServiceCallback.EMPTY);
                                     }
                                 } else if (request.getPersisted()) {

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/AbstractGatewayDeviceSessionContext.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/AbstractGatewayDeviceSessionContext.java
@@ -107,7 +107,11 @@ public abstract class AbstractGatewayDeviceSessionContext<T extends AbstractGate
         try {
             parent.getPayloadAdaptor().convertToGatewayPublish(this, getDeviceInfo().getDeviceName(), request).ifPresent(
                     payload -> {
-                        if (isAckExpected(payload)) {
+                        // Non-persistent one-way RPCs self-complete on send; a delivery status for them
+                        // only yields a benign "already removed from pending map" WARN. Skip those
+                        // (mirrors MqttTransportHandler#sendToDeviceRpcRequest).
+                        boolean oneWayNonPersisted = request.getOneway() && !request.getPersisted();
+                        if (!oneWayNonPersisted && isAckExpected(payload)) {
                             int msgId = ((MqttPublishMessage) payload).variableHeader().packetId();
                             parent.registerRpcAwaitingAck(msgId, getSessionInfo(), request);
                         }
@@ -115,7 +119,9 @@ public abstract class AbstractGatewayDeviceSessionContext<T extends AbstractGate
                         channelFuture.addListener(result -> {
                             if (result.cause() == null) {
                                 if (!isAckExpected(payload)) {
-                                    transportService.process(getSessionInfo(), request, RpcStatus.DELIVERED, TransportServiceCallback.EMPTY);
+                                    if (!oneWayNonPersisted) {
+                                        transportService.process(getSessionInfo(), request, RpcStatus.DELIVERED, TransportServiceCallback.EMPTY);
+                                    }
                                 } else if (request.getPersisted()) {
                                     transportService.process(getSessionInfo(), request, RpcStatus.SENT, TransportServiceCallback.EMPTY);
                                 }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/AbstractGatewaySessionHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/AbstractGatewaySessionHandler.java
@@ -50,9 +50,9 @@ import org.thingsboard.server.common.data.Device;
 import org.thingsboard.server.common.data.DeviceProfile;
 import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.common.data.util.TbPair;
 import org.thingsboard.server.common.msg.gateway.metrics.GatewayMetadata;
-import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.common.msg.tools.TbRateLimitsException;
 import org.thingsboard.server.common.transport.TransportService;
 import org.thingsboard.server.common.transport.TransportServiceCallback;
@@ -262,7 +262,7 @@ public abstract class AbstractGatewaySessionHandler<T extends AbstractGatewayDev
         return deviceSessionCtx.nextMsgId();
     }
 
-    public void registerRpcAwaitingAck(int msgId, SessionInfoProto deviceSessionInfo, TransportProtos.ToDeviceRpcRequestMsg rpc) {
+    void registerRpcAwaitingAck(int msgId, SessionInfoProto deviceSessionInfo, TransportProtos.ToDeviceRpcRequestMsg rpc) {
         rpcAwaitingAck.put(msgId, new RpcAwaitingAck(deviceSessionInfo, rpc));
         long delay = Math.max(0, Math.min(deviceSessionCtx.getContext().getTimeout(),
                 rpc.getExpirationTime() - System.currentTimeMillis()));

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/AbstractGatewaySessionHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/AbstractGatewaySessionHandler.java
@@ -52,6 +52,7 @@ import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.util.TbPair;
 import org.thingsboard.server.common.msg.gateway.metrics.GatewayMetadata;
+import org.thingsboard.server.common.data.rpc.RpcStatus;
 import org.thingsboard.server.common.msg.tools.TbRateLimitsException;
 import org.thingsboard.server.common.transport.TransportService;
 import org.thingsboard.server.common.transport.TransportServiceCallback;
@@ -80,6 +81,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
@@ -122,6 +124,10 @@ public abstract class AbstractGatewaySessionHandler<T extends AbstractGatewayDev
     protected final ChannelHandlerContext channel;
     protected final DeviceSessionCtx deviceSessionCtx;
     protected final GatewayMetricsService gatewayMetricsService;
+
+    private final ConcurrentMap<Integer, RpcAwaitingAck> rpcAwaitingAck = new ConcurrentHashMap<>();
+
+    private record RpcAwaitingAck(SessionInfoProto deviceSessionInfo, TransportProtos.ToDeviceRpcRequestMsg rpc) {}
 
     @Getter
     @Setter
@@ -201,6 +207,10 @@ public abstract class AbstractGatewaySessionHandler<T extends AbstractGatewayDev
 
     public void onDevicesDisconnect() {
         log.debug("[{}] Gateway disconnect [{}]", gateway.getTenantId(), gateway.getDeviceId());
+        if (!rpcAwaitingAck.isEmpty()) {
+            log.debug("[{}] Cleanup gateway RPC awaiting ack map due to session close!", sessionId);
+            rpcAwaitingAck.clear();
+        }
         try {
             deviceFutures.forEach((name, future) -> {
                 Futures.addCallback(future, new FutureCallback<T>() {
@@ -250,6 +260,28 @@ public abstract class AbstractGatewaySessionHandler<T extends AbstractGatewayDev
 
     int nextMsgId() {
         return deviceSessionCtx.nextMsgId();
+    }
+
+    public void registerRpcAwaitingAck(int msgId, SessionInfoProto deviceSessionInfo, TransportProtos.ToDeviceRpcRequestMsg rpc) {
+        rpcAwaitingAck.put(msgId, new RpcAwaitingAck(deviceSessionInfo, rpc));
+        long delay = Math.max(0, Math.min(deviceSessionCtx.getContext().getTimeout(),
+                rpc.getExpirationTime() - System.currentTimeMillis()));
+        context.getScheduler().schedule(() -> {
+            RpcAwaitingAck pending = rpcAwaitingAck.remove(msgId);
+            if (pending != null) {
+                log.trace("[{}] Gateway RPC [{}] PUBACK timeout, sending TIMEOUT status", sessionId, rpc.getRequestId());
+                transportService.process(pending.deviceSessionInfo(), pending.rpc(), RpcStatus.TIMEOUT, TransportServiceCallback.EMPTY);
+            }
+        }, delay, TimeUnit.MILLISECONDS);
+    }
+
+    public void onPubAck(int msgId) {
+        RpcAwaitingAck pending = rpcAwaitingAck.remove(msgId);
+        if (pending == null) {
+            return;
+        }
+        log.trace("[{}] Gateway RPC [{}] PUBACK received, sending DELIVERED status", sessionId, pending.rpc().getRequestId());
+        transportService.process(pending.deviceSessionInfo(), pending.rpc(), RpcStatus.DELIVERED, true, TransportServiceCallback.EMPTY);
     }
 
     protected boolean isJsonPayloadType() {

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/util/MqttRpcStatusUtil.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/util/MqttRpcStatusUtil.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.transport.mqtt.util;
+
+import org.thingsboard.server.gen.transport.TransportProtos.ToDeviceRpcRequestMsg;
+
+public final class MqttRpcStatusUtil {
+
+    private MqttRpcStatusUtil() {
+    }
+
+    /**
+     * Whether the transport should track and emit a delivery status (DELIVERED / TIMEOUT) for the given RPC.
+     * Non-persistent one-way RPCs self-complete on send in the device actor and are never added to its pending
+     * map, so a delivery status for them lands on nothing and only produces a benign
+     * "RPC has already been removed from pending map" warning. Every other RPC is tracked.
+     */
+    public static boolean requireDeliveryTracking(ToDeviceRpcRequestMsg rpc) {
+        return !(rpc.getOneway() && !rpc.getPersisted());
+    }
+
+}


### PR DESCRIPTION
## Pull Request description

`lts-4.3` counterpart of #15884.

MQTT gateway sub-device persistent RPC previously had the lifecycle `QUEUED → SENT → SUCCESSFUL` — it never reached `DELIVERED`, because the gateway send path never registered the outbound publish's packetId, so the gateway `PUBACK` mapped to nothing (unlike direct devices). This PR wires `DELIVERED` for gateway persistent RPC and aligns the gateway RPC status handling with the direct-device path.

**Scope of changes**
- `AbstractGatewaySessionHandler` — a per-connection `packetId → {device sessionInfo, rpc}` awaiting-ack map, `registerRpcAwaitingAck` (schedules a `TIMEOUT` if no PUBACK), `onPubAck` (emits `DELIVERED` against the sub-device session), and a silent map cleanup on gateway disconnect.
- `AbstractGatewayDeviceSessionContext.onToDeviceRpcRequest` — registers the packetId **before** the write (mirrors `MqttTransportHandler#sendToDeviceRpcRequest`), so a loopback `PUBACK` can't be processed ahead of registration and drop `DELIVERED`; `SENT` is still emitted from the write-completion listener, so the order stays `QUEUED → SENT → DELIVERED`.
- `MqttTransportHandler` PUBACK handler delegates to the gateway handler on a miss in its own map.
- `MqttRpcStatusUtil.requireDeliveryTracking` — skip the redundant `DELIVERED` for non-persistent one-way RPCs on both the gateway and direct-device paths; they self-complete on send and are never tracked in the device actor's pending map, so a delivery status for them only produced a benign `"RPC has already been removed from pending map"` warning.

**Tests**
- `MqttServerSideRpcJsonIntegrationTest#testGatewayServerMqttPersistentRpcDeliveredOnPuback` — gateway persistent RPC reaches `DELIVERED` after the gateway PUBACKs.
- `MqttGatewayServerSideRpcDeliveryTimeoutIntegrationTest` — gateway persistent RPC re-queues (`QUEUED`) after the delivery timeout when the gateway never PUBACKs.

**Documentation:** no user-facing documentation changes required — this only aligns the MQTT gateway persistent-RPC status lifecycle with direct devices; no new API, configuration property, or UI.

**Related:** `lts-4.2` counterpart — #15884.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [x] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).
