### PR TITLE
Skip subscription forwarding when tenant no longer exists

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/telemetry/AbstractSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/telemetry/AbstractSubscriptionService.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.thingsboard.common.util.ThingsBoardThreadFactory;
 import org.thingsboard.server.cluster.TbClusterService;
+import org.thingsboard.server.common.data.exception.TenantNotFoundException;
 import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.msg.queue.ServiceType;
@@ -86,7 +87,15 @@ public abstract class AbstractSubscriptionService extends TbApplicationEventList
     protected void forwardToSubscriptionManagerService(TenantId tenantId, EntityId entityId,
                                                        Consumer<SubscriptionManagerService> toSubscriptionManagerService,
                                                        Supplier<TransportProtos.ToCoreMsg> toCore) {
-        TopicPartitionInfo tpi = partitionService.resolve(ServiceType.TB_CORE, tenantId, entityId);
+        TopicPartitionInfo tpi;
+        try {
+            tpi = partitionService.resolve(ServiceType.TB_CORE, tenantId, entityId);
+        } catch (TenantNotFoundException e) {
+            // The tenant was deleted (e.g. concurrently with an in-flight asynchronous save callback),
+            // so there is no partition to route to and no subscribers to notify. Nothing to forward.
+            log.debug("[{}][{}] Skipping subscription update: tenant no longer exists.", tenantId, entityId);
+            return;
+        }
         if (currentPartitions.contains(tpi)) {
             if (subscriptionManagerService.isPresent()) {
                 toSubscriptionManagerService.accept(subscriptionManagerService.get());

--- a/application/src/test/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionServiceTest.java
@@ -40,6 +40,7 @@ import org.thingsboard.server.common.data.ApiUsageStateValue;
 import org.thingsboard.server.common.data.AttributeScope;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.EntityView;
+import org.thingsboard.server.common.data.exception.TenantNotFoundException;
 import org.thingsboard.server.common.data.id.ApiUsageStateId;
 import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.DeviceId;
@@ -89,6 +90,7 @@ import java.util.stream.Stream;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -1153,6 +1155,26 @@ class DefaultTelemetrySubscriptionServiceTest {
 
         // THEN
         then(deviceStateManager).shouldHaveNoInteractions();
+    }
+
+    /* --- Subscription forwarding --- */
+
+    @Test
+    void shouldSkipSubscriptionForwardWhenTenantWasDeleted() {
+        // GIVEN the tenant was deleted concurrently, so partition resolution fails
+        given(partitionService.resolve(ServiceType.TB_CORE, tenantId, entityId))
+                .willThrow(new TenantNotFoundException(tenantId));
+
+        // WHEN forwarding a subscription update (e.g. from an in-flight async save callback)
+        // THEN it must not propagate the exception
+        assertThatNoException().isThrownBy(() -> telemetryService.forwardToSubscriptionManagerService(
+                tenantId, entityId,
+                sm -> sm.onAttributesUpdate(tenantId, entityId, AttributeScope.SERVER_SCOPE.name(), List.of(), TbCallback.EMPTY),
+                () -> null));
+
+        // AND nothing is forwarded, since there is no partition to route to and no subscribers to notify
+        then(subscriptionManagerService).shouldHaveNoInteractions();
+        then(clusterService).shouldHaveNoInteractions();
     }
 
     // used to emulate versions returned by save APIs


### PR DESCRIPTION
## Root cause

When a device connects or reports activity, `DefaultDeviceStateService` persists device-state server attributes (`active`, `lastConnectTime`, `lastActivityTime`, `inactivityAlarmTime`) **asynchronously** via `tsSubService.saveAttributesInternal(...)`. 

On success, a callback runs on the `*-service-ws-callback` executor and forwards a WS/subscription update through `AbstractSubscriptionService.forwardToSubscriptionManagerService(...)`, which calls `partitionService.resolve(...)` → `getRoutingInfo(...)` → `TbTenantProfileCache.get(tenantId)`.

If the tenant has been deleted in the meantime (its profile evicted from `TbTenantProfileCache`), `getRoutingInfo` throws `TenantNotFoundException`. 

Because the attribute save itself already succeeded, this is thrown from the **post-save callback** — i.e. asynchronously, on the `ws-callback` worker thread, downstream of the successful DB write. `AbstractSubscriptionService.addCallback` does not guard `onSuccess`, so the exception escapes **uncaught** on that worker thread.

`DefaultDeviceStateService` already anticipates this race in its periodic inactivity-check path — `checkStates()` catches `TenantNotFoundException` and stops tracking the device — but that **synchronous** guard cannot catch an exception thrown later from the **asynchronous** WS-forward callback.

The condition is benign but noisy: a deleted tenant legitimately has no partition to route to and no subscribers to notify, yet the in-flight callback still tries to resolve it and fails.

## Fix

Handle `TenantNotFoundException` at the point where it is thrown — inside `forwardToSubscriptionManagerService`. When the tenant no longer exists, there is no partition and no subscribers, so the subscription update is simply skipped (logged at `debug`). This mirrors the existing "tenant gone → stop" handling in `DefaultDeviceStateService.checkStates()` and keeps the exception from escaping the asynchronous callback.

## Tests

Added `DefaultTelemetrySubscriptionServiceTest.shouldSkipSubscriptionForwardWhenTenantWasDeleted`: it stubs `partitionService.resolve(...)` to throw `TenantNotFoundException` and verifies that `forwardToSubscriptionManagerService` neither propagates the exception nor forwards anything to the subscription manager or core.

## General checklist

- [x] You have reviewed the guidelines document.
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation. _(No documentation changes required.)_
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s).
- [x] If new dependency was added: the dependency tree is checked for conflicts. _(No new dependencies.)_
- [x] If new service was added: the service is marked with corresponding component annotation. _(No new services.)_
- [x] If new REST API was added: the RestClient.java was updated. _(No new REST API.)_
- [x] If new yml property was added: make sure a description is added. _(No new properties.)_
