### PR TITLE
Fix dashboard widgets not refreshing actions after config apply

### DIFF
--- a/ui-ngx/src/app/modules/home/components/dashboard/dashboard.component.html
+++ b/ui-ngx/src/app/modules/home/components/dashboard/dashboard.component.html
@@ -78,7 +78,7 @@
   </mat-menu>
   <div [class]="dashboardClass" id="gridster-background">
     <gridster #gridster id="gridster-child" [options]="gridsterOpts">
-      @for (widget of dashboardWidgets; track widget.widgetId) {
+      @for (widget of dashboardWidgets; track widget) {
         <gridster-item #gridsterItem [item]="widget" [class]="{'tb-noselect': isEdit}">
           <tb-widget-container
             [gridsterItem]="gridsterItem"


### PR DESCRIPTION
## Bug

In dashboard edit mode, after editing a widget's configuration (e.g. adding or changing widget actions / header buttons) and clicking **Apply changes**, the changes do not appear on the dashboard until the page is fully reloaded.

Reproduce: dashboard → Edit mode → edit any widget → Actions tab → add a header-button action → Apply changes → the header button does not appear (reload the page and it does).

## Root cause

The Angular 20 migration commit ff0e33c075 changed the dashboard widget grid loop from `track widget` to `track widget.widgetId`. When a config edit is applied, `doCheck()` swaps in a new `DashboardWidget` instance for the same `widgetId`, so with id-based tracking the `WidgetComponent` is no longer recreated. Since `widgetContext.customHeaderActions` / `actionsApi` are built only in `ngOnInit` (`ngOnChanges` only handles `isEdit`/`isMobile`), the component keeps rendering the stale context.

## Fix

Restore object-identity tracking (`track widget`) for the loop — the pre-migration `trackBy` behavior, so a swapped-in `DashboardWidget` recreates its `WidgetComponent`.

## Affected versions

None released: ff0e33c075 is not in any release tag (latest v4.3.1.3 / v4.2.2.3 predate it), but it is on `master`, `release-4.4` and `lts-4.4` — worth cherry-picking this fix to the 4.4 branches.

Extracted from #15920, where the regression was found while testing widget actions import.
