### PR TITLE
Move LTS version range check into LtsVersion

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/install/lts/LtsMigrationService.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/lts/LtsMigrationService.java
@@ -126,9 +126,7 @@ public class LtsMigrationService {
     // so a cross-family upgrade is fully handled by the target-family migrations.
     // Excluding the dormant older-family beans avoids double-processing.
     static boolean isInRangeForTargetFamily(LtsVersion version, LtsVersion from, LtsVersion to) {
-        return version.sameFamily(to)
-                && version.compareTo(from) > 0
-                && version.compareTo(to) <= 0;
+        return version.sameFamily(to) && version.isInRange(from, to);
     }
 
     private void runSchemaUpdate(String version) {

--- a/application/src/main/java/org/thingsboard/server/service/install/lts/LtsVersion.java
+++ b/application/src/main/java/org/thingsboard/server/service/install/lts/LtsVersion.java
@@ -37,6 +37,14 @@ public record LtsVersion(int major, int minor, int maintenance, int patch) imple
         return major == other.major && minor == other.minor;
     }
 
+    /**
+     * Half-open range check: {@code from < this <= to}. The lower bound is exclusive (a source already at
+     * {@code from} has applied that version) and the upper bound inclusive (the target version's own migration runs).
+     */
+    public boolean isInRange(LtsVersion from, LtsVersion to) {
+        return compareTo(from) > 0 && compareTo(to) <= 0;
+    }
+
     @Override
     public int compareTo(LtsVersion o) {
         int c = Integer.compare(major, o.major);


### PR DESCRIPTION
Extracts the half-open `(from, to]` range check into an instance method `LtsVersion.isInRange(from, to)`, so the reusable primitive lives on the version value type instead of a static helper on the service.

`LtsMigrationService.isInRangeForTargetFamily` now delegates: `version.sameFamily(to) && version.isInRange(from, to)` — the family gate stays in the service. Behavior is unchanged (`LtsMigrationServiceTest` 12/12).

Addresses a review comment from thingsboard/thingsboard#15925. Landing it on `lts-4.2` so it rides the standard cascade up to `lts-4.3`/`lts-4.4`; no separate per-family PR needed.