### PR TITLE
Fixed arbitrary file write in TBEL script sandbox

### DIFF
--- a/application/src/test/java/org/thingsboard/server/service/script/TbelInvokeServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/script/TbelInvokeServiceTest.java
@@ -301,6 +301,20 @@ class TbelInvokeServiceTest extends AbstractTbelInvokeTest {
                 });
     }
 
+    @Test
+    void givenForbiddenFormatter_whenInvoking_thenThrowsRuntimeError() throws ExecutionException, InterruptedException {
+        UUID scriptId = evalScript("new java.util.Formatter(\"/tmp/test.txt\")");
+        assertThatThrownBy(() -> invokeScript(scriptId, "{\"temperature\":25}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.RUNTIME);
+                    assertThat(ex.getCause().getMessage()).contains("could not resolve class: java.util.Formatter");
+                });
+    }
+
     private void assertThatScriptIsBlocked(UUID scriptId) {
         assertThatThrownBy(() -> {
             invokeScriptResultString(scriptId, "{}");

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <zookeeper.version>3.9.5</zookeeper.version> <!-- to fix CVE-2026-24308 and CVE-2026-24281. TODO: remove override when fixed in curator-client -->
         <protobuf.version>3.25.5</protobuf.version> <!-- A Major v4 does not support by the pubsub yet-->
         <grpc.version>1.76.0</grpc.version>
-        <tbel.version>1.2.10</tbel.version>
+        <tbel.version>1.2.11</tbel.version>
         <lombok.version>1.18.46</lombok.version> <!-- must be in sync with spring-boot-dependencies; needed for maven-compiler-plugin annotationProcessorPaths -->
         <paho.client.version>1.2.5</paho.client.version>
         <paho.mqttv5.client.version>1.2.5</paho.mqttv5.client.version>


### PR DESCRIPTION
## Summary
- Bump `tbel` dependency 1.2.10 → 1.2.11 (see thingsboard/tbel#50)
- Add an integration test in `TbelInvokeServiceTest` verifying the sandbox blocks `java.util.Formatter`

## Problem
The TBEL sandbox `allowedPackages` entry `"java.util"` uses `startsWith` prefix matching, which permits every top-level `java.util` class. `java.util.Formatter` has a `Formatter(String fileName)` constructor that opens the named file for writing, so a Tenant Admin can write arbitrary content to an arbitrary path from a TBEL rule-node / calculated-field script:

```
new java.util.Formatter("/path/of/attackers/choosing").format("...", 1337).close()
```

## Fix
tbel 1.2.11 adds `java.util.Formatter` to a `forbiddenClasses` denylist in `SandboxedClassLoader`, checked before the `java.util` package allow, so the class can no longer be loaded. The escape now fails at class resolution with `could not resolve class: java.util.Formatter`, identical to the blocked subpackages.

## Test plan
Automated test in `TbelInvokeServiceTest`:
- `givenForbiddenFormatter_whenInvoking_thenThrowsRuntimeError`
