### PR TITLE
rule-engine: broadcast partition changes only to affected tenant actors

### DIFF
--- a/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
+++ b/application/src/main/java/org/thingsboard/server/actors/app/AppActor.java
@@ -24,6 +24,7 @@ import org.thingsboard.server.actors.TbActorException;
 import org.thingsboard.server.actors.TbActorId;
 import org.thingsboard.server.actors.TbActorRef;
 import org.thingsboard.server.actors.TbEntityActorId;
+import org.thingsboard.server.actors.TbEntityTypeActorIdPredicate;
 import org.thingsboard.server.actors.device.SessionTimeoutCheckMsg;
 import org.thingsboard.server.actors.service.ContextAwareActor;
 import org.thingsboard.server.actors.service.ContextBasedCreator;
@@ -31,6 +32,7 @@ import org.thingsboard.server.actors.service.DefaultActorService;
 import org.thingsboard.server.actors.tenant.TenantActor;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.Tenant;
+import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.id.TenantProfileId;
 import org.thingsboard.server.common.data.page.PageDataIterable;
@@ -40,6 +42,7 @@ import org.thingsboard.server.common.msg.TbActorMsg;
 import org.thingsboard.server.common.msg.ToCalculatedFieldSystemMsg;
 import org.thingsboard.server.common.msg.aware.TenantAwareMsg;
 import org.thingsboard.server.common.msg.plugin.ComponentLifecycleMsg;
+import org.thingsboard.server.common.msg.queue.PartitionChangeMsg;
 import org.thingsboard.server.common.msg.queue.QueueToRuleEngineMsg;
 import org.thingsboard.server.common.msg.queue.RuleEngineException;
 import org.thingsboard.server.common.msg.queue.ServiceType;
@@ -88,6 +91,8 @@ public class AppActor extends ContextAwareActor {
             case APP_INIT_MSG:
                 break;
             case PARTITION_CHANGE_MSG:
+                onPartitionChangeMsg((PartitionChangeMsg) msg);
+                break;
             case CF_PARTITIONS_CHANGE_MSG:
             case CF_STATE_PARTITION_RESTORE_MSG:
                 ctx.broadcastToChildren(msg, true);
@@ -213,6 +218,21 @@ public class AppActor extends ContextAwareActor {
         }, () -> {
             msg.getCallback().onSuccess();
         });
+    }
+
+    private void onPartitionChangeMsg(PartitionChangeMsg msg) {
+        Set<TenantId> affectedTenants = msg.getAffectedTenants();
+        log.info("Partition change for {}: notifying {} affected tenant(s)", msg.getServiceType(), affectedTenants == null ? "ALL" : affectedTenants.size());
+        if (affectedTenants == null) {
+            ctx.broadcastToChildren(msg, true);
+        } else {
+            ctx.broadcastToChildren(msg, new TbEntityTypeActorIdPredicate(EntityType.TENANT) {
+                @Override
+                protected boolean testEntityId(EntityId entityId) {
+                    return super.testEntityId(entityId) && affectedTenants.contains(entityId);
+                }
+            }, true);
+        }
     }
 
     private Optional<TbActorRef> getOrCreateTenantActor(TenantId tenantId) {

--- a/application/src/main/java/org/thingsboard/server/actors/service/DefaultActorService.java
+++ b/application/src/main/java/org/thingsboard/server/actors/service/DefaultActorService.java
@@ -32,14 +32,18 @@ import org.thingsboard.server.actors.TbActorSystemSettings;
 import org.thingsboard.server.actors.app.AppActor;
 import org.thingsboard.server.actors.app.AppInitMsg;
 import org.thingsboard.server.actors.stats.StatsActor;
+import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.msg.queue.PartitionChangeMsg;
 import org.thingsboard.server.common.msg.queue.ServiceType;
+import org.thingsboard.server.queue.discovery.QueueKey;
 import org.thingsboard.server.queue.discovery.TbApplicationEventListener;
 import org.thingsboard.server.queue.discovery.event.PartitionChangeEvent;
 import org.thingsboard.server.queue.util.AfterStartUp;
 
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -133,7 +137,33 @@ public class DefaultActorService extends TbApplicationEventListener<PartitionCha
     @Override
     protected void onTbApplicationEvent(PartitionChangeEvent event) {
         log.info("Received partition change event.");
-        appActor.tellWithHighPriority(new PartitionChangeMsg(event.getServiceType()));
+        appActor.tellWithHighPriority(new PartitionChangeMsg(event.getServiceType(), resolveAffectedTenants(event)));
+    }
+
+    /**
+     * Resolves which tenants are affected by a partition-ownership change, so the caller can
+     * notify only those tenant actors instead of every live one.
+     * <p>
+     * Despite its name, {@link PartitionChangeEvent#getNewPartitions()} carries only the
+     * <b>changed subset</b> of queue keys — including removed ones, mapped to an empty partition
+     * set — never the full current assignment. That invariant is what makes this method correct;
+     * if it ever carried the full assignment instead, every recalculation would resolve to
+     * "everyone".
+     * <p>
+     * Returns {@code null} when any changed queue key belongs to the shared (non-isolated) tenant
+     * pool (a sys-tenant-keyed queue) — that pool's tenants aren't individually tracked as queue
+     * keys, so they can't be enumerated, and every tenant actor must be notified. Otherwise
+     * returns the non-empty set of affected tenant IDs. Callers must treat {@code null} as
+     * "notify everyone", never as "notify nobody" — an empty set would mean the latter, but this
+     * method never returns one today, since it is only invoked when the diff is non-empty.
+     */
+    static Set<TenantId> resolveAffectedTenants(PartitionChangeEvent event) {
+        Set<QueueKey> changedQueueKeys = event.getNewPartitions().keySet();
+        boolean sharedPoolChanged = changedQueueKeys.stream().anyMatch(queueKey -> queueKey.getTenantId().isSysTenantId());
+        if (sharedPoolChanged) {
+            return null;
+        }
+        return changedQueueKeys.stream().map(QueueKey::getTenantId).collect(Collectors.toSet());
     }
 
     @Override

--- a/application/src/test/java/org/thingsboard/server/actors/app/AppActorTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/app/AppActorTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.actors.app;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.thingsboard.server.actors.ActorSystemContext;
+import org.thingsboard.server.actors.TbActorCtx;
+import org.thingsboard.server.actors.TbActorId;
+import org.thingsboard.server.actors.TbEntityActorId;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.msg.queue.PartitionChangeMsg;
+import org.thingsboard.server.common.msg.queue.ServiceType;
+import org.thingsboard.server.dao.tenant.TenantService;
+import org.thingsboard.server.queue.discovery.TbServiceInfoProvider;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AppActorTest {
+
+    AppActor appActor;
+    TbActorCtx ctx;
+    TenantId tenant1 = new TenantId(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+    TenantId tenant2 = new TenantId(UUID.fromString("22222222-2222-2222-2222-222222222222"));
+
+    @Before
+    public void setUp() throws Exception {
+        ActorSystemContext systemContext = mock(ActorSystemContext.class);
+        TenantService tenantService = mock(TenantService.class);
+        when(systemContext.getTenantService()).thenReturn(tenantService);
+        when(systemContext.isTenantComponentsInitEnabled()).thenReturn(false);
+        when(systemContext.getServiceInfoProvider()).thenReturn(mock(TbServiceInfoProvider.class));
+
+        appActor = (AppActor) new AppActor.ActorCreator(systemContext).createActor();
+        ctx = mock(TbActorCtx.class);
+        appActor.init(ctx);
+        appActor.doProcess(new AppInitMsg());
+    }
+
+    @Test
+    public void onPartitionChangeMsgWithAffectedTenants_onlyForwardsToThoseTenants() {
+        PartitionChangeMsg msg = new PartitionChangeMsg(ServiceType.TB_RULE_ENGINE, Set.of(tenant1));
+
+        appActor.doProcess(msg);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Predicate<TbActorId>> filterCaptor = ArgumentCaptor.forClass(Predicate.class);
+        verify(ctx).broadcastToChildren(eq(msg), filterCaptor.capture(), eq(true));
+        Predicate<TbActorId> filter = filterCaptor.getValue();
+
+        assertTrue(filter.test(new TbEntityActorId(tenant1)));
+        assertFalse(filter.test(new TbEntityActorId(tenant2)));
+        assertFalse(filter.test(new TbEntityActorId(new DeviceId(UUID.randomUUID()))));
+    }
+
+    @Test
+    public void onPartitionChangeMsgWithNullAffectedTenants_broadcastsToEveryone() {
+        PartitionChangeMsg msg = new PartitionChangeMsg(ServiceType.TB_RULE_ENGINE);
+
+        appActor.doProcess(msg);
+
+        verify(ctx).broadcastToChildren(msg, true);
+        verify(ctx, never()).broadcastToChildren(any(), any(), anyBoolean());
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/actors/service/DefaultActorServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/actors/service/DefaultActorServiceTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.actors.service;
+
+import org.junit.Test;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.msg.queue.ServiceType;
+import org.thingsboard.server.common.msg.queue.TopicPartitionInfo;
+import org.thingsboard.server.queue.discovery.QueueKey;
+import org.thingsboard.server.queue.discovery.event.PartitionChangeEvent;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class DefaultActorServiceTest {
+
+    @Test
+    public void resolveAffectedTenants_onlyTenantSpecificQueueKeysChanged_returnsThoseTenants() {
+        TenantId tenant1 = new TenantId(UUID.randomUUID());
+        TenantId tenant2 = new TenantId(UUID.randomUUID());
+        QueueKey mainQueueTenant1 = new QueueKey(ServiceType.TB_RULE_ENGINE, "Main", tenant1);
+        QueueKey highPriorityQueueTenant1 = new QueueKey(ServiceType.TB_RULE_ENGINE, "HighPriority", tenant1);
+        QueueKey mainQueueTenant2 = new QueueKey(ServiceType.TB_RULE_ENGINE, "Main", tenant2);
+
+        Map<QueueKey, Set<TopicPartitionInfo>> newPartitions = Map.of(
+                mainQueueTenant1, Collections.emptySet(),
+                highPriorityQueueTenant1, Collections.emptySet(),
+                mainQueueTenant2, Collections.emptySet());
+        PartitionChangeEvent event = new PartitionChangeEvent(this, ServiceType.TB_RULE_ENGINE, newPartitions, Map.of());
+
+        Set<TenantId> affected = DefaultActorService.resolveAffectedTenants(event);
+
+        assertEquals(Set.of(tenant1, tenant2), affected);
+    }
+
+    @Test
+    public void resolveAffectedTenants_sysTenantQueueKeyChanged_returnsNull() {
+        QueueKey sharedMainQueue = new QueueKey(ServiceType.TB_RULE_ENGINE, "Main", TenantId.SYS_TENANT_ID);
+        Map<QueueKey, Set<TopicPartitionInfo>> newPartitions = Map.of(sharedMainQueue, Collections.emptySet());
+        PartitionChangeEvent event = new PartitionChangeEvent(this, ServiceType.TB_RULE_ENGINE, newPartitions, Map.of());
+
+        Set<TenantId> affected = DefaultActorService.resolveAffectedTenants(event);
+
+        assertNull(affected);
+    }
+}

--- a/common/actor/src/main/java/org/thingsboard/server/actors/DefaultTbActorSystem.java
+++ b/common/actor/src/main/java/org/thingsboard/server/actors/DefaultTbActorSystem.java
@@ -168,7 +168,8 @@ public class DefaultTbActorSystem implements TbActorSystem {
         broadcastToChildren(parent, childFilter, msg, false);
     }
 
-    private void broadcastToChildren(TbActorId parent, Predicate<TbActorId> childFilter, TbActorMsg msg, boolean highPriority) {
+    @Override
+    public void broadcastToChildren(TbActorId parent, Predicate<TbActorId> childFilter, TbActorMsg msg, boolean highPriority) {
         Set<TbActorId> children = parentChildMap.get(parent);
         if (children != null) {
             children.stream().filter(childFilter).forEach(id -> {

--- a/common/actor/src/main/java/org/thingsboard/server/actors/TbActorCtx.java
+++ b/common/actor/src/main/java/org/thingsboard/server/actors/TbActorCtx.java
@@ -42,5 +42,7 @@ public interface TbActorCtx extends TbActorRef {
 
     void broadcastToChildren(TbActorMsg msg, Predicate<TbActorId> childFilter);
 
+    void broadcastToChildren(TbActorMsg msg, Predicate<TbActorId> childFilter, boolean highPriority);
+
     List<TbActorId> filterChildren(Predicate<TbActorId> childFilter);
 }

--- a/common/actor/src/main/java/org/thingsboard/server/actors/TbActorMailbox.java
+++ b/common/actor/src/main/java/org/thingsboard/server/actors/TbActorMailbox.java
@@ -210,6 +210,11 @@ public final class TbActorMailbox implements TbActorCtx {
     }
 
     @Override
+    public void broadcastToChildren(TbActorMsg msg, Predicate<TbActorId> childFilter, boolean highPriority) {
+        system.broadcastToChildren(selfId, childFilter, msg, highPriority);
+    }
+
+    @Override
     public List<TbActorId> filterChildren(Predicate<TbActorId> childFilter) {
         return system.filterChildren(selfId, childFilter);
     }

--- a/common/actor/src/main/java/org/thingsboard/server/actors/TbActorSystem.java
+++ b/common/actor/src/main/java/org/thingsboard/server/actors/TbActorSystem.java
@@ -52,5 +52,7 @@ public interface TbActorSystem {
 
     void broadcastToChildren(TbActorId parent, Predicate<TbActorId> childFilter, TbActorMsg msg);
 
+    void broadcastToChildren(TbActorId parent, Predicate<TbActorId> childFilter, TbActorMsg msg, boolean highPriority);
+
     List<TbActorId> filterChildren(TbActorId parent, Predicate<TbActorId> childFilter);
 }

--- a/common/actor/src/test/java/org/thingsboard/server/actors/ActorSystemTest.java
+++ b/common/actor/src/test/java/org/thingsboard/server/actors/ActorSystemTest.java
@@ -198,6 +198,32 @@ public class ActorSystemTest {
     }
 
     @Test
+    public void testBroadcastToChildrenWithFilterAndPriority() throws InterruptedException {
+        executor = ThingsBoardExecutors.newWorkStealingPool(parallelism, getClass());
+        actorSystem.createDispatcher(ROOT_DISPATCHER, executor);
+
+        TbActorId parentId = new TbEntityActorId(new DeviceId(UUID.randomUUID()));
+        ActorTestCtx parentTestCtx = getActorTestCtx(1);
+        actorSystem.createRootActor(ROOT_DISPATCHER, new TestRootActor.TestRootActorCreator(parentId, parentTestCtx));
+
+        TbActorId matchingChildId = new TbEntityActorId(new DeviceId(UUID.randomUUID()));
+        ActorTestCtx matchingChildCtx = getActorTestCtx(1);
+        actorSystem.createChildActor(ROOT_DISPATCHER,
+                new TestRootActor.TestRootActorCreator(matchingChildId, matchingChildCtx), parentId);
+
+        TbActorId otherChildId = new TbEntityActorId(new DeviceId(UUID.randomUUID()));
+        ActorTestCtx otherChildCtx = getActorTestCtx(1);
+        actorSystem.createChildActor(ROOT_DISPATCHER,
+                new TestRootActor.TestRootActorCreator(otherChildId, otherChildCtx), parentId);
+
+        actorSystem.broadcastToChildren(parentId, id -> id.equals(matchingChildId), new IntTbActorMsg(7), true);
+
+        Assertions.assertTrue(matchingChildCtx.getLatch().await(TIMEOUT_AWAIT_MAX_SEC, TimeUnit.SECONDS));
+        Assertions.assertEquals(7L, matchingChildCtx.getActual().get());
+        Assertions.assertFalse(otherChildCtx.getLatch().await(1, TimeUnit.SECONDS));
+    }
+
+    @Test
     public void testFailedInit() throws InterruptedException {
         executor = ThingsBoardExecutors.newWorkStealingPool(parallelism, getClass());
         actorSystem.createDispatcher(ROOT_DISPATCHER, executor);

--- a/common/message/src/main/java/org/thingsboard/server/common/msg/queue/PartitionChangeMsg.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/queue/PartitionChangeMsg.java
@@ -16,9 +16,11 @@
 package org.thingsboard.server.common.msg.queue;
 
 import lombok.Data;
-import lombok.Getter;
+import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.msg.MsgType;
 import org.thingsboard.server.common.msg.TbActorMsg;
+
+import java.util.Set;
 
 /**
  * @author Andrew Shvayka
@@ -26,8 +28,24 @@ import org.thingsboard.server.common.msg.TbActorMsg;
 @Data
 public final class PartitionChangeMsg implements TbActorMsg {
 
-    @Getter
     private final ServiceType serviceType;
+
+    /**
+     * Tenants whose partition ownership changed. Null means the shared
+     * (non-isolated) tenant pool itself changed, so every tenant actor must
+     * re-verify — shared-pool tenants aren't individually tracked as
+     * queueKeys, so they can't be enumerated here.
+     */
+    private final Set<TenantId> affectedTenants;
+
+    public PartitionChangeMsg(ServiceType serviceType) {
+        this(serviceType, null);
+    }
+
+    public PartitionChangeMsg(ServiceType serviceType, Set<TenantId> affectedTenants) {
+        this.serviceType = serviceType;
+        this.affectedTenants = affectedTenants;
+    }
 
     @Override
     public MsgType getMsgType() {

--- a/common/message/src/test/java/org/thingsboard/server/common/msg/queue/PartitionChangeMsgTest.java
+++ b/common/message/src/test/java/org/thingsboard/server/common/msg/queue/PartitionChangeMsgTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.common.msg.queue;
+
+import org.junit.jupiter.api.Test;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.msg.MsgType;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class PartitionChangeMsgTest {
+
+    @Test
+    public void singleArgConstructor_defaultsAffectedTenantsToNull() {
+        PartitionChangeMsg msg = new PartitionChangeMsg(ServiceType.TB_RULE_ENGINE);
+
+        assertEquals(ServiceType.TB_RULE_ENGINE, msg.getServiceType());
+        assertNull(msg.getAffectedTenants());
+        assertEquals(MsgType.PARTITION_CHANGE_MSG, msg.getMsgType());
+    }
+
+    @Test
+    public void twoArgConstructor_carriesAffectedTenants() {
+        TenantId tenant = new TenantId(UUID.randomUUID());
+        PartitionChangeMsg msg = new PartitionChangeMsg(ServiceType.TB_RULE_ENGINE, Set.of(tenant));
+
+        assertEquals(ServiceType.TB_RULE_ENGINE, msg.getServiceType());
+        assertEquals(Set.of(tenant), msg.getAffectedTenants());
+    }
+}


### PR DESCRIPTION
## Summary

`AppActor` currently broadcasts `PARTITION_CHANGE_MSG` at high priority to **every** live `TenantActor` on an instance whenever a partition-ownership change occurs, regardless of whether a given tenant's ownership actually changed. On a shared rule-engine instance hosting many tenants, this means a single tenant's partition change (e.g. moving to an isolated queue) interrupts every other tenant's in-flight message processing, even though only one tenant's ownership changed — a same-priority message gets jumped ahead of already-queued work for every tenant, not just the affected one.

This PR makes the notification targeted:

1. **`actor`** — expose the actor system's existing (previously private) filtered + priority-aware `broadcastToChildren` capability publicly, so a caller can target a subset of children without giving up delivery priority.
2. **`msg`** — `PartitionChangeMsg` optionally carries the set of affected tenant IDs. `null` preserves today's meaning ("could affect anyone, notify everyone" — e.g. when the shared/non-isolated pool itself changes, since those tenants aren't individually tracked as queue keys). A non-null set means only those tenants are affected. The existing single-arg constructor is unchanged and still defaults to `null`, so no existing caller's behavior changes.
3. **`rule-engine`** — `DefaultActorService` resolves the affected-tenant set from the partition-change diff it already has on hand, and `AppActor` uses it to broadcast only to the affected tenant actors (reusing the existing `TbEntityTypeActorIdPredicate` filtering idiom already used elsewhere for the same kind of type-filtered broadcast), falling back to the original broadcast-to-everyone behavior whenever the set can't be narrowed down (e.g. `TB_CORE` events, or a change to the shared pool itself).

## Example scenario: a tenant profile switched from SharedQueue to DedicatedQueue

Consider a cluster of shared rule-engine instances serving tenants `T1..Tn` on a common queue pool. A tenant profile is switched via the tenant-profile API from `SharedQueue` (non-isolated) to `DedicatedQueue` (isolated) for `T1` only — this creates new dedicated queue(s) for `T1` and triggers `HashPartitionService.recalculatePartitions()`, whose diff contains only `T1`'s new queue keys; no other tenant's assignment changes.

```
BEFORE THE FIX
==============

  API: switch T1's profile  SharedQueue -> DedicatedQueue
                    |
                    v
  HashPartitionService.recalculatePartitions()
    computes changed-queue-key diff: { T1 -> [Main, HighPriority, ...] }
                    |
                    v
  DefaultActorService.onTbApplicationEvent(event)
    new PartitionChangeMsg(serviceType)        <- diff is dropped here
                    |
                    v   appActor.tellWithHighPriority(msg)
               +-----------+
               |  AppActor |
               +-----------+
                    |
       ctx.broadcastToChildren(msg, true)      <- unconditional: every child
                    |
     +--------+--------+--------+--------+--------+
     v        v        v        v        v        v
  Tenant   Tenant   Tenant   Tenant   Tenant   Tenant
  Actor    Actor    Actor    Actor    Actor    Actor
  (T1)     (T2)     (T3)     (T4)     (T5)     (Tn)
     |        |        |        |        |        |
  owner-   mailbox  mailbox  mailbox  mailbox  mailbox
  ship     jumped   jumped   jumped   jumped   jumped
  changed, by msg,  by msg,  by msg,  by msg,  by msg,
  re-init  then     then     then     then     then
  rule     re-check re-check re-check re-check re-check
  chains   "still   "still   "still   "still   "still
           mine?"   mine?"   mine?"   mine?"   mine?"
           = yes,   = yes,   = yes,   = yes,   = yes,
           no-op    no-op    no-op    no-op    no-op

  T2..Tn's already-queued messages all wait behind this
  high-priority interrupt, even though none of their
  partition assignments changed.


AFTER THE FIX
=============

  API: switch T1's profile  SharedQueue -> DedicatedQueue
                    |
                    v
  HashPartitionService.recalculatePartitions()
    computes changed-queue-key diff: { T1 -> [Main, HighPriority, ...] }
                    |
                    v
  DefaultActorService.onTbApplicationEvent(event)
    resolveAffectedTenants(event)  ->  Set.of(T1)
    new PartitionChangeMsg(serviceType, affectedTenants = {T1})
                    |
                    v   appActor.tellWithHighPriority(msg)
               +-----------+
               |  AppActor |
               +-----------+
                    |
   ctx.broadcastToChildren(msg, matches(T1), true)   <- filtered
                    |
                    v
              TenantActor (T1)        <- the only actor notified
                    |
             ownership changed,
             re-init rule chains

    TenantActor(T2)   TenantActor(T3)   ...   TenantActor(Tn)
          |                  |                       |
    never touched:     never touched:          never touched:
    mailbox intact,     mailbox intact,          mailbox intact,
    in-flight work       in-flight work           in-flight work
    proceeds on          proceeds on              proceeds on
    schedule             schedule                 schedule
```

## Why this works, precisely

1. **The diff already exists; nothing new is computed.** `HashPartitionService.recalculatePartitions()` already computes exactly which queue keys changed ownership before publishing `PartitionChangeEvent` — this PR does not add new tracking, it stops discarding information that was already available. `DefaultActorService.resolveAffectedTenants()` reads `event.getNewPartitions().keySet()`, which is precisely that diff.

2. **A tenant absent from the diff has, by construction, an unchanged assignment.** If `T2`'s queue-key ownership didn't change in a given recompute, there is nothing for `T2`'s `TenantActor` to react to — the only effect `onPartitionChangeMsg` would have had for an unaffected tenant is a no-op re-verification ("am I still managed?" → yes, unchanged). Skipping delivery to `T2` removes only that no-op, never a real state transition.

3. **The fallback is conservative, not optimistic.** `resolveAffectedTenants()` returns `null` (→ broadcast to everyone, exactly like today) whenever *any* changed queue key belongs to the shared/non-isolated pool (a sys-tenant-keyed queue) — that pool's individual tenants aren't tracked as separate queue keys and can't be safely enumerated from the diff. There is no code path where the fix narrows the notified set incorrectly; it only narrows when the narrower set is provably complete.

4. **Delivery guarantees for the affected tenant are unchanged.** `T1` still receives the message via the same `ctx.broadcastToChildren(msg, ..., true)` high-priority path as before. The fix changes *who* receives the message, not *how* the affected tenant is notified.

5. **The filtering mechanism is not new.** `TbEntityTypeActorIdPredicate` is the same type-filtered-broadcast helper `TenantActor` already uses for filtering device actors elsewhere in the codebase — this reuses established, already-exercised broadcast-filtering machinery with the correct match set, instead of introducing new filtering logic.

## How this propagates in a microservice (MSA) deployment: tb-core → tb-rule-engine, via Kafka + proto

There are two distinct messages in this pipeline, and only one of them ever crosses the network — worth being explicit about which, since it's easy to assume `PartitionChangeMsg` itself travels over Kafka. It doesn't.

**1. The cross-cluster message — carries the tenant.** When a queue is created/updated/deleted for a tenant, `DefaultTbClusterService.onQueuesUpdate()`/`onQueuesDelete()` builds a `QueueUpdateMsg`/`QueueDeleteMsg` protobuf (`common/proto/src/main/proto/queue.proto`) that explicitly carries `tenantIdMSB`/`tenantIdLSB`:
```proto
message QueueUpdateMsg {
  int64 tenantIdMSB = 1;
  int64 tenantIdLSB = 2;
  int64 queueIdMSB = 3;
  int64 queueIdLSB = 4;
  string queueName = 5;
  ...
}
```
This gets wrapped in `ToRuleEngineNotificationMsg` and sent — not to one shared topic, but once per currently-registered `TB_RULE_ENGINE` service instance, each to that instance's own dedicated single-partition topic (`TopicService.getNotificationsTopic()`, topic name `tb_rule_engine.notifications.<serviceId>`). Kafka has no native "deliver to every consumer" broadcast primitive, so this fan-out is done explicitly on the producer side: one send per known instance ID.

**2. The purely local message (`PartitionChangeMsg`) — this PR's subject, never serialized.** Each instance's own consumer reads `ToRuleEngineNotificationMsg` off *its own* topic, updates its local `HashPartitionService` maps, and calls `recalculatePartitions()` — entirely in-process. That method diffs old vs. new local ownership and publishes a Spring `PartitionChangeEvent`, which `DefaultActorService` turns into `PartitionChangeMsg` and hands directly to the local `AppActor` reference (`appActor.tellWithHighPriority(...)`) — a plain Java method call, no network I/O, no Kafka, no proto.

```
 tb-core (any instance)                                              tb-rule-engine-0        tb-rule-engine-1   ...
 ───────────────────────                                              ─────────────────       ─────────────────
 DefaultTbQueueService
   .updateQueuesByTenants()
         │
         v
 DefaultTbClusterService.onQueuesUpdate(queues)
         │
   build QueueUpdateMsg{ tenantIdMSB, tenantIdLSB,   <-- tenant IS on the wire
                          queueIdMSB, queueName, ... }
         │
   wrap: ToRuleEngineNotificationMsg{ queueUpdateMsgs: [...] }
         │
   for each known TB_RULE_ENGINE serviceId:            (fan-out loop, N sends)
         │
         ├──── Kafka topic "tb_rule_engine.notifications.tb-rule-engine-0" ───►  consumer thread
         │       (protobuf-encoded ToRuleEngineNotificationMsg)                  reads msg, deserializes
         │                                                                             │
         ├──── Kafka topic "tb_rule_engine.notifications.tb-rule-engine-1" ─────────────────────────►  consumer thread
         │                                                                                                    │
        ...                                                                                                  ...
                                                                                        │                     │
                                                                                        v                     v
                                                                          DefaultTbRuleEngineConsumerService
                                                                            .handleNotification()
                                                                            .updateQueues(queueUpdateMsgs)
                                                                                        │
                                                                          partitionService.updateQueues(...)   (local map update)
                                                                          partitionService.recalculatePartitions()  (local diff)
                                                                                        │
                                                                          [[[ NOTHING CROSSES THE NETWORK PAST THIS POINT ]]]
                                                                                        │
                                                                          PartitionChangeEvent (Spring, in-process)
                                                                                        │
                                                                          DefaultActorService.onTbApplicationEvent()
                                                                            resolveAffectedTenants(event) -> Set<TenantId>  <-- this instance's own local diff
                                                                                        │
                                                                          new PartitionChangeMsg(serviceType, affectedTenants)
                                                                                        │
                                                                          appActor.tellWithHighPriority(msg)   (plain Java call, same JVM)
                                                                                        │
                                                                          AppActor.onPartitionChangeMsg(msg)
                                                                            ctx.broadcastToChildren(msg, filter, true)
```

By the time `PartitionChangeMsg` is constructed, the tenant identity has already been consumed once (to update the local partition maps) and — before this PR — was thrown away a second time before reaching `AppActor`. The fix is entirely about not re-discarding information that was already available one hop earlier, purely within a single JVM; it does not add any new cross-cluster tracking.

A second, independent trigger exists too: a rule-engine instance's own service-discovery membership changing (pod join/leave) reaches `recalculatePartitions()` via ZooKeeper `CuratorCache` watches, not Kafka, and carries only `ServiceInfo` (instance identity), never a specific tenant ID. Both triggers converge on the same local `recalculatePartitions()` → `PartitionChangeEvent` → `resolveAffectedTenants()` chain, which is why the fix is correct regardless of which one fired it.


## Observability: existing log flow is already sufficient

Every log line on this path is already at INFO level in production code, no config change needed to see it:
- `"Received queue update msg: [...]"` / `"Received queue delete msg: [...]"` (`DefaultTbRuleEngineConsumerService`)
- `"Received partition change event."` (`DefaultActorService`)
- `"Recalculating partitions"` / `"Partitions changed: ..."` (`HashPartitionService`)
- `"Tenant {} is now managed by this service, initializing rule chains"` / `"...is not managed..."` / `"...no longer managed..."` (`TenantActor`)
- `"Partition change for {}: notifying {} affected tenant(s)"` — the new line this PR adds (`AppActor`)

The default shipped logback config sets `org.thingsboard.server` (and root) to `INFO`, with no narrower override raising any of these packages above it — so this entire flow is observable out of the box in any deployment, no debug logging needs to be enabled to trace a partition-change event end to end.


## Test plan

- [x] `ActorSystemTest` — filtered + priority broadcast delivers only to matching children
- [x] `PartitionChangeMsgTest` — both constructors, backward-compatible default
- [x] `DefaultActorServiceTest` — affected-tenant resolution, including the shared-pool → `null` fallback
- [x] `AppActorTest` — targeted broadcast path and the unaffected "everyone" path
- [x] `TenantActorTest`, `ComponentActorTest` — no regression in related actor plumbing
- [x] Full reactor build (`common/actor`, `common/message`, `application` + upstream, `-am`): **BUILD SUCCESS**, 8/8 relevant tests passing
- [x] `mvn license:format` — clean


