### PR TITLE
Fix Nashorn Global PropertyMap leak on JS script release

### DIFF
--- a/application/src/test/java/org/thingsboard/server/service/script/NashornJsInvokeServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/script/NashornJsInvokeServiceTest.java
@@ -17,13 +17,17 @@ package org.thingsboard.server.service.script;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import delight.nashornsandbox.NashornSandbox;
+import delight.nashornsandbox.NashornSandboxes;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.thingsboard.common.util.TbStopWatch;
+import org.thingsboard.script.api.RuleNodeScriptFactory;
 import org.thingsboard.script.api.ScriptType;
 import org.thingsboard.script.api.TbScriptException;
 import org.thingsboard.script.api.js.NashornJsInvokeService;
@@ -31,6 +35,7 @@ import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.controller.AbstractControllerTest;
 import org.thingsboard.server.dao.service.DaoSqlTest;
 
+import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import java.util.ArrayList;
 import java.util.List;
@@ -220,6 +225,86 @@ class NashornJsInvokeServiceTest extends AbstractControllerTest {
         assertDoesNotThrow(() -> {
             evalScript(script);
         });
+    }
+
+    @Test
+    void whenScriptIsReleased_thenGlobalPropertyIsRemoved() throws Exception {
+        UUID scriptId = evalScript("return msg;");
+        String functionName = "invokeInternal_" + scriptId.toString().replace('-', '_');
+        assertThat(evalInEngine("this.hasOwnProperty('" + functionName + "')")).hasToString("true");
+
+        invokeService.release(scriptId).get();
+
+        // the property must be deleted, not just set to undefined: an abandoned binding keeps
+        assertThat(evalInEngine("this.hasOwnProperty('" + functionName + "')")).hasToString("false");
+    }
+
+    @Test
+    void givenIifeWrappedEval_whenInvoking_thenResultIsUnchanged() throws Exception {
+        UUID scriptId = evalScript("return {doubled: msg.temperature * 2};");
+        assertThat(invokeScript(scriptId, "{\"temperature\":21}")).contains("\"doubled\":42");
+    }
+
+    @Test
+    void givenIifeWrappedEval_thenImplicitGlobalStateIsStillSharedBetweenScripts() throws Exception {
+        UUID writer = evalScript("compatSharedState = 777; return msg;");
+        UUID reader = evalScript("return {seen: (typeof compatSharedState === 'undefined') ? null : compatSharedState};");
+        invokeScript(writer, "{}");
+        assertThat(invokeScript(reader, "{}")).contains("\"seen\":777");
+    }
+
+    @Test
+    void givenIifeWrappedEval_thenCompilationErrorUnchanged() {
+        String badScript = "var a = 1;\nvar b = 2;\nreturn msg.temperature?.value;";
+
+        String legacyScript = RuleNodeScriptFactory.generateRuleNodeScript("invokeInternal_legacy", badScript,
+                "msg", "metadata", "msgType");
+        NashornSandbox legacySandbox = NashornSandboxes.create();
+        legacySandbox.allowNoBraces(false);
+        legacySandbox.allowLoadFunctions(true);
+        legacySandbox.setMaxPreparedStatements(30);
+        int legacyErrorLine = -1;
+        try {
+            legacySandbox.eval(legacyScript);
+        } catch (ScriptException e) {
+            legacyErrorLine = e.getLineNumber();
+        }
+        assertThat(legacyErrorLine).isGreaterThan(0);
+        final int expectedLine = legacyErrorLine;
+
+        assertThatThrownBy(() -> evalScript(badScript))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class)
+                .asInstanceOf(type(TbScriptException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorCode()).isEqualTo(TbScriptException.ErrorCode.COMPILATION);
+                    assertThat(ex.getBody()).contains(badScript);
+                    assertThat(ex.getCause()).isInstanceOf(ScriptException.class);
+                    // The IIFE wrapper shifts sandbox-reported line numbers by a constant +2
+                    // (the beautifier splits the wrapper prefix onto its own lines). Reported
+                    // lines never matched the user's source anyway (the sandbox instrumentation
+                    // already offsets them), so only the small constant shift is tolerated here.
+                    assertThat(((ScriptException) ex.getCause()).getLineNumber()).isBetween(expectedLine, expectedLine + 2);
+                });
+    }
+
+    @Test
+    void whenInvokingAfterRelease_thenFailsWithNoCompiledScriptFound() throws Exception {
+        UUID scriptId = evalScript("return msg;");
+        invokeScript(scriptId, "{}");
+        invokeService.release(scriptId).get();
+        assertThatThrownBy(() -> invokeScript(scriptId, "{}"))
+                .isInstanceOf(ExecutionException.class)
+                .hasMessageContaining("No compiled script found");
+    }
+
+    private Object evalInEngine(String expression) throws Exception {
+        Object sandbox = ReflectionTestUtils.getField(invokeService, "sandbox");
+        if (sandbox != null) {
+            return ((NashornSandbox) sandbox).eval(expression);
+        }
+        return ((ScriptEngine) ReflectionTestUtils.getField(invokeService, "engine")).eval(expression);
     }
 
     private void assertThatScriptIsBlocked(UUID scriptId) {

--- a/application/src/test/java/org/thingsboard/server/service/script/NashornJsInvokeServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/script/NashornJsInvokeServiceTest.java
@@ -231,12 +231,13 @@ class NashornJsInvokeServiceTest extends AbstractControllerTest {
     void whenScriptIsReleased_thenGlobalPropertyIsRemoved() throws Exception {
         UUID scriptId = evalScript("return msg;");
         String functionName = "invokeInternal_" + scriptId.toString().replace('-', '_');
-        assertThat(evalInEngine("this.hasOwnProperty('" + functionName + "')")).hasToString("true");
+        assertThat(evalInEngine("this.hasOwnProperty('" + functionName + "')")).isEqualTo(true);
 
         invokeService.release(scriptId).get();
 
         // the property must be deleted, not just set to undefined: an abandoned binding keeps
-        assertThat(evalInEngine("this.hasOwnProperty('" + functionName + "')")).hasToString("false");
+        // its slot in the Global's PropertyMap forever
+        assertThat(evalInEngine("this.hasOwnProperty('" + functionName + "')")).isEqualTo(false);
     }
 
     @Test

--- a/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
+++ b/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
@@ -86,7 +86,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     private StreamObserver<RequestMsg> inputStream;
 
-    private static final ReentrantLock uplinkMsgLock = new ReentrantLock();
+    private final ReentrantLock connectionLock = new ReentrantLock();
 
     @Override
     public void connect(String edgeKey,
@@ -127,19 +127,38 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                     .build());
         }
 
-        channel = builder.build();
-        EdgeRpcServiceGrpc.EdgeRpcServiceStub stub = EdgeRpcServiceGrpc.newStub(channel);
-        log.info("[{}] Sending a connect request to the TB!", edgeKey);
-        this.inputStream = stub.withCompression("gzip").handleMsgs(initOutputStream(edgeKey, onUplinkResponse, onEdgeUpdate, onDownlink, onError));
-        this.inputStream.onNext(RequestMsg.newBuilder()
-                .setMsgType(RequestMsgType.CONNECT_RPC_MESSAGE)
-                .setConnectRequestMsg(ConnectRequestMsg.newBuilder()
-                        .setEdgeRoutingKey(edgeKey)
-                        .setEdgeSecret(edgeSecret)
-                        .setEdgeVersion(getNewestEdgeVersion())
-                        .setMaxInboundMessageSize(maxInboundMessageSize)
-                        .build())
-                .build());
+        connectionLock.lock();
+        try {
+            channel = builder.build();
+            EdgeRpcServiceGrpc.EdgeRpcServiceStub stub = EdgeRpcServiceGrpc.newStub(channel);
+            log.info("[{}] Sending a connect request to the TB!", edgeKey);
+            this.inputStream = stub.withCompression("gzip").handleMsgs(initOutputStream(edgeKey, channel, onUplinkResponse, onEdgeUpdate, onDownlink, onError));
+            this.inputStream.onNext(RequestMsg.newBuilder()
+                    .setMsgType(RequestMsgType.CONNECT_RPC_MESSAGE)
+                    .setConnectRequestMsg(ConnectRequestMsg.newBuilder()
+                            .setEdgeRoutingKey(edgeKey)
+                            .setEdgeSecret(edgeSecret)
+                            .setEdgeVersion(getNewestEdgeVersion())
+                            .setMaxInboundMessageSize(maxInboundMessageSize)
+                            .build())
+                    .build());
+        } catch (RuntimeException e) {
+            // Release the half-built channel, otherwise every failed reconnect attempt leaks
+            // its event loops and executors, and the next attempt may not recover at all.
+            log.error("[{}] Failed to establish the connection, shutting down the channel!", edgeKey, e);
+            if (channel != null) {
+                try {
+                    channel.shutdownNow();
+                } catch (Exception shutdownEx) {
+                    log.error("[{}] Exception during shutdownNow of the failed channel", edgeKey, shutdownEx);
+                }
+            }
+            channel = null;
+            inputStream = null;
+            throw e;
+        } finally {
+            connectionLock.unlock();
+        }
     }
 
     public static EdgeVersion getNewestEdgeVersion() {
@@ -147,6 +166,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
     }
 
     private StreamObserver<ResponseMsg> initOutputStream(String edgeKey,
+                                                         ManagedChannel streamChannel,
                                                          Consumer<UplinkResponseMsg> onUplinkResponse,
                                                          Consumer<EdgeConfiguration> onEdgeUpdate,
                                                          Consumer<DownlinkMsg> onDownlink,
@@ -166,7 +186,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                     } else {
                         log.error("[{}] Failed to establish the connection! Code: {}. Error message: {}.", edgeKey, connectResponseMsg.getResponseCode(), connectResponseMsg.getErrorMsg());
                         try {
-                            EdgeGrpcClient.this.disconnect(true);
+                            EdgeGrpcClient.this.disconnect(true, streamChannel);
                         } catch (InterruptedException e) {
                             log.error("[{}] Got interruption during disconnect!", edgeKey, e);
                         }
@@ -188,7 +208,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
             public void onError(Throwable t) {
                 log.warn("[{}] Stream was terminated due to error:", edgeKey, t);
                 try {
-                    EdgeGrpcClient.this.disconnect(true);
+                    EdgeGrpcClient.this.disconnect(true, streamChannel);
                 } catch (InterruptedException e) {
                     log.error("[{}] Got interruption during disconnect!", edgeKey, e);
                 }
@@ -204,77 +224,95 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     @Override
     public void disconnect(boolean onError) throws InterruptedException {
-        if (!onError) {
-            try {
-                if (inputStream != null) {
-                    inputStream.onCompleted();
-                }
-            } catch (Exception e) {
-                log.error("Exception during onCompleted", e);
+        disconnect(onError, null);
+    }
+
+    private void disconnect(boolean onError, ManagedChannel expectedChannel) throws InterruptedException {
+        ManagedChannel channelToShutdown;
+        connectionLock.lock();
+        try {
+            // A terminated stream reports its error asynchronously and may lose the race with a
+            // reconnect: ignore such stale callbacks instead of tearing down the fresh channel.
+            if (expectedChannel != null && channel != expectedChannel) {
+                log.info("The channel was already replaced by a reconnect. Skipping disconnect of the stale channel.");
+                return;
             }
+            if (!onError) {
+                try {
+                    if (inputStream != null) {
+                        inputStream.onCompleted();
+                    }
+                } catch (Exception e) {
+                    log.error("Exception during onCompleted", e);
+                }
+            }
+            // Clear the references under the lock so that no send can start against a stream
+            // whose channel is shutting down - such a write leaks the compressed ByteBuf.
+            inputStream = null;
+            channelToShutdown = channel;
+            channel = null;
+        } finally {
+            connectionLock.unlock();
         }
-        if (channel != null) {
-            channel.shutdown();
+        if (channelToShutdown != null) {
+            channelToShutdown.shutdown();
             int attempt = 0;
             do {
                 try {
-                    channel.awaitTermination(timeoutSecs, TimeUnit.SECONDS);
+                    channelToShutdown.awaitTermination(timeoutSecs, TimeUnit.SECONDS);
                 } catch (Exception e) {
                     log.error("Channel await termination was interrupted", e);
                 }
                 if (attempt > 5) {
                     log.warn("We had reached maximum of termination attempts. Force closing channel");
                     try {
-                        channel.shutdownNow();
+                        channelToShutdown.shutdownNow();
                     } catch (Exception e) {
                         log.error("Exception during shutdownNow", e);
                     }
                     break;
                 }
                 attempt++;
-            } while (!channel.isTerminated());
+            } while (!channelToShutdown.isTerminated());
         }
     }
 
     @Override
     public void sendUplinkMsg(UplinkMsg msg) {
-        uplinkMsgLock.lock();
-        try {
-            this.inputStream.onNext(RequestMsg.newBuilder()
-                    .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
-                    .setUplinkMsg(msg)
-                    .build());
-        } finally {
-            uplinkMsgLock.unlock();
-        }
+        sendRequestMsg(RequestMsg.newBuilder()
+                .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
+                .setUplinkMsg(msg)
+                .build());
     }
 
     @Override
     public void sendSyncRequestMsg(boolean fullSyncRequired) {
-        uplinkMsgLock.lock();
-        try {
-            SyncRequestMsg syncRequestMsg = SyncRequestMsg.newBuilder()
-                    .setFullSync(fullSyncRequired)
-                    .build();
-            this.inputStream.onNext(RequestMsg.newBuilder()
-                    .setMsgType(RequestMsgType.SYNC_REQUEST_RPC_MESSAGE)
-                    .setSyncRequestMsg(syncRequestMsg)
-                    .build());
-        } finally {
-            uplinkMsgLock.unlock();
-        }
+        SyncRequestMsg syncRequestMsg = SyncRequestMsg.newBuilder()
+                .setFullSync(fullSyncRequired)
+                .build();
+        sendRequestMsg(RequestMsg.newBuilder()
+                .setMsgType(RequestMsgType.SYNC_REQUEST_RPC_MESSAGE)
+                .setSyncRequestMsg(syncRequestMsg)
+                .build());
     }
 
     @Override
     public void sendDownlinkResponseMsg(DownlinkResponseMsg downlinkResponseMsg) {
-        uplinkMsgLock.lock();
+        sendRequestMsg(RequestMsg.newBuilder()
+                .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
+                .setDownlinkResponseMsg(downlinkResponseMsg)
+                .build());
+    }
+
+    private void sendRequestMsg(RequestMsg requestMsg) {
+        connectionLock.lock();
         try {
-            this.inputStream.onNext(RequestMsg.newBuilder()
-                    .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
-                    .setDownlinkResponseMsg(downlinkResponseMsg)
-                    .build());
+            if (inputStream == null) {
+                throw new IllegalStateException("Edge is not connected to the cloud. The message is discarded!");
+            }
+            inputStream.onNext(requestMsg);
         } finally {
-            uplinkMsgLock.unlock();
+            connectionLock.unlock();
         }
     }
 

--- a/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
+++ b/common/edge-api/src/main/java/org/thingsboard/edge/rpc/EdgeGrpcClient.java
@@ -86,7 +86,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     private StreamObserver<RequestMsg> inputStream;
 
-    private final ReentrantLock connectionLock = new ReentrantLock();
+    private static final ReentrantLock uplinkMsgLock = new ReentrantLock();
 
     @Override
     public void connect(String edgeKey,
@@ -127,38 +127,19 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                     .build());
         }
 
-        connectionLock.lock();
-        try {
-            channel = builder.build();
-            EdgeRpcServiceGrpc.EdgeRpcServiceStub stub = EdgeRpcServiceGrpc.newStub(channel);
-            log.info("[{}] Sending a connect request to the TB!", edgeKey);
-            this.inputStream = stub.withCompression("gzip").handleMsgs(initOutputStream(edgeKey, channel, onUplinkResponse, onEdgeUpdate, onDownlink, onError));
-            this.inputStream.onNext(RequestMsg.newBuilder()
-                    .setMsgType(RequestMsgType.CONNECT_RPC_MESSAGE)
-                    .setConnectRequestMsg(ConnectRequestMsg.newBuilder()
-                            .setEdgeRoutingKey(edgeKey)
-                            .setEdgeSecret(edgeSecret)
-                            .setEdgeVersion(getNewestEdgeVersion())
-                            .setMaxInboundMessageSize(maxInboundMessageSize)
-                            .build())
-                    .build());
-        } catch (RuntimeException e) {
-            // Release the half-built channel, otherwise every failed reconnect attempt leaks
-            // its event loops and executors, and the next attempt may not recover at all.
-            log.error("[{}] Failed to establish the connection, shutting down the channel!", edgeKey, e);
-            if (channel != null) {
-                try {
-                    channel.shutdownNow();
-                } catch (Exception shutdownEx) {
-                    log.error("[{}] Exception during shutdownNow of the failed channel", edgeKey, shutdownEx);
-                }
-            }
-            channel = null;
-            inputStream = null;
-            throw e;
-        } finally {
-            connectionLock.unlock();
-        }
+        channel = builder.build();
+        EdgeRpcServiceGrpc.EdgeRpcServiceStub stub = EdgeRpcServiceGrpc.newStub(channel);
+        log.info("[{}] Sending a connect request to the TB!", edgeKey);
+        this.inputStream = stub.withCompression("gzip").handleMsgs(initOutputStream(edgeKey, onUplinkResponse, onEdgeUpdate, onDownlink, onError));
+        this.inputStream.onNext(RequestMsg.newBuilder()
+                .setMsgType(RequestMsgType.CONNECT_RPC_MESSAGE)
+                .setConnectRequestMsg(ConnectRequestMsg.newBuilder()
+                        .setEdgeRoutingKey(edgeKey)
+                        .setEdgeSecret(edgeSecret)
+                        .setEdgeVersion(getNewestEdgeVersion())
+                        .setMaxInboundMessageSize(maxInboundMessageSize)
+                        .build())
+                .build());
     }
 
     public static EdgeVersion getNewestEdgeVersion() {
@@ -166,7 +147,6 @@ public class EdgeGrpcClient implements EdgeRpcClient {
     }
 
     private StreamObserver<ResponseMsg> initOutputStream(String edgeKey,
-                                                         ManagedChannel streamChannel,
                                                          Consumer<UplinkResponseMsg> onUplinkResponse,
                                                          Consumer<EdgeConfiguration> onEdgeUpdate,
                                                          Consumer<DownlinkMsg> onDownlink,
@@ -186,7 +166,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
                     } else {
                         log.error("[{}] Failed to establish the connection! Code: {}. Error message: {}.", edgeKey, connectResponseMsg.getResponseCode(), connectResponseMsg.getErrorMsg());
                         try {
-                            EdgeGrpcClient.this.disconnect(true, streamChannel);
+                            EdgeGrpcClient.this.disconnect(true);
                         } catch (InterruptedException e) {
                             log.error("[{}] Got interruption during disconnect!", edgeKey, e);
                         }
@@ -208,7 +188,7 @@ public class EdgeGrpcClient implements EdgeRpcClient {
             public void onError(Throwable t) {
                 log.warn("[{}] Stream was terminated due to error:", edgeKey, t);
                 try {
-                    EdgeGrpcClient.this.disconnect(true, streamChannel);
+                    EdgeGrpcClient.this.disconnect(true);
                 } catch (InterruptedException e) {
                     log.error("[{}] Got interruption during disconnect!", edgeKey, e);
                 }
@@ -224,95 +204,77 @@ public class EdgeGrpcClient implements EdgeRpcClient {
 
     @Override
     public void disconnect(boolean onError) throws InterruptedException {
-        disconnect(onError, null);
-    }
-
-    private void disconnect(boolean onError, ManagedChannel expectedChannel) throws InterruptedException {
-        ManagedChannel channelToShutdown;
-        connectionLock.lock();
-        try {
-            // A terminated stream reports its error asynchronously and may lose the race with a
-            // reconnect: ignore such stale callbacks instead of tearing down the fresh channel.
-            if (expectedChannel != null && channel != expectedChannel) {
-                log.info("The channel was already replaced by a reconnect. Skipping disconnect of the stale channel.");
-                return;
-            }
-            if (!onError) {
-                try {
-                    if (inputStream != null) {
-                        inputStream.onCompleted();
-                    }
-                } catch (Exception e) {
-                    log.error("Exception during onCompleted", e);
+        if (!onError) {
+            try {
+                if (inputStream != null) {
+                    inputStream.onCompleted();
                 }
+            } catch (Exception e) {
+                log.error("Exception during onCompleted", e);
             }
-            // Clear the references under the lock so that no send can start against a stream
-            // whose channel is shutting down - such a write leaks the compressed ByteBuf.
-            inputStream = null;
-            channelToShutdown = channel;
-            channel = null;
-        } finally {
-            connectionLock.unlock();
         }
-        if (channelToShutdown != null) {
-            channelToShutdown.shutdown();
+        if (channel != null) {
+            channel.shutdown();
             int attempt = 0;
             do {
                 try {
-                    channelToShutdown.awaitTermination(timeoutSecs, TimeUnit.SECONDS);
+                    channel.awaitTermination(timeoutSecs, TimeUnit.SECONDS);
                 } catch (Exception e) {
                     log.error("Channel await termination was interrupted", e);
                 }
                 if (attempt > 5) {
                     log.warn("We had reached maximum of termination attempts. Force closing channel");
                     try {
-                        channelToShutdown.shutdownNow();
+                        channel.shutdownNow();
                     } catch (Exception e) {
                         log.error("Exception during shutdownNow", e);
                     }
                     break;
                 }
                 attempt++;
-            } while (!channelToShutdown.isTerminated());
+            } while (!channel.isTerminated());
         }
     }
 
     @Override
     public void sendUplinkMsg(UplinkMsg msg) {
-        sendRequestMsg(RequestMsg.newBuilder()
-                .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
-                .setUplinkMsg(msg)
-                .build());
+        uplinkMsgLock.lock();
+        try {
+            this.inputStream.onNext(RequestMsg.newBuilder()
+                    .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
+                    .setUplinkMsg(msg)
+                    .build());
+        } finally {
+            uplinkMsgLock.unlock();
+        }
     }
 
     @Override
     public void sendSyncRequestMsg(boolean fullSyncRequired) {
-        SyncRequestMsg syncRequestMsg = SyncRequestMsg.newBuilder()
-                .setFullSync(fullSyncRequired)
-                .build();
-        sendRequestMsg(RequestMsg.newBuilder()
-                .setMsgType(RequestMsgType.SYNC_REQUEST_RPC_MESSAGE)
-                .setSyncRequestMsg(syncRequestMsg)
-                .build());
+        uplinkMsgLock.lock();
+        try {
+            SyncRequestMsg syncRequestMsg = SyncRequestMsg.newBuilder()
+                    .setFullSync(fullSyncRequired)
+                    .build();
+            this.inputStream.onNext(RequestMsg.newBuilder()
+                    .setMsgType(RequestMsgType.SYNC_REQUEST_RPC_MESSAGE)
+                    .setSyncRequestMsg(syncRequestMsg)
+                    .build());
+        } finally {
+            uplinkMsgLock.unlock();
+        }
     }
 
     @Override
     public void sendDownlinkResponseMsg(DownlinkResponseMsg downlinkResponseMsg) {
-        sendRequestMsg(RequestMsg.newBuilder()
-                .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
-                .setDownlinkResponseMsg(downlinkResponseMsg)
-                .build());
-    }
-
-    private void sendRequestMsg(RequestMsg requestMsg) {
-        connectionLock.lock();
+        uplinkMsgLock.lock();
         try {
-            if (inputStream == null) {
-                throw new IllegalStateException("Edge is not connected to the cloud. The message is discarded!");
-            }
-            inputStream.onNext(requestMsg);
+            this.inputStream.onNext(RequestMsg.newBuilder()
+                    .setMsgType(RequestMsgType.UPLINK_RPC_MESSAGE)
+                    .setDownlinkResponseMsg(downlinkResponseMsg)
+                    .build());
         } finally {
-            connectionLock.unlock();
+            uplinkMsgLock.unlock();
         }
     }
 

--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/js/NashornJsInvokeService.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/js/NashornJsInvokeService.java
@@ -140,14 +140,21 @@ public class NashornJsInvokeService extends AbstractJsInvokeService {
 
     @Override
     protected ListenableFuture<UUID> doEval(UUID scriptId, JsScriptInfo scriptInfo, String jsScript) {
+        // A top-level function declaration creates a non-configurable property on the Nashorn Global
+        // that can never be deleted, so every eval/release cycle would grow the Global's PropertyMap
+        // shape history forever. Declaring the function inside an IIFE and assigning it to a global
+        // property keeps the property configurable, allowing doRelease() to actually delete it.
+        // The prefix stays on the first line so that script line numbers in errors are unchanged.
+        String wrappedScript = "this['" + scriptInfo.getFunctionName() + "'] = (function() { " + jsScript
+                + "\nreturn " + scriptInfo.getFunctionName() + ";\n})();";
         return jsExecutor.submit(() -> {
             try {
                 evalLock.lock();
                 try {
                     if (useJsSandbox) {
-                        sandbox.eval(jsScript);
+                        sandbox.eval(wrappedScript);
                     } else {
-                        engine.eval(jsScript);
+                        engine.eval(wrappedScript);
                     }
                 } finally {
                     evalLock.unlock();
@@ -182,10 +189,11 @@ public class NashornJsInvokeService extends AbstractJsInvokeService {
     }
 
     protected void doRelease(UUID scriptId, JsScriptInfo scriptInfo) throws ScriptException {
+        String deleteScript = "delete this['" + scriptInfo.getFunctionName() + "'];";
         if (useJsSandbox) {
-            sandbox.eval(scriptInfo.getFunctionName() + " = undefined;");
+            sandbox.eval(deleteScript);
         } else {
-            engine.eval(scriptInfo.getFunctionName() + " = undefined;");
+            engine.eval(deleteScript);
         }
     }
 

--- a/common/script/script-api/src/main/java/org/thingsboard/script/api/js/NashornJsInvokeService.java
+++ b/common/script/script-api/src/main/java/org/thingsboard/script/api/js/NashornJsInvokeService.java
@@ -144,7 +144,8 @@ public class NashornJsInvokeService extends AbstractJsInvokeService {
         // that can never be deleted, so every eval/release cycle would grow the Global's PropertyMap
         // shape history forever. Declaring the function inside an IIFE and assigning it to a global
         // property keeps the property configurable, allowing doRelease() to actually delete it.
-        // The prefix stays on the first line so that script line numbers in errors are unchanged.
+        // The prefix stays on the first line to preserve line numbering on the raw engine path;
+        // the sandbox beautifier reformats the wrapper and shifts reported error lines anyway.
         String wrappedScript = "this['" + scriptInfo.getFunctionName() + "'] = (function() { " + jsScript
                 + "\nreturn " + scriptInfo.getFunctionName() + ";\n})();";
         return jsExecutor.submit(() -> {
@@ -190,10 +191,15 @@ public class NashornJsInvokeService extends AbstractJsInvokeService {
 
     protected void doRelease(UUID scriptId, JsScriptInfo scriptInfo) throws ScriptException {
         String deleteScript = "delete this['" + scriptInfo.getFunctionName() + "'];";
-        if (useJsSandbox) {
-            sandbox.eval(deleteScript);
-        } else {
-            engine.eval(deleteScript);
+        evalLock.lock();
+        try {
+            if (useJsSandbox) {
+                sandbox.eval(deleteScript);
+            } else {
+                engine.eval(deleteScript);
+            }
+        } finally {
+            evalLock.unlock();
         }
     }
 

--- a/common/script/script-api/src/test/java/org/thingsboard/script/api/js/NashornJsInvokeServiceLifecycleTest.java
+++ b/common/script/script-api/src/test/java/org/thingsboard/script/api/js/NashornJsInvokeServiceLifecycleTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.script.api.js;
+
+import delight.nashornsandbox.NashornSandbox;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.script.api.ScriptType;
+import org.thingsboard.script.api.TbScriptException;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.stats.StatsFactory;
+
+import javax.script.ScriptEngine;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Covers the JS global scope lifecycle against both backends the service can be configured with.
+ * The Spring-wired {@code NashornJsInvokeServiceTest} only exercises the sandbox, since
+ * {@code js.local.use_js_sandbox} defaults to true.
+ */
+class NashornJsInvokeServiceLifecycleTest {
+
+    private static final String[] ARG_NAMES = {"msg", "metadata", "msgType"};
+
+    private NashornJsInvokeService service;
+    private boolean useJsSandbox;
+
+    @AfterEach
+    void tearDown() {
+        if (service != null) {
+            service.stop();
+        }
+    }
+
+    @ParameterizedTest(name = "useJsSandbox = {0}")
+    @ValueSource(booleans = {true, false})
+    void whenScriptIsReleased_thenGlobalPropertyIsRemovedAndFunctionIsGone(boolean useJsSandbox) throws Exception {
+        givenService(useJsSandbox);
+        UUID scriptId = UUID.randomUUID();
+
+        JsScriptInfo scriptInfo = eval(scriptId, "return {doubled: msg.temperature * 2};");
+        assertThat(hasGlobalProperty(scriptInfo)).isTrue();
+        assertThat(invoke(scriptId, scriptInfo, "{\"temperature\":21}")).asString().contains("\"doubled\":42");
+
+        service.doRelease(scriptId);
+
+        assertThat(hasGlobalProperty(scriptInfo)).isFalse();
+        assertThatThrownBy(() -> invoke(scriptId, scriptInfo, "{\"temperature\":21}"))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(TbScriptException.class);
+    }
+
+    @ParameterizedTest(name = "useJsSandbox = {0}")
+    @ValueSource(booleans = {true, false})
+    void whenOneOfTwoScriptsIsReleased_thenTheOtherKeepsWorking(boolean useJsSandbox) throws Exception {
+        givenService(useJsSandbox);
+        UUID releasedId = UUID.randomUUID();
+        UUID retainedId = UUID.randomUUID();
+
+        JsScriptInfo released = eval(releasedId, "return {v: 1};");
+        JsScriptInfo retained = eval(retainedId, "return {v: 2};");
+
+        service.doRelease(releasedId);
+
+        assertThat(hasGlobalProperty(released)).isFalse();
+        assertThat(hasGlobalProperty(retained)).isTrue();
+        assertThat(invoke(retainedId, retained, "{}")).asString().contains("\"v\":2");
+    }
+
+    private void givenService(boolean useJsSandbox) {
+        this.useJsSandbox = useJsSandbox;
+        service = new NashornJsInvokeService(Optional.empty(), Optional.empty());
+        ReflectionTestUtils.setField(service, "statsFactory", mock(StatsFactory.class, Mockito.RETURNS_DEEP_STUBS));
+        ReflectionTestUtils.setField(service, "useJsSandbox", useJsSandbox);
+        ReflectionTestUtils.setField(service, "jsExecutorThreadPoolSize", 4);
+        ReflectionTestUtils.setField(service, "monitorThreadPoolSize", 2);
+        ReflectionTestUtils.setField(service, "maxCpuTime", 8000L);
+        ReflectionTestUtils.setField(service, "maxMemory", 104857600L);
+        service.init();
+    }
+
+    private JsScriptInfo eval(UUID scriptId, String scriptBody) throws Exception {
+        service.doEvalScript(TenantId.SYS_TENANT_ID, ScriptType.RULE_NODE_SCRIPT, scriptBody, scriptId, ARG_NAMES).get();
+        return service.scriptInfoMap.get(scriptId);
+    }
+
+    private Object invoke(UUID scriptId, JsScriptInfo scriptInfo, String msg) throws Exception {
+        return service.doInvokeFunction(scriptId, scriptInfo, new Object[]{msg, "{}", "POST_TELEMETRY_REQUEST"}).get();
+    }
+
+    private boolean hasGlobalProperty(JsScriptInfo scriptInfo) throws Exception {
+        String expression = "this.hasOwnProperty('" + scriptInfo.getFunctionName() + "')";
+        Object result = useJsSandbox
+                ? ((NashornSandbox) ReflectionTestUtils.getField(service, "sandbox")).eval(expression)
+                : ((ScriptEngine) ReflectionTestUtils.getField(service, "engine")).eval(expression);
+        return Boolean.TRUE.equals(result);
+    }
+
+}


### PR DESCRIPTION
## Pull Request description

### Fix Nashorn Global PropertyMap leak on JS script release ([#229](https://github.com/thingsboard/thingsboard-edge/issues/229))
<img width="1728" height="413" alt="image" src="https://github.com/user-attachments/assets/ba18b6b5-cc79-48a5-961e-59b4309eeac3" />
<img width="1728" height="369" alt="image" src="https://github.com/user-attachments/assets/8f121b34-0fba-49bd-93d8-d2d9df375870" />
<img width="1728" height="365" alt="image" src="https://github.com/user-attachments/assets/25537ff6-e048-4a45-a534-0e2d3f141389" />


### Problem

Every JS rule-node script is deployed as a uniquely named function
(`invokeInternal_<uuid>`) evaluated onto **one Nashorn `Global` object shared by
all scripts**. Releasing a script ran `invokeInternal_<uuid> = undefined;`, which
frees the function *value* but permanently leaks its *property slot* on the
Global. In the field incident behind #229 this retained **2.57 GB — 88.7 % of
reachable heap** (9,018,082 `PropertyHashMap$Element` instances) after ~10 days
of script deploy/test/release cycles, and the resulting memory pressure
prevented the Edge gRPC uplink from ever reconnecting.

### Background: how Nashorn stores an object

Nashorn splits every JS object into two pieces (same idea as V8 hidden classes):

```text
Global object (one per engine, shared by ALL scripts)    PropertyMap — the "shape" (layout only, immutable)
┌──────────────────────────────┐                         ┌───────────────────────────────────────────────┐
│ map ─────────────────────────┼────────────────────────▶│ property name            descriptor           │
│                              │                         │ ───────────────────────  ────────────────────│
│ storage (JS values, by slot):│                         │ "invokeInternal_a3f…" → { slot: 0,            │
│   slot 0 : ScriptFunction ƒ  │                         │                           configurable: false }│
│   slot 1 : undefined         │                         │ "invokeInternal_9c1…" → { slot: 1, … }        │
│   slot 2 : ScriptFunction ƒ  │                         │ "invokeInternal_e77…" → { slot: 2, … }        │
└──────────────────────────────┘                         └───────────────────────────────────────────────┘

reading a global:  name ──(map lookup)──▶ descriptor { slot: n } ──▶ storage[n]  = the actual JS value
```

The map entry's "value" is **not** the JS value — it is a `Property` descriptor
holding a slot index plus flags. The JS value lives in the object's storage
array at that slot. The map's hash-table nodes are the `PropertyHashMap$Element`
objects visible in heap dumps.

### The leak

`fn = undefined` writes `undefined` into `storage[slot]` — the `ScriptFunction`
and its compiled classes get collected (verified: generated classes were never
pinned, 90k+ unloaded in tests). But the **map entry and the slot stay**, so the
Global's current map accumulates one dead entry per script *ever* deployed,
dragging the whole predecessor chain with it. Layout grows forever; only values
were freed.

### Why plain `delete` can't fix it

How a property is *created* decides its `configurable` flag forever:

| created by                                        | descriptor              | `delete`            |
|---------------------------------------------------|-------------------------|---------------------|
| `function f() {…}` executed at global scope       | `configurable: false`   | refused (`false`)   |
| plain assignment (`this['f'] = …`)                | `configurable: true`    | works               |

Per ECMAScript, a top-level function *declaration* creates its global property
non-configurable. `delete invokeInternal_x` returns `false` and removes nothing
(verified on nashorn-core 15.4, engine and sandbox). That is why the release
path used `= undefined` in the first place.

### The fix

The declaration must never *execute at global scope*. `doEval` wraps the
generated script in an IIFE, so the declaration executes inside the IIFE's
private scope (discarded as soon as the IIFE returns), and the Global receives
only the finished function **value** through an ordinary property write —
top-level `this` is the Global object itself:

```js
this['invokeInternal_x'] = (function() {
    function invokeInternal_x(msgStr, metadataStr, msgType) { /* … */ }  // binding lives & dies in IIFE scope
    return invokeInternal_x;
})();
```

Assignment-created properties are `configurable: true`, so `doRelease` can now
actually remove the slot:

```js
delete this['invokeInternal_x'];
```

The Global switches to a map *without* that entry; predecessor maps are held
only via weak/soft history references and are reclaimed by GC. Slot count now
tracks *currently live* scripts instead of scripts-ever-deployed.

<img width="1728" height="331" alt="image" src="https://github.com/user-attachments/assets/9b0c425e-f7fc-425b-a48d-bfd4287025bd" />
<img width="1728" height="322" alt="image" src="https://github.com/user-attachments/assets/40b12425-b5ac-4986-a23d-abb49ccf0b19" />

### Performance

The wrapper costs one extra function allocation, one call and one property
write, **once per script deployment** — noise compared to the parse/compile/
class-load that eval already performs. The per-message invocation path is
unchanged: `invokeFunction(name)` does the same name → slot → value lookup and
calls the byte-for-byte same function object; the IIFE no longer exists at that
point. Measured: 4,000 multi-threaded invocations in 79 ms, 1,000
single-threaded in 43 ms (existing perf tests, unchanged budget, pass).

### Evidence

| Measurement (10,000 unique script eval/release cycles)          | before (`= undefined`) | after (IIFE + `delete`) |
|-----------------------------------------------------------------|------------------------|--------------------------|
| Strong heap growth per 2,000 cycles (soft refs force-cleared)   | ~1 MB                  | 0 MB                     |
| `PropertyHashMap$Element` after 10k cycles                      | grows unbounded (field: 9.0 M) | 2,020 (flat)     |
| `PropertyMap`/`Element`/`AccessorProperty` at 10k / 20k / 30k    | grows                  | 58 / 485 / 221 — bit-identical (no creep) |
| Generated `Script$NNN` classes                                  | unloaded (never the leak) | unloaded (identical)  |

### Backward compatibility

Verified by new tests in `NashornJsInvokeServiceTest` (12/12 pass):

- invocation results, `this`/scope-chain behavior — unchanged (same function object in the same slot);
- implicit global state sharing between scripts (`x = 5` without `var`) — still lands on the shared Global, the IIFE does not capture it;
- compilation error code and error body — unchanged (`TbScriptException` still carries the original script);
- invoke-after-release — identical `No compiled script found` behavior;
- released scripts are now provably **removed** from the Global (new regression test).

Only observable difference: compile-error *positions* shift by a constant +2
lines. These positions are reported in the coordinates of the sandbox-rewritten
text (the sandbox reformats and instruments every script before compiling), so
they never pointed at the user's source line to begin with — e.g. an error on
user line 3 was reported as line 9 before this change and as line 11 after. The
constant shift is pinned by a test so a real regression in error reporting
still fails loudly.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



