### PR TITLE
fix: sort time series chart series to match legend sortDataKeys order

### DIFF
--- a/ui-ngx/src/app/modules/home/components/widget/lib/chart/time-series-chart-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/chart/time-series-chart-widget.component.ts
@@ -136,7 +136,8 @@ export class TimeSeriesChartWidgetComponent implements OnInit, OnDestroy, AfterV
   }
 
   ngAfterViewInit() {
-    this.timeSeriesChart = new TbTimeSeriesChart(this.ctx, this.settings, this.chartShape.nativeElement, this.renderer);
+    this.timeSeriesChart = new TbTimeSeriesChart(this.ctx, this.settings, this.chartShape.nativeElement, this.renderer,
+      true, this.settings.legendConfig?.sortDataKeys ?? false);
     this.ctx.widgetActions = this.timeSeriesChart.getWidgetActions();
   }
 

--- a/ui-ngx/src/app/modules/home/components/widget/lib/chart/time-series-chart.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/chart/time-series-chart.ts
@@ -186,7 +186,8 @@ export class TbTimeSeriesChart {
               private readonly inputSettings: DeepPartial<TimeSeriesChartSettings>,
               private chartElement: HTMLElement,
               private renderer: Renderer2,
-              private autoResize = true) {
+              private autoResize = true,
+              private sortDataKeys = false) {
 
     let tooltipValueFormatFunction: TimeSeriesChartTooltipValueFormatFunction;
 
@@ -517,6 +518,9 @@ export class TbTimeSeriesChart {
           });
         }
       }
+    }
+    if (this.sortDataKeys) {
+      this.dataItems.sort((a, b) => a.dataKey.label.localeCompare(b.dataKey.label));
     }
   }
 


### PR DESCRIPTION
## Pull Request description

### Issue

  When `sortDataKeys` is enabled in the legend configuration, the legend entries are sorted alphabetically but the chart bars and tooltip rows remain in subscription arrival order (`createdTime DESC`), creating a visual mismatch.

  ### Root cause

  `sortDataKeys` only re-ordered the legend display (`legendKeys` array in the widget component). The underlying `dataItems` array used by `TbTimeSeriesChart` for series and tooltip rendering was never sorted — it preserved the order
  received from the entity subscription.

  ### Fix

  Added a `sortDataKeys` parameter to `TbTimeSeriesChart` constructor (defaults to `false`, so existing call sites are unaffected). When `true`, `dataItems` are sorted alphabetically by `dataKey.label` at the end of `setupData()`,
  ensuring chart series and tooltip rows align with the legend order.

  This mirrors the existing pattern in `latest-chart.ts` which already sorts both `dataItems` and `legendItems` when `sortSeries` is enabled.

### Screenshots
- Before
<img width="1583" height="614" alt="image" src="https://github.com/user-attachments/assets/a0834358-3226-4a9a-b66e-8bc2eaf5a2c8" />
- After
<img width="1581" height="610" alt="image" src="https://github.com/user-attachments/assets/b650c420-04d8-4317-a5e2-3da7ae171ce3" />


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [x] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



