### PR TITLE
Sync gateway device attributes from cloud to edge (#14218)

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncService.java
@@ -30,6 +30,8 @@ import org.thingsboard.rule.engine.api.AttributesSaveRequest;
 import org.thingsboard.server.common.data.DataConstants;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.stats.DefaultCounter;
+import org.thingsboard.server.common.stats.StatsFactory;
 
 import java.util.EnumMap;
 import java.util.List;
@@ -70,10 +72,14 @@ import java.util.function.Consumer;
 @RequiredArgsConstructor
 public class AttributesEdgeSyncService {
 
+    private static final String STATS_NAME = "edge.attributes.sync";
+
     private final List<AttributesEdgeSyncStrategy> strategies;
+    private final StatsFactory statsFactory;
 
     private final Map<EntityType, AttributesEdgeSyncStrategy> strategyByEntityType = new EnumMap<>(EntityType.class);
     private ExecutorService[] executors;
+    private DefaultCounter discardedCounter;
 
     @Value("${edges.enabled:false}")
     private boolean edgesEnabled;
@@ -85,6 +91,7 @@ public class AttributesEdgeSyncService {
     @PostConstruct
     public void init() {
         strategies.forEach(s -> strategyByEntityType.put(s.getEntityType(), s));
+        discardedCounter = statsFactory.createDefaultCounter(STATS_NAME, "result", "discarded");
         if (edgesEnabled) {
             // single-thread workers selected by the entity id, so that the events of the same entity
             // are delivered to the edge in the order they were saved (e.g. save and delete of the same attribute)
@@ -178,6 +185,7 @@ public class AttributesEdgeSyncService {
             try {
                 executor.execute(command);
             } catch (RejectedExecutionException e) {
+                discardedCounter.increment();
                 log.warn("[{}] Attributes edge sync queue is full, discarding the event", entityId);
             }
         };

--- a/application/src/main/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncService.java
@@ -15,6 +15,9 @@
  */
 package org.thingsboard.server.service.edge.attributes;
 
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +34,7 @@ import org.thingsboard.server.common.data.id.EntityId;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -51,7 +55,15 @@ import java.util.function.Consumer;
  * </ul>
  * The checks are lightweight and executed synchronously on the attributes save path. The actual synchronization
  * is executed on dedicated single-thread workers selected by the entity id - to avoid blocking the telemetry
- * callback threads and to preserve the per-entity order of the events.
+ * callback threads and to preserve the per-entity order of the events. The sync task is submitted by the callback
+ * of the attributes save itself, so no shared pool sits between the save and the worker and can reorder the events;
+ * everything downstream of the worker preserves the order as well - the edge notification queue is partitioned
+ * by the entity id and the edge events are delivered by seq id.
+ * <p>
+ * The order is therefore the order in which the writes completed, not the order in which they were issued.
+ * For a caller that issues the updates sequentially these are the same, because the save is acknowledged only
+ * after its future completes. Truly concurrent updates of the same attribute have no defined order on the cloud
+ * either, so such conflicts are resolved on the edge by the update ts (see BaseTelemetryProcessor#filterAttributesByTs).
  */
 @Slf4j
 @Service
@@ -109,13 +121,23 @@ public class AttributesEdgeSyncService {
         return syncStrategy != null && syncStrategy.isEdgeSyncRequired(request);
     }
 
-    public void onAttributesUpdate(AttributesSaveRequest request) {
-        onAttributesEvent(request.getEntityId(),
+    /**
+     * Syncs the update to the edges once the attributes are persisted.
+     * Must be called only if {@link #isEdgeSyncRequired(AttributesSaveRequest)} returned true - the general rules
+     * are not re-evaluated here.
+     */
+    public void onAttributesUpdate(AttributesSaveRequest request, ListenableFuture<?> saveFuture) {
+        onAttributesEvent(request.getEntityId(), saveFuture,
                 syncStrategy -> syncStrategy.onAttributesUpdate(request));
     }
 
-    public void onAttributesDelete(AttributesDeleteRequest request) {
-        onAttributesEvent(request.getEntityId(),
+    /**
+     * Syncs the delete to the edges once the attributes are removed.
+     * Must be called only if {@link #isEdgeSyncRequired(AttributesDeleteRequest)} returned true - the general rules
+     * are not re-evaluated here.
+     */
+    public void onAttributesDelete(AttributesDeleteRequest request, ListenableFuture<?> deleteFuture) {
+        onAttributesEvent(request.getEntityId(), deleteFuture,
                 syncStrategy -> syncStrategy.onAttributesDelete(request));
     }
 
@@ -123,26 +145,42 @@ public class AttributesEdgeSyncService {
         return edgesEnabled && !DataConstants.EDGE_MSG_SOURCE.equals(msgSource);
     }
 
-    private void onAttributesEvent(EntityId entityId, Consumer<AttributesEdgeSyncStrategy> action) {
+    private void onAttributesEvent(EntityId entityId, ListenableFuture<?> resultFuture, Consumer<AttributesEdgeSyncStrategy> action) {
         AttributesEdgeSyncStrategy syncStrategy = strategyByEntityType.get(entityId.getEntityType());
         if (syncStrategy == null || executors == null) {
             return;
         }
-        try {
-            executorByEntityId(entityId).execute(() -> {
+        Futures.addCallback(resultFuture, new FutureCallback<Object>() {
+            @Override
+            public void onSuccess(Object result) {
                 try {
                     action.accept(syncStrategy);
                 } catch (Exception e) {
                     log.error("[{}] Failed to sync attributes event to edge", entityId, e);
                 }
-            });
-        } catch (RejectedExecutionException e) {
-            log.warn("[{}] Attributes edge sync queue is full, discarding the event", entityId);
-        }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                // attributes were not persisted - nothing to sync
+            }
+        }, executorByEntityId(entityId));
     }
 
-    private ExecutorService executorByEntityId(EntityId entityId) {
-        return executors[Math.floorMod(entityId.hashCode(), executors.length)];
+    /**
+     * The worker of the entity, wrapped to discard the event on overflow instead of letting the rejection surface
+     * as an unhandled listener failure: the callback is dispatched when the write completes, long after it was
+     * registered, so the overflow of the bounded queue can not be handled by the caller.
+     */
+    private Executor executorByEntityId(EntityId entityId) {
+        ExecutorService executor = executors[Math.floorMod(entityId.hashCode(), executors.length)];
+        return command -> {
+            try {
+                executor.execute(command);
+            } catch (RejectedExecutionException e) {
+                log.warn("[{}] Attributes edge sync queue is full, discarding the event", entityId);
+            }
+        };
     }
 
 }

--- a/application/src/main/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncService.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.attributes;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.thingsboard.common.util.ThingsBoardExecutors;
+import org.thingsboard.rule.engine.api.AttributesDeleteRequest;
+import org.thingsboard.rule.engine.api.AttributesSaveRequest;
+import org.thingsboard.server.common.data.DataConstants;
+import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.id.EntityId;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.Consumer;
+
+/**
+ * Propagates attribute updates to the edges related to the updated entity.
+ * <p>
+ * Without this service, attribute updates made on the cloud are propagated to the edge only if the tenant's
+ * rule chains contain a 'push to edge' node that handles attribute messages. This service makes the synchronization
+ * work out of the box for the entity types that require it (see AttributesEdgeSyncStrategy implementations).
+ * <p>
+ * General rules applied to all attribute updates before the entity type specific strategy is consulted:
+ * <ul>
+ *     <li>edges must be enabled;</li>
+ *     <li>updates that originate from the edge are skipped, to avoid echoing the data back to the edge;</li>
+ *     <li>updates that do not persist attributes are skipped.</li>
+ * </ul>
+ * The checks are lightweight and executed synchronously on the attributes save path. The actual synchronization
+ * is executed on dedicated single-thread workers selected by the entity id - to avoid blocking the telemetry
+ * callback threads and to preserve the per-entity order of the events.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AttributesEdgeSyncService {
+
+    private final List<AttributesEdgeSyncStrategy> strategies;
+
+    private final Map<EntityType, AttributesEdgeSyncStrategy> strategyByEntityType = new EnumMap<>(EntityType.class);
+    private ExecutorService[] executors;
+
+    @Value("${edges.enabled:false}")
+    private boolean edgesEnabled;
+    @Value("${edges.attributes_sync_pool_size:4}")
+    private int poolSize;
+    @Value("${edges.attributes_sync_max_queue_size:10000}")
+    private int maxQueueSize;
+
+    @PostConstruct
+    public void init() {
+        strategies.forEach(s -> strategyByEntityType.put(s.getEntityType(), s));
+        if (edgesEnabled) {
+            // single-thread workers selected by the entity id, so that the events of the same entity
+            // are delivered to the edge in the order they were saved (e.g. save and delete of the same attribute)
+            executors = new ExecutorService[poolSize];
+            for (int i = 0; i < poolSize; i++) {
+                executors[i] = ThingsBoardExecutors.newLimitedTasksExecutor(
+                        1, maxQueueSize, "edge-attributes-sync-" + i, new ThreadPoolExecutor.AbortPolicy());
+            }
+        }
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (executors != null) {
+            for (ExecutorService executor : executors) {
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    public boolean isEdgeSyncRequired(AttributesSaveRequest request) {
+        if (!isEdgeSyncAllowed(request.getMsgSource()) || !request.getStrategy().saveAttributes()) {
+            return false;
+        }
+        AttributesEdgeSyncStrategy syncStrategy = strategyByEntityType.get(request.getEntityId().getEntityType());
+        return syncStrategy != null && syncStrategy.isEdgeSyncRequired(request);
+    }
+
+    public boolean isEdgeSyncRequired(AttributesDeleteRequest request) {
+        if (!isEdgeSyncAllowed(request.getMsgSource())) {
+            return false;
+        }
+        AttributesEdgeSyncStrategy syncStrategy = strategyByEntityType.get(request.getEntityId().getEntityType());
+        return syncStrategy != null && syncStrategy.isEdgeSyncRequired(request);
+    }
+
+    public void onAttributesUpdate(AttributesSaveRequest request) {
+        onAttributesEvent(request.getEntityId(),
+                syncStrategy -> syncStrategy.onAttributesUpdate(request));
+    }
+
+    public void onAttributesDelete(AttributesDeleteRequest request) {
+        onAttributesEvent(request.getEntityId(),
+                syncStrategy -> syncStrategy.onAttributesDelete(request));
+    }
+
+    private boolean isEdgeSyncAllowed(String msgSource) {
+        return edgesEnabled && !DataConstants.EDGE_MSG_SOURCE.equals(msgSource);
+    }
+
+    private void onAttributesEvent(EntityId entityId, Consumer<AttributesEdgeSyncStrategy> action) {
+        AttributesEdgeSyncStrategy syncStrategy = strategyByEntityType.get(entityId.getEntityType());
+        if (syncStrategy == null || executors == null) {
+            return;
+        }
+        try {
+            executorByEntityId(entityId).execute(() -> {
+                try {
+                    action.accept(syncStrategy);
+                } catch (Exception e) {
+                    log.error("[{}] Failed to sync attributes event to edge", entityId, e);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            log.warn("[{}] Attributes edge sync queue is full, discarding the event", entityId);
+        }
+    }
+
+    private ExecutorService executorByEntityId(EntityId entityId) {
+        return executors[Math.floorMod(entityId.hashCode(), executors.length)];
+    }
+
+}

--- a/application/src/main/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncService.java
@@ -77,9 +77,9 @@ public class AttributesEdgeSyncService {
 
     @Value("${edges.enabled:false}")
     private boolean edgesEnabled;
-    @Value("${edges.attributes_sync_pool_size:4}")
+    @Value("${edges.attributes_sync_pool_size:8}")
     private int poolSize;
-    @Value("${edges.attributes_sync_max_queue_size:10000}")
+    @Value("${edges.attributes_sync_max_queue_size:5000}")
     private int maxQueueSize;
 
     @PostConstruct

--- a/application/src/main/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncStrategy.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncStrategy.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.attributes;
+
+import org.thingsboard.rule.engine.api.AttributesDeleteRequest;
+import org.thingsboard.rule.engine.api.AttributesSaveRequest;
+import org.thingsboard.server.common.data.EntityType;
+
+/**
+ * Entity type specific strategy of the attributes synchronization to edge.
+ * Implementations decide whether a particular attributes update of the supported entity type must be
+ * propagated to related edges and how to propagate it. See AttributesEdgeSyncService for the general rules
+ * applied to all attribute updates before the strategy is consulted.
+ */
+public interface AttributesEdgeSyncStrategy {
+
+    EntityType getEntityType();
+
+    /**
+     * Lightweight check executed synchronously on the attributes save path.
+     * Implementations must not perform any blocking calls here (no DB or distributed cache lookups) -
+     * in-memory checks only. Entity lookups must be deferred to the async part of the sync.
+     */
+    boolean isEdgeSyncRequired(AttributesSaveRequest request);
+
+    /**
+     * Lightweight check executed synchronously on the attributes delete path.
+     * Implementations must not perform any blocking calls here (no DB or distributed cache lookups) -
+     * in-memory checks only. Entity lookups must be deferred to the async part of the sync.
+     */
+    boolean isEdgeSyncRequired(AttributesDeleteRequest request);
+
+    void onAttributesUpdate(AttributesSaveRequest request);
+
+    void onAttributesDelete(AttributesDeleteRequest request);
+
+}

--- a/application/src/main/java/org/thingsboard/server/service/edge/attributes/GatewayAttributesEdgeSyncStrategy.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/attributes/GatewayAttributesEdgeSyncStrategy.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.attributes;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.rule.engine.api.AttributesDeleteRequest;
+import org.thingsboard.rule.engine.api.AttributesSaveRequest;
+import org.thingsboard.server.cluster.TbClusterService;
+import org.thingsboard.server.common.data.AttributeScope;
+import org.thingsboard.server.common.data.DataConstants;
+import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.edge.EdgeEventActionType;
+import org.thingsboard.server.common.data.edge.EdgeEventType;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
+import org.thingsboard.server.service.gateway_device.GatewayFlagCache;
+import org.thingsboard.server.service.state.DefaultDeviceStateService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Pushes attribute updates of gateway devices to the edges the gateway is assigned to.
+ * <p>
+ * Gateway configuration (connectors, remote logging level, etc.) is stored in attributes of the gateway device.
+ * This strategy converts such updates into edge notifications that are processed asynchronously
+ * by the edge notification queue consumer (see DeviceEdgeProcessor).
+ * <p>
+ * SHARED_SCOPE attributes are propagated. SERVER_SCOPE attributes are propagated except the device activity keys:
+ * configuration of the disabled connectors is stored in SERVER_SCOPE attributes named after the connector,
+ * so the keys can not be limited to a predefined set. This matches the behavior of the attributes sync
+ * on the edge assignment/reconnect (see DefaultEdgeRequestsService). 'inactivityTimeout' is deliberately
+ * propagated (not treated as an activity key) so that it applies to the device state tracked on the edge,
+ * where the gateway is actually connected. CLIENT_SCOPE attributes are reported by the gateway itself
+ * and reach the cloud via the edge uplink, so there is nothing to propagate back.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GatewayAttributesEdgeSyncStrategy implements AttributesEdgeSyncStrategy {
+
+    private final TbClusterService clusterService;
+    private final GatewayFlagCache gatewayFlagCache;
+
+    @Override
+    public EntityType getEntityType() {
+        return EntityType.DEVICE;
+    }
+
+    @Override
+    public boolean isEdgeSyncRequired(AttributesSaveRequest request) {
+        // key based checks are free and short-circuit the frequent writes (e.g. device activity state);
+        // the gateway flag check is in-memory only - the flag is resolved by the async part of the sync
+        return hasGatewaySyncSupportedAttributes(request.getScope(), request.getEntries(), AttributeKvEntry::getKey)
+                && gatewayFlagCache.isPotentialGateway(request.getEntityId());
+    }
+
+    @Override
+    public boolean isEdgeSyncRequired(AttributesDeleteRequest request) {
+        return hasGatewaySyncSupportedAttributes(request.getScope(), request.getKeys(), key -> key)
+                && gatewayFlagCache.isPotentialGateway(request.getEntityId());
+    }
+
+    @Override
+    public void onAttributesUpdate(AttributesSaveRequest request) {
+        TenantId tenantId = request.getTenantId();
+        DeviceId deviceId = new DeviceId(request.getEntityId().getId());
+        // executed on the sync pool only: the gateway flag resolution may be blocking
+        if (!gatewayFlagCache.isGateway(tenantId, deviceId)) {
+            return;
+        }
+        List<AttributeKvEntry> entries = filterGatewayAttributes(request.getScope(), request.getEntries(), AttributeKvEntry::getKey);
+        Map<String, Object> body = new HashMap<>();
+        body.put("kv", toJson(entries));
+        body.put("ts", entries.stream().mapToLong(AttributeKvEntry::getLastUpdateTs).max().orElseGet(System::currentTimeMillis));
+        body.put(DataConstants.SCOPE, request.getScope().name());
+        log.debug("[{}][{}] Pushing gateway attributes update to edge, scope [{}], body [{}]", tenantId, deviceId, request.getScope(), body);
+        clusterService.sendNotificationMsgToEdge(tenantId, null, deviceId, JacksonUtil.toString(body),
+                EdgeEventType.DEVICE, EdgeEventActionType.ATTRIBUTES_UPDATED, null);
+    }
+
+    @Override
+    public void onAttributesDelete(AttributesDeleteRequest request) {
+        TenantId tenantId = request.getTenantId();
+        DeviceId deviceId = new DeviceId(request.getEntityId().getId());
+        // executed on the sync pool only: the gateway flag resolution may be blocking
+        if (!gatewayFlagCache.isGateway(tenantId, deviceId)) {
+            return;
+        }
+        Map<String, Object> body = new HashMap<>();
+        body.put("keys", filterGatewayAttributes(request.getScope(), request.getKeys(), key -> key));
+        body.put(DataConstants.SCOPE, request.getScope().name());
+        log.debug("[{}][{}] Pushing gateway attributes delete to edge, scope [{}], body [{}]", tenantId, deviceId, request.getScope(), body);
+        clusterService.sendNotificationMsgToEdge(tenantId, null, deviceId, JacksonUtil.toString(body),
+                EdgeEventType.DEVICE, EdgeEventActionType.ATTRIBUTES_DELETED, null);
+    }
+
+    private static <T> boolean hasGatewaySyncSupportedAttributes(AttributeScope scope, List<T> entries, Function<T, String> keyExtractor) {
+        return switch (scope) {
+            case SHARED_SCOPE -> !entries.isEmpty();
+            case SERVER_SCOPE -> entries.stream().anyMatch(entry -> !isActivityKey(keyExtractor.apply(entry)));
+            case CLIENT_SCOPE -> false;
+        };
+    }
+
+    private static <T> List<T> filterGatewayAttributes(AttributeScope scope, List<T> entries, Function<T, String> keyExtractor) {
+        if (scope == AttributeScope.SERVER_SCOPE) {
+            return entries.stream().filter(entry -> !isActivityKey(keyExtractor.apply(entry))).toList();
+        }
+        return entries;
+    }
+
+    private static boolean isActivityKey(String key) {
+        return DefaultDeviceStateService.ACTIVITY_KEYS_WITHOUT_INACTIVITY_TIMEOUT.contains(key);
+    }
+
+    private static ObjectNode toJson(List<AttributeKvEntry> entries) {
+        ObjectNode attributes = JacksonUtil.newObjectNode();
+        entries.forEach(entry -> JacksonUtil.addKvEntry(attributes, entry));
+        return attributes;
+    }
+
+}

--- a/application/src/main/java/org/thingsboard/server/service/edge/attributes/GatewayAttributesEdgeSyncStrategy.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/attributes/GatewayAttributesEdgeSyncStrategy.java
@@ -37,7 +37,9 @@ import org.thingsboard.server.service.state.DefaultDeviceStateService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Pushes attribute updates of gateway devices to the edges the gateway is assigned to.
@@ -90,13 +92,18 @@ public class GatewayAttributesEdgeSyncStrategy implements AttributesEdgeSyncStra
             return;
         }
         List<AttributeKvEntry> entries = filterGatewayAttributes(request.getScope(), request.getEntries(), AttributeKvEntry::getKey);
-        Map<String, Object> body = new HashMap<>();
-        body.put("kv", toJson(entries));
-        body.put("ts", entries.stream().mapToLong(AttributeKvEntry::getLastUpdateTs).max().orElseGet(System::currentTimeMillis));
-        body.put(DataConstants.SCOPE, request.getScope().name());
-        log.debug("[{}][{}] Pushing gateway attributes update to edge, scope [{}], body [{}]", tenantId, deviceId, request.getScope(), body);
-        clusterService.sendNotificationMsgToEdge(tenantId, null, deviceId, JacksonUtil.toString(body),
-                EdgeEventType.DEVICE, EdgeEventActionType.ATTRIBUTES_UPDATED, null);
+        // the body carries a single ts for all of its keys, so entries are grouped by their own update ts, oldest first
+        entries.stream()
+                .collect(Collectors.groupingBy(AttributeKvEntry::getLastUpdateTs, TreeMap::new, Collectors.toList()))
+                .forEach((ts, sameTsEntries) -> {
+                    Map<String, Object> body = new HashMap<>();
+                    body.put("kv", toJson(sameTsEntries));
+                    body.put("ts", ts);
+                    body.put(DataConstants.SCOPE, request.getScope().name());
+                    log.debug("[{}][{}] Pushing gateway attributes update to edge, scope [{}], body [{}]", tenantId, deviceId, request.getScope(), body);
+                    clusterService.sendNotificationMsgToEdge(tenantId, null, deviceId, JacksonUtil.toString(body),
+                            EdgeEventType.DEVICE, EdgeEventActionType.ATTRIBUTES_UPDATED, null);
+                });
     }
 
     @Override

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessor.java
@@ -118,7 +118,7 @@ public abstract class BaseEdgeProcessor implements EdgeProcessor {
                 if (activeOpt.get().getBooleanValue().isPresent() && activeOpt.get().getBooleanValue().get()) {
                     return doSaveEdgeEvent(tenantId, edgeId, type, action, entityId, body);
                 } else {
-                    if (doSaveIfEdgeIsOffline(type, action)) {
+                    if (isTypeSavedWhileEdgeIsOffline(type, action)) {
                         return doSaveEdgeEvent(tenantId, edgeId, type, action, entityId, body);
                     } else {
                         log.trace("Edge is not active at the moment. Skipping event. tenantId [{}], edgeId [{}], type[{}], " +
@@ -133,16 +133,16 @@ public abstract class BaseEdgeProcessor implements EdgeProcessor {
         }
     }
 
-    private boolean doSaveIfEdgeIsOffline(EdgeEventType type, EdgeEventActionType action) {
+    private boolean isTypeSavedWhileEdgeIsOffline(EdgeEventType type, EdgeEventActionType action) {
         return switch (action) {
             case TIMESERIES_UPDATED, ALARM_ACK, ALARM_CLEAR, ALARM_ASSIGNED, ALARM_UNASSIGNED, ADDED_COMMENT,
                  UPDATED_COMMENT, DELETED -> true;
-            case ATTRIBUTES_UPDATED, ATTRIBUTES_DELETED -> type == EdgeEventType.DEVICE || doSaveIfEdgeIsOffline(type);
-            default -> doSaveIfEdgeIsOffline(type);
+            case ATTRIBUTES_UPDATED, ATTRIBUTES_DELETED -> type == EdgeEventType.DEVICE || isTypeSavedWhileEdgeIsOffline(type);
+            default -> isTypeSavedWhileEdgeIsOffline(type);
         };
     }
 
-    private boolean doSaveIfEdgeIsOffline(EdgeEventType type) {
+    private boolean isTypeSavedWhileEdgeIsOffline(EdgeEventType type) {
         return switch (type) {
             case ALARM, ALARM_COMMENT, RULE_CHAIN, RULE_CHAIN_METADATA, USER, CUSTOMER, TENANT, TENANT_PROFILE,
                  WIDGETS_BUNDLE, WIDGET_TYPE, ADMIN_SETTINGS, OTA_PACKAGE, QUEUE, RELATION, CALCULATED_FIELD, NOTIFICATION_TEMPLATE,

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessor.java
@@ -137,12 +137,17 @@ public abstract class BaseEdgeProcessor implements EdgeProcessor {
         return switch (action) {
             case TIMESERIES_UPDATED, ALARM_ACK, ALARM_CLEAR, ALARM_ASSIGNED, ALARM_UNASSIGNED, ADDED_COMMENT,
                  UPDATED_COMMENT, DELETED -> true;
-            default -> switch (type) {
-                case ALARM, ALARM_COMMENT, RULE_CHAIN, RULE_CHAIN_METADATA, USER, CUSTOMER, TENANT, TENANT_PROFILE,
-                     WIDGETS_BUNDLE, WIDGET_TYPE, ADMIN_SETTINGS, OTA_PACKAGE, QUEUE, RELATION, CALCULATED_FIELD, NOTIFICATION_TEMPLATE,
-                     NOTIFICATION_TARGET, NOTIFICATION_RULE -> true;
-                default -> false;
-            };
+            case ATTRIBUTES_UPDATED, ATTRIBUTES_DELETED -> type == EdgeEventType.DEVICE || doSaveIfEdgeIsOffline(type);
+            default -> doSaveIfEdgeIsOffline(type);
+        };
+    }
+
+    private boolean doSaveIfEdgeIsOffline(EdgeEventType type) {
+        return switch (type) {
+            case ALARM, ALARM_COMMENT, RULE_CHAIN, RULE_CHAIN_METADATA, USER, CUSTOMER, TENANT, TENANT_PROFILE,
+                 WIDGETS_BUNDLE, WIDGET_TYPE, ADMIN_SETTINGS, OTA_PACKAGE, QUEUE, RELATION, CALCULATED_FIELD, NOTIFICATION_TEMPLATE,
+                 NOTIFICATION_TARGET, NOTIFICATION_RULE -> true;
+            default -> false;
         };
     }
 

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessor.java
@@ -224,6 +224,9 @@ public abstract class BaseEdgeProcessor implements EdgeProcessor {
                     } else {
                         return processNotificationToRelatedEdges(tenantId, entityId, entityId, type, actionType, originatorEdgeId);
                     }
+                case ATTRIBUTES_UPDATED:
+                case ATTRIBUTES_DELETED:
+                    return processNotificationToRelatedEdges(tenantId, entityId, entityId, type, actionType, body, originatorEdgeId);
                 case DELETED:
                     EdgeEventActionType deleted = EdgeEventActionType.DELETED;
                     if (edgeId != null) {
@@ -262,12 +265,17 @@ public abstract class BaseEdgeProcessor implements EdgeProcessor {
 
     protected ListenableFuture<Void> processNotificationToRelatedEdges(TenantId tenantId, EntityId ownerEntityId, EntityId entityId, EdgeEventType type,
                                                                        EdgeEventActionType actionType, EdgeId sourceEdgeId) {
+        return processNotificationToRelatedEdges(tenantId, ownerEntityId, entityId, type, actionType, null, sourceEdgeId);
+    }
+
+    protected ListenableFuture<Void> processNotificationToRelatedEdges(TenantId tenantId, EntityId ownerEntityId, EntityId entityId, EdgeEventType type,
+                                                                       EdgeEventActionType actionType, JsonNode body, EdgeId sourceEdgeId) {
         List<ListenableFuture<Void>> futures = new ArrayList<>();
         PageDataIterableByTenantIdEntityId<EdgeId> edgeIds =
                 new PageDataIterableByTenantIdEntityId<>(edgeCtx.getEdgeService()::findRelatedEdgeIdsByEntityId, tenantId, ownerEntityId, RELATED_EDGES_CACHE_ITEMS);
         for (EdgeId relatedEdgeId : edgeIds) {
             if (!relatedEdgeId.equals(sourceEdgeId)) {
-                futures.add(saveEdgeEvent(tenantId, relatedEdgeId, type, actionType, entityId, null));
+                futures.add(saveEdgeEvent(tenantId, relatedEdgeId, type, actionType, entityId, body));
             }
         }
         return Futures.transform(Futures.allAsList(futures), voids -> null, dbCallbackExecutorService);

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/telemetry/BaseTelemetryProcessor.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/processor/telemetry/BaseTelemetryProcessor.java
@@ -325,6 +325,7 @@ public abstract class BaseTelemetryProcessor extends BaseEdgeProcessor {
                         .entityId(entityId)
                         .scope(scope)
                         .entries(attributesToSave)
+                        .msgSource(getMsgSourceKey())
                         .callback(new FutureCallback<>() {
                             @Override
                             public void onSuccess(@Nullable Void tmp) {

--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/sync/DefaultEdgeRequestsService.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/sync/DefaultEdgeRequestsService.java
@@ -44,7 +44,6 @@ import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.id.UserId;
 import org.thingsboard.server.common.data.id.WidgetsBundleId;
 import org.thingsboard.server.common.data.kv.AttributeKvEntry;
-import org.thingsboard.server.common.data.kv.DataType;
 import org.thingsboard.server.common.data.kv.TsKvEntry;
 import org.thingsboard.server.common.data.relation.EntityRelation;
 import org.thingsboard.server.common.data.relation.EntityRelationsQuery;
@@ -160,17 +159,7 @@ public class DefaultEdgeRequestsService implements EdgeRequestsService {
                     if (DefaultDeviceStateService.ACTIVITY_KEYS_WITHOUT_INACTIVITY_TIMEOUT.contains(attr.getKey())) {
                         continue;
                     }
-                    if (attr.getDataType() == DataType.BOOLEAN && attr.getBooleanValue().isPresent()) {
-                        attributes.put(attr.getKey(), attr.getBooleanValue().get());
-                    } else if (attr.getDataType() == DataType.DOUBLE && attr.getDoubleValue().isPresent()) {
-                        attributes.put(attr.getKey(), attr.getDoubleValue().get());
-                    } else if (attr.getDataType() == DataType.LONG && attr.getLongValue().isPresent()) {
-                        attributes.put(attr.getKey(), attr.getLongValue().get());
-                    } else if (attr.getDataType() == DataType.JSON && attr.getJsonValue().isPresent()) {
-                        attributes.set(attr.getKey(), JacksonUtil.toJsonNode(attr.getJsonValue().get()));
-                    } else {
-                        attributes.put(attr.getKey(), attr.getValueAsString());
-                    }
+                    JacksonUtil.addKvEntry(attributes, attr);
                 }
                 if (!attributes.isEmpty()) {
                     entityData.put("kv", attributes);

--- a/application/src/main/java/org/thingsboard/server/service/gateway_device/GatewayFlagCache.java
+++ b/application/src/main/java/org/thingsboard/server/service/gateway_device/GatewayFlagCache.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.gateway_device;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.thingsboard.server.common.data.DataConstants;
+import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.EntityId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.msg.plugin.ComponentLifecycleMsg;
+import org.thingsboard.server.dao.device.DeviceService;
+
+import java.time.Duration;
+
+/**
+ * Local in-memory cache of the device gateway flag. Provides two levels of the check:
+ * <ul>
+ *     <li>{@link #isPotentialGateway(EntityId)} - non-blocking, safe to call on any hot path:
+ *     consults the local cache only and treats a device with the unknown flag as a potential gateway;</li>
+ *     <li>{@link #isGateway(TenantId, DeviceId)} - resolves the flag from the device and caches it.
+ *     BLOCKING: performs a device lookup that may be a distributed cache call or a DB read,
+ *     so it must not be called on hot paths - offload it to a dedicated pool.</li>
+ * </ul>
+ * The gateway flag lives in the device additional info, so any change of it is a device UPDATED
+ * lifecycle event, that is broadcast to all core and rule engine nodes and republished
+ * as an application event on each of them (see DefaultTbClusterService#broadcast and
+ * AbstractConsumerService#handleComponentLifecycleMsg) - the cached flag is invalidated on it.
+ * <p>
+ * The expiration stays as a backstop even though the flag is invalidated on the lifecycle events:
+ * a broadcast may be missed (e.g. around a node restart, or on a device save path that bypasses
+ * the entity service layer), and DEVICE DELETED events are broadcast to the rule engine service nodes only
+ * (see the core node entity type filter in DefaultTbClusterService#broadcast), so on the dedicated core nodes
+ * the entries of the deleted devices are cleaned up by the expiration only.
+ */
+@Component
+@RequiredArgsConstructor
+public class GatewayFlagCache {
+
+    private final DeviceService deviceService;
+
+    @Value("${cache.gateway_flag.max_size:100000}")
+    private int maxSize;
+    @Value("${cache.gateway_flag.time_to_live_in_minutes:5}")
+    private int timeToLiveInMinutes;
+
+    private Cache<DeviceId, Boolean> gatewayFlagByDeviceId;
+
+    @PostConstruct
+    public void init() {
+        gatewayFlagByDeviceId = Caffeine.newBuilder()
+                .maximumSize(maxSize)
+                .expireAfterWrite(Duration.ofMinutes(timeToLiveInMinutes))
+                .build();
+    }
+
+    @EventListener(ComponentLifecycleMsg.class)
+    public void onDeviceLifecycleEvent(ComponentLifecycleMsg event) {
+        if (event.getEntityId().getEntityType() == EntityType.DEVICE) {
+            gatewayFlagByDeviceId.invalidate(new DeviceId(event.getEntityId().getId()));
+        }
+    }
+
+    /**
+     * Non-blocking check against the local cache only: never performs a device lookup,
+     * a device with the unknown flag is treated as a potential gateway.
+     */
+    public boolean isPotentialGateway(EntityId entityId) {
+        return !Boolean.FALSE.equals(gatewayFlagByDeviceId.getIfPresent(new DeviceId(entityId.getId())));
+    }
+
+    /**
+     * Returns the cached gateway flag, resolving it from the device on a cache miss.
+     * BLOCKING on a miss: the device lookup may be a distributed cache call or a DB read -
+     * do not call on hot paths.
+     */
+    public boolean isGateway(TenantId tenantId, DeviceId deviceId) {
+        return gatewayFlagByDeviceId.get(deviceId, id -> resolveGatewayFlag(tenantId, id));
+    }
+
+    private boolean resolveGatewayFlag(TenantId tenantId, DeviceId deviceId) {
+        Device device = deviceService.findDeviceById(tenantId, deviceId);
+        return device != null && device.getAdditionalInfo() != null
+                && device.getAdditionalInfo().has(DataConstants.GATEWAY_PARAMETER)
+                && device.getAdditionalInfo().get(DataConstants.GATEWAY_PARAMETER).asBoolean();
+    }
+}

--- a/application/src/main/java/org/thingsboard/server/service/gateway_device/GatewayFlagCache.java
+++ b/application/src/main/java/org/thingsboard/server/service/gateway_device/GatewayFlagCache.java
@@ -52,6 +52,12 @@ import java.time.Duration;
  * the entity service layer), and DEVICE DELETED events are broadcast to the rule engine service nodes only
  * (see the core node entity type filter in DefaultTbClusterService#broadcast), so on the dedicated core nodes
  * the entries of the deleted devices are cleaned up by the expiration only.
+ * <p>
+ * The expiration is based on the last access, not on the last write: a device that keeps receiving attribute
+ * updates keeps its flag cached, so the rate of the device lookups is proportional to the number of the devices
+ * that are new to the node or went idle, and not to the rate of the attribute updates. Expiring after write
+ * would re-resolve the flag of every actively updated device once per TTL, which on a large installation is
+ * a constant lookup load that no size of the sync pool can absorb.
  */
 @Component
 @RequiredArgsConstructor
@@ -59,9 +65,9 @@ public class GatewayFlagCache {
 
     private final DeviceService deviceService;
 
-    @Value("${cache.gateway_flag.max_size:100000}")
+    @Value("${cache.gateway_flag.max_size:500000}")
     private int maxSize;
-    @Value("${cache.gateway_flag.time_to_live_in_minutes:5}")
+    @Value("${cache.gateway_flag.time_to_live_in_minutes:30}")
     private int timeToLiveInMinutes;
 
     private Cache<DeviceId, Boolean> gatewayFlagByDeviceId;
@@ -70,7 +76,7 @@ public class GatewayFlagCache {
     public void init() {
         gatewayFlagByDeviceId = Caffeine.newBuilder()
                 .maximumSize(maxSize)
-                .expireAfterWrite(Duration.ofMinutes(timeToLiveInMinutes))
+                .expireAfterAccess(Duration.ofMinutes(timeToLiveInMinutes))
                 .build();
     }
 

--- a/application/src/main/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionService.java
@@ -230,7 +230,7 @@ public class DefaultTelemetrySubscriptionService extends AbstractSubscriptionSer
         }
 
         if (attributesEdgeSyncService.isEdgeSyncRequired(request)) {
-            addMainCallback(resultFuture, success -> attributesEdgeSyncService.onAttributesUpdate(request));
+            attributesEdgeSyncService.onAttributesUpdate(request, resultFuture);
         }
 
         if (strategy.sendWsUpdate()) {
@@ -296,7 +296,7 @@ public class DefaultTelemetrySubscriptionService extends AbstractSubscriptionSer
         }
 
         if (attributesEdgeSyncService.isEdgeSyncRequired(request)) {
-            addMainCallback(deleteFuture, success -> attributesEdgeSyncService.onAttributesDelete(request));
+            attributesEdgeSyncService.onAttributesDelete(request, deleteFuture);
         }
 
         addWsCallback(deleteFuture, success -> onAttributesDelete(tenantId, entityId, request.getScope().name(), request.getKeys()));

--- a/application/src/main/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionService.java
@@ -58,6 +58,7 @@ import org.thingsboard.server.dao.timeseries.TimeseriesService;
 import org.thingsboard.server.dao.util.KvUtils;
 import org.thingsboard.server.service.apiusage.TbApiUsageStateService;
 import org.thingsboard.server.service.cf.CalculatedFieldQueueService;
+import org.thingsboard.server.service.edge.attributes.AttributesEdgeSyncService;
 import org.thingsboard.server.service.entitiy.entityview.TbEntityViewService;
 import org.thingsboard.server.service.state.DefaultDeviceStateService;
 import org.thingsboard.server.service.subscription.TbSubscriptionUtils;
@@ -90,6 +91,7 @@ public class DefaultTelemetrySubscriptionService extends AbstractSubscriptionSer
     private final TbApiUsageStateService apiUsageStateService;
     private final CalculatedFieldQueueService calculatedFieldQueueService;
     private final DeviceStateManager deviceStateManager;
+    private final AttributesEdgeSyncService attributesEdgeSyncService;
 
     private ExecutorService tsCallBackExecutor;
 
@@ -104,7 +106,8 @@ public class DefaultTelemetrySubscriptionService extends AbstractSubscriptionSer
                                                TbApiUsageReportClient apiUsageClient,
                                                TbApiUsageStateService apiUsageStateService,
                                                CalculatedFieldQueueService calculatedFieldQueueService,
-                                               DeviceStateManager deviceStateManager) {
+                                               DeviceStateManager deviceStateManager,
+                                               AttributesEdgeSyncService attributesEdgeSyncService) {
         this.attrService = attrService;
         this.tsService = tsService;
         this.tbEntityViewService = tbEntityViewService;
@@ -112,6 +115,7 @@ public class DefaultTelemetrySubscriptionService extends AbstractSubscriptionSer
         this.apiUsageStateService = apiUsageStateService;
         this.calculatedFieldQueueService = calculatedFieldQueueService;
         this.deviceStateManager = deviceStateManager;
+        this.attributesEdgeSyncService = attributesEdgeSyncService;
     }
 
     @PostConstruct
@@ -225,6 +229,10 @@ public class DefaultTelemetrySubscriptionService extends AbstractSubscriptionSer
             );
         }
 
+        if (attributesEdgeSyncService.isEdgeSyncRequired(request)) {
+            addMainCallback(resultFuture, success -> attributesEdgeSyncService.onAttributesUpdate(request));
+        }
+
         if (strategy.sendWsUpdate()) {
             addWsCallback(resultFuture, success -> onAttributesUpdate(tenantId, entityId, request.getScope().name(), request.getEntries()));
         }
@@ -285,6 +293,10 @@ public class DefaultTelemetrySubscriptionService extends AbstractSubscriptionSer
             addMainCallback(deleteFuture, success -> deviceStateManager.onDeviceInactivityTimeoutUpdate(
                     tenantId, new DeviceId(entityId.getId()), 0L, TbCallback.EMPTY)
             );
+        }
+
+        if (attributesEdgeSyncService.isEdgeSyncRequired(request)) {
+            addMainCallback(deleteFuture, success -> attributesEdgeSyncService.onAttributesDelete(request));
         }
 
         addWsCallback(deleteFuture, success -> onAttributesDelete(tenantId, entityId, request.getScope().name(), request.getKeys()));

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -654,6 +654,11 @@ cache:
     # Will enable cache-aside strategy for SQL timeseries latest DAO.
     # make sure that if cache.type is 'redis' and cache.ts_latest.enabled is 'true' if you change 'maxmemory-policy' Redis config property to 'allkeys-lru', 'allkeys-lfu' or 'allkeys-random'
     enabled: "${CACHE_TS_LATEST_ENABLED:true}"
+  gateway_flag:
+    # Maximum number of entries in the local (always in-memory, per node) cache of the device gateway flag, used by the attributes sync to edge
+    max_size: "${CACHE_GATEWAY_FLAG_MAX_SIZE:100000}"
+    # Time to live of the cached gateway flag. Bounds the flag staleness in case a device lifecycle broadcast is missed
+    time_to_live_in_minutes: "${CACHE_GATEWAY_FLAG_TTL:5}"
   specs:
     relations:
       timeToLiveInMinutes: "${CACHE_SPECS_RELATIONS_TTL:1440}" # Relations cache TTL
@@ -1644,6 +1649,10 @@ edges:
   send_scheduler_pool_size: "${EDGES_SEND_SCHEDULER_POOL_SIZE:4}"
   # Number of threads that are used to convert edge events from DB into downlink messages and send them for delivery
   grpc_callback_thread_pool_size: "${EDGES_GRPC_CALLBACK_POOL_SIZE:4}"
+  # Number of single-thread workers that are used to sync attribute updates to edge (e.g. configuration attributes of gateway devices). The worker is selected by the entity id to preserve the per-entity order of events
+  attributes_sync_pool_size: "${EDGES_ATTRIBUTES_SYNC_POOL_SIZE:4}"
+  # Maximum number of pending attribute sync tasks per worker. When the queue is full, new tasks are discarded - such updates reach the edge only with the next update of the same attributes or a manual edge synchronization
+  attributes_sync_max_queue_size: "${EDGES_ATTRIBUTES_SYNC_MAX_QUEUE_SIZE:10000}"
   state:
     # Persist state of edge (active, last connect, last disconnect) into timeseries or attributes tables. 'false' means to store edge state into attributes table
     persistToTelemetry: "${EDGES_PERSIST_STATE_TO_TELEMETRY:false}"

--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -656,9 +656,9 @@ cache:
     enabled: "${CACHE_TS_LATEST_ENABLED:true}"
   gateway_flag:
     # Maximum number of entries in the local (always in-memory, per node) cache of the device gateway flag, used by the attributes sync to edge
-    max_size: "${CACHE_GATEWAY_FLAG_MAX_SIZE:100000}"
-    # Time to live of the cached gateway flag. Bounds the flag staleness in case a device lifecycle broadcast is missed
-    time_to_live_in_minutes: "${CACHE_GATEWAY_FLAG_TTL:5}"
+    max_size: "${CACHE_GATEWAY_FLAG_MAX_SIZE:500000}"
+    # Time to live of the cached gateway flag, counted since the last access. Bounds the flag staleness in case a device lifecycle broadcast is missed
+    time_to_live_in_minutes: "${CACHE_GATEWAY_FLAG_TTL:30}"
   specs:
     relations:
       timeToLiveInMinutes: "${CACHE_SPECS_RELATIONS_TTL:1440}" # Relations cache TTL
@@ -1650,9 +1650,9 @@ edges:
   # Number of threads that are used to convert edge events from DB into downlink messages and send them for delivery
   grpc_callback_thread_pool_size: "${EDGES_GRPC_CALLBACK_POOL_SIZE:4}"
   # Number of single-thread workers that are used to sync attribute updates to edge (e.g. configuration attributes of gateway devices). The worker is selected by the entity id to preserve the per-entity order of events
-  attributes_sync_pool_size: "${EDGES_ATTRIBUTES_SYNC_POOL_SIZE:4}"
+  attributes_sync_pool_size: "${EDGES_ATTRIBUTES_SYNC_POOL_SIZE:8}"
   # Maximum number of pending attribute sync tasks per worker. When the queue is full, new tasks are discarded - such updates reach the edge only with the next update of the same attributes or a manual edge synchronization
-  attributes_sync_max_queue_size: "${EDGES_ATTRIBUTES_SYNC_MAX_QUEUE_SIZE:10000}"
+  attributes_sync_max_queue_size: "${EDGES_ATTRIBUTES_SYNC_MAX_QUEUE_SIZE:5000}"
   state:
     # Persist state of edge (active, last connect, last disconnect) into timeseries or attributes tables. 'false' means to store edge state into attributes table
     persistToTelemetry: "${EDGES_PERSIST_STATE_TO_TELEMETRY:false}"

--- a/application/src/test/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncServiceTest.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.attributes;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.rule.engine.api.AttributesDeleteRequest;
+import org.thingsboard.rule.engine.api.AttributesSaveRequest;
+import org.thingsboard.server.common.data.AttributeScope;
+import org.thingsboard.server.common.data.DataConstants;
+import org.thingsboard.server.common.data.EntityType;
+import org.thingsboard.server.common.data.id.AssetId;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.BaseAttributeKvEntry;
+import org.thingsboard.server.common.data.kv.StringDataEntry;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class AttributesEdgeSyncServiceTest {
+
+    final TenantId tenantId = TenantId.fromUUID(UUID.fromString("a00ec470-c6b4-11ef-8c88-63b5533fb5bc"));
+    final DeviceId deviceId = DeviceId.fromString("cc51e450-53e1-11ee-883e-e56b48fd2088");
+
+    @Mock
+    AttributesEdgeSyncStrategy deviceSyncStrategy;
+
+    AttributesEdgeSyncService service;
+
+    @BeforeEach
+    void setup() {
+        lenient().when(deviceSyncStrategy.getEntityType()).thenReturn(EntityType.DEVICE);
+        service = new AttributesEdgeSyncService(List.of(deviceSyncStrategy));
+        // init() with edges disabled only builds the strategy registry; enable edges and inject a direct executor afterwards
+        service.init();
+        ReflectionTestUtils.setField(service, "edgesEnabled", true);
+        ReflectionTestUtils.setField(service, "executors", new ExecutorService[]{MoreExecutors.newDirectExecutorService()});
+    }
+
+    @Test
+    void shouldConsultStrategyWhenGeneralRulesPass() {
+        given(deviceSyncStrategy.isEdgeSyncRequired(any(AttributesSaveRequest.class))).willReturn(true);
+        assertThat(service.isEdgeSyncRequired(saveRequest(null, AttributesSaveRequest.Strategy.PROCESS_ALL))).isTrue();
+
+        given(deviceSyncStrategy.isEdgeSyncRequired(any(AttributesDeleteRequest.class))).willReturn(true);
+        assertThat(service.isEdgeSyncRequired(deleteRequest(null))).isTrue();
+    }
+
+    @Test
+    void shouldNotBeRequiredWhenEdgesDisabled() {
+        ReflectionTestUtils.setField(service, "edgesEnabled", false);
+
+        assertThat(service.isEdgeSyncRequired(saveRequest(null, AttributesSaveRequest.Strategy.PROCESS_ALL))).isFalse();
+        assertThat(service.isEdgeSyncRequired(deleteRequest(null))).isFalse();
+        then(deviceSyncStrategy).should(never()).isEdgeSyncRequired(any(AttributesSaveRequest.class));
+        then(deviceSyncStrategy).should(never()).isEdgeSyncRequired(any(AttributesDeleteRequest.class));
+    }
+
+    @Test
+    void shouldNotBeRequiredWhenUpdateOriginatedFromEdge() {
+        assertThat(service.isEdgeSyncRequired(saveRequest(DataConstants.EDGE_MSG_SOURCE, AttributesSaveRequest.Strategy.PROCESS_ALL))).isFalse();
+        assertThat(service.isEdgeSyncRequired(deleteRequest(DataConstants.EDGE_MSG_SOURCE))).isFalse();
+        then(deviceSyncStrategy).should(never()).isEdgeSyncRequired(any(AttributesSaveRequest.class));
+        then(deviceSyncStrategy).should(never()).isEdgeSyncRequired(any(AttributesDeleteRequest.class));
+    }
+
+    @Test
+    void shouldNotBeRequiredWhenSaveStrategyDoesNotPersistAttributes() {
+        assertThat(service.isEdgeSyncRequired(saveRequest(null, AttributesSaveRequest.Strategy.WS_ONLY))).isFalse();
+        then(deviceSyncStrategy).should(never()).isEdgeSyncRequired(any(AttributesSaveRequest.class));
+    }
+
+    @Test
+    void shouldNotBeRequiredWhenNoStrategyRegisteredForEntityType() {
+        var request = AttributesSaveRequest.builder()
+                .tenantId(tenantId)
+                .entityId(new AssetId(UUID.randomUUID()))
+                .scope(AttributeScope.SHARED_SCOPE)
+                .entry(new BaseAttributeKvEntry(new StringDataEntry("key", "value"), 100L))
+                .build();
+
+        assertThat(service.isEdgeSyncRequired(request)).isFalse();
+        then(deviceSyncStrategy).should(never()).isEdgeSyncRequired(any(AttributesSaveRequest.class));
+    }
+
+    @Test
+    void shouldDispatchUpdateToStrategy() {
+        var request = saveRequest(null, AttributesSaveRequest.Strategy.PROCESS_ALL);
+
+        service.onAttributesUpdate(request);
+
+        then(deviceSyncStrategy).should().onAttributesUpdate(request);
+    }
+
+    @Test
+    void shouldDispatchDeleteToStrategy() {
+        var request = deleteRequest(null);
+
+        service.onAttributesDelete(request);
+
+        then(deviceSyncStrategy).should().onAttributesDelete(request);
+    }
+
+    @Test
+    void shouldIgnoreEventsForEntityTypesWithoutStrategy() {
+        var request = AttributesDeleteRequest.builder()
+                .tenantId(tenantId)
+                .entityId(new AssetId(UUID.randomUUID()))
+                .scope(AttributeScope.SHARED_SCOPE)
+                .keys(List.of("key"))
+                .build();
+
+        service.onAttributesDelete(request);
+
+        then(deviceSyncStrategy).should(never()).onAttributesDelete(any());
+    }
+
+    AttributesSaveRequest saveRequest(String msgSource, AttributesSaveRequest.Strategy strategy) {
+        return AttributesSaveRequest.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .scope(AttributeScope.SHARED_SCOPE)
+                .entry(new BaseAttributeKvEntry(new StringDataEntry("Modbus", "{}"), 100L))
+                .msgSource(msgSource)
+                .strategy(strategy)
+                .build();
+    }
+
+    AttributesDeleteRequest deleteRequest(String msgSource) {
+        return AttributesDeleteRequest.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .scope(AttributeScope.SHARED_SCOPE)
+                .keys(List.of("Modbus"))
+                .msgSource(msgSource)
+                .build();
+    }
+}

--- a/application/src/test/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncServiceTest.java
@@ -36,12 +36,17 @@ import org.thingsboard.server.common.data.kv.StringDataEntry;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
@@ -115,7 +120,7 @@ class AttributesEdgeSyncServiceTest {
     void shouldDispatchUpdateToStrategy() {
         var request = saveRequest(null, AttributesSaveRequest.Strategy.PROCESS_ALL);
 
-        service.onAttributesUpdate(request);
+        service.onAttributesUpdate(request, immediateFuture(null));
 
         then(deviceSyncStrategy).should().onAttributesUpdate(request);
     }
@@ -124,9 +129,40 @@ class AttributesEdgeSyncServiceTest {
     void shouldDispatchDeleteToStrategy() {
         var request = deleteRequest(null);
 
-        service.onAttributesDelete(request);
+        service.onAttributesDelete(request, immediateFuture(null));
 
         then(deviceSyncStrategy).should().onAttributesDelete(request);
+    }
+
+    @Test
+    void shouldNotDispatchUpdateWhenAttributesWereNotPersisted() {
+        var request = saveRequest(null, AttributesSaveRequest.Strategy.PROCESS_ALL);
+
+        service.onAttributesUpdate(request, immediateFailedFuture(new RuntimeException("failed to save")));
+
+        then(deviceSyncStrategy).should(never()).onAttributesUpdate(any());
+    }
+
+    @Test
+    void shouldNotDispatchDeleteWhenAttributesWereNotRemoved() {
+        var request = deleteRequest(null);
+
+        service.onAttributesDelete(request, immediateFailedFuture(new RuntimeException("failed to remove")));
+
+        then(deviceSyncStrategy).should(never()).onAttributesDelete(any());
+    }
+
+    @Test
+    void shouldDiscardEventWhenWorkerQueueIsFull() {
+        var rejectingExecutor = mock(ExecutorService.class);
+        willThrow(new RejectedExecutionException("queue is full")).given(rejectingExecutor).execute(any());
+        ReflectionTestUtils.setField(service, "executors", new ExecutorService[]{rejectingExecutor});
+        var request = saveRequest(null, AttributesSaveRequest.Strategy.PROCESS_ALL);
+
+        // the rejection must be swallowed - it must not propagate to the attributes save path
+        service.onAttributesUpdate(request, immediateFuture(null));
+
+        then(deviceSyncStrategy).should(never()).onAttributesUpdate(any());
     }
 
     @Test
@@ -138,7 +174,7 @@ class AttributesEdgeSyncServiceTest {
                 .keys(List.of("key"))
                 .build();
 
-        service.onAttributesDelete(request);
+        service.onAttributesDelete(request, immediateFuture(null));
 
         then(deviceSyncStrategy).should(never()).onAttributesDelete(any());
     }

--- a/application/src/test/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/attributes/AttributesEdgeSyncServiceTest.java
@@ -32,6 +32,8 @@ import org.thingsboard.server.common.data.id.DeviceId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.kv.BaseAttributeKvEntry;
 import org.thingsboard.server.common.data.kv.StringDataEntry;
+import org.thingsboard.server.common.stats.DefaultCounter;
+import org.thingsboard.server.common.stats.DefaultStatsFactory;
 
 import java.util.List;
 import java.util.UUID;
@@ -63,7 +65,9 @@ class AttributesEdgeSyncServiceTest {
     @BeforeEach
     void setup() {
         lenient().when(deviceSyncStrategy.getEntityType()).thenReturn(EntityType.DEVICE);
-        service = new AttributesEdgeSyncService(List.of(deviceSyncStrategy));
+        var statsFactory = new DefaultStatsFactory();
+        ReflectionTestUtils.setField(statsFactory, "metricsEnabled", false);
+        service = new AttributesEdgeSyncService(List.of(deviceSyncStrategy), statsFactory);
         // init() with edges disabled only builds the strategy registry; enable edges and inject a direct executor afterwards
         service.init();
         ReflectionTestUtils.setField(service, "edgesEnabled", true);
@@ -163,6 +167,11 @@ class AttributesEdgeSyncServiceTest {
         service.onAttributesUpdate(request, immediateFuture(null));
 
         then(deviceSyncStrategy).should(never()).onAttributesUpdate(any());
+        assertThat(discardedCounter()).isEqualTo(1);
+    }
+
+    int discardedCounter() {
+        return ((DefaultCounter) ReflectionTestUtils.getField(service, "discardedCounter")).get();
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/server/service/edge/attributes/GatewayAttributesEdgeSyncStrategyTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/attributes/GatewayAttributesEdgeSyncStrategyTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.attributes;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.rule.engine.api.AttributesDeleteRequest;
+import org.thingsboard.rule.engine.api.AttributesSaveRequest;
+import org.thingsboard.server.cluster.TbClusterService;
+import org.thingsboard.server.common.data.AttributeScope;
+import org.thingsboard.server.common.data.edge.EdgeEventActionType;
+import org.thingsboard.server.common.data.edge.EdgeEventType;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
+import org.thingsboard.server.common.data.kv.BaseAttributeKvEntry;
+import org.thingsboard.server.common.data.kv.LongDataEntry;
+import org.thingsboard.server.common.data.kv.StringDataEntry;
+import org.thingsboard.server.service.gateway_device.GatewayFlagCache;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class GatewayAttributesEdgeSyncStrategyTest {
+
+    final TenantId tenantId = TenantId.fromUUID(UUID.fromString("a00ec470-c6b4-11ef-8c88-63b5533fb5bc"));
+    final DeviceId deviceId = DeviceId.fromString("cc51e450-53e1-11ee-883e-e56b48fd2088");
+
+    @Mock
+    TbClusterService clusterService;
+    @Mock
+    GatewayFlagCache gatewayFlagCache;
+
+    GatewayAttributesEdgeSyncStrategy strategy;
+
+    @BeforeEach
+    void setup() {
+        strategy = new GatewayAttributesEdgeSyncStrategy(clusterService, gatewayFlagCache);
+        lenient().when(gatewayFlagCache.isPotentialGateway(deviceId)).thenReturn(true);
+    }
+
+    @Test
+    void sharedScopeUpdateRequiresSync() {
+        assertThat(strategy.isEdgeSyncRequired(saveRequest(AttributeScope.SHARED_SCOPE, "Modbus"))).isTrue();
+    }
+
+    @Test
+    void clientScopeUpdateDoesNotRequireSync() {
+        assertThat(strategy.isEdgeSyncRequired(saveRequest(AttributeScope.CLIENT_SCOPE, "current_configuration"))).isFalse();
+    }
+
+    @Test
+    void serverScopeUpdateRequiresSyncExceptActivityKeys() {
+        assertThat(strategy.isEdgeSyncRequired(saveRequest(AttributeScope.SERVER_SCOPE, "inactive_connectors"))).isTrue();
+        // configuration of a disabled connector is stored in the SERVER_SCOPE attribute named after the connector
+        assertThat(strategy.isEdgeSyncRequired(saveRequest(AttributeScope.SERVER_SCOPE, "Modbus"))).isTrue();
+        assertThat(strategy.isEdgeSyncRequired(saveRequest(AttributeScope.SERVER_SCOPE,
+                "active", "lastConnectTime", "lastDisconnectTime", "lastActivityTime", "inactivityAlarmTime"))).isFalse();
+    }
+
+    @Test
+    void deleteSyncRequiredChecks() {
+        assertThat(strategy.isEdgeSyncRequired(deleteRequest(AttributeScope.SHARED_SCOPE, "Modbus"))).isTrue();
+        assertThat(strategy.isEdgeSyncRequired(deleteRequest(AttributeScope.CLIENT_SCOPE, "Modbus"))).isFalse();
+        assertThat(strategy.isEdgeSyncRequired(deleteRequest(AttributeScope.SERVER_SCOPE, "inactive_connectors"))).isTrue();
+        assertThat(strategy.isEdgeSyncRequired(deleteRequest(AttributeScope.SERVER_SCOPE, "Modbus"))).isTrue();
+        assertThat(strategy.isEdgeSyncRequired(deleteRequest(AttributeScope.SERVER_SCOPE, "lastActivityTime"))).isFalse();
+    }
+
+    @Test
+    void shouldNotRequireSyncWhenDeviceIsKnownToBeNotAGateway() {
+        given(gatewayFlagCache.isPotentialGateway(deviceId)).willReturn(false);
+
+        assertThat(strategy.isEdgeSyncRequired(saveRequest(AttributeScope.SHARED_SCOPE, "Modbus"))).isFalse();
+        assertThat(strategy.isEdgeSyncRequired(deleteRequest(AttributeScope.SHARED_SCOPE, "Modbus"))).isFalse();
+    }
+
+    @Test
+    void shouldNotSendNotificationWhenDeviceIsNotGateway() {
+        given(gatewayFlagCache.isGateway(tenantId, deviceId)).willReturn(false);
+
+        strategy.onAttributesUpdate(saveRequest(AttributeScope.SHARED_SCOPE, "Modbus"));
+
+        then(clusterService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void shouldSendAttributesUpdatedNotificationForGateway() {
+        given(gatewayFlagCache.isGateway(tenantId, deviceId)).willReturn(true);
+
+        AttributesSaveRequest request = AttributesSaveRequest.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .scope(AttributeScope.SHARED_SCOPE)
+                .entries(List.of(
+                        new BaseAttributeKvEntry(new StringDataEntry("Modbus", "{\"name\":\"Modbus\"}"), 100L),
+                        new BaseAttributeKvEntry(new LongDataEntry("RemoteLoggingLevel", 42L), 200L)
+                ))
+                .build();
+        strategy.onAttributesUpdate(request);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        then(clusterService).should().sendNotificationMsgToEdge(eq(tenantId), isNull(), eq(deviceId), bodyCaptor.capture(),
+                eq(EdgeEventType.DEVICE), eq(EdgeEventActionType.ATTRIBUTES_UPDATED), isNull());
+
+        JsonNode body = JacksonUtil.toJsonNode(bodyCaptor.getValue());
+        assertThat(body.get("scope").asText()).isEqualTo("SHARED_SCOPE");
+        assertThat(body.get("ts").asLong()).isEqualTo(200L);
+        assertThat(body.get("kv").get("Modbus").asText()).isEqualTo("{\"name\":\"Modbus\"}");
+        assertThat(body.get("kv").get("RemoteLoggingLevel").asLong()).isEqualTo(42L);
+    }
+
+    @Test
+    void shouldFilterActivityKeysOutOfServerScopeNotification() {
+        given(gatewayFlagCache.isGateway(tenantId, deviceId)).willReturn(true);
+
+        strategy.onAttributesUpdate(saveRequest(AttributeScope.SERVER_SCOPE, "inactive_connectors", "Modbus", "lastActivityTime"));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        then(clusterService).should().sendNotificationMsgToEdge(eq(tenantId), isNull(), eq(deviceId), bodyCaptor.capture(),
+                eq(EdgeEventType.DEVICE), eq(EdgeEventActionType.ATTRIBUTES_UPDATED), isNull());
+
+        JsonNode kv = JacksonUtil.toJsonNode(bodyCaptor.getValue()).get("kv");
+        assertThat(kv.has("inactive_connectors")).isTrue();
+        assertThat(kv.has("Modbus")).isTrue();
+        assertThat(kv.has("lastActivityTime")).isFalse();
+    }
+
+    @Test
+    void shouldSendAttributesDeletedNotificationForGateway() {
+        given(gatewayFlagCache.isGateway(tenantId, deviceId)).willReturn(true);
+
+        strategy.onAttributesDelete(deleteRequest(AttributeScope.SHARED_SCOPE, "Modbus"));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        then(clusterService).should().sendNotificationMsgToEdge(eq(tenantId), isNull(), eq(deviceId), bodyCaptor.capture(),
+                eq(EdgeEventType.DEVICE), eq(EdgeEventActionType.ATTRIBUTES_DELETED), isNull());
+
+        JsonNode body = JacksonUtil.toJsonNode(bodyCaptor.getValue());
+        assertThat(body.get("scope").asText()).isEqualTo("SHARED_SCOPE");
+        assertThat(body.get("keys")).hasSize(1);
+        assertThat(body.get("keys").get(0).asText()).isEqualTo("Modbus");
+    }
+
+    AttributesSaveRequest saveRequest(AttributeScope scope, String... keys) {
+        return AttributesSaveRequest.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .scope(scope)
+                .entries(Stream.of(keys)
+                        .<AttributeKvEntry>map(key -> new BaseAttributeKvEntry(new StringDataEntry(key, "value"), 100L))
+                        .toList())
+                .build();
+    }
+
+    AttributesDeleteRequest deleteRequest(AttributeScope scope, String... keys) {
+        return AttributesDeleteRequest.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .scope(scope)
+                .keys(List.of(keys))
+                .build();
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/service/edge/attributes/GatewayAttributesEdgeSyncStrategyTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/attributes/GatewayAttributesEdgeSyncStrategyTest.java
@@ -47,6 +47,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class GatewayAttributesEdgeSyncStrategyTest {
@@ -122,7 +123,7 @@ class GatewayAttributesEdgeSyncStrategyTest {
                 .scope(AttributeScope.SHARED_SCOPE)
                 .entries(List.of(
                         new BaseAttributeKvEntry(new StringDataEntry("Modbus", "{\"name\":\"Modbus\"}"), 100L),
-                        new BaseAttributeKvEntry(new LongDataEntry("RemoteLoggingLevel", 42L), 200L)
+                        new BaseAttributeKvEntry(new LongDataEntry("RemoteLoggingLevel", 42L), 100L)
                 ))
                 .build();
         strategy.onAttributesUpdate(request);
@@ -133,9 +134,40 @@ class GatewayAttributesEdgeSyncStrategyTest {
 
         JsonNode body = JacksonUtil.toJsonNode(bodyCaptor.getValue());
         assertThat(body.get("scope").asText()).isEqualTo("SHARED_SCOPE");
-        assertThat(body.get("ts").asLong()).isEqualTo(200L);
+        assertThat(body.get("ts").asLong()).isEqualTo(100L);
         assertThat(body.get("kv").get("Modbus").asText()).isEqualTo("{\"name\":\"Modbus\"}");
         assertThat(body.get("kv").get("RemoteLoggingLevel").asLong()).isEqualTo(42L);
+    }
+
+    @Test
+    void shouldSendSeparateNotificationPerUpdateTsSoThatKeysKeepTheirOwnTs() {
+        given(gatewayFlagCache.isGateway(tenantId, deviceId)).willReturn(true);
+
+        AttributesSaveRequest request = AttributesSaveRequest.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .scope(AttributeScope.SHARED_SCOPE)
+                .entries(List.of(
+                        new BaseAttributeKvEntry(new StringDataEntry("Modbus", "{\"name\":\"Modbus\"}"), 100L),
+                        new BaseAttributeKvEntry(new LongDataEntry("RemoteLoggingLevel", 42L), 200L)
+                ))
+                .build();
+        strategy.onAttributesUpdate(request);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        then(clusterService).should(times(2)).sendNotificationMsgToEdge(eq(tenantId), isNull(), eq(deviceId), bodyCaptor.capture(),
+                eq(EdgeEventType.DEVICE), eq(EdgeEventActionType.ATTRIBUTES_UPDATED), isNull());
+
+        // the oldest group is sent first, and no key is stamped with another key's ts
+        JsonNode older = JacksonUtil.toJsonNode(bodyCaptor.getAllValues().get(0));
+        assertThat(older.get("ts").asLong()).isEqualTo(100L);
+        assertThat(older.get("kv").get("Modbus").asText()).isEqualTo("{\"name\":\"Modbus\"}");
+        assertThat(older.get("kv").has("RemoteLoggingLevel")).isFalse();
+
+        JsonNode newer = JacksonUtil.toJsonNode(bodyCaptor.getAllValues().get(1));
+        assertThat(newer.get("ts").asLong()).isEqualTo(200L);
+        assertThat(newer.get("kv").get("RemoteLoggingLevel").asLong()).isEqualTo(42L);
+        assertThat(newer.get("kv").has("Modbus")).isFalse();
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessorTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/edge/rpc/processor/BaseEdgeProcessorTest.java
@@ -1,0 +1,177 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.edge.rpc.processor;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.AttributeScope;
+import org.thingsboard.server.common.data.edge.EdgeEvent;
+import org.thingsboard.server.common.data.edge.EdgeEventActionType;
+import org.thingsboard.server.common.data.edge.EdgeEventType;
+import org.thingsboard.server.common.data.id.AssetId;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.EdgeId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
+import org.thingsboard.server.common.data.kv.BaseAttributeKvEntry;
+import org.thingsboard.server.common.data.kv.BooleanDataEntry;
+import org.thingsboard.server.dao.attributes.AttributesService;
+import org.thingsboard.server.dao.edge.EdgeEventService;
+import org.thingsboard.server.service.edge.EdgeContextComponent;
+import org.thingsboard.server.service.executors.DbCallbackExecutorService;
+import org.thingsboard.server.service.state.DefaultDeviceStateService;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class BaseEdgeProcessorTest {
+
+    final TenantId tenantId = TenantId.fromUUID(UUID.fromString("a00ec470-c6b4-11ef-8c88-63b5533fb5bc"));
+    final EdgeId edgeId = new EdgeId(UUID.fromString("d1f0e6a0-53e1-11ee-883e-e56b48fd2088"));
+    final DeviceId deviceId = DeviceId.fromString("cc51e450-53e1-11ee-883e-e56b48fd2088");
+
+    @Mock
+    EdgeContextComponent edgeCtx;
+    @Mock
+    AttributesService attributesService;
+    @Mock
+    EdgeEventService edgeEventService;
+    @Mock
+    DbCallbackExecutorService dbCallbackExecutorService;
+
+    TestEdgeProcessor processor;
+
+    static class TestEdgeProcessor extends BaseEdgeProcessor {
+    }
+
+    @BeforeEach
+    void setup() {
+        processor = new TestEdgeProcessor();
+        ReflectionTestUtils.setField(processor, "edgeCtx", edgeCtx);
+        ReflectionTestUtils.setField(processor, "dbCallbackExecutorService", dbCallbackExecutorService);
+        doAnswer(invocation -> {
+            invocation.getArgument(0, Runnable.class).run();
+            return null;
+        }).when(dbCallbackExecutorService).execute(any());
+        lenient().when(edgeCtx.getAttributesService()).thenReturn(attributesService);
+        lenient().when(edgeCtx.getEdgeEventService()).thenReturn(edgeEventService);
+        lenient().when(edgeEventService.saveAsync(any())).thenReturn(immediateFuture(null));
+    }
+
+    void givenEdgeIsOffline() {
+        AttributeKvEntry active = new BaseAttributeKvEntry(new BooleanDataEntry(DefaultDeviceStateService.ACTIVITY_STATE, false), 100L);
+        given(attributesService.find(tenantId, edgeId, AttributeScope.SERVER_SCOPE, DefaultDeviceStateService.ACTIVITY_STATE))
+                .willReturn(immediateFuture(Optional.of(active)));
+    }
+
+    JsonNode attributesBody() {
+        return JacksonUtil.toJsonNode("{\"kv\":{\"Modbus\":\"{}\"},\"ts\":100,\"scope\":\"SHARED_SCOPE\"}");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EdgeEventActionType.class, names = {"ATTRIBUTES_UPDATED", "ATTRIBUTES_DELETED"})
+    void shouldSaveDeviceAttributesEventWhileEdgeIsOffline(EdgeEventActionType action) throws Exception {
+        // GIVEN
+        givenEdgeIsOffline();
+
+        // WHEN
+        processor.saveEdgeEvent(tenantId, edgeId, EdgeEventType.DEVICE, action, deviceId, attributesBody()).get();
+
+        // THEN
+        ArgumentCaptor<EdgeEvent> captor = ArgumentCaptor.forClass(EdgeEvent.class);
+        then(edgeEventService).should().saveAsync(captor.capture());
+
+        EdgeEvent edgeEvent = captor.getValue();
+        assertThat(edgeEvent.getEdgeId()).isEqualTo(edgeId);
+        assertThat(edgeEvent.getType()).isEqualTo(EdgeEventType.DEVICE);
+        assertThat(edgeEvent.getAction()).isEqualTo(action);
+        assertThat(edgeEvent.getEntityId()).isEqualTo(deviceId.getId());
+        assertThat(edgeEvent.getBody()).isEqualTo(attributesBody());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EdgeEventActionType.class, names = {"ATTRIBUTES_UPDATED", "ATTRIBUTES_DELETED"})
+    void shouldNotSaveAttributesEventOfOtherEntityTypesWhileEdgeIsOffline(EdgeEventActionType action) throws Exception {
+        // GIVEN
+        givenEdgeIsOffline();
+        var assetId = new AssetId(UUID.randomUUID());
+
+        // WHEN
+        processor.saveEdgeEvent(tenantId, edgeId, EdgeEventType.ASSET, action, assetId, attributesBody()).get();
+
+        // THEN
+        then(edgeEventService).should(never()).saveAsync(any());
+    }
+
+    @Test
+    void shouldNotSaveDeviceUpdatedEventWhileEdgeIsOffline() throws Exception {
+        // GIVEN
+        givenEdgeIsOffline();
+
+        // WHEN
+        processor.saveEdgeEvent(tenantId, edgeId, EdgeEventType.DEVICE, EdgeEventActionType.UPDATED, deviceId, null).get();
+
+        // THEN
+        then(edgeEventService).should(never()).saveAsync(any());
+    }
+
+    @Test
+    void shouldNotSaveDeviceAttributesEventWhenEdgeWasNeverActivated() throws Exception {
+        // GIVEN
+        given(attributesService.find(tenantId, edgeId, AttributeScope.SERVER_SCOPE, DefaultDeviceStateService.ACTIVITY_STATE))
+                .willReturn(immediateFuture(Optional.empty()));
+
+        // WHEN
+        processor.saveEdgeEvent(tenantId, edgeId, EdgeEventType.DEVICE, EdgeEventActionType.ATTRIBUTES_UPDATED, deviceId, attributesBody()).get();
+
+        // THEN
+        then(edgeEventService).should(never()).saveAsync(any());
+    }
+
+    @Test
+    void shouldSaveDeviceAttributesEventWhileEdgeIsActive() throws Exception {
+        // GIVEN
+        AttributeKvEntry active = new BaseAttributeKvEntry(new BooleanDataEntry(DefaultDeviceStateService.ACTIVITY_STATE, true), 100L);
+        given(attributesService.find(tenantId, edgeId, AttributeScope.SERVER_SCOPE, DefaultDeviceStateService.ACTIVITY_STATE))
+                .willReturn(immediateFuture(Optional.of(active)));
+
+        // WHEN
+        processor.saveEdgeEvent(tenantId, edgeId, EdgeEventType.DEVICE, EdgeEventActionType.ATTRIBUTES_UPDATED, deviceId, attributesBody()).get();
+
+        // THEN
+        then(edgeEventService).should().saveAsync(any());
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/service/gateway_device/GatewayFlagCacheTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/gateway_device/GatewayFlagCacheTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.gateway_device;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.server.common.data.DataConstants;
+import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.id.AssetId;
+import org.thingsboard.server.common.data.id.DeviceId;
+import org.thingsboard.server.common.data.id.TenantId;
+import org.thingsboard.server.common.data.plugin.ComponentLifecycleEvent;
+import org.thingsboard.server.common.msg.plugin.ComponentLifecycleMsg;
+import org.thingsboard.server.dao.device.DeviceService;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class GatewayFlagCacheTest {
+
+    final TenantId tenantId = TenantId.fromUUID(UUID.fromString("a00ec470-c6b4-11ef-8c88-63b5533fb5bc"));
+    final DeviceId deviceId = DeviceId.fromString("cc51e450-53e1-11ee-883e-e56b48fd2088");
+
+    @Mock
+    DeviceService deviceService;
+
+    GatewayFlagCache cache;
+
+    @BeforeEach
+    void setup() {
+        cache = new GatewayFlagCache(deviceService);
+        ReflectionTestUtils.setField(cache, "maxSize", 100);
+        ReflectionTestUtils.setField(cache, "timeToLiveInMinutes", 5);
+        cache.init();
+    }
+
+    Device device(boolean gateway) {
+        Device device = new Device(deviceId);
+        device.setTenantId(tenantId);
+        if (gateway) {
+            device.setAdditionalInfo(JacksonUtil.newObjectNode().put(DataConstants.GATEWAY_PARAMETER, true));
+        }
+        return device;
+    }
+
+    @Test
+    void unknownFlagIsTreatedAsPotentialGateway() {
+        assertThat(cache.isPotentialGateway(deviceId)).isTrue();
+    }
+
+    @Test
+    void resolvedFlagIsCachedAndUsedByPotentialGatewayCheck() {
+        given(deviceService.findDeviceById(tenantId, deviceId)).willReturn(device(false));
+
+        assertThat(cache.isGateway(tenantId, deviceId)).isFalse();
+        assertThat(cache.isPotentialGateway(deviceId)).isFalse();
+
+        // subsequent checks are served from the cache without a device lookup
+        assertThat(cache.isGateway(tenantId, deviceId)).isFalse();
+        then(deviceService).should(times(1)).findDeviceById(tenantId, deviceId);
+    }
+
+    @Test
+    void flagIsResolvedAgainAfterInvalidation() {
+        given(deviceService.findDeviceById(tenantId, deviceId)).willReturn(device(false));
+        assertThat(cache.isGateway(tenantId, deviceId)).isFalse();
+
+        cache.onDeviceLifecycleEvent(ComponentLifecycleMsg.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .event(ComponentLifecycleEvent.UPDATED)
+                .build());
+
+        given(deviceService.findDeviceById(tenantId, deviceId)).willReturn(device(true));
+        assertThat(cache.isGateway(tenantId, deviceId)).isTrue();
+        then(deviceService).should(times(2)).findDeviceById(tenantId, deviceId);
+    }
+
+    @Test
+    void missingDeviceIsResolvedAsNotAGateway() {
+        given(deviceService.findDeviceById(tenantId, deviceId)).willReturn(null);
+
+        assertThat(cache.isGateway(tenantId, deviceId)).isFalse();
+        assertThat(cache.isPotentialGateway(deviceId)).isFalse();
+    }
+
+    @Test
+    void deviceLifecycleEventInvalidatesTheFlag() {
+        given(deviceService.findDeviceById(tenantId, deviceId)).willReturn(device(false));
+        cache.isGateway(tenantId, deviceId);
+        assertThat(cache.isPotentialGateway(deviceId)).isFalse();
+
+        cache.onDeviceLifecycleEvent(ComponentLifecycleMsg.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .event(ComponentLifecycleEvent.UPDATED)
+                .build());
+
+        assertThat(cache.isPotentialGateway(deviceId)).isTrue();
+    }
+
+    @Test
+    void nonDeviceLifecycleEventIsIgnored() {
+        given(deviceService.findDeviceById(tenantId, deviceId)).willReturn(device(false));
+        cache.isGateway(tenantId, deviceId);
+
+        cache.onDeviceLifecycleEvent(ComponentLifecycleMsg.builder()
+                .tenantId(tenantId)
+                .entityId(new AssetId(deviceId.getId()))
+                .event(ComponentLifecycleEvent.UPDATED)
+                .build());
+
+        assertThat(cache.isPotentialGateway(deviceId)).isFalse();
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionServiceTest.java
@@ -987,7 +987,7 @@ class DefaultTelemetrySubscriptionServiceTest {
         then(clusterService).should().pushMsgToCore(eq(expectedAttributesDeletedMsg), isNull());
     }
 
-§    @Test
+    @Test
     void shouldNotifyAttributesEdgeSyncServiceWhenEdgeSyncIsRequiredForDelete() {
         // GIVEN
         var deviceId = DeviceId.fromString("cc51e450-53e1-11ee-883e-e56b48fd2088");

--- a/application/src/test/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionServiceTest.java
@@ -754,7 +754,7 @@ class DefaultTelemetrySubscriptionServiceTest {
         telemetryService.saveAttributes(request);
 
         // THEN
-        then(attributesEdgeSyncService).should().onAttributesUpdate(request);
+        then(attributesEdgeSyncService).should().onAttributesUpdate(eq(request), any());
     }
 
     @Test
@@ -777,7 +777,7 @@ class DefaultTelemetrySubscriptionServiceTest {
         telemetryService.saveAttributes(request);
 
         // THEN
-        then(attributesEdgeSyncService).should(never()).onAttributesUpdate(any());
+        then(attributesEdgeSyncService).should(never()).onAttributesUpdate(any(), any());
     }
 
     @Test
@@ -1008,7 +1008,7 @@ class DefaultTelemetrySubscriptionServiceTest {
         telemetryService.deleteAttributes(request);
 
         // THEN
-        then(attributesEdgeSyncService).should().onAttributesDelete(request);
+        then(attributesEdgeSyncService).should().onAttributesDelete(eq(request), any());
     }
 
     @Test
@@ -1032,7 +1032,7 @@ class DefaultTelemetrySubscriptionServiceTest {
         telemetryService.deleteAttributes(request);
 
         // THEN
-        then(attributesEdgeSyncService).should(never()).onAttributesDelete(any());
+        then(attributesEdgeSyncService).should(never()).onAttributesDelete(any(), any());
     }
 
     @ParameterizedTest

--- a/application/src/test/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/telemetry/DefaultTelemetrySubscriptionServiceTest.java
@@ -71,6 +71,7 @@ import org.thingsboard.server.queue.discovery.QueueKey;
 import org.thingsboard.server.queue.discovery.event.PartitionChangeEvent;
 import org.thingsboard.server.service.apiusage.TbApiUsageStateService;
 import org.thingsboard.server.service.cf.CalculatedFieldQueueService;
+import org.thingsboard.server.service.edge.attributes.AttributesEdgeSyncService;
 import org.thingsboard.server.service.entitiy.entityview.TbEntityViewService;
 import org.thingsboard.server.service.subscription.SubscriptionManagerService;
 
@@ -142,12 +143,14 @@ class DefaultTelemetrySubscriptionServiceTest {
     CalculatedFieldQueueService calculatedFieldQueueService;
     @Mock
     DeviceStateManager deviceStateManager;
+    @Mock
+    AttributesEdgeSyncService attributesEdgeSyncService;
 
     DefaultTelemetrySubscriptionService telemetryService;
 
     @BeforeEach
     void setup() {
-        telemetryService = new DefaultTelemetrySubscriptionService(attrService, tsService, tbEntityViewService, apiUsageClient, apiUsageStateService, calculatedFieldQueueService, deviceStateManager);
+        telemetryService = new DefaultTelemetrySubscriptionService(attrService, tsService, tbEntityViewService, apiUsageClient, apiUsageStateService, calculatedFieldQueueService, deviceStateManager, attributesEdgeSyncService);
         ReflectionTestUtils.setField(telemetryService, "clusterService", clusterService);
         ReflectionTestUtils.setField(telemetryService, "partitionService", partitionService);
         ReflectionTestUtils.setField(telemetryService, "subscriptionManagerService", Optional.of(subscriptionManagerService));
@@ -732,6 +735,52 @@ class DefaultTelemetrySubscriptionServiceTest {
     }
 
     @Test
+    void shouldNotifyAttributesEdgeSyncServiceWhenEdgeSyncIsRequiredForSave() {
+        // GIVEN
+        var deviceId = DeviceId.fromString("cc51e450-53e1-11ee-883e-e56b48fd2088");
+        var request = AttributesSaveRequest.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .scope(AttributeScope.SHARED_SCOPE)
+                .entry(new BaseAttributeKvEntry(123L, new StringDataEntry("Modbus", "{}")))
+                .strategy(new AttributesSaveRequest.Strategy(true, false, false))
+                .build();
+
+        given(attributesEdgeSyncService.isEdgeSyncRequired(request)).willReturn(true);
+        given(attrService.save(tenantId, deviceId, request.getScope(), request.getEntries()))
+                .willReturn(immediateFuture(AttributesSaveResult.of(listOfNNumbers(request.getEntries().size()))));
+
+        // WHEN
+        telemetryService.saveAttributes(request);
+
+        // THEN
+        then(attributesEdgeSyncService).should().onAttributesUpdate(request);
+    }
+
+    @Test
+    void shouldNotNotifyAttributesEdgeSyncServiceWhenEdgeSyncIsNotRequiredForSave() {
+        // GIVEN
+        var deviceId = DeviceId.fromString("cc51e450-53e1-11ee-883e-e56b48fd2088");
+        var request = AttributesSaveRequest.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .scope(AttributeScope.CLIENT_SCOPE)
+                .entry(new BaseAttributeKvEntry(123L, new StringDataEntry("clientKey", "value")))
+                .strategy(new AttributesSaveRequest.Strategy(true, false, false))
+                .build();
+
+        given(attributesEdgeSyncService.isEdgeSyncRequired(request)).willReturn(false);
+        given(attrService.save(tenantId, deviceId, request.getScope(), request.getEntries()))
+                .willReturn(immediateFuture(AttributesSaveResult.of(listOfNNumbers(request.getEntries().size()))));
+
+        // WHEN
+        telemetryService.saveAttributes(request);
+
+        // THEN
+        then(attributesEdgeSyncService).should(never()).onAttributesUpdate(any());
+    }
+
+    @Test
     void shouldNotNotifyDeviceStateManagerWhenDeviceInactivityTimeoutSaveWasSkipped() {
         // GIVEN
         var deviceId = DeviceId.fromString("cc51e450-53e1-11ee-883e-e56b48fd2088");
@@ -936,6 +985,54 @@ class DefaultTelemetrySubscriptionServiceTest {
         var expectedAttributesDeletedMsg = DeviceAttributesEventNotificationMsg.onDelete(tenantId, deviceId, "SHARED_SCOPE", List.of("attributeKeyToDelete1", "attributeKeyToDelete2"));
 
         then(clusterService).should().pushMsgToCore(eq(expectedAttributesDeletedMsg), isNull());
+    }
+
+§    @Test
+    void shouldNotifyAttributesEdgeSyncServiceWhenEdgeSyncIsRequiredForDelete() {
+        // GIVEN
+        var deviceId = DeviceId.fromString("cc51e450-53e1-11ee-883e-e56b48fd2088");
+        List<String> keys = List.of("Modbus");
+
+        var request = AttributesDeleteRequest.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .scope(AttributeScope.SHARED_SCOPE)
+                .keys(keys)
+                .notifyDevice(false)
+                .build();
+
+        given(attributesEdgeSyncService.isEdgeSyncRequired(request)).willReturn(true);
+        given(attrService.removeAll(tenantId, deviceId, request.getScope(), keys)).willReturn(immediateFuture(keys));
+
+        // WHEN
+        telemetryService.deleteAttributes(request);
+
+        // THEN
+        then(attributesEdgeSyncService).should().onAttributesDelete(request);
+    }
+
+    @Test
+    void shouldNotNotifyAttributesEdgeSyncServiceWhenEdgeSyncIsNotRequiredForDelete() {
+        // GIVEN
+        var deviceId = DeviceId.fromString("cc51e450-53e1-11ee-883e-e56b48fd2088");
+        List<String> keys = List.of("clientKey");
+
+        var request = AttributesDeleteRequest.builder()
+                .tenantId(tenantId)
+                .entityId(deviceId)
+                .scope(AttributeScope.CLIENT_SCOPE)
+                .keys(keys)
+                .notifyDevice(false)
+                .build();
+
+        given(attributesEdgeSyncService.isEdgeSyncRequired(request)).willReturn(false);
+        given(attrService.removeAll(tenantId, deviceId, request.getScope(), keys)).willReturn(immediateFuture(keys));
+
+        // WHEN
+        telemetryService.deleteAttributes(request);
+
+        // THEN
+        then(attributesEdgeSyncService).should(never()).onAttributesDelete(any());
     }
 
     @ParameterizedTest

--- a/common/util/src/main/java/org/thingsboard/common/util/ThingsBoardExecutors.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/ThingsBoardExecutors.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -60,10 +61,14 @@ public class ThingsBoardExecutors {
      * executor with limited tasks queue size
      * */
     public static ExecutorService newLimitedTasksExecutor(int threads, int maxQueueSize, String name) {
+        return newLimitedTasksExecutor(threads, maxQueueSize, name, new ThreadPoolExecutor.CallerRunsPolicy());
+    }
+
+    public static ExecutorService newLimitedTasksExecutor(int threads, int maxQueueSize, String name, RejectedExecutionHandler rejectedExecutionHandler) {
         ThreadPoolExecutor executor = new ThreadPoolExecutor(threads, threads,
                 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(maxQueueSize),
                 ThingsBoardThreadFactory.forName(name),
-                new ThreadPoolExecutor.CallerRunsPolicy());
+                rejectedExecutionHandler);
         executor.allowCoreThreadTimeOut(true);
         return executor;
     }

--- a/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/AttributesDeleteRequest.java
+++ b/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/AttributesDeleteRequest.java
@@ -46,6 +46,7 @@ public class AttributesDeleteRequest implements CalculatedFieldSystemAwareReques
     private final List<CalculatedFieldId> previousCalculatedFieldIds;
     private final UUID tbMsgId;
     private final TbMsgType tbMsgType;
+    private final String msgSource;
     private final FutureCallback<Void> callback;
 
     public static Builder builder() {
@@ -62,6 +63,7 @@ public class AttributesDeleteRequest implements CalculatedFieldSystemAwareReques
         private List<CalculatedFieldId> previousCalculatedFieldIds;
         private UUID tbMsgId;
         private TbMsgType tbMsgType;
+        private String msgSource;
         private FutureCallback<Void> callback;
 
         Builder() {}
@@ -116,6 +118,11 @@ public class AttributesDeleteRequest implements CalculatedFieldSystemAwareReques
             return this;
         }
 
+        public Builder msgSource(String msgSource) {
+            this.msgSource = msgSource;
+            return this;
+        }
+
         public Builder callback(FutureCallback<Void> callback) {
             this.callback = callback;
             return this;
@@ -137,7 +144,7 @@ public class AttributesDeleteRequest implements CalculatedFieldSystemAwareReques
 
         public AttributesDeleteRequest build() {
             return new AttributesDeleteRequest(
-                    tenantId, entityId, scope, keys, notifyDevice, previousCalculatedFieldIds, tbMsgId, tbMsgType, requireNonNullElse(callback, NoOpFutureCallback.instance())
+                    tenantId, entityId, scope, keys, notifyDevice, previousCalculatedFieldIds, tbMsgId, tbMsgType, msgSource, requireNonNullElse(callback, NoOpFutureCallback.instance())
             );
         }
 

--- a/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/AttributesSaveRequest.java
+++ b/rule-engine/rule-engine-api/src/main/java/org/thingsboard/rule/engine/api/AttributesSaveRequest.java
@@ -50,6 +50,7 @@ public class AttributesSaveRequest implements CalculatedFieldSystemAwareRequest 
     private final List<CalculatedFieldId> previousCalculatedFieldIds;
     private final UUID tbMsgId;
     private final TbMsgType tbMsgType;
+    private final String msgSource;
     private final FutureCallback<Void> callback;
 
     public record Strategy(boolean saveAttributes, boolean sendWsUpdate, boolean processCalculatedFields) {
@@ -76,6 +77,7 @@ public class AttributesSaveRequest implements CalculatedFieldSystemAwareRequest 
         private List<CalculatedFieldId> previousCalculatedFieldIds;
         private UUID tbMsgId;
         private TbMsgType tbMsgType;
+        private String msgSource;
         private FutureCallback<Void> callback;
 
         Builder() {}
@@ -143,6 +145,11 @@ public class AttributesSaveRequest implements CalculatedFieldSystemAwareRequest 
             return this;
         }
 
+        public Builder msgSource(String msgSource) {
+            this.msgSource = msgSource;
+            return this;
+        }
+
         public Builder callback(FutureCallback<Void> callback) {
             this.callback = callback;
             return this;
@@ -165,7 +172,7 @@ public class AttributesSaveRequest implements CalculatedFieldSystemAwareRequest 
         public AttributesSaveRequest build() {
             return new AttributesSaveRequest(
                     tenantId, entityId, scope, entries, notifyDevice, requireNonNullElse(strategy, Strategy.PROCESS_ALL),
-                    previousCalculatedFieldIds, tbMsgId, tbMsgType, requireNonNullElse(callback, NoOpFutureCallback.instance())
+                    previousCalculatedFieldIds, tbMsgId, tbMsgType, msgSource, requireNonNullElse(callback, NoOpFutureCallback.instance())
             );
         }
 

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgAttributesNode.java
@@ -33,6 +33,7 @@ import org.thingsboard.rule.engine.api.util.TbNodeUtils;
 import org.thingsboard.rule.engine.telemetry.settings.AttributesProcessingSettings;
 import org.thingsboard.server.common.adaptor.JsonConverter;
 import org.thingsboard.server.common.data.AttributeScope;
+import org.thingsboard.server.common.data.DataConstants;
 import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.kv.AttributeKvEntry;
 import org.thingsboard.server.common.data.kv.KvEntry;
@@ -212,6 +213,7 @@ public class TbMsgAttributesNode implements TbNode {
                 .previousCalculatedFieldIds(msg.getPreviousCalculatedFieldIds())
                 .tbMsgId(msg.getId())
                 .tbMsgType(msg.getInternalType())
+                .msgSource(msg.getMetaData().getValue(DataConstants.MSG_SOURCE_KEY))
                 .callback(callback)
                 .build());
     }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgDeleteAttributesNode.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/telemetry/TbMsgDeleteAttributesNode.java
@@ -23,6 +23,7 @@ import org.thingsboard.rule.engine.api.TbNodeConfiguration;
 import org.thingsboard.rule.engine.api.TbNodeException;
 import org.thingsboard.rule.engine.api.util.TbNodeUtils;
 import org.thingsboard.server.common.data.AttributeScope;
+import org.thingsboard.server.common.data.DataConstants;
 import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.plugin.ComponentType;
 import org.thingsboard.server.common.msg.TbMsg;
@@ -78,6 +79,7 @@ public class TbMsgDeleteAttributesNode implements TbNode {
                     .previousCalculatedFieldIds(msg.getPreviousCalculatedFieldIds())
                     .tbMsgId(msg.getId())
                     .tbMsgType(msg.getInternalType())
+                    .msgSource(msg.getMetaData().getValue(DataConstants.MSG_SOURCE_KEY))
                     .callback(config.isSendAttributesDeletedNotification() ?
                             new AttributesDeleteNodeCallback(ctx, msg, scope.name(), keysToDelete) :
                             new TelemetryNodeCallback(ctx, msg))


### PR DESCRIPTION
## Pull Request description

Fixes #14218 — gateway configuration created or edited on the Cloud stays
"OUT OF SYNC" on the Edge unless the tenant manually wires a `push to edge`
rule node.

### Problem
Gateway configuration (connectors,
`active_connectors`/`inactive_connectors`, `RemoteLoggingLevel`, etc.) is
stored in attributes of the gateway device. Attribute updates made on the
Cloud were propagated to the Edge only by the `push to edge` rule node,
which is not present in the default rule chains — so out of the box,
connectors configured from the Cloud UI never reached the Edge (and
edits/renames/deletes of disabled connectors leaked or orphaned SERVER_SCOPE
attributes).

### Solution
Attribute saves/deletes of gateway devices are now converted into edge 
notifications out of the box, with no rule chain changes required:

- `AttributesEdgeSyncService` — entry point hooked into 
`DefaultTelemetrySubscriptionService` via async post-save callbacks. General
rules (edges enabled, not an edge-originated update, attributes actually 
persisted) are checked synchronously with in-memory-only predicates; the 
actual sync runs on dedicated single-thread workers selected by entity id 
(per-device event ordering, bounded queues with discard-and-log on 
overflow).
- `AttributesEdgeSyncStrategy` — per-entity-type extension point 
(open-closed); `GatewayAttributesEdgeSyncStrategy` is the DEVICE 
implementation:
    - SHARED_SCOPE: all keys; SERVER_SCOPE: all keys except device activity 
keys (disabled-connector configs live under arbitrary `<connectorName>` 
keys, matching the assignment/reconnect sync filtering in 
`DefaultEdgeRequestsService`); CLIENT_SCOPE: not synced (reported by the
gateway itself via the edge uplink).
    - `inactivityTimeout` is deliberately propagated so it applies to the
device state tracked on the Edge.
- `GatewayFlagCache` — local per-node cache of the gateway flag so the sync
task rate is proportional to the number of gateways, not devices:
non-blocking check on the save path (unknown → potential gateway),
cache-first blocking resolution on the sync pool only, invalidation on
device lifecycle broadcasts, size/TTL-bounded as a backstop for missed
broadcasts.
- Echo suppression: `AttributesSaveRequest`/`AttributesDeleteRequest` carry
- `BaseEdgeProcessor` now handles `ATTRIBUTES_UPDATED`/`ATTRIBUTES_DELETED`
notifications by fanning them out to related edges with the body preserved;
downlink conversion reuses the existing telemetry processor path, so no
Edge-side changes and no protocol changes are required (older Edge versions
work as-is).

### Configuration (new, with defaults)
- `edges.attributes_sync_pool_size` (8),
`edges.attributes_sync_max_queue_size` (5000 per worker)
- `cache.gateway_flag.max_size` (500000),
`cache.gateway_flag.time_to_live_in_minutes` (30, counted from last access)

### Backward compatibility
No schema, proto, or breaking API changes. Tenants that already use a `push
to edge` node for gateway attributes will produce duplicate edge events
(deduplicated on the Edge by ts filtering) — the workaround node can be
removed after upgrade. During a rolling upgrade, notifications produced by
upgraded nodes are ignored by not-yet-upgraded consumers (no errors).

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



