### PR TITLE
Avoid logging PEM certificate contents

### DIFF
--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/credentials/CertPemCredentials.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/credentials/CertPemCredentials.java
@@ -67,7 +67,7 @@ public class CertPemCredentials implements ClientCredentials {
             }
             return builder.build();
         } catch (Exception e) {
-            log.error("[{}:{}] Creating TLS factory failed!", caCert, cert, e);
+            log.error("Creating TLS factory failed!", e);
             throw new RuntimeException("Creating TLS factory failed!", e);
         }
     }


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/19435226.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Removed CA and client certificate contents from TLS setup error logs while retaining the exception.

Issue: https://github.com/thingsboard/thingsboard/issues/15998

## Back-end checklist

- [x] No dependency, service, REST API, or configuration property was added.
- [x] The change is backward compatible.
- [x] No documentation update is required.

