### PR TITLE
Fix TelemetryObserveStrategy enum values in OpenAPI spec

### DIFF
--- a/common/data/src/main/java/org/thingsboard/server/common/data/device/profile/lwm2m/TelemetryObserveStrategy.java
+++ b/common/data/src/main/java/org/thingsboard/server/common/data/device/profile/lwm2m/TelemetryObserveStrategy.java
@@ -15,8 +15,13 @@
  */
 package org.thingsboard.server.common.data.device.profile.lwm2m;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+@Schema(description = "Observation strategy for telemetry. " +
+        "SINGLE (0): one resource equals one single observe request. " +
+        "COMPOSITE_ALL (1): all resources in one composite observe request. " +
+        "COMPOSITE_BY_OBJECT (2): grouped composite observe requests by object.")
 public enum TelemetryObserveStrategy {
 
     SINGLE("One resource equals one single observe request", 0),
@@ -52,8 +57,4 @@ public enum TelemetryObserveStrategy {
         throw new IllegalArgumentException("Unknown TelemetryObserveStrategy id: " + id);
     }
 
-    @Override
-    public String toString() {
-        return name() + " (" + id + "): " + description;
-    }
 }


### PR DESCRIPTION
## Pull Request description

Fix TelemetryObserveStrategy enum values in OpenAPI spec                                                                                                                                                                 
                                                                                                                                                                                                                           
The `toString()` override rendered constants as `"NAME (id): description"`, and springdoc publishes enum values using that rendering. The spec therefore advertised `"SINGLE (0): One resource equals one single observe request"` for a field Jackson serializes as `"SINGLE"`, so generated REST clients rejected every response containing `observeStrategy` and wrote the description string back on save.                                                                                                                                                                                         
                                                                                                                                                                                                                         
Drop the override so the published values match the wire format, and move the human-readable strategy descriptions to `@Schema(description)`, where they stay visible in Swagger UI. `toString()` and `fromDescription()` had no callers.

There are no conflicts with PE and lts-4.3

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



