### PR TITLE
fix(device-state): prevent stale-clock nodes from marking active devices inactive

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
+++ b/application/src/main/java/org/thingsboard/server/service/state/DefaultDeviceStateService.java
@@ -559,6 +559,18 @@ public class DefaultDeviceStateService extends AbstractPartitionBasedService<Dev
                     && (state.getLastInactivityAlarmTime() == 0L || state.getLastInactivityAlarmTime() <= state.getLastActivityTime())
                     && stateData.getDeviceCreationTime() + state.getInactivityTimeout() <= ts) {
                 if (partitionService.resolve(ServiceType.TB_CORE, stateData.getTenantId(), deviceId).isMyPartition()) {
+                    // Guard against stale-clock inactivity writes. After a partition rebalance a node may still hold
+                    // a device whose activity is now handled by another (owning) node; its local lastActivityTime is
+                    // then frozen and would wrongly flip the shared 'active' flag to false. Re-read the authoritative
+                    // persisted lastActivityTime; if it shows the device is still active, reconcile the local state
+                    // and skip the inactivity report.
+                    long persistedLastActivityTime = getPersistedLastActivityTime(deviceId);
+                    if (persistedLastActivityTime > state.getLastActivityTime()) {
+                        state.setLastActivityTime(persistedLastActivityTime);
+                        if (isActive(ts, state)) {
+                            return;
+                        }
+                    }
                     reportInactivity(ts, stateData);
                 } else {
                     cleanupEntity(deviceId);
@@ -567,6 +579,23 @@ public class DefaultDeviceStateService extends AbstractPartitionBasedService<Dev
         } else {
             log.debug("[{}] Device that belongs to other server is detected and removed.", deviceId);
             cleanupEntity(deviceId);
+        }
+    }
+
+    // Reads the authoritative persisted lastActivityTime (source of truth) so a node with a stale in-memory
+    // clock cannot mark a still-active device inactive. Returns 0 on failure to preserve default behavior.
+    long getPersistedLastActivityTime(DeviceId deviceId) {
+        try {
+            if (persistToTelemetry) {
+                Optional<TsKvEntry> entry = tsService.findLatest(TenantId.SYS_TENANT_ID, deviceId, LAST_ACTIVITY_TIME).get();
+                return entry.flatMap(KvEntry::getLongValue).orElse(0L);
+            } else {
+                Optional<AttributeKvEntry> entry = attributesService.find(TenantId.SYS_TENANT_ID, deviceId, AttributeScope.SERVER_SCOPE, LAST_ACTIVITY_TIME).get();
+                return entry.flatMap(KvEntry::getLongValue).orElse(0L);
+            }
+        } catch (Exception e) {
+            log.warn("[{}] Failed to re-read persisted lastActivityTime; proceeding with local state.", deviceId, e);
+            return 0L;
         }
     }
 

--- a/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/state/DefaultDeviceStateServiceTest.java
@@ -39,6 +39,8 @@ import org.thingsboard.server.common.data.id.EntityId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.kv.AttributeKvEntry;
 import org.thingsboard.server.common.data.kv.AttributesSaveResult;
+import org.thingsboard.server.common.data.kv.BasicTsKvEntry;
+import org.thingsboard.server.common.data.kv.LongDataEntry;
 import org.thingsboard.server.common.data.msg.TbMsgType;
 import org.thingsboard.server.common.data.notification.rule.trigger.DeviceActivityTrigger;
 import org.thingsboard.server.common.msg.TbMsg;
@@ -60,6 +62,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1120,6 +1123,49 @@ class DefaultDeviceStateServiceTest {
                             request.getEntries().get(0).getValue().equals(true)
             ));
         });
+    }
+
+    // After a partition rebalance a node may hold a device with a stale in-memory lastActivityTime while the true
+    // owner keeps it alive. Such a node must NOT persist active=false: it must re-check the authoritative persisted
+    // lastActivityTime and skip the inactivity report.
+    @Test
+    void givenStaleLocalClockButFreshPersistedActivity_whenUpdateInactivityStateIfExpired_thenDoesNotPersistInactive() {
+        // GIVEN persist-to-telemetry mode
+        ReflectionTestUtils.setField(service, "persistToTelemetry", true);
+        lenient().when(telemetrySubscriptionService.saveTimeseriesInternal(any())).thenReturn(Futures.immediateFuture(null));
+
+        long now = 10_000_000L;
+        long timeout = 100_000L;
+
+        // in-memory state is STALE: last activity long ago, so locally the device looks inactive
+        var state = DeviceState.builder()
+                .active(true)
+                .lastActivityTime(now - 10 * timeout)
+                .lastInactivityAlarmTime(0L)
+                .inactivityTimeout(timeout)
+                .build();
+        var stateData = DeviceStateData.builder()
+                .tenantId(tenantId).deviceId(deviceId).deviceCreationTime(0L)
+                .metaData(new TbMsgMetaData()).state(state).build();
+
+        given(partitionService.resolve(ServiceType.TB_CORE, tenantId, deviceId)).willReturn(tpi);
+
+        // the authoritative persisted lastActivityTime is FRESH (the true owner is keeping the device alive)
+        long freshLastActivityTime = now - 1;
+        lenient().when(tsService.findLatest(TenantId.SYS_TENANT_ID, deviceId, LAST_ACTIVITY_TIME))
+                .thenReturn(Futures.immediateFuture(Optional.of(
+                        new BasicTsKvEntry(freshLastActivityTime, new LongDataEntry(LAST_ACTIVITY_TIME, freshLastActivityTime)))));
+
+        // WHEN
+        service.updateInactivityStateIfExpired(now, deviceId, stateData);
+
+        // THEN the device is NOT persisted as inactive...
+        then(telemetrySubscriptionService).should(never()).saveTimeseriesInternal(argThat(request ->
+                request.getEntries().get(0).getKey().equals(ACTIVITY_STATE)
+                        && request.getEntries().get(0).getValue().equals(false)));
+        // ...and the stale local clock is reconciled from the source of truth
+        assertThat(state.getLastActivityTime()).isEqualTo(freshLastActivityTime);
+        assertThat(state.isActive()).isTrue();
     }
 
     private void mockSuccessfulSaveAttributes() {


### PR DESCRIPTION
## Problem

In a clustered TB Core deployment a device can become **permanently stuck showing "inactive"** even though it is actively sending telemetry.

The root cause is a partition-ownership race:

1. A TB Core node briefly loses its ZooKeeper session (network blip, long GC, etc.). The remaining nodes recalculate partition ownership and take over its partitions, while the affected node keeps operating on its **stale** view of the cluster.
2. During that window two nodes consider themselves the owner of the same device. The device's activity messages are routed to the *new* owner, so the *stale* node stops receiving them and its in-memory `lastActivityTime` freezes.
3. The stale node's periodic inactivity check then fires and persists `active=false` (device state is a shared value in `ts_kv_latest` / server attributes).
4. Ownership settles. The real owner still has `active=true` in memory; `updateActivityState` only writes `active` on a `false → true` transition, so it never re-writes the flag. The device is shown as inactive indefinitely, with no self-healing short of a restart.

## Fix

Before a node persists `active=false` in `updateInactivityStateIfExpired`, it now re-reads the **authoritative persisted `lastActivityTime`** (the source of truth). If that value shows the device is still active — because another owner is keeping it alive — the node reconciles its local state and **skips** the inactivity report.

This makes the persisted value the arbiter, so a node with a stale clock can no longer mark a still-active device inactive. The read fails safe (returns `0` → previous behavior) so a transient read error cannot suppress legitimate inactivity reporting.

## Test

`DefaultDeviceStateServiceTest#givenStaleLocalClockButFreshPersistedActivity_whenUpdateInactivityStateIfExpired_thenDoesNotPersistInactive` reproduces the scenario (stale local `lastActivityTime`, fresh persisted value) and asserts that `active=false` is **not** written and that the local clock is reconciled from the source of truth. Verified red → green; the full `DefaultDeviceStateServiceTest` suite passes.

LTS-4.3: https://github.com/thingsboard/thingsboard/pull/16018
