### PR TITLE
Add REST client method for device publish telemetry commands

### DIFF
--- a/rest-client/src/main/java/org/thingsboard/rest/client/RestClient.java
+++ b/rest-client/src/main/java/org/thingsboard/rest/client/RestClient.java
@@ -236,7 +236,7 @@ public class RestClient implements Closeable {
     public RestClient(RestTemplate restTemplate, String baseURL, String accessToken) {
         this.restTemplate = restTemplate;
         this.loginRestTemplate = new RestTemplate(restTemplate.getRequestFactory());
-        this.baseURL = baseURL;
+        this.baseURL = org.springframework.util.StringUtils.trimTrailingCharacter(baseURL, '/');
         this.restTemplate.getInterceptors().add((request, bytes, execution) -> {
             HttpRequest wrapper = new HttpRequestWrapper(request);
             if (accessToken == null) {
@@ -1342,6 +1342,10 @@ public class RestClient implements Closeable {
                 throw exception;
             }
         }
+    }
+
+    public JsonNode getDevicePublishTelemetryCommands(DeviceId deviceId) {
+        return restTemplate.getForEntity(baseURL + "/api/device-connectivity/{deviceId}", JsonNode.class, deviceId.getId()).getBody();
     }
 
     public DeviceCredentials saveDeviceCredentials(DeviceCredentials deviceCredentials) {


### PR DESCRIPTION
4.3 LTS line — merges the 4.2 branch of the same name (thingsboard/thingsboard#16022), where the change was originally implemented.

Adds `RestClient.getDevicePublishTelemetryCommands(DeviceId)`, wrapping `GET /api/device-connectivity/{deviceId}`, and strips trailing slashes from the base URL in the constructor. See the 4.2 PR for the rationale.

No 4.3-specific changes on top; the merge applied cleanly.
