### PR TITLE
Add REST client method for device publish telemetry commands

### DIFF
--- a/rest-client/src/main/java/org/thingsboard/rest/client/RestClient.java
+++ b/rest-client/src/main/java/org/thingsboard/rest/client/RestClient.java
@@ -236,7 +236,7 @@ public class RestClient implements Closeable {
     public RestClient(RestTemplate restTemplate, String baseURL, String accessToken) {
         this.restTemplate = restTemplate;
         this.loginRestTemplate = new RestTemplate(restTemplate.getRequestFactory());
-        this.baseURL = baseURL;
+        this.baseURL = org.springframework.util.StringUtils.trimTrailingCharacter(baseURL, '/');
         this.restTemplate.getInterceptors().add((request, bytes, execution) -> {
             HttpRequest wrapper = new HttpRequestWrapper(request);
             if (accessToken == null) {
@@ -1342,6 +1342,10 @@ public class RestClient implements Closeable {
                 throw exception;
             }
         }
+    }
+
+    public JsonNode getDevicePublishTelemetryCommands(DeviceId deviceId) {
+        return restTemplate.getForEntity(baseURL + "/api/device-connectivity/{deviceId}", JsonNode.class, deviceId.getId()).getBody();
     }
 
     public DeviceCredentials saveDeviceCredentials(DeviceCredentials deviceCredentials) {


### PR DESCRIPTION
Original implementation for the 4.2 LTS line; forward-merged into the other three.

Adds `RestClient.getDevicePublishTelemetryCommands(DeviceId)`, wrapping `GET /api/device-connectivity/{deviceId}`.

The endpoint had no method on the REST client, so callers had to build the absolute URL themselves and issue the request through `getRestTemplate()`. The AI service does exactly that today, which also forces it to expose its own normalized base URL just so a caller can concatenate a path onto it.

Also strips trailing slashes from the base URL in the constructor. Every method appends a path to `baseURL`, so a client constructed with a trailing slash produces a malformed `//api/...` URL that some ingress configurations fail to route. All four constructors delegate to the one that assigns the field, so the normalization applies to every entry point. `org.springframework.util.StringUtils` is fully qualified at that call site because the file already single-type-imports `org.thingsboard.server.common.data.StringUtils`.