### PR TITLE
Decouple BC-provider instantiation for FIPS-provider readiness

### DIFF
--- a/common/message/src/main/java/org/thingsboard/server/common/msg/EncryptionUtil.java
+++ b/common/message/src/main/java/org/thingsboard/server/common/msg/EncryptionUtil.java
@@ -16,14 +16,30 @@
 package org.thingsboard.server.common.msg;
 
 import lombok.extern.slf4j.Slf4j;
-import org.bouncycastle.crypto.digests.SHA3Digest;
 import org.bouncycastle.util.encoders.Hex;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.security.Security;
 
 /**
  * @author Valerii Sosliuk
  */
 @Slf4j
 public class EncryptionUtil {
+
+    /**
+     * JCE provider used for SHA3 hashing. Defaults to the standard BouncyCastle
+     * provider ("BC"); override with -Dthingsboard.bc.provider=BCFIPS once a
+     * FIPS-certified provider is registered on the classpath instead.
+     */
+    private static final String PROVIDER_NAME = System.getProperty("thingsboard.bc.provider", "BC");
+
+    static {
+        registerProviderIfAbsent(PROVIDER_NAME);
+    }
 
     private EncryptionUtil() {
     }
@@ -61,13 +77,12 @@ public class EncryptionUtil {
     public static String getSha3Hash(String data) {
         String trimmedData = certTrimNewLines(data);
         byte[] dataBytes = trimmedData.getBytes();
-        SHA3Digest md = new SHA3Digest(256);
-        md.reset();
-        md.update(dataBytes, 0, dataBytes.length);
-        byte[] hashedBytes = new byte[256 / 8];
-        md.doFinal(hashedBytes, 0);
-        String sha3Hash = Hex.toHexString(hashedBytes);
-        return sha3Hash;
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA3-256", PROVIDER_NAME);
+            return Hex.toHexString(md.digest(dataBytes));
+        } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+            throw new IllegalStateException("SHA3-256 not available from JCE provider '" + PROVIDER_NAME + "'", e);
+        }
     }
 
     public static String getSha3Hash(String delim, String... tokens) {
@@ -84,5 +99,22 @@ public class EncryptionUtil {
             }
         }
         return getSha3Hash(sb.toString());
+    }
+
+    private static void registerProviderIfAbsent(String providerName) {
+        if (Security.getProvider(providerName) != null) {
+            return;
+        }
+        String providerClass = switch (providerName) {
+            case "BC" -> "org.bouncycastle.jce.provider.BouncyCastleProvider";
+            case "BCFIPS" -> "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
+            default -> throw new IllegalStateException("Unknown JCE provider name '" + providerName
+                    + "'; no provider class mapping and no provider already registered under that name");
+        };
+        try {
+            Security.addProvider((Provider) Class.forName(providerClass).getDeclaredConstructor().newInstance());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to instantiate JCE provider '" + providerName + "' (" + providerClass + ")", e);
+        }
     }
 }

--- a/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/config/ssl/PemSslCredentials.java
+++ b/common/transport/transport-api/src/main/java/org/thingsboard/server/common/transport/config/ssl/PemSslCredentials.java
@@ -20,7 +20,6 @@ import lombok.EqualsAndHashCode;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMDecryptorProvider;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
 import org.bouncycastle.openssl.PEMKeyPair;
@@ -37,6 +36,7 @@ import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.Security;
 import java.security.cert.CertPath;
 import java.security.cert.Certificate;
@@ -52,6 +52,13 @@ public class PemSslCredentials extends AbstractSslCredentials {
 
     private static final String DEFAULT_KEY_ALIAS = "server";
 
+    /**
+     * JCE provider used for PEM parsing. Defaults to the standard BouncyCastle
+     * provider ("BC"); override with -Dthingsboard.bc.provider=BCFIPS once a
+     * FIPS-certified provider is registered on the classpath instead.
+     */
+    private static final String PROVIDER_NAME = System.getProperty("thingsboard.bc.provider", "BC");
+
     private String certFile;
     private String keyFile;
     private String keyPassword;
@@ -63,9 +70,7 @@ public class PemSslCredentials extends AbstractSslCredentials {
 
     @Override
     protected KeyStore loadKeyStore(boolean trustsOnly, char[] keyPasswordArray) throws IOException, GeneralSecurityException {
-        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
+        registerProviderIfAbsent(PROVIDER_NAME);
         List<X509Certificate> certificates = new ArrayList<>();
         PrivateKey privateKey = null;
         JcaX509CertificateConverter certConverter = new JcaX509CertificateConverter();
@@ -154,6 +159,23 @@ public class PemSslCredentials extends AbstractSslCredentials {
             // Include the path even if the file doesn't exist yet — the watcher uses mtime=0 / checksum="" as
             // baseline, so a late-appearing file (e.g. mounted after boot) will be detected and trigger a reload.
             paths.add(Path.of(filePath).toAbsolutePath());
+        }
+    }
+
+    private static void registerProviderIfAbsent(String providerName) {
+        if (Security.getProvider(providerName) != null) {
+            return;
+        }
+        String providerClass = switch (providerName) {
+            case "BC" -> "org.bouncycastle.jce.provider.BouncyCastleProvider";
+            case "BCFIPS" -> "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
+            default -> throw new IllegalStateException("Unknown JCE provider name '" + providerName
+                    + "'; no provider class mapping and no provider already registered under that name");
+        };
+        try {
+            Security.addProvider((Provider) Class.forName(providerClass).getDeclaredConstructor().newInstance());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to instantiate JCE provider '" + providerName + "' (" + providerClass + ")", e);
         }
     }
 

--- a/common/util/src/main/java/org/thingsboard/common/util/SslUtil.java
+++ b/common/util/src/main/java/org/thingsboard/common/util/SslUtil.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMDecryptorProvider;
 import org.bouncycastle.openssl.PEMEncryptedKeyPair;
 import org.bouncycastle.openssl.PEMKeyPair;
@@ -38,6 +37,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.Security;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -49,12 +49,15 @@ public class SslUtil {
 
     public static final char[] EMPTY_PASS = {};
 
-    public static final BouncyCastleProvider DEFAULT_PROVIDER = new BouncyCastleProvider();
+    /**
+     * JCE provider used for PEM/PKCS8 decryption. Defaults to the standard
+     * BouncyCastle provider ("BC"); override with -Dthingsboard.bc.provider=BCFIPS
+     * once a FIPS-certified provider is registered on the classpath instead.
+     */
+    public static final String PROVIDER_NAME = System.getProperty("thingsboard.bc.provider", "BC");
 
     static {
-        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-            Security.addProvider(DEFAULT_PROVIDER);
-        }
+        registerProviderIfAbsent(PROVIDER_NAME);
     }
 
     private SslUtil() {
@@ -116,7 +119,7 @@ public class SslUtil {
                     break;
                 } else if (object instanceof PKCS8EncryptedPrivateKeyInfo) {
                     InputDecryptorProvider decProv =
-                            new JcePKCSPBEInputDecryptorProviderBuilder().setProvider(DEFAULT_PROVIDER).build(password);
+                            new JcePKCSPBEInputDecryptorProviderBuilder().setProvider(PROVIDER_NAME).build(password);
                     privateKey = keyConverter.getPrivateKey(((PKCS8EncryptedPrivateKeyInfo) object).decryptPrivateKeyInfo(decProv));
                     break;
                 } else if (object instanceof PEMKeyPair) {
@@ -132,6 +135,23 @@ public class SslUtil {
 
     public static char[] getPassword(String passStr) {
         return StringUtils.isEmpty(passStr) ? EMPTY_PASS : passStr.toCharArray();
+    }
+
+    private static void registerProviderIfAbsent(String providerName) {
+        if (Security.getProvider(providerName) != null) {
+            return;
+        }
+        String providerClass = switch (providerName) {
+            case "BC" -> "org.bouncycastle.jce.provider.BouncyCastleProvider";
+            case "BCFIPS" -> "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
+            default -> throw new IllegalStateException("Unknown JCE provider name '" + providerName
+                    + "'; no provider class mapping and no provider already registered under that name");
+        };
+        try {
+            Security.addProvider((Provider) Class.forName(providerClass).getDeclaredConstructor().newInstance());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to instantiate JCE provider '" + providerName + "' (" + providerClass + ")", e);
+        }
     }
 
 }

--- a/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/AzureIotHubSasCredentials.java
+++ b/rule-engine/rule-engine-components/src/main/java/org/thingsboard/rule/engine/mqtt/azure/AzureIotHubSasCredentials.java
@@ -22,11 +22,11 @@ import io.netty.handler.ssl.SslContextBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.thingsboard.common.util.AzureIotHubUtil;
 import org.thingsboard.rule.engine.credentials.CertPemCredentials;
 import org.thingsboard.rule.engine.credentials.CredentialsType;
 
+import java.security.Provider;
 import java.security.Security;
 
 @Data
@@ -34,12 +34,20 @@ import java.security.Security;
 @Slf4j
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AzureIotHubSasCredentials extends CertPemCredentials {
+
+    /**
+     * JCE provider used for TLS trust material. Defaults to the standard
+     * BouncyCastle provider ("BC"); override with -Dthingsboard.bc.provider=BCFIPS
+     * once a FIPS-certified provider is registered on the classpath instead.
+     */
+    private static final String PROVIDER_NAME = System.getProperty("thingsboard.bc.provider", "BC");
+
     private String sasKey;
 
     @Override
     public SslContext initSslContext() {
         try {
-            Security.addProvider(new BouncyCastleProvider());
+            registerProviderIfAbsent(PROVIDER_NAME);
             if (caCert == null || caCert.isEmpty()) {
                 caCert = AzureIotHubUtil.getDefaultCaCert();
             }
@@ -56,6 +64,23 @@ public class AzureIotHubSasCredentials extends CertPemCredentials {
     @Override
     public CredentialsType getType() {
         return CredentialsType.SAS;
+    }
+
+    private static void registerProviderIfAbsent(String providerName) {
+        if (Security.getProvider(providerName) != null) {
+            return;
+        }
+        String providerClass = switch (providerName) {
+            case "BC" -> "org.bouncycastle.jce.provider.BouncyCastleProvider";
+            case "BCFIPS" -> "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
+            default -> throw new IllegalStateException("Unknown JCE provider name '" + providerName
+                    + "'; no provider class mapping and no provider already registered under that name");
+        };
+        try {
+            Security.addProvider((Provider) Class.forName(providerClass).getDeclaredConstructor().newInstance());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Unable to instantiate JCE provider '" + providerName + "' (" + providerClass + ")", e);
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- `SslUtil` (`common/util`), `PemSslCredentials` (`common/transport/transport-api`), `EncryptionUtil` (`common/message`), and `AzureIotHubSasCredentials` (`rule-engine-components`) each hardcoded `new org.bouncycastle.jce.provider.BouncyCastleProvider()` (the plain, non-FIPS-certified BC provider class), and `EncryptionUtil` additionally instantiated `org.bouncycastle.crypto.digests.SHA3Digest` directly.
- Both classes are unavailable, at those package paths, in FIPS-certified BouncyCastle (`bc-fips`) — `bc-fips`'s provider lives at `org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider` (a `final` class), so hardcoding the plain-BC provider class rules out ever swapping in a FIPS-certified provider without touching these call sites again.
- This PR decouples all four call sites from the concrete provider class: they now resolve a JCE provider by name (`-Dthingsboard.bc.provider`, defaulting to `"BC"` so today's behavior is unchanged) and lazily register it via reflection. `EncryptionUtil.getSha3Hash` now goes through `java.security.MessageDigest.getInstance("SHA3-256", provider)` instead of instantiating `SHA3Digest` directly.
- No dependency or runtime behavior change in this PR — verified byte-identical SHA3-256 output against the previous implementation, and end-to-end PEM cert/key parsing still works. Actually wiring a FIPS-certified provider onto the classpath is a separate, larger effort (`dao` and `rule-engine-components` still pull `bcprov-jdk18on`/`bcpkix-jdk18on` transitively elsewhere; a full migration needs to ban plain BC repo-wide to avoid a split-package classpath with `bc-fips`).
- `dao`'s only BouncyCastle usage (`DeviceConnectivityServiceImpl`, PEM parsing) never instantiates a provider class, so it needed no change.

## Test plan
- [x] Compiled the four changed files against the project's existing dependency graph (`javac` against local `.m2` + module `target/classes`, with lombok annotation processing) — no errors.
- [x] Verified `MessageDigest.getInstance("SHA3-256", "BC")` produces byte-identical output to the previous `SHA3Digest`-based implementation for the same input.
- [x] Runtime smoke test: generated a real self-signed cert/key pair, confirmed `SslUtil.readCertFile`/`readPrivateKey` still parse correctly and the `BC` provider registers under the new lookup path.
- [ ] Full `mvn verify` (not run in this environment — no local Maven install available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)