### PR TITLE
tb-monitoring: export probe metrics and add a transport-accepted fallback

### DIFF
--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -137,7 +137,10 @@
                  protobuf-java version at runtime; overrides the root pom's 3.25.5 pin (kept there for pubsub)
                  for this module only. protobuf-java-util is pinned to the same version right below so the
                  whole protobuf family stays consistent on this module's classpath (a mixed-version protobuf
-                 runtime causes the exact same class of failure this pin fixes). -->
+                 runtime causes the exact same class of failure this pin fixes). Verified tb-monitoring's own
+                 code never references common/data's 3.x-era DynamicProtoUtils/ProtoTransportPayloadConfiguration
+                 (grep), and `mvn dependency:tree` on this module resolves a single protobuf-java version
+                 (4.28.3) everywhere, so there's no mixed-version runtime risk on this module's classpath. -->
             <version>4.28.3</version>
         </dependency>
         <dependency>

--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -123,6 +123,29 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <!-- opentelemetry-proto (pulled in transitively by micrometer-registry-otlp) requires this
+                 protobuf-java version at runtime; overrides the root pom's 3.25.5 pin (kept there for pubsub)
+                 for this module only. protobuf-java-util is pinned to the same version right below so the
+                 whole protobuf family stays consistent on this module's classpath (a mixed-version protobuf
+                 runtime causes the exact same class of failure this pin fixes). -->
+            <version>4.28.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>4.28.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/monitoring/src/main/java/org/thingsboard/monitoring/client/WsClientFactory.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/client/WsClientFactory.java
@@ -59,7 +59,7 @@ public class WsClientFactory {
         // reuse the same value for both the latency report and the probe metric
         long connectLatencyNanos = stopWatch.getTime();
         monitoringReporter.reportLatency(Latencies.WS_CONNECT, connectLatencyNanos);
-        probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.WS, "connect", connectLatencyNanos / 1_000_000);
+        probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.WS, ProbeMetricsRecorder.ACTION_CONNECT, connectLatencyNanos / 1_000_000);
         return wsClient;
     }
 

--- a/monitoring/src/main/java/org/thingsboard/monitoring/client/WsClientFactory.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/client/WsClientFactory.java
@@ -22,6 +22,8 @@ import org.apache.http.ssl.TrustStrategy;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.thingsboard.monitoring.data.Latencies;
+import org.thingsboard.monitoring.data.MonitoredServiceKey;
+import org.thingsboard.monitoring.metrics.ProbeMetricsRecorder;
 import org.thingsboard.monitoring.service.MonitoringReporter;
 import org.thingsboard.monitoring.util.TbStopWatch;
 
@@ -33,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 public class WsClientFactory {
 
     private final MonitoringReporter monitoringReporter;
+    private final ProbeMetricsRecorder probeMetricsRecorder;
     private final TbStopWatch stopWatch;
     @Value("${monitoring.ws.base_url}")
     private String baseUrl;
@@ -52,7 +55,11 @@ public class WsClientFactory {
         if (!connected) {
             throw new IllegalStateException("Failed to establish WS session");
         }
-        monitoringReporter.reportLatency(Latencies.WS_CONNECT, stopWatch.getTime());
+        // TbStopWatch.getTime() stops/resets internally, so it can only be called once here -
+        // reuse the same value for both the latency report and the probe metric
+        long connectLatencyNanos = stopWatch.getTime();
+        monitoringReporter.reportLatency(Latencies.WS_CONNECT, connectLatencyNanos);
+        probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.WS, "connect", connectLatencyNanos / 1_000_000);
         return wsClient;
     }
 

--- a/monitoring/src/main/java/org/thingsboard/monitoring/data/MonitoredServiceKey.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/data/MonitoredServiceKey.java
@@ -21,6 +21,8 @@ public class MonitoredServiceKey {
     public static final String LOGIN = "Login";
     public static final String WS_CONNECT = "WS Connect";
     public static final String WS_SUBSCRIBE = "WS Subscribe";
+    public static final String WS = "WS";
     public static final String EDQS = "*EDQS*";
+    public static final String OTLP_EXPORT = "OTLP Export";
 
 }

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeLabelResolver.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeLabelResolver.java
@@ -45,7 +45,12 @@ public final class ProbeLabelResolver {
     // is a stateless utility, so warning-dedup across repeated calls for the same target is the
     // caller's (ProbeMetricsRecorder's) responsibility, not this class's
     public static ProbeLabels resolveTransportLabels(TransportType type, String baseUrl) {
-        URI uri = URI.create(baseUrl);
+        URI uri;
+        try {
+            uri = URI.create(baseUrl);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return null; // malformed or null baseUrl - treated the same as unresolvable below
+        }
         String checkType = resolveCheckType(type, uri);
         String endpoint = resolveEndpoint(uri, checkType);
         if (endpoint == null) {
@@ -119,16 +124,21 @@ public final class ProbeLabelResolver {
                 return null;
             }
             String hostPort = authority.contains("@") ? authority.substring(authority.lastIndexOf('@') + 1) : authority;
-            int colonIdx = hostPort.lastIndexOf(':');
-            if (colonIdx != -1) {
-                host = hostPort.substring(0, colonIdx);
-                try {
-                    port = Integer.parseInt(hostPort.substring(colonIdx + 1));
-                } catch (NumberFormatException e) {
-                    port = -1;
-                }
-            } else {
+            if (hostPort.indexOf(':') != hostPort.lastIndexOf(':')) {
+                // multiple colons = bare IPv6 literal, not host:port - don't mangle it by splitting
                 host = hostPort;
+            } else {
+                int colonIdx = hostPort.lastIndexOf(':');
+                if (colonIdx != -1) {
+                    host = hostPort.substring(0, colonIdx);
+                    try {
+                        port = Integer.parseInt(hostPort.substring(colonIdx + 1));
+                    } catch (NumberFormatException e) {
+                        port = -1;
+                    }
+                } else {
+                    host = hostPort;
+                }
             }
         }
         return host + ":" + (port != -1 ? port : defaultPort);

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeLabelResolver.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeLabelResolver.java
@@ -41,19 +41,40 @@ public final class ProbeLabelResolver {
     public record ProbeLabels(String check, String endpoint) {
     }
 
+    // returns null (rather than logging) when the endpoint can't be resolved (missing scheme?) - this
+    // is a stateless utility, so warning-dedup across repeated calls for the same target is the
+    // caller's (ProbeMetricsRecorder's) responsibility, not this class's
     public static ProbeLabels resolveTransportLabels(TransportType type, String baseUrl) {
         URI uri = URI.create(baseUrl);
         String checkType = resolveCheckType(type, uri);
         String endpoint = resolveEndpoint(uri, checkType);
+        if (endpoint == null) {
+            return null;
+        }
         return new ProbeLabels(checkType, endpoint);
     }
 
-    public static String tryResolveEndpoint(String configKey, String baseUrl, String probeName,
-                                             Function<String, String> postProcess) {
+    public static String resolveLoginEndpoint(String restBaseUrl) {
+        return tryResolve("monitoring.rest.base_url", restBaseUrl, "login", endpoint -> endpoint + LOGIN_PATH);
+    }
+
+    public static String resolveWsEndpoint(String wsBaseUrl) {
+        return tryResolve("monitoring.ws.base_url", wsBaseUrl, "ws", Function.identity());
+    }
+
+    private static String tryResolve(String configKey, String baseUrl, String probeName,
+                                      Function<String, String> postProcess) {
         try {
             URI uri = URI.create(baseUrl);
             boolean secureScheme = "https".equalsIgnoreCase(uri.getScheme()) || "wss".equalsIgnoreCase(uri.getScheme());
-            return postProcess.apply(resolveHostPort(uri, secureScheme ? 443 : 80));
+            String hostPort = resolveHostPort(uri, secureScheme ? 443 : 80);
+            if (hostPort == null) {
+                // schemeless/opaque URL - just as much a misconfiguration as an unparseable one
+                log.warn("Failed to resolve endpoint from {} [{}] - \"{}\" probe telemetry will not be recorded",
+                        configKey, baseUrl, probeName);
+                return null;
+            }
+            return postProcess.apply(hostPort);
         } catch (Exception e) {
             // an invalid base URL must not fail app startup - caller treats null as "skip this probe"
             log.warn("Failed to resolve endpoint from {} [{}] - \"{}\" probe telemetry will not be recorded",
@@ -84,19 +105,22 @@ public final class ProbeLabelResolver {
         int port = uri.getPort();
         if (host == null) {
             String authority = uri.getAuthority();
-            if (authority != null) {
-                String hostPort = authority.contains("@") ? authority.substring(authority.lastIndexOf('@') + 1) : authority;
-                int colonIdx = hostPort.lastIndexOf(':');
-                if (colonIdx != -1) {
-                    host = hostPort.substring(0, colonIdx);
-                    try {
-                        port = Integer.parseInt(hostPort.substring(colonIdx + 1));
-                    } catch (NumberFormatException e) {
-                        port = -1;
-                    }
-                } else {
-                    host = hostPort;
+            if (authority == null) {
+                // schemeless URLs (e.g. "acme.example.com:1883") parse as opaque, with neither a host
+                // nor an authority at all - nothing to fall back to, so let the caller skip the probe
+                return null;
+            }
+            String hostPort = authority.contains("@") ? authority.substring(authority.lastIndexOf('@') + 1) : authority;
+            int colonIdx = hostPort.lastIndexOf(':');
+            if (colonIdx != -1) {
+                host = hostPort.substring(0, colonIdx);
+                try {
+                    port = Integer.parseInt(hostPort.substring(colonIdx + 1));
+                } catch (NumberFormatException e) {
+                    port = -1;
                 }
+            } else {
+                host = hostPort;
             }
         }
         return host + ":" + (port != -1 ? port : defaultPort);

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeLabelResolver.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeLabelResolver.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.metrics;
+
+import lombok.extern.slf4j.Slf4j;
+import org.thingsboard.monitoring.config.transport.TransportType;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.function.Function;
+
+// Derives the "check"/"endpoint" labels used to tag probe metrics.
+@Slf4j
+public final class ProbeLabelResolver {
+
+    public static final String LOGIN_PATH = "/api/auth/login";
+
+    private static final Map<String, Integer> DEFAULT_PORTS = Map.of(
+            "mqtt", 1883, "mqtts", 8883,
+            "coap", 5683, "coaps", 5684,
+            "http", 80, "https", 443,
+            "lwm2m", 5685
+    );
+
+    private ProbeLabelResolver() {
+    }
+
+    public record ProbeLabels(String check, String endpoint) {
+    }
+
+    public static ProbeLabels resolveTransportLabels(TransportType type, String baseUrl) {
+        URI uri = URI.create(baseUrl);
+        String checkType = resolveCheckType(type, uri);
+        String endpoint = resolveEndpoint(uri, checkType);
+        return new ProbeLabels(checkType, endpoint);
+    }
+
+    public static String tryResolveEndpoint(String configKey, String baseUrl, String probeName,
+                                             Function<String, String> postProcess) {
+        try {
+            URI uri = URI.create(baseUrl);
+            boolean secureScheme = "https".equalsIgnoreCase(uri.getScheme()) || "wss".equalsIgnoreCase(uri.getScheme());
+            return postProcess.apply(resolveHostPort(uri, secureScheme ? 443 : 80));
+        } catch (Exception e) {
+            // an invalid base URL must not fail app startup - caller treats null as "skip this probe"
+            log.warn("Failed to resolve endpoint from {} [{}] - \"{}\" probe telemetry will not be recorded",
+                    configKey, baseUrl, probeName, e);
+            return null;
+        }
+    }
+
+    private static String resolveCheckType(TransportType type, URI uri) {
+        String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase();
+        return switch (type) {
+            case MQTT -> "ssl".equals(scheme) ? "mqtts" : "mqtt";
+            case COAP -> "coaps".equals(scheme) ? "coaps" : "coap";
+            case HTTP -> "https".equals(scheme) ? "https" : "http";
+            case LWM2M -> "lwm2m";
+        };
+    }
+
+    private static String resolveEndpoint(URI uri, String checkType) {
+        return resolveHostPort(uri, DEFAULT_PORTS.get(checkType));
+    }
+
+    // URI.getHost()/getPort() return null/-1 for authorities Java doesn't consider valid hostnames
+    // (e.g. underscores in docker-compose service names, a common target naming convention) - fall
+    // back to parsing the authority component directly instead of silently losing the host.
+    public static String resolveHostPort(URI uri, int defaultPort) {
+        String host = uri.getHost();
+        int port = uri.getPort();
+        if (host == null) {
+            String authority = uri.getAuthority();
+            if (authority != null) {
+                String hostPort = authority.contains("@") ? authority.substring(authority.lastIndexOf('@') + 1) : authority;
+                int colonIdx = hostPort.lastIndexOf(':');
+                if (colonIdx != -1) {
+                    host = hostPort.substring(0, colonIdx);
+                    try {
+                        port = Integer.parseInt(hostPort.substring(colonIdx + 1));
+                    } catch (NumberFormatException e) {
+                        port = -1;
+                    }
+                } else {
+                    host = hostPort;
+                }
+            }
+        }
+        return host + ":" + (port != -1 ? port : defaultPort);
+    }
+
+}

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeLabelResolver.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeLabelResolver.java
@@ -70,16 +70,24 @@ public final class ProbeLabelResolver {
             String hostPort = resolveHostPort(uri, secureScheme ? 443 : 80);
             if (hostPort == null) {
                 // schemeless/opaque URL - just as much a misconfiguration as an unparseable one
-                log.warn("Failed to resolve endpoint from {} [{}] - \"{}\" probe telemetry will not be recorded",
-                        configKey, baseUrl, probeName);
+                warnUnresolvable(configKey, baseUrl, probeName, null);
                 return null;
             }
             return postProcess.apply(hostPort);
         } catch (Exception e) {
             // an invalid base URL must not fail app startup - caller treats null as "skip this probe"
-            log.warn("Failed to resolve endpoint from {} [{}] - \"{}\" probe telemetry will not be recorded",
-                    configKey, baseUrl, probeName, e);
+            warnUnresolvable(configKey, baseUrl, probeName, e);
             return null;
+        }
+    }
+
+    private static void warnUnresolvable(String configKey, String baseUrl, String probeName, Exception cause) {
+        if (cause != null) {
+            log.warn("Failed to resolve endpoint from {} [{}] - \"{}\" probe telemetry will not be recorded",
+                    configKey, baseUrl, probeName, cause);
+        } else {
+            log.warn("Failed to resolve endpoint from {} [{}] - \"{}\" probe telemetry will not be recorded",
+                    configKey, baseUrl, probeName);
         }
     }
 

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
@@ -58,6 +58,9 @@ public class ProbeMetricsRecorder {
     private final Set<Tags> warnedCollisions = ConcurrentHashMap.newKeySet();
     // action gauges recorded per probe, so removeProbe can clean them up without knowing them upfront
     private final Map<Tags, Set<String>> actionsByBaseTags = new ConcurrentHashMap<>();
+    // tags that already got fresh data this cycle - so a colliding sibling's removeProbe/removeAcceptedProbe
+    // (e.g. crashing right after this one succeeded) can't wipe what was just correctly recorded
+    private final Set<Tags> freshThisCycle = ConcurrentHashMap.newKeySet();
 
     public ProbeMetricsRecorder(MeterRegistry meterRegistry,
                                  @Value("${monitoring.metrics.otlp.enabled:false}") boolean otlpEnabled,
@@ -76,10 +79,16 @@ public class ProbeMetricsRecorder {
                 Function.identity()) : null;
     }
 
+    // resets which Tags have fresh data this cycle - called once at the start of each runChecks()
+    public void startCycle() {
+        freshThisCycle.clear();
+    }
+
     public void recordProbe(Object serviceKey, boolean success) {
         withTags(serviceKey, "record", tags -> {
             warnIfLabelCollision(serviceKey, tags);
             setGauge(PROBE_SUCCESS_METRIC, tags, success ? 1d : 0d);
+            freshThisCycle.add(tags);
         });
     }
 
@@ -96,15 +105,33 @@ public class ProbeMetricsRecorder {
             return;
         }
         try {
-            setGauge(PROBE_SUCCESS_METRIC, acceptedTags(transportInfo), success ? 1d : 0d);
+            Tags tags = acceptedTags(transportInfo);
+            setGauge(PROBE_SUCCESS_METRIC, tags, success ? 1d : 0d);
+            freshThisCycle.add(tags);
         } catch (Exception e) {
             log.warn("Failed to record accepted probe metric for [{}]", serviceKey, e);
         }
     }
 
-    // for a probe no longer checked this cycle - without this its gauge keeps its last value
+    // permanent removal (e.g. decommissioning a domain-IP associate) - always removes the gauge,
+    // even if its tags got fresh data this cycle, since the target is gone for good either way
     public void removeProbe(Object serviceKey) {
+        removeProbe(serviceKey, false);
+    }
+
+    // for a probe no longer checked THIS cycle only - skips removal if its tags already have fresh
+    // data this cycle (from a colliding sibling target sharing the same resolved tags), so that a
+    // crashing sibling's stale-clearing can't wipe another target's just-recorded gauge
+    public void removeStaleProbe(Object serviceKey) {
+        removeProbe(serviceKey, true);
+    }
+
+    private void removeProbe(Object serviceKey, boolean skipIfFresh) {
         withTags(serviceKey, "remove", tags -> {
+            if (skipIfFresh && freshThisCycle.contains(tags)) {
+                log.debug("Skipping removal of probe metric for [{}] - tags {} already have fresh data this cycle from a colliding target", serviceKey, tags);
+                return;
+            }
             removeGauge(PROBE_SUCCESS_METRIC, tags);
             Set<String> actions = actionsByBaseTags.remove(tags);
             if (actions != null) {
@@ -112,6 +139,7 @@ public class ProbeMetricsRecorder {
             }
             tagsOwners.remove(tags);
             warnedCollisions.remove(tags);
+            freshThisCycle.remove(tags); // a permanent removal must not leave a stale fresh-flag behind
         });
         if (serviceKey instanceof TransportInfo transportInfo) {
             // otherwise this cache leaks the same way the gauges just did
@@ -119,13 +147,29 @@ public class ProbeMetricsRecorder {
         }
     }
 
-    // doesn't evict acceptedTagsCache - this runs every healthy cycle, which would defeat the cache
+    // permanent removal - see removeProbe(Object) for why this never skips
     public void removeAcceptedProbe(Object serviceKey) {
+        removeAcceptedProbe(serviceKey, false);
+    }
+
+    // for an accepted-fallback probe no longer checked THIS cycle only - see removeStaleProbe(Object)
+    public void removeStaleAcceptedProbe(Object serviceKey) {
+        removeAcceptedProbe(serviceKey, true);
+    }
+
+    // doesn't evict acceptedTagsCache - this runs every healthy cycle, which would defeat the cache
+    private void removeAcceptedProbe(Object serviceKey, boolean skipIfFresh) {
         if (!enabled || !(serviceKey instanceof TransportInfo transportInfo)) {
             return;
         }
         try {
-            removeGauge(PROBE_SUCCESS_METRIC, acceptedTags(transportInfo));
+            Tags tags = acceptedTags(transportInfo);
+            if (skipIfFresh && freshThisCycle.contains(tags)) {
+                log.debug("Skipping removal of accepted probe metric for [{}] - tags {} already have fresh data this cycle from a colliding target", transportInfo, tags);
+                return;
+            }
+            removeGauge(PROBE_SUCCESS_METRIC, tags);
+            freshThisCycle.remove(tags);
         } catch (Exception e) {
             log.warn("Failed to remove accepted probe metric for [{}]", transportInfo, e);
         }

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
@@ -175,7 +175,11 @@ public class ProbeMetricsRecorder {
             warnedCollisions.remove(tags);
             freshThisCycle.remove(tags); // a permanent removal must not leave a stale fresh-flag behind
         });
-        if (serviceKey instanceof TransportInfo transportInfo) {
+        // only on permanent removal - a stale (per-cycle) removal runs every unhealthy cycle (e.g.
+        // for the whole duration of a login/WS outage), so evicting here would defeat the cache and,
+        // for warnedUnresolvable, make an unresolvable target's warning re-fire every such cycle
+        // instead of once - exactly what that dedup set exists to prevent
+        if (!skipIfFresh && serviceKey instanceof TransportInfo transportInfo) {
             // otherwise these caches leak the same way the gauges just did
             TransportTagKey key = TransportTagKey.of(transportInfo);
             transportTagsCache.remove(key);

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
@@ -26,6 +26,7 @@ import org.thingsboard.monitoring.config.transport.TransportType;
 import org.thingsboard.monitoring.data.MonitoredServiceKey;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -41,6 +42,13 @@ public class ProbeMetricsRecorder {
     private static final String KIND_PROBE = "probe";
     private static final String KIND_ACCEPTED = "accepted";
 
+    // action names shared with BaseHealthChecker/BaseMonitoringService/WsClientFactory, so a
+    // recordActionDuration call and its matching removeActionDuration can't drift via a typo
+    public static final String ACTION_REQUEST = "request";
+    public static final String ACTION_WS_UPDATE = "ws_update";
+    public static final String ACTION_CONNECT = "connect";
+    public static final String ACTION_SUBSCRIBE = "subscribe";
+
     private final MeterRegistry meterRegistry;
     private final boolean enabled;
     private final String domain;
@@ -49,8 +57,10 @@ public class ProbeMetricsRecorder {
     private final String wsEndpoint;
 
     private final Map<GaugeKey, AtomicReference<Double>> gaugeValues = new ConcurrentHashMap<>();
-    private final Map<TransportTagKey, Tags> transportTagsCache = new ConcurrentHashMap<>();
-    private final Map<TransportTagKey, Tags> acceptedTagsCache = new ConcurrentHashMap<>();
+    // Optional-valued so an unresolvable target's negative result is cached too (a plain
+    // computeIfAbsent never stores a null return, so it would otherwise re-resolve every call)
+    private final Map<TransportTagKey, Optional<Tags>> transportTagsCache = new ConcurrentHashMap<>();
+    private final Map<TransportTagKey, Optional<Tags>> acceptedTagsCache = new ConcurrentHashMap<>();
     // detects two probes resolving to identical labels (e.g. same host:port, different queue) so
     // the collision is logged instead of one gauge silently overwriting the other
     private final Map<Tags, Object> tagsOwners = new ConcurrentHashMap<>();
@@ -61,7 +71,10 @@ public class ProbeMetricsRecorder {
     // action gauges recorded per probe, so removeProbe can clean them up without knowing them upfront
     private final Map<Tags, Set<String>> actionsByBaseTags = new ConcurrentHashMap<>();
     // tags that already got fresh data this cycle - so a colliding sibling's removeProbe/removeAcceptedProbe
-    // (e.g. crashing right after this one succeeded) can't wipe what was just correctly recorded
+    // (e.g. crashing right after this one succeeded) can't wipe what was just correctly recorded.
+    // Safe only because every BaseMonitoringService's runChecks() cycle runs on one shared
+    // single-threaded executor (see ThingsboardMonitoringApplication) - a second thread/pool
+    // touching this set concurrently would break the protection with no compile-time signal.
     private final Set<Tags> freshThisCycle = ConcurrentHashMap.newKeySet();
 
     public ProbeMetricsRecorder(MeterRegistry meterRegistry,
@@ -100,9 +113,15 @@ public class ProbeMetricsRecorder {
     }
 
     // removes just this one action's duration gauge (the specific probe that didn't respond),
-    // without touching probe_success or any other action recorded for this target
+    // without touching probe_success or any other action recorded for this target. Skips removal
+    // if these tags already have fresh data this cycle (from a colliding sibling target that
+    // recorded successfully first) - same protection removeStaleProbe already gives probe_success.
     public void removeActionDuration(Object serviceKey, String action) {
         withTags(serviceKey, "remove action duration", tags -> {
+            if (freshThisCycle.contains(tags)) {
+                log.debug("Skipping removal of action duration for [{}] action {} - tags {} already have fresh data this cycle from a colliding target", serviceKey, action, tags);
+                return;
+            }
             removeGauge(PROBE_DURATION_METRIC, tags.and("action", action));
             Set<String> actions = actionsByBaseTags.get(tags);
             if (actions != null) {
@@ -157,8 +176,10 @@ public class ProbeMetricsRecorder {
             freshThisCycle.remove(tags); // a permanent removal must not leave a stale fresh-flag behind
         });
         if (serviceKey instanceof TransportInfo transportInfo) {
-            // otherwise this cache leaks the same way the gauges just did
-            transportTagsCache.remove(TransportTagKey.of(transportInfo));
+            // otherwise these caches leak the same way the gauges just did
+            TransportTagKey key = TransportTagKey.of(transportInfo);
+            transportTagsCache.remove(key);
+            warnedUnresolvable.remove(key);
         }
     }
 
@@ -254,17 +275,17 @@ public class ProbeMetricsRecorder {
     }
 
     // keyed on type+baseUrl, not the whole TransportInfo (its equals/hashCode reach mutable state)
-    private Tags cachedTags(Map<TransportTagKey, Tags> cache, TransportInfo info, String kind) {
+    private Tags cachedTags(Map<TransportTagKey, Optional<Tags>> cache, TransportInfo info, String kind) {
         return cache.computeIfAbsent(TransportTagKey.of(info), key -> {
             ProbeLabelResolver.ProbeLabels labels = ProbeLabelResolver.resolveTransportLabels(key.type(), key.baseUrl());
             if (labels == null) {
                 if (warnedUnresolvable.add(key)) {
                     log.warn("Failed to resolve host:port from transport base URL \"{}\" (missing scheme?) - its probe metrics will not be recorded", key.baseUrl());
                 }
-                return null;
+                return Optional.empty();
             }
-            return baseTags(labels.check(), labels.endpoint(), kind);
-        });
+            return Optional.of(baseTags(labels.check(), labels.endpoint(), kind));
+        }).orElse(null);
     }
 
     private Tags baseTags(String check, String endpoint, String kind) {

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 @Component
 @Slf4j
@@ -56,6 +55,9 @@ public class ProbeMetricsRecorder {
     // the collision is logged instead of one gauge silently overwriting the other
     private final Map<Tags, Object> tagsOwners = new ConcurrentHashMap<>();
     private final Set<Tags> warnedCollisions = ConcurrentHashMap.newKeySet();
+    // dedupes the "can't resolve this transport's endpoint" warning so a permanently-misconfigured
+    // target logs it once instead of every probe cycle forever (computeIfAbsent doesn't cache nulls)
+    private final Set<TransportTagKey> warnedUnresolvable = ConcurrentHashMap.newKeySet();
     // action gauges recorded per probe, so removeProbe can clean them up without knowing them upfront
     private final Map<Tags, Set<String>> actionsByBaseTags = new ConcurrentHashMap<>();
     // tags that already got fresh data this cycle - so a colliding sibling's removeProbe/removeAcceptedProbe
@@ -73,10 +75,8 @@ public class ProbeMetricsRecorder {
         this.enabled = otlpEnabled || prometheusEnabled;
         this.domain = domain;
         this.label = label;
-        this.loginEndpoint = this.enabled ? ProbeLabelResolver.tryResolveEndpoint("monitoring.rest.base_url", restBaseUrl, "login",
-                endpoint -> endpoint + ProbeLabelResolver.LOGIN_PATH) : null;
-        this.wsEndpoint = this.enabled ? ProbeLabelResolver.tryResolveEndpoint("monitoring.ws.base_url", wsBaseUrl, "ws",
-                Function.identity()) : null;
+        this.loginEndpoint = this.enabled ? ProbeLabelResolver.resolveLoginEndpoint(restBaseUrl) : null;
+        this.wsEndpoint = this.enabled ? ProbeLabelResolver.resolveWsEndpoint(wsBaseUrl) : null;
     }
 
     // resets which Tags have fresh data this cycle - called once at the start of each runChecks()
@@ -99,6 +99,18 @@ public class ProbeMetricsRecorder {
         });
     }
 
+    // removes just this one action's duration gauge (the specific probe that didn't respond),
+    // without touching probe_success or any other action recorded for this target
+    public void removeActionDuration(Object serviceKey, String action) {
+        withTags(serviceKey, "remove action duration", tags -> {
+            removeGauge(PROBE_DURATION_METRIC, tags.and("action", action));
+            Set<String> actions = actionsByBaseTags.get(tags);
+            if (actions != null) {
+                actions.remove(action);
+            }
+        });
+    }
+
     // true once the transport itself acknowledges a message, independent of the login/WS session
     public void recordAcceptedProbe(Object serviceKey, boolean success) {
         if (!enabled || !(serviceKey instanceof TransportInfo transportInfo)) {
@@ -106,6 +118,9 @@ public class ProbeMetricsRecorder {
         }
         try {
             Tags tags = acceptedTags(transportInfo);
+            if (tags == null) {
+                return;
+            }
             setGauge(PROBE_SUCCESS_METRIC, tags, success ? 1d : 0d);
             freshThisCycle.add(tags);
         } catch (Exception e) {
@@ -157,19 +172,28 @@ public class ProbeMetricsRecorder {
         removeAcceptedProbe(serviceKey, true);
     }
 
-    // doesn't evict acceptedTagsCache - this runs every healthy cycle, which would defeat the cache
+    // only evicts acceptedTagsCache on permanent removal (see below) - the stale path runs every
+    // healthy cycle, which would defeat the cache
     private void removeAcceptedProbe(Object serviceKey, boolean skipIfFresh) {
         if (!enabled || !(serviceKey instanceof TransportInfo transportInfo)) {
             return;
         }
         try {
             Tags tags = acceptedTags(transportInfo);
+            if (tags == null) {
+                return;
+            }
             if (skipIfFresh && freshThisCycle.contains(tags)) {
                 log.debug("Skipping removal of accepted probe metric for [{}] - tags {} already have fresh data this cycle from a colliding target", transportInfo, tags);
                 return;
             }
             removeGauge(PROBE_SUCCESS_METRIC, tags);
             freshThisCycle.remove(tags);
+            if (!skipIfFresh) {
+                // permanent removal (decommissioning) - safe to evict here, unlike the stale path which
+                // runs every healthy cycle and would otherwise defeat the cache
+                acceptedTagsCache.remove(TransportTagKey.of(transportInfo));
+            }
         } catch (Exception e) {
             log.warn("Failed to remove accepted probe metric for [{}]", transportInfo, e);
         }
@@ -202,7 +226,7 @@ public class ProbeMetricsRecorder {
         try {
             Tags tags = resolveTags(serviceKey);
             if (tags == null) {
-                return; // GENERAL, EDQS, or anything outside the documented label taxonomy
+                return; // GENERAL, EDQS, an unresolvable transport endpoint, or anything outside the documented label taxonomy
             }
             body.accept(tags);
         } catch (Exception e) {
@@ -233,6 +257,12 @@ public class ProbeMetricsRecorder {
     private Tags cachedTags(Map<TransportTagKey, Tags> cache, TransportInfo info, String kind) {
         return cache.computeIfAbsent(TransportTagKey.of(info), key -> {
             ProbeLabelResolver.ProbeLabels labels = ProbeLabelResolver.resolveTransportLabels(key.type(), key.baseUrl());
+            if (labels == null) {
+                if (warnedUnresolvable.add(key)) {
+                    log.warn("Failed to resolve host:port from transport base URL \"{}\" (missing scheme?) - its probe metrics will not be recorded", key.baseUrl());
+                }
+                return null;
+            }
             return baseTags(labels.check(), labels.endpoint(), kind);
         });
     }

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
@@ -42,8 +42,7 @@ public class ProbeMetricsRecorder {
     private static final String KIND_PROBE = "probe";
     private static final String KIND_ACCEPTED = "accepted";
 
-    // action names shared with BaseHealthChecker/BaseMonitoringService/WsClientFactory, so a
-    // recordActionDuration call and its matching removeActionDuration can't drift via a typo
+    // shared with BaseHealthChecker/BaseMonitoringService/WsClientFactory to avoid literal drift
     public static final String ACTION_REQUEST = "request";
     public static final String ACTION_WS_UPDATE = "ws_update";
     public static final String ACTION_CONNECT = "connect";
@@ -57,24 +56,18 @@ public class ProbeMetricsRecorder {
     private final String wsEndpoint;
 
     private final Map<GaugeKey, AtomicReference<Double>> gaugeValues = new ConcurrentHashMap<>();
-    // Optional-valued so an unresolvable target's negative result is cached too (a plain
-    // computeIfAbsent never stores a null return, so it would otherwise re-resolve every call)
+    // Optional-valued so an unresolvable target's negative result is cached too, not re-resolved every call
     private final Map<TransportTagKey, Optional<Tags>> transportTagsCache = new ConcurrentHashMap<>();
     private final Map<TransportTagKey, Optional<Tags>> acceptedTagsCache = new ConcurrentHashMap<>();
-    // detects two probes resolving to identical labels (e.g. same host:port, different queue) so
-    // the collision is logged instead of one gauge silently overwriting the other
+    // detects two probes resolving to identical labels, so it's logged instead of silently overwritten
     private final Map<Tags, Object> tagsOwners = new ConcurrentHashMap<>();
     private final Set<Tags> warnedCollisions = ConcurrentHashMap.newKeySet();
-    // dedupes the "can't resolve this transport's endpoint" warning so a permanently-misconfigured
-    // target logs it once instead of every probe cycle forever (computeIfAbsent doesn't cache nulls)
+    // dedupes the "can't resolve endpoint" warning so a misconfigured target logs it once, not every cycle
     private final Set<TransportTagKey> warnedUnresolvable = ConcurrentHashMap.newKeySet();
     // action gauges recorded per probe, so removeProbe can clean them up without knowing them upfront
     private final Map<Tags, Set<String>> actionsByBaseTags = new ConcurrentHashMap<>();
-    // tags that already got fresh data this cycle - so a colliding sibling's removeProbe/removeAcceptedProbe
-    // (e.g. crashing right after this one succeeded) can't wipe what was just correctly recorded.
-    // Safe only because every BaseMonitoringService's runChecks() cycle runs on one shared
-    // single-threaded executor (see ThingsboardMonitoringApplication) - a second thread/pool
-    // touching this set concurrently would break the protection with no compile-time signal.
+    // tags with fresh data this cycle - protects a colliding sibling from wiping a just-recorded gauge;
+    // relies on runChecks() cycles never overlapping (single-threaded executor)
     private final Set<Tags> freshThisCycle = ConcurrentHashMap.newKeySet();
 
     public ProbeMetricsRecorder(MeterRegistry meterRegistry,
@@ -112,10 +105,7 @@ public class ProbeMetricsRecorder {
         });
     }
 
-    // removes just this one action's duration gauge (the specific probe that didn't respond),
-    // without touching probe_success or any other action recorded for this target. Skips removal
-    // if these tags already have fresh data this cycle (from a colliding sibling target that
-    // recorded successfully first) - same protection removeStaleProbe already gives probe_success.
+    // removes just this action's duration gauge; skips if a colliding sibling already has fresh data
     public void removeActionDuration(Object serviceKey, String action) {
         withTags(serviceKey, "remove action duration", tags -> {
             if (freshThisCycle.contains(tags)) {
@@ -147,22 +137,14 @@ public class ProbeMetricsRecorder {
         }
     }
 
-    // permanent removal (e.g. decommissioning a domain-IP associate) - always removes the gauge,
-    // even if its tags got fresh data this cycle, since the target is gone for good either way
-    public void removeProbe(Object serviceKey) {
-        removeProbe(serviceKey, false);
+    // PERMANENT always removes (decommissioning); STALE_THIS_CYCLE skips if a colliding sibling is fresh
+    public enum Removal {
+        PERMANENT, STALE_THIS_CYCLE
     }
 
-    // for a probe no longer checked THIS cycle only - skips removal if its tags already have fresh
-    // data this cycle (from a colliding sibling target sharing the same resolved tags), so that a
-    // crashing sibling's stale-clearing can't wipe another target's just-recorded gauge
-    public void removeStaleProbe(Object serviceKey) {
-        removeProbe(serviceKey, true);
-    }
-
-    private void removeProbe(Object serviceKey, boolean skipIfFresh) {
+    public void removeProbe(Object serviceKey, Removal removal) {
         withTags(serviceKey, "remove", tags -> {
-            if (skipIfFresh && freshThisCycle.contains(tags)) {
+            if (removal == Removal.STALE_THIS_CYCLE && freshThisCycle.contains(tags)) {
                 log.debug("Skipping removal of probe metric for [{}] - tags {} already have fresh data this cycle from a colliding target", serviceKey, tags);
                 return;
             }
@@ -175,11 +157,8 @@ public class ProbeMetricsRecorder {
             warnedCollisions.remove(tags);
             freshThisCycle.remove(tags); // a permanent removal must not leave a stale fresh-flag behind
         });
-        // only on permanent removal - a stale (per-cycle) removal runs every unhealthy cycle (e.g.
-        // for the whole duration of a login/WS outage), so evicting here would defeat the cache and,
-        // for warnedUnresolvable, make an unresolvable target's warning re-fire every such cycle
-        // instead of once - exactly what that dedup set exists to prevent
-        if (!skipIfFresh && serviceKey instanceof TransportInfo transportInfo) {
+        // only on permanent removal - a stale removal runs every unhealthy cycle and would defeat the cache
+        if (removal == Removal.PERMANENT && serviceKey instanceof TransportInfo transportInfo) {
             // otherwise these caches leak the same way the gauges just did
             TransportTagKey key = TransportTagKey.of(transportInfo);
             transportTagsCache.remove(key);
@@ -187,19 +166,8 @@ public class ProbeMetricsRecorder {
         }
     }
 
-    // permanent removal - see removeProbe(Object) for why this never skips
-    public void removeAcceptedProbe(Object serviceKey) {
-        removeAcceptedProbe(serviceKey, false);
-    }
-
-    // for an accepted-fallback probe no longer checked THIS cycle only - see removeStaleProbe(Object)
-    public void removeStaleAcceptedProbe(Object serviceKey) {
-        removeAcceptedProbe(serviceKey, true);
-    }
-
-    // only evicts acceptedTagsCache on permanent removal (see below) - the stale path runs every
-    // healthy cycle, which would defeat the cache
-    private void removeAcceptedProbe(Object serviceKey, boolean skipIfFresh) {
+    // see removeProbe(Object, Removal) for what PERMANENT vs STALE_THIS_CYCLE mean here
+    public void removeAcceptedProbe(Object serviceKey, Removal removal) {
         if (!enabled || !(serviceKey instanceof TransportInfo transportInfo)) {
             return;
         }
@@ -208,16 +176,14 @@ public class ProbeMetricsRecorder {
             if (tags == null) {
                 return;
             }
-            if (skipIfFresh && freshThisCycle.contains(tags)) {
+            if (removal == Removal.STALE_THIS_CYCLE && freshThisCycle.contains(tags)) {
                 log.debug("Skipping removal of accepted probe metric for [{}] - tags {} already have fresh data this cycle from a colliding target", transportInfo, tags);
                 return;
             }
             removeGauge(PROBE_SUCCESS_METRIC, tags);
             freshThisCycle.remove(tags);
-            if (!skipIfFresh) {
-                // permanent removal (decommissioning) - safe to evict here, unlike the stale path which
-                // runs every healthy cycle and would otherwise defeat the cache
-                acceptedTagsCache.remove(TransportTagKey.of(transportInfo));
+            if (removal == Removal.PERMANENT) {
+                acceptedTagsCache.remove(TransportTagKey.of(transportInfo)); // stale path would defeat the cache
             }
         } catch (Exception e) {
             log.warn("Failed to remove accepted probe metric for [{}]", transportInfo, e);

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
@@ -130,6 +130,7 @@ public class ProbeMetricsRecorder {
             if (tags == null) {
                 return;
             }
+            warnIfLabelCollision(serviceKey, tags);
             setGauge(PROBE_SUCCESS_METRIC, tags, success ? 1d : 0d);
             freshThisCycle.add(tags);
         } catch (Exception e) {
@@ -153,8 +154,9 @@ public class ProbeMetricsRecorder {
             if (actions != null) {
                 actions.forEach(action -> removeGauge(PROBE_DURATION_METRIC, tags.and("action", action)));
             }
-            tagsOwners.remove(tags);
-            warnedCollisions.remove(tags);
+            if (removal == Removal.PERMANENT) {
+                clearCollisionState(tags);
+            }
             freshThisCycle.remove(tags); // a permanent removal must not leave a stale fresh-flag behind
         });
         // only on permanent removal - a stale removal runs every unhealthy cycle and would defeat the cache
@@ -173,17 +175,22 @@ public class ProbeMetricsRecorder {
         }
         try {
             Tags tags = acceptedTags(transportInfo);
-            if (tags == null) {
-                return;
+            if (tags != null) {
+                if (removal == Removal.STALE_THIS_CYCLE && freshThisCycle.contains(tags)) {
+                    log.debug("Skipping removal of accepted probe metric for [{}] - tags {} already have fresh data this cycle from a colliding target", transportInfo, tags);
+                } else {
+                    removeGauge(PROBE_SUCCESS_METRIC, tags);
+                    freshThisCycle.remove(tags);
+                    if (removal == Removal.PERMANENT) {
+                        clearCollisionState(tags);
+                    }
+                }
             }
-            if (removal == Removal.STALE_THIS_CYCLE && freshThisCycle.contains(tags)) {
-                log.debug("Skipping removal of accepted probe metric for [{}] - tags {} already have fresh data this cycle from a colliding target", transportInfo, tags);
-                return;
-            }
-            removeGauge(PROBE_SUCCESS_METRIC, tags);
-            freshThisCycle.remove(tags);
+            // only on permanent removal - a stale removal runs every healthy cycle and would defeat
+            // the cache. Evicted unconditionally, even when tags resolved to null above, otherwise a
+            // decommissioned unresolvable target leaks its Optional.empty() entry here forever.
             if (removal == Removal.PERMANENT) {
-                acceptedTagsCache.remove(TransportTagKey.of(transportInfo)); // stale path would defeat the cache
+                acceptedTagsCache.remove(TransportTagKey.of(transportInfo));
             }
         } catch (Exception e) {
             log.warn("Failed to remove accepted probe metric for [{}]", transportInfo, e);
@@ -200,6 +207,11 @@ public class ProbeMetricsRecorder {
         } catch (Exception e) {
             log.warn("Failed to record monitoring heartbeat metric", e);
         }
+    }
+
+    private void clearCollisionState(Tags tags) {
+        tagsOwners.remove(tags);
+        warnedCollisions.remove(tags);
     }
 
     private void warnIfLabelCollision(Object serviceKey, Tags tags) {

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorder.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.metrics;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.thingsboard.monitoring.config.transport.TransportInfo;
+import org.thingsboard.monitoring.config.transport.TransportType;
+import org.thingsboard.monitoring.data.MonitoredServiceKey;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@Component
+@Slf4j
+public class ProbeMetricsRecorder {
+
+    public static final String PROBE_SUCCESS_METRIC = "probe_success";
+    public static final String PROBE_DURATION_METRIC = "probe_duration_ms";
+    public static final String MONITORING_HEARTBEAT_METRIC = "tb_monitoring_last_run_timestamp_seconds";
+    private static final String KIND_PROBE = "probe";
+    private static final String KIND_ACCEPTED = "accepted";
+
+    private final MeterRegistry meterRegistry;
+    private final boolean enabled;
+    private final String domain;
+    private final String label;
+    private final String loginEndpoint;
+    private final String wsEndpoint;
+
+    private final Map<GaugeKey, AtomicReference<Double>> gaugeValues = new ConcurrentHashMap<>();
+    private final Map<TransportTagKey, Tags> transportTagsCache = new ConcurrentHashMap<>();
+    private final Map<TransportTagKey, Tags> acceptedTagsCache = new ConcurrentHashMap<>();
+    // detects two probes resolving to identical labels (e.g. same host:port, different queue) so
+    // the collision is logged instead of one gauge silently overwriting the other
+    private final Map<Tags, Object> tagsOwners = new ConcurrentHashMap<>();
+    private final Set<Tags> warnedCollisions = ConcurrentHashMap.newKeySet();
+    // action gauges recorded per probe, so removeProbe can clean them up without knowing them upfront
+    private final Map<Tags, Set<String>> actionsByBaseTags = new ConcurrentHashMap<>();
+
+    public ProbeMetricsRecorder(MeterRegistry meterRegistry,
+                                 @Value("${monitoring.metrics.otlp.enabled:false}") boolean otlpEnabled,
+                                 @Value("${monitoring.metrics.prometheus.enabled:false}") boolean prometheusEnabled,
+                                 @Value("${monitoring.domain}") String domain,
+                                 @Value("${monitoring.rest.base_url}") String restBaseUrl,
+                                 @Value("${monitoring.ws.base_url}") String wsBaseUrl,
+                                 @Value("${monitoring.label:}") String label) {
+        this.meterRegistry = meterRegistry;
+        this.enabled = otlpEnabled || prometheusEnabled;
+        this.domain = domain;
+        this.label = label;
+        this.loginEndpoint = this.enabled ? ProbeLabelResolver.tryResolveEndpoint("monitoring.rest.base_url", restBaseUrl, "login",
+                endpoint -> endpoint + ProbeLabelResolver.LOGIN_PATH) : null;
+        this.wsEndpoint = this.enabled ? ProbeLabelResolver.tryResolveEndpoint("monitoring.ws.base_url", wsBaseUrl, "ws",
+                Function.identity()) : null;
+    }
+
+    public void recordProbe(Object serviceKey, boolean success) {
+        withTags(serviceKey, "record", tags -> {
+            warnIfLabelCollision(serviceKey, tags);
+            setGauge(PROBE_SUCCESS_METRIC, tags, success ? 1d : 0d);
+        });
+    }
+
+    public void recordActionDuration(Object serviceKey, String action, long durationMs) {
+        withTags(serviceKey, "record action duration", tags -> {
+            actionsByBaseTags.computeIfAbsent(tags, k -> ConcurrentHashMap.newKeySet()).add(action);
+            setGauge(PROBE_DURATION_METRIC, tags.and("action", action), (double) durationMs);
+        });
+    }
+
+    // true once the transport itself acknowledges a message, independent of the login/WS session
+    public void recordAcceptedProbe(Object serviceKey, boolean success) {
+        if (!enabled || !(serviceKey instanceof TransportInfo transportInfo)) {
+            return;
+        }
+        try {
+            setGauge(PROBE_SUCCESS_METRIC, acceptedTags(transportInfo), success ? 1d : 0d);
+        } catch (Exception e) {
+            log.warn("Failed to record accepted probe metric for [{}]", serviceKey, e);
+        }
+    }
+
+    // for a probe no longer checked this cycle - without this its gauge keeps its last value
+    public void removeProbe(Object serviceKey) {
+        withTags(serviceKey, "remove", tags -> {
+            removeGauge(PROBE_SUCCESS_METRIC, tags);
+            Set<String> actions = actionsByBaseTags.remove(tags);
+            if (actions != null) {
+                actions.forEach(action -> removeGauge(PROBE_DURATION_METRIC, tags.and("action", action)));
+            }
+            tagsOwners.remove(tags);
+            warnedCollisions.remove(tags);
+        });
+        if (serviceKey instanceof TransportInfo transportInfo) {
+            // otherwise this cache leaks the same way the gauges just did
+            transportTagsCache.remove(TransportTagKey.of(transportInfo));
+        }
+    }
+
+    // doesn't evict acceptedTagsCache - this runs every healthy cycle, which would defeat the cache
+    public void removeAcceptedProbe(Object serviceKey) {
+        if (!enabled || !(serviceKey instanceof TransportInfo transportInfo)) {
+            return;
+        }
+        try {
+            removeGauge(PROBE_SUCCESS_METRIC, acceptedTags(transportInfo));
+        } catch (Exception e) {
+            log.warn("Failed to remove accepted probe metric for [{}]", transportInfo, e);
+        }
+    }
+
+    // distinguishes "the prober is dead" (this goes stale) from "a target is down" (probe_success does)
+    public void recordHeartbeat() {
+        if (!enabled) {
+            return;
+        }
+        try {
+            setGauge(MONITORING_HEARTBEAT_METRIC, Tags.of("domain", domain, "label", label), (double) (System.currentTimeMillis() / 1000));
+        } catch (Exception e) {
+            log.warn("Failed to record monitoring heartbeat metric", e);
+        }
+    }
+
+    private void warnIfLabelCollision(Object serviceKey, Tags tags) {
+        Object previousOwner = tagsOwners.put(tags, serviceKey);
+        if (previousOwner != null && !previousOwner.equals(serviceKey) && warnedCollisions.add(tags)) {
+            log.warn("Probe metrics collision: [{}] and [{}] both resolve to labels {} - " +
+                    "one will silently overwrite the other's gauge every cycle", previousOwner, serviceKey, tags);
+        }
+    }
+
+    private void withTags(Object serviceKey, String verb, Consumer<Tags> body) {
+        if (!enabled) {
+            return;
+        }
+        try {
+            Tags tags = resolveTags(serviceKey);
+            if (tags == null) {
+                return; // GENERAL, EDQS, or anything outside the documented label taxonomy
+            }
+            body.accept(tags);
+        } catch (Exception e) {
+            log.warn("Failed to {} probe metric for [{}]", verb, serviceKey, e);
+        }
+    }
+
+    private Tags resolveTags(Object serviceKey) {
+        if (serviceKey instanceof TransportInfo transportInfo) {
+            return transportTags(transportInfo);
+        } else if (loginEndpoint != null && MonitoredServiceKey.LOGIN.equals(serviceKey)) {
+            return baseTags("login", loginEndpoint, KIND_PROBE);
+        } else if (wsEndpoint != null && MonitoredServiceKey.WS.equals(serviceKey)) {
+            return baseTags("ws", wsEndpoint, KIND_PROBE);
+        }
+        return null;
+    }
+
+    private Tags transportTags(TransportInfo info) {
+        return cachedTags(transportTagsCache, info, KIND_PROBE);
+    }
+
+    private Tags acceptedTags(TransportInfo info) {
+        return cachedTags(acceptedTagsCache, info, KIND_ACCEPTED);
+    }
+
+    // keyed on type+baseUrl, not the whole TransportInfo (its equals/hashCode reach mutable state)
+    private Tags cachedTags(Map<TransportTagKey, Tags> cache, TransportInfo info, String kind) {
+        return cache.computeIfAbsent(TransportTagKey.of(info), key -> {
+            ProbeLabelResolver.ProbeLabels labels = ProbeLabelResolver.resolveTransportLabels(key.type(), key.baseUrl());
+            return baseTags(labels.check(), labels.endpoint(), kind);
+        });
+    }
+
+    private Tags baseTags(String check, String endpoint, String kind) {
+        return Tags.of("domain", domain, "check", check, "endpoint", endpoint, "kind", kind, "label", label);
+    }
+
+    private void setGauge(String metricName, Tags tags, double value) {
+        gaugeValues.computeIfAbsent(new GaugeKey(metricName, tags), k -> {
+            AtomicReference<Double> ref = new AtomicReference<>(value);
+            Gauge.builder(metricName, ref, r -> r.get())
+                    .tags(tags)
+                    .register(meterRegistry);
+            return ref;
+        }).set(value);
+    }
+
+    private void removeGauge(String metricName, Tags tags) {
+        // skip find()'s full-registry scan when gaugeValues shows there's nothing to remove
+        if (gaugeValues.remove(new GaugeKey(metricName, tags)) != null) {
+            meterRegistry.find(metricName).tags(tags).meters().forEach(meterRegistry::remove);
+        }
+    }
+
+    private record GaugeKey(String metricName, Tags tags) {
+    }
+
+    private record TransportTagKey(TransportType type, String baseUrl) {
+        static TransportTagKey of(TransportInfo info) {
+            return new TransportTagKey(info.getType(), info.getTarget().getBaseUrl());
+        }
+    }
+
+}

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfig.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfig.java
@@ -41,12 +41,15 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Configuration
 @Slf4j
 public class ProbeMetricsRegistryConfig {
 
     private HttpServer prometheusServer;
+    private ExecutorService prometheusExecutor;
 
     @Bean
     public MeterRegistry probeMeterRegistry(
@@ -56,15 +59,23 @@ public class ProbeMetricsRegistryConfig {
             @Value("${monitoring.metrics.otlp.alerting_enabled:false}") boolean otlpAlertingEnabled,
             @Value("${monitoring.metrics.prometheus.enabled:false}") boolean prometheusEnabled,
             @Value("${monitoring.metrics.prometheus.port:9100}") int prometheusPort,
+            @Value("${monitoring.metrics.prometheus.bind_address:0.0.0.0}") String prometheusBindAddress,
             MonitoringReporter reporter) throws IOException {
         CompositeMeterRegistry composite = new CompositeMeterRegistry();
-        if (otlpEnabled) {
-            composite.add(createOtlpRegistry(otlpEndpoint, otlpStepMs, otlpAlertingEnabled, reporter));
-            log.info("Probe metrics: OTLP export enabled, pushing to {}", otlpEndpoint);
-        }
-        if (prometheusEnabled) {
-            composite.add(createPrometheusRegistry(prometheusPort));
-            log.info("Probe metrics: Prometheus scrape endpoint enabled on port {}", prometheusPort);
+        try {
+            if (otlpEnabled) {
+                composite.add(createOtlpRegistry(otlpEndpoint, otlpStepMs, otlpAlertingEnabled, reporter));
+                log.info("Probe metrics: OTLP export enabled, pushing to {}", otlpEndpoint);
+            }
+            if (prometheusEnabled) {
+                composite.add(createPrometheusRegistry(prometheusPort, prometheusBindAddress));
+                log.info("Probe metrics: Prometheus scrape endpoint enabled on port {}", prometheusPort);
+            }
+        } catch (Exception e) {
+            // an already-started OTLP registry's internal publish thread would otherwise leak and
+            // block JVM exit, defeating the intended "fail loud" crash on Prometheus bind failure
+            composite.close();
+            throw e;
         }
         return composite;
     }
@@ -114,9 +125,13 @@ public class ProbeMetricsRegistryConfig {
         };
     }
 
-    private PrometheusMeterRegistry createPrometheusRegistry(int port) throws IOException {
+    private PrometheusMeterRegistry createPrometheusRegistry(int port, String bindAddress) throws IOException {
+        // JDK HttpServer has no default request/response timeout - without these, a single slow/stalled
+        // client connection can hang the (otherwise single-threaded) server forever
+        System.setProperty("sun.net.httpserver.maxReqTime", "30");
+        System.setProperty("sun.net.httpserver.maxRspTime", "30");
         PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-        prometheusServer = HttpServer.create(new InetSocketAddress(port), 0);
+        prometheusServer = HttpServer.create(new InetSocketAddress(bindAddress, port), 0);
         prometheusServer.createContext("/metrics", exchange -> {
             byte[] response = registry.scrape().getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().set("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
@@ -125,7 +140,8 @@ public class ProbeMetricsRegistryConfig {
                 os.write(response);
             }
         });
-        prometheusServer.setExecutor(null);
+        prometheusExecutor = Executors.newFixedThreadPool(4);
+        prometheusServer.setExecutor(prometheusExecutor);
         prometheusServer.start();
         return registry;
     }
@@ -134,6 +150,10 @@ public class ProbeMetricsRegistryConfig {
     public void shutdown() {
         if (prometheusServer != null) {
             prometheusServer.stop(0);
+        }
+        if (prometheusExecutor != null) {
+            // HttpServer.stop() doesn't shut down a caller-supplied executor - we own its lifecycle
+            prometheusExecutor.shutdownNow();
         }
     }
 

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfig.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfig.java
@@ -48,20 +48,15 @@ import java.util.concurrent.Executors;
 @Slf4j
 public class ProbeMetricsRegistryConfig {
 
-    // small fixed pool for the /metrics scrape endpoint - PrometheusMeterRegistry.scrape() is
-    // thread-safe, so a few concurrent scrapers are safe; this also makes scraping genuinely
-    // concurrent instead of serialized, unlike the previous setExecutor(null) default
+    // small fixed pool for the /metrics scrape endpoint - PrometheusMeterRegistry.scrape() is thread-safe
     private static final int PROMETHEUS_SCRAPE_THREAD_POOL_SIZE = 4;
 
     static {
-        // JDK HttpServer has no default request/response timeout - without these, a single slow/stalled
-        // client connection can hang the (otherwise single-threaded) server forever. Set in a static
-        // initializer so this runs at class-load time, before this class's own bean method (or
-        // anything else in the JVM) can construct an HttpServer: sun.net.httpserver.ServerConfig
-        // reads these properties only once, in its own static initializer triggered by the first
-        // HttpServer use anywhere in the process - setting them any later risks a silent no-op.
-        System.setProperty("sun.net.httpserver.maxReqTime", "30");
-        System.setProperty("sun.net.httpserver.maxRspTime", "30");
+        // sun.net.httpserver.ServerConfig reads these once, on the JVM's first HttpServer use - must be
+        // set before that (a static initializer, not @Value, since Spring isn't up yet at that point)
+        String timeoutS = System.getenv().getOrDefault("METRICS_PROMETHEUS_HTTP_TIMEOUT_S", "30");
+        System.setProperty("sun.net.httpserver.maxReqTime", timeoutS);
+        System.setProperty("sun.net.httpserver.maxRspTime", timeoutS);
     }
 
     private HttpServer prometheusServer;

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfig.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfig.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.metrics;
+
+import com.sun.net.httpserver.HttpServer;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.micrometer.registry.otlp.OtlpConfig;
+import io.micrometer.registry.otlp.OtlpHttpMetricsSender;
+import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import io.micrometer.registry.otlp.OtlpMetricsSender;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thingsboard.monitoring.data.MonitoredServiceKey;
+import org.thingsboard.monitoring.service.MonitoringReporter;
+
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@Slf4j
+public class ProbeMetricsRegistryConfig {
+
+    private HttpServer prometheusServer;
+
+    @Bean
+    public MeterRegistry probeMeterRegistry(
+            @Value("${monitoring.metrics.otlp.enabled:false}") boolean otlpEnabled,
+            @Value("${monitoring.metrics.otlp.endpoint:http://localhost:4318/v1/metrics}") String otlpEndpoint,
+            @Value("${monitoring.metrics.otlp.step_ms:60000}") long otlpStepMs,
+            @Value("${monitoring.metrics.otlp.alerting_enabled:false}") boolean otlpAlertingEnabled,
+            @Value("${monitoring.metrics.prometheus.enabled:false}") boolean prometheusEnabled,
+            @Value("${monitoring.metrics.prometheus.port:9100}") int prometheusPort,
+            MonitoringReporter reporter) throws IOException {
+        CompositeMeterRegistry composite = new CompositeMeterRegistry();
+        if (otlpEnabled) {
+            composite.add(createOtlpRegistry(otlpEndpoint, otlpStepMs, otlpAlertingEnabled, reporter));
+            log.info("Probe metrics: OTLP export enabled, pushing to {}", otlpEndpoint);
+        }
+        if (prometheusEnabled) {
+            composite.add(createPrometheusRegistry(prometheusPort));
+            log.info("Probe metrics: Prometheus scrape endpoint enabled on port {}", prometheusPort);
+        }
+        return composite;
+    }
+
+    private OtlpMeterRegistry createOtlpRegistry(String endpoint, long stepMs, boolean alertingEnabled, MonitoringReporter reporter) {
+        OtlpConfig otlpConfig = new OtlpConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public String url() {
+                return endpoint;
+            }
+
+            @Override
+            public Duration step() {
+                return Duration.ofMillis(stepMs);
+            }
+
+            @Override
+            public Map<String, String> resourceAttributes() {
+                Map<String, String> attributes = new HashMap<>(OtlpConfig.super.resourceAttributes());
+                attributes.putIfAbsent("service.name", "tb-monitoring");
+                return attributes;
+            }
+        };
+        OtlpMetricsSender sender = new OtlpHttpMetricsSender(new HttpUrlConnectionSender());
+        if (alertingEnabled) {
+            sender = withAlerting(sender, reporter);
+        }
+        return OtlpMeterRegistry.builder(otlpConfig).clock(Clock.SYSTEM).metricsSender(sender).build();
+    }
+
+    // alerts on real OTLP push failures via Slack/incident, not as a probe metric - a broken
+    // metrics pipe can't be expected to report its own breakage
+    private static OtlpMetricsSender withAlerting(OtlpMetricsSender delegate, MonitoringReporter reporter) {
+        return request -> {
+            try {
+                delegate.send(request);
+                reporter.serviceIsOk(MonitoredServiceKey.OTLP_EXPORT);
+            } catch (Exception e) {
+                reporter.serviceFailure(MonitoredServiceKey.OTLP_EXPORT, e);
+                throw e; // preserve OtlpMeterRegistry's own "Failed to publish metrics" warning log
+            }
+        };
+    }
+
+    private PrometheusMeterRegistry createPrometheusRegistry(int port) throws IOException {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        prometheusServer = HttpServer.create(new InetSocketAddress(port), 0);
+        prometheusServer.createContext("/metrics", exchange -> {
+            byte[] response = registry.scrape().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+            exchange.sendResponseHeaders(200, response.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        });
+        prometheusServer.setExecutor(null);
+        prometheusServer.start();
+        return registry;
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (prometheusServer != null) {
+            prometheusServer.stop(0);
+        }
+    }
+
+}

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfig.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfig.java
@@ -48,6 +48,22 @@ import java.util.concurrent.Executors;
 @Slf4j
 public class ProbeMetricsRegistryConfig {
 
+    // small fixed pool for the /metrics scrape endpoint - PrometheusMeterRegistry.scrape() is
+    // thread-safe, so a few concurrent scrapers are safe; this also makes scraping genuinely
+    // concurrent instead of serialized, unlike the previous setExecutor(null) default
+    private static final int PROMETHEUS_SCRAPE_THREAD_POOL_SIZE = 4;
+
+    static {
+        // JDK HttpServer has no default request/response timeout - without these, a single slow/stalled
+        // client connection can hang the (otherwise single-threaded) server forever. Set in a static
+        // initializer so this runs at class-load time, before this class's own bean method (or
+        // anything else in the JVM) can construct an HttpServer: sun.net.httpserver.ServerConfig
+        // reads these properties only once, in its own static initializer triggered by the first
+        // HttpServer use anywhere in the process - setting them any later risks a silent no-op.
+        System.setProperty("sun.net.httpserver.maxReqTime", "30");
+        System.setProperty("sun.net.httpserver.maxRspTime", "30");
+    }
+
     private HttpServer prometheusServer;
     private ExecutorService prometheusExecutor;
 
@@ -126,10 +142,6 @@ public class ProbeMetricsRegistryConfig {
     }
 
     private PrometheusMeterRegistry createPrometheusRegistry(int port, String bindAddress) throws IOException {
-        // JDK HttpServer has no default request/response timeout - without these, a single slow/stalled
-        // client connection can hang the (otherwise single-threaded) server forever
-        System.setProperty("sun.net.httpserver.maxReqTime", "30");
-        System.setProperty("sun.net.httpserver.maxRspTime", "30");
         PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         prometheusServer = HttpServer.create(new InetSocketAddress(bindAddress, port), 0);
         prometheusServer.createContext("/metrics", exchange -> {
@@ -140,7 +152,7 @@ public class ProbeMetricsRegistryConfig {
                 os.write(response);
             }
         });
-        prometheusExecutor = Executors.newFixedThreadPool(4);
+        prometheusExecutor = Executors.newFixedThreadPool(PROMETHEUS_SCRAPE_THREAD_POOL_SIZE);
         prometheusServer.setExecutor(prometheusExecutor);
         prometheusServer.start();
         return registry;

--- a/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfig.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfig.java
@@ -48,7 +48,8 @@ import java.util.concurrent.Executors;
 @Slf4j
 public class ProbeMetricsRegistryConfig {
 
-    // small fixed pool for the /metrics scrape endpoint - PrometheusMeterRegistry.scrape() is thread-safe
+    // 4 concurrent scrapers is plenty for a single Prometheus target polling this endpoint - was
+    // effectively 1 (setExecutor(null)) before; scrape() is thread-safe so raising it is safe
     private static final int PROMETHEUS_SCRAPE_THREAD_POOL_SIZE = 4;
 
     static {

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
@@ -28,6 +28,7 @@ import org.thingsboard.monitoring.config.MonitoringTarget;
 import org.thingsboard.monitoring.data.Latencies;
 import org.thingsboard.monitoring.data.MonitoredServiceKey;
 import org.thingsboard.monitoring.data.ServiceFailureException;
+import org.thingsboard.monitoring.data.notification.ShortNameProvider;
 import org.thingsboard.monitoring.metrics.ProbeMetricsRecorder;
 import org.thingsboard.monitoring.util.TbStopWatch;
 
@@ -128,18 +129,37 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
         probeMetricsRecorder.removeActionDuration(info, ProbeMetricsRecorder.ACTION_WS_UPDATE);
     }
 
+    // separate identity from info, so this fallback's alerts/recoveries never touch check()'s own
+    // failuresCounter (and vice versa) - mirrors the metrics side's separate kind="accepted" tag
+    private record AcceptedProbeKey(Object delegate) implements ShortNameProvider {
+        @Override
+        public String getShortName() {
+            String base = delegate instanceof ShortNameProvider provider ? provider.getShortName() : String.valueOf(delegate);
+            return base + " (accepted)";
+        }
+
+        @Override
+        public String toString() {
+            return delegate + " (accepted)";
+        }
+    }
+
     // unlike check(), doesn't wait for WS/core confirmation - not final since LwM2M overrides it as
-    // a no-op. Never calls reporter.serviceIsOk: sharing check()'s key could wrongly resolve a real incident.
+    // a no-op. Reports under AcceptedProbeKey rather than info, so this weaker signal can alert and
+    // recover on its own without ever resolving (or reopening) the real end-to-end check's incident.
     protected void checkAccepted() {
+        Object acceptedKey = new AcceptedProbeKey(info);
         boolean success;
         try {
             initClient();
-            sendTestPayload(createTestPayload(UUID.randomUUID().toString(), ACCEPTED_TEST_TELEMETRY_KEY));
-            log.info("[{}] (accepted) is OK", info); // plain log, not reporter.serviceIsOk - see above
+            sendAcceptedTestPayload(createTestPayload(UUID.randomUUID().toString(), ACCEPTED_TEST_TELEMETRY_KEY));
             success = true;
         } catch (Throwable e) {
-            reporter.serviceFailure(info, e);
+            reporter.serviceFailure(acceptedKey, e);
             success = false;
+        }
+        if (success) {
+            reporter.serviceIsOk(acceptedKey);
         }
         probeMetricsRecorder.recordAcceptedProbe(info, success);
         associates.values().forEach(healthChecker -> healthChecker.checkAccepted());
@@ -181,6 +201,11 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
     protected abstract String createTestPayload(String testValue, String telemetryKey);
 
     protected abstract void sendTestPayload(String payload) throws Exception;
+
+    // overridable so a transport whose regular send doesn't guarantee delivery confirmation (e.g. MQTT at QoS 0) can force one here
+    protected void sendAcceptedTestPayload(String payload) throws Exception {
+        sendTestPayload(payload);
+    }
 
     @PreDestroy
     protected abstract void destroyClient() throws Exception;

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
@@ -95,6 +95,9 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
                 probeMetricsRecorder.recordActionDuration(info, "request", requestLatencyNanos / 1_000_000);
                 log.trace("[{}] Sent test payload ({})", info, testPayload);
             } catch (Throwable e) {
+                probeMetricsRecorder.removeActionDuration(info, "request");
+                // ws_update never runs this cycle either - its last value is now stale too
+                probeMetricsRecorder.removeActionDuration(info, "ws_update");
                 throw new ServiceFailureException(info, e);
             }
 
@@ -135,29 +138,34 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
     }
 
     private void checkWsUpdates(WsClient wsClient, String testValue) {
-        stopWatch.start();
-        wsClient.waitForUpdates(resultCheckTimeoutMs);
-        log.trace("[{}] Waited for WS update. Last WS msgs: {}", info, wsClient.lastMsgs);
-        Map<String, String> latest = wsClient.getLatest(target.getDeviceId());
-        if (latest.isEmpty()) {
-            throw new ServiceFailureException(info, "No WS update arrived within " + resultCheckTimeoutMs + " ms");
-        }
-        String actualValue = latest.get(TEST_TELEMETRY_KEY);
-        if (!testValue.equals(actualValue)) {
-            throw new ServiceFailureException(info, "Was expecting value " + testValue + " but got " + actualValue);
-        }
-        if (isCfMonitoringEnabled()) {
-            String cfTestValue = testValue + "-cf";
-            String actualCfValue = latest.get(TEST_CF_TELEMETRY_KEY);
-            if (actualCfValue == null) {
-                throw new ServiceFailureException(info, "No calculated field value arrived");
-            } else if (!cfTestValue.equals(actualCfValue)) {
-                throw new ServiceFailureException(info, "Was expecting calculated field value " + cfTestValue + " but got " + actualCfValue);
+        try {
+            stopWatch.start();
+            wsClient.waitForUpdates(resultCheckTimeoutMs);
+            log.trace("[{}] Waited for WS update. Last WS msgs: {}", info, wsClient.lastMsgs);
+            Map<String, String> latest = wsClient.getLatest(target.getDeviceId());
+            if (latest.isEmpty()) {
+                throw new ServiceFailureException(info, "No WS update arrived within " + resultCheckTimeoutMs + " ms");
             }
+            String actualValue = latest.get(TEST_TELEMETRY_KEY);
+            if (!testValue.equals(actualValue)) {
+                throw new ServiceFailureException(info, "Was expecting value " + testValue + " but got " + actualValue);
+            }
+            if (isCfMonitoringEnabled()) {
+                String cfTestValue = testValue + "-cf";
+                String actualCfValue = latest.get(TEST_CF_TELEMETRY_KEY);
+                if (actualCfValue == null) {
+                    throw new ServiceFailureException(info, "No calculated field value arrived");
+                } else if (!cfTestValue.equals(actualCfValue)) {
+                    throw new ServiceFailureException(info, "Was expecting calculated field value " + cfTestValue + " but got " + actualCfValue);
+                }
+            }
+            long wsUpdateLatencyNanos = stopWatch.getTime();
+            reporter.reportLatency(Latencies.wsUpdate(getKey()), wsUpdateLatencyNanos);
+            probeMetricsRecorder.recordActionDuration(info, "ws_update", wsUpdateLatencyNanos / 1_000_000);
+        } catch (Throwable e) {
+            probeMetricsRecorder.removeActionDuration(info, "ws_update");
+            throw e;
         }
-        long wsUpdateLatencyNanos = stopWatch.getTime();
-        reporter.reportLatency(Latencies.wsUpdate(getKey()), wsUpdateLatencyNanos);
-        probeMetricsRecorder.recordActionDuration(info, "ws_update", wsUpdateLatencyNanos / 1_000_000);
     }
 
     protected abstract void initClient() throws Exception;

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
@@ -89,9 +89,7 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
                 testValue = UUID.randomUUID().toString();
                 testPayload = createTestPayload(testValue, TEST_TELEMETRY_KEY);
             } catch (Throwable e) {
-                // neither action has recorded anything yet this cycle - clear both, same as the
-                // inner try below, so a failure here doesn't leave last cycle's durations stale
-                clearOwnActionDurations();
+                clearOwnActionDurations(); // neither action recorded this cycle yet
                 throw new ServiceFailureException(info, e);
             }
             try {
@@ -125,23 +123,19 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
         });
     }
 
-    // clears both this probe's action durations - used wherever a failure means neither "request"
-    // nor "ws_update" got refreshed this cycle, whether or not either was ever attempted
     private void clearOwnActionDurations() {
         probeMetricsRecorder.removeActionDuration(info, ProbeMetricsRecorder.ACTION_REQUEST);
         probeMetricsRecorder.removeActionDuration(info, ProbeMetricsRecorder.ACTION_WS_UPDATE);
     }
 
-    // unlike check(), doesn't wait for WS/core confirmation - true once the transport itself
-    // acknowledges the message, so a transport-only outage still alerts while login/WS is down.
-    // Not final: LwM2M overrides this as a no-op since its send() has no such acknowledgment.
-    // Never reports serviceIsOk: this shares check()'s service key, and an "ok" from this fallback
-    // alone could resolve/reset a real, still-open incident that only the full check() should clear.
+    // unlike check(), doesn't wait for WS/core confirmation - not final since LwM2M overrides it as
+    // a no-op. Never calls reporter.serviceIsOk: sharing check()'s key could wrongly resolve a real incident.
     protected void checkAccepted() {
         boolean success;
         try {
             initClient();
             sendTestPayload(createTestPayload(UUID.randomUUID().toString(), ACCEPTED_TEST_TELEMETRY_KEY));
+            log.info("[{}] (accepted) is OK", info); // plain log, not reporter.serviceIsOk - see above
             success = true;
         } catch (Throwable e) {
             reporter.serviceFailure(info, e);

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
@@ -81,23 +81,29 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
         log.debug("[{}] Checking", info);
         boolean success = false;
         try {
-            int expectedUpdatesCount = isCfMonitoringEnabled() ? 2 : 1;
-            wsClient.registerWaitForUpdates(expectedUpdatesCount);
-
-            String testValue = UUID.randomUUID().toString();
-            String testPayload = createTestPayload(testValue, TEST_TELEMETRY_KEY);
+            String testValue;
+            String testPayload;
+            try {
+                int expectedUpdatesCount = isCfMonitoringEnabled() ? 2 : 1;
+                wsClient.registerWaitForUpdates(expectedUpdatesCount);
+                testValue = UUID.randomUUID().toString();
+                testPayload = createTestPayload(testValue, TEST_TELEMETRY_KEY);
+            } catch (Throwable e) {
+                // neither action has recorded anything yet this cycle - clear both, same as the
+                // inner try below, so a failure here doesn't leave last cycle's durations stale
+                clearOwnActionDurations();
+                throw new ServiceFailureException(info, e);
+            }
             try {
                 initClient();
                 stopWatch.start();
                 sendTestPayload(testPayload);
                 long requestLatencyNanos = stopWatch.getTime();
                 reporter.reportLatency(Latencies.request(getKey()), requestLatencyNanos);
-                probeMetricsRecorder.recordActionDuration(info, "request", requestLatencyNanos / 1_000_000);
+                probeMetricsRecorder.recordActionDuration(info, ProbeMetricsRecorder.ACTION_REQUEST, requestLatencyNanos / 1_000_000);
                 log.trace("[{}] Sent test payload ({})", info, testPayload);
             } catch (Throwable e) {
-                probeMetricsRecorder.removeActionDuration(info, "request");
-                // ws_update never runs this cycle either - its last value is now stale too
-                probeMetricsRecorder.removeActionDuration(info, "ws_update");
+                clearOwnActionDurations();
                 throw new ServiceFailureException(info, e);
             }
 
@@ -119,15 +125,23 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
         });
     }
 
+    // clears both this probe's action durations - used wherever a failure means neither "request"
+    // nor "ws_update" got refreshed this cycle, whether or not either was ever attempted
+    private void clearOwnActionDurations() {
+        probeMetricsRecorder.removeActionDuration(info, ProbeMetricsRecorder.ACTION_REQUEST);
+        probeMetricsRecorder.removeActionDuration(info, ProbeMetricsRecorder.ACTION_WS_UPDATE);
+    }
+
     // unlike check(), doesn't wait for WS/core confirmation - true once the transport itself
     // acknowledges the message, so a transport-only outage still alerts while login/WS is down.
     // Not final: LwM2M overrides this as a no-op since its send() has no such acknowledgment.
+    // Never reports serviceIsOk: this shares check()'s service key, and an "ok" from this fallback
+    // alone could resolve/reset a real, still-open incident that only the full check() should clear.
     protected void checkAccepted() {
         boolean success;
         try {
             initClient();
             sendTestPayload(createTestPayload(UUID.randomUUID().toString(), ACCEPTED_TEST_TELEMETRY_KEY));
-            reporter.serviceIsOk(info);
             success = true;
         } catch (Throwable e) {
             reporter.serviceFailure(info, e);
@@ -161,9 +175,9 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
             }
             long wsUpdateLatencyNanos = stopWatch.getTime();
             reporter.reportLatency(Latencies.wsUpdate(getKey()), wsUpdateLatencyNanos);
-            probeMetricsRecorder.recordActionDuration(info, "ws_update", wsUpdateLatencyNanos / 1_000_000);
+            probeMetricsRecorder.recordActionDuration(info, ProbeMetricsRecorder.ACTION_WS_UPDATE, wsUpdateLatencyNanos / 1_000_000);
         } catch (Throwable e) {
-            probeMetricsRecorder.removeActionDuration(info, "ws_update");
+            probeMetricsRecorder.removeActionDuration(info, ProbeMetricsRecorder.ACTION_WS_UPDATE);
             throw e;
         }
     }

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseHealthChecker.java
@@ -28,6 +28,7 @@ import org.thingsboard.monitoring.config.MonitoringTarget;
 import org.thingsboard.monitoring.data.Latencies;
 import org.thingsboard.monitoring.data.MonitoredServiceKey;
 import org.thingsboard.monitoring.data.ServiceFailureException;
+import org.thingsboard.monitoring.metrics.ProbeMetricsRecorder;
 import org.thingsboard.monitoring.util.TbStopWatch;
 
 import java.util.HashMap;
@@ -50,6 +51,8 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
     @Autowired
     private MonitoringReporter reporter;
     @Autowired
+    private ProbeMetricsRecorder probeMetricsRecorder;
+    @Autowired
     private TbStopWatch stopWatch;
     @Value("${monitoring.check_timeout_ms}")
     private int resultCheckTimeoutMs;
@@ -59,27 +62,37 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
 
     public static final String TEST_TELEMETRY_KEY = "testData";
     public static final String TEST_CF_TELEMETRY_KEY = "testDataCf";
+    // separate key so a late checkAccepted() message can't be mistaken for check()'s expected value
+    public static final String ACCEPTED_TEST_TELEMETRY_KEY = "acceptedTestData";
 
     @PostConstruct
     private void init() {
         info = getInfo();
     }
 
+    // the value recordProbe(info, ...) was called with, unlike getInfo() which recomputes a fresh one
+    Object getCachedInfo() {
+        return info;
+    }
+
     protected abstract void initialize();
 
     public final void check(WsClient wsClient) {
         log.debug("[{}] Checking", info);
+        boolean success = false;
         try {
             int expectedUpdatesCount = isCfMonitoringEnabled() ? 2 : 1;
             wsClient.registerWaitForUpdates(expectedUpdatesCount);
 
             String testValue = UUID.randomUUID().toString();
-            String testPayload = createTestPayload(testValue);
+            String testPayload = createTestPayload(testValue, TEST_TELEMETRY_KEY);
             try {
                 initClient();
                 stopWatch.start();
                 sendTestPayload(testPayload);
-                reporter.reportLatency(Latencies.request(getKey()), stopWatch.getTime());
+                long requestLatencyNanos = stopWatch.getTime();
+                reporter.reportLatency(Latencies.request(getKey()), requestLatencyNanos);
+                probeMetricsRecorder.recordActionDuration(info, "request", requestLatencyNanos / 1_000_000);
                 log.trace("[{}] Sent test payload ({})", info, testPayload);
             } catch (Throwable e) {
                 throw new ServiceFailureException(info, e);
@@ -89,15 +102,36 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
             checkWsUpdates(wsClient, testValue);
 
             reporter.serviceIsOk(info);
+            success = true;
         } catch (ServiceFailureException e) {
             reporter.serviceFailure(e.getServiceKey(), e);
         } catch (Exception e) {
             reporter.serviceFailure(info, e);
+        } finally {
+            probeMetricsRecorder.recordProbe(info, success);
         }
 
         associates.values().forEach(healthChecker -> {
             healthChecker.check(wsClient);
         });
+    }
+
+    // unlike check(), doesn't wait for WS/core confirmation - true once the transport itself
+    // acknowledges the message, so a transport-only outage still alerts while login/WS is down.
+    // Not final: LwM2M overrides this as a no-op since its send() has no such acknowledgment.
+    protected void checkAccepted() {
+        boolean success;
+        try {
+            initClient();
+            sendTestPayload(createTestPayload(UUID.randomUUID().toString(), ACCEPTED_TEST_TELEMETRY_KEY));
+            reporter.serviceIsOk(info);
+            success = true;
+        } catch (Throwable e) {
+            reporter.serviceFailure(info, e);
+            success = false;
+        }
+        probeMetricsRecorder.recordAcceptedProbe(info, success);
+        associates.values().forEach(healthChecker -> healthChecker.checkAccepted());
     }
 
     private void checkWsUpdates(WsClient wsClient, String testValue) {
@@ -121,12 +155,14 @@ public abstract class BaseHealthChecker<C extends MonitoringConfig, T extends Mo
                 throw new ServiceFailureException(info, "Was expecting calculated field value " + cfTestValue + " but got " + actualCfValue);
             }
         }
-        reporter.reportLatency(Latencies.wsUpdate(getKey()), stopWatch.getTime());
+        long wsUpdateLatencyNanos = stopWatch.getTime();
+        reporter.reportLatency(Latencies.wsUpdate(getKey()), wsUpdateLatencyNanos);
+        probeMetricsRecorder.recordActionDuration(info, "ws_update", wsUpdateLatencyNanos / 1_000_000);
     }
 
     protected abstract void initClient() throws Exception;
 
-    protected abstract String createTestPayload(String testValue);
+    protected abstract String createTestPayload(String testValue, String telemetryKey);
 
     protected abstract void sendTestPayload(String payload) throws Exception;
 

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseMonitoringService.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseMonitoringService.java
@@ -133,12 +133,12 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
                 accessToken = tbClient.logIn();
                 long loginLatencyNanos = stopWatch.getTime();
                 reporter.reportLatency(Latencies.LOG_IN, loginLatencyNanos);
-                probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.LOGIN, "request", loginLatencyNanos / 1_000_000);
+                probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.LOGIN, ProbeMetricsRecorder.ACTION_REQUEST, loginLatencyNanos / 1_000_000);
                 reporter.serviceIsOk(MonitoredServiceKey.LOGIN);
                 loginSuccess = true;
             } catch (Exception e) {
                 reporter.serviceFailure(MonitoredServiceKey.LOGIN, e);
-                probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.LOGIN, "request");
+                probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.LOGIN, ProbeMetricsRecorder.ACTION_REQUEST);
                 // WS and transport checks never ran this cycle - clear their gauges instead of
                 // leaving last cycle's value stale, then fall back to the WS-independent signal
                 probeMetricsRecorder.removeStaleProbe(MonitoredServiceKey.WS);
@@ -155,9 +155,9 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
                 reporter.serviceIsOk(MonitoredServiceKey.WS_CONNECT);
             } catch (Exception e) {
                 reporter.serviceFailure(MonitoredServiceKey.WS_CONNECT, e);
-                probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.WS, "connect");
+                probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.WS, ProbeMetricsRecorder.ACTION_CONNECT);
                 // subscribe never runs this cycle either - its last value is now stale too
-                probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.WS, "subscribe");
+                probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.WS, ProbeMetricsRecorder.ACTION_SUBSCRIBE);
                 probeMetricsRecorder.recordProbe(MonitoredServiceKey.WS, false);
                 clearAllTransportProbeMetrics();
                 checkTransportsAccepted();
@@ -170,12 +170,12 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
                     ws.subscribeForTelemetry(devices, getTestTelemetryKeys()).waitForReply();
                     long subscribeLatencyNanos = stopWatch.getTime();
                     reporter.reportLatency(Latencies.WS_SUBSCRIBE, subscribeLatencyNanos);
-                    probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.WS, "subscribe", subscribeLatencyNanos / 1_000_000);
+                    probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.WS, ProbeMetricsRecorder.ACTION_SUBSCRIBE, subscribeLatencyNanos / 1_000_000);
                     reporter.serviceIsOk(MonitoredServiceKey.WS_SUBSCRIBE);
                     probeMetricsRecorder.recordProbe(MonitoredServiceKey.WS, true);
                 } catch (Exception e) {
                     reporter.serviceFailure(MonitoredServiceKey.WS_SUBSCRIBE, e);
-                    probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.WS, "subscribe");
+                    probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.WS, ProbeMetricsRecorder.ACTION_SUBSCRIBE);
                     probeMetricsRecorder.recordProbe(MonitoredServiceKey.WS, false);
                     clearAllTransportProbeMetrics();
                     checkTransportsAccepted();
@@ -342,7 +342,11 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
         healthChecker.getAssociates().values().forEach(this::clearAcceptedProbeMetricsFor);
     }
 
-    // always runs, regardless of OTLP/Prometheus export - the fallback alert must work on every deployment
+    // always runs, regardless of OTLP/Prometheus export - the fallback alert must work on every deployment.
+    // Deliberately serial: each target already bounds its own attempt via its transport's
+    // request_timeout_ms, and parallelizing would violate ProbeMetricsRecorder's single-threaded-
+    // cycle assumption (see its freshThisCycle field) - acceptable given typical deployments
+    // monitor a handful of targets, not hundreds.
     private void checkTransportsAccepted() {
         healthCheckers.forEach(healthChecker -> healthChecker.checkAccepted());
     }

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseMonitoringService.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseMonitoringService.java
@@ -138,26 +138,28 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
                 loginSuccess = true;
             } catch (Exception e) {
                 reporter.serviceFailure(MonitoredServiceKey.LOGIN, e);
+                probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.LOGIN, "request");
                 // WS and transport checks never ran this cycle - clear their gauges instead of
                 // leaving last cycle's value stale, then fall back to the WS-independent signal
                 probeMetricsRecorder.removeStaleProbe(MonitoredServiceKey.WS);
-                clearTransportProbeMetrics();
+                clearAllTransportProbeMetrics();
                 checkTransportsAccepted();
                 return;
             } finally {
                 probeMetricsRecorder.recordProbe(MonitoredServiceKey.LOGIN, loginSuccess);
             }
 
-            long wsStartNanos = System.nanoTime();
             WsClient wsClient;
             try {
                 wsClient = wsClientFactory.createClient(accessToken);
-                probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.WS, "connect", (System.nanoTime() - wsStartNanos) / 1_000_000);
                 reporter.serviceIsOk(MonitoredServiceKey.WS_CONNECT);
             } catch (Exception e) {
                 reporter.serviceFailure(MonitoredServiceKey.WS_CONNECT, e);
+                probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.WS, "connect");
+                // subscribe never runs this cycle either - its last value is now stale too
+                probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.WS, "subscribe");
                 probeMetricsRecorder.recordProbe(MonitoredServiceKey.WS, false);
-                clearTransportProbeMetrics();
+                clearAllTransportProbeMetrics();
                 checkTransportsAccepted();
                 return;
             }
@@ -173,8 +175,9 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
                     probeMetricsRecorder.recordProbe(MonitoredServiceKey.WS, true);
                 } catch (Exception e) {
                     reporter.serviceFailure(MonitoredServiceKey.WS_SUBSCRIBE, e);
+                    probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.WS, "subscribe");
                     probeMetricsRecorder.recordProbe(MonitoredServiceKey.WS, false);
-                    clearTransportProbeMetrics();
+                    clearAllTransportProbeMetrics();
                     checkTransportsAccepted();
                     return;
                 }
@@ -207,11 +210,11 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
             reporter.serviceFailure(e.getServiceKey(), e);
             // clear only the healthCheckers this cycle didn't get to - the ones before checkedCount
             // already have fresh data this cycle and must not be wiped
-            clearTransportProbeMetrics(checkedCount);
-            clearAcceptedProbeMetrics(checkedCount);
+            clearUncheckedTransportProbeMetrics(checkedCount);
+            clearUncheckedAcceptedProbeMetrics(checkedCount);
         } catch (Throwable error) {
-            clearTransportProbeMetrics(checkedCount);
-            clearAcceptedProbeMetrics(checkedCount);
+            clearUncheckedTransportProbeMetrics(checkedCount);
+            clearUncheckedAcceptedProbeMetrics(checkedCount);
             try {
                 reporter.serviceFailure(MonitoredServiceKey.GENERAL, error);
             } catch (Throwable reportError) {
@@ -222,7 +225,7 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
 
     private void check(BaseHealthChecker<C, T> healthChecker, WsClient wsClient) throws Exception {
         healthChecker.check(wsClient);
-        clearAcceptedProbeMetrics(healthChecker);
+        clearAcceptedProbeMetricsFor(healthChecker);
 
         T target = healthChecker.getTarget();
         if (target.isCheckDomainIps()) {
@@ -251,10 +254,11 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
         }
         for (String url : prevAssociatedUrls) {
             if (!associatedUrls.contains(url)) {
+                BaseHealthChecker<C, T> retiredAssociate = associates.get(url);
                 // remove the metric before stopHealthChecker(), which can throw and skip everything after it
-                probeMetricsRecorder.removeProbe(associates.get(url).getCachedInfo());
-                probeMetricsRecorder.removeAcceptedProbe(associates.get(url).getCachedInfo());
-                stopHealthChecker(healthChecker);
+                probeMetricsRecorder.removeProbe(retiredAssociate.getCachedInfo());
+                probeMetricsRecorder.removeAcceptedProbe(retiredAssociate.getCachedInfo());
+                stopHealthChecker(retiredAssociate);
                 associates.remove(url);
                 changed = true;
             }
@@ -316,30 +320,26 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
         return checkCalculatedFields ? List.of(TEST_TELEMETRY_KEY, TEST_CF_TELEMETRY_KEY) : List.of(TEST_TELEMETRY_KEY);
     }
 
-    private void clearTransportProbeMetrics() {
-        clearTransportProbeMetrics(0);
+    private void clearAllTransportProbeMetrics() {
+        clearUncheckedTransportProbeMetrics(0);
     }
 
-    private void clearTransportProbeMetrics(int fromIndex) {
-        healthCheckers.subList(fromIndex, healthCheckers.size()).forEach(this::clearTransportProbeMetrics);
+    private void clearUncheckedTransportProbeMetrics(int fromIndex) {
+        healthCheckers.subList(fromIndex, healthCheckers.size()).forEach(this::clearTransportProbeMetricsFor);
     }
 
-    private void clearTransportProbeMetrics(BaseHealthChecker<C, T> healthChecker) {
+    private void clearTransportProbeMetricsFor(BaseHealthChecker<C, T> healthChecker) {
         probeMetricsRecorder.removeStaleProbe(healthChecker.getCachedInfo());
-        healthChecker.getAssociates().values().forEach(this::clearTransportProbeMetrics);
+        healthChecker.getAssociates().values().forEach(this::clearTransportProbeMetricsFor);
     }
 
-    private void clearAcceptedProbeMetrics() {
-        clearAcceptedProbeMetrics(0);
+    private void clearUncheckedAcceptedProbeMetrics(int fromIndex) {
+        healthCheckers.subList(fromIndex, healthCheckers.size()).forEach(this::clearAcceptedProbeMetricsFor);
     }
 
-    private void clearAcceptedProbeMetrics(int fromIndex) {
-        healthCheckers.subList(fromIndex, healthCheckers.size()).forEach(this::clearAcceptedProbeMetrics);
-    }
-
-    private void clearAcceptedProbeMetrics(BaseHealthChecker<C, T> healthChecker) {
+    private void clearAcceptedProbeMetricsFor(BaseHealthChecker<C, T> healthChecker) {
         probeMetricsRecorder.removeStaleAcceptedProbe(healthChecker.getCachedInfo());
-        healthChecker.getAssociates().values().forEach(this::clearAcceptedProbeMetrics);
+        healthChecker.getAssociates().values().forEach(this::clearAcceptedProbeMetricsFor);
     }
 
     // always runs, regardless of OTLP/Prometheus export - the fallback alert must work on every deployment

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseMonitoringService.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseMonitoringService.java
@@ -30,6 +30,7 @@ import org.thingsboard.monitoring.config.MonitoringTarget;
 import org.thingsboard.monitoring.data.Latencies;
 import org.thingsboard.monitoring.data.MonitoredServiceKey;
 import org.thingsboard.monitoring.data.ServiceFailureException;
+import org.thingsboard.monitoring.metrics.ProbeMetricsRecorder;
 import org.thingsboard.monitoring.util.TbStopWatch;
 import org.thingsboard.server.common.data.EntityType;
 import org.thingsboard.server.common.data.page.PageData;
@@ -77,6 +78,8 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
     @Autowired
     private MonitoringReporter reporter;
     @Autowired
+    private ProbeMetricsRecorder probeMetricsRecorder;
+    @Autowired
     protected ApplicationContext applicationContext;
 
     @Value("${monitoring.edqs.enabled:false}")
@@ -115,26 +118,46 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
         if (healthCheckers.isEmpty()) {
             return;
         }
+        // how many healthCheckers completed check() this cycle - so an unexpected failure partway
+        // through the loop below only clears the ones not yet reached, not everyone's fresh data
+        int checkedCount = 0;
         try {
             log.info("Starting {}", getName());
+            probeMetricsRecorder.recordHeartbeat();
 
             String accessToken;
+            boolean loginSuccess = false;
             try {
                 stopWatch.start();
                 accessToken = tbClient.logIn();
-                reporter.reportLatency(Latencies.LOG_IN, stopWatch.getTime());
+                long loginLatencyNanos = stopWatch.getTime();
+                reporter.reportLatency(Latencies.LOG_IN, loginLatencyNanos);
+                probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.LOGIN, "request", loginLatencyNanos / 1_000_000);
                 reporter.serviceIsOk(MonitoredServiceKey.LOGIN);
+                loginSuccess = true;
             } catch (Exception e) {
                 reporter.serviceFailure(MonitoredServiceKey.LOGIN, e);
+                // WS and transport checks never ran this cycle - clear their gauges instead of
+                // leaving last cycle's value stale, then fall back to the WS-independent signal
+                probeMetricsRecorder.removeProbe(MonitoredServiceKey.WS);
+                clearTransportProbeMetrics();
+                checkTransportsAccepted();
                 return;
+            } finally {
+                probeMetricsRecorder.recordProbe(MonitoredServiceKey.LOGIN, loginSuccess);
             }
 
+            long wsStartNanos = System.nanoTime();
             WsClient wsClient;
             try {
                 wsClient = wsClientFactory.createClient(accessToken);
+                probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.WS, "connect", (System.nanoTime() - wsStartNanos) / 1_000_000);
                 reporter.serviceIsOk(MonitoredServiceKey.WS_CONNECT);
             } catch (Exception e) {
                 reporter.serviceFailure(MonitoredServiceKey.WS_CONNECT, e);
+                probeMetricsRecorder.recordProbe(MonitoredServiceKey.WS, false);
+                clearTransportProbeMetrics();
+                checkTransportsAccepted();
                 return;
             }
 
@@ -142,15 +165,22 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
                 try {
                     stopWatch.start();
                     ws.subscribeForTelemetry(devices, getTestTelemetryKeys()).waitForReply();
-                    reporter.reportLatency(Latencies.WS_SUBSCRIBE, stopWatch.getTime());
+                    long subscribeLatencyNanos = stopWatch.getTime();
+                    reporter.reportLatency(Latencies.WS_SUBSCRIBE, subscribeLatencyNanos);
+                    probeMetricsRecorder.recordActionDuration(MonitoredServiceKey.WS, "subscribe", subscribeLatencyNanos / 1_000_000);
                     reporter.serviceIsOk(MonitoredServiceKey.WS_SUBSCRIBE);
+                    probeMetricsRecorder.recordProbe(MonitoredServiceKey.WS, true);
                 } catch (Exception e) {
                     reporter.serviceFailure(MonitoredServiceKey.WS_SUBSCRIBE, e);
+                    probeMetricsRecorder.recordProbe(MonitoredServiceKey.WS, false);
+                    clearTransportProbeMetrics();
+                    checkTransportsAccepted();
                     return;
                 }
 
                 for (BaseHealthChecker<C, T> healthChecker : healthCheckers) {
                     check(healthChecker, ws);
+                    checkedCount++;
                 }
             }
 
@@ -174,7 +204,13 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
             log.debug("Finished {}", getName());
         } catch (ServiceFailureException e) {
             reporter.serviceFailure(e.getServiceKey(), e);
+            // clear only the healthCheckers this cycle didn't get to - the ones before checkedCount
+            // already have fresh data this cycle and must not be wiped
+            clearTransportProbeMetrics(checkedCount);
+            clearAcceptedProbeMetrics(checkedCount);
         } catch (Throwable error) {
+            clearTransportProbeMetrics(checkedCount);
+            clearAcceptedProbeMetrics(checkedCount);
             try {
                 reporter.serviceFailure(MonitoredServiceKey.GENERAL, error);
             } catch (Throwable reportError) {
@@ -185,31 +221,45 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
 
     private void check(BaseHealthChecker<C, T> healthChecker, WsClient wsClient) throws Exception {
         healthChecker.check(wsClient);
+        clearAcceptedProbeMetrics(healthChecker);
 
         T target = healthChecker.getTarget();
         if (target.isCheckDomainIps()) {
-            Set<String> associatedUrls = getAssociatedUrls(target.getBaseUrl());
-            Map<String, BaseHealthChecker<C, T>> associates = healthChecker.getAssociates();
-            Set<String> prevAssociatedUrls = new HashSet<>(associates.keySet());
+            try {
+                reconcileAssociates(healthChecker, target);
+            } catch (Exception e) {
+                // check() above already recorded this cycle's data - a reconciliation failure
+                // must not look like a failure of the probe itself
+                log.warn("Failed to reconcile associate IPs for {}", target.getBaseUrl(), e);
+            }
+        }
+    }
 
-            boolean changed = false;
-            for (String url : associatedUrls) {
-                if (!prevAssociatedUrls.contains(url)) {
-                    BaseHealthChecker<C, T> associate = initHealthChecker(createTarget(url), healthChecker.getConfig());
-                    associates.put(url, associate);
-                    changed = true;
-                }
+    private void reconcileAssociates(BaseHealthChecker<C, T> healthChecker, T target) throws Exception {
+        Set<String> associatedUrls = getAssociatedUrls(target.getBaseUrl());
+        Map<String, BaseHealthChecker<C, T>> associates = healthChecker.getAssociates();
+        Set<String> prevAssociatedUrls = new HashSet<>(associates.keySet());
+
+        boolean changed = false;
+        for (String url : associatedUrls) {
+            if (!prevAssociatedUrls.contains(url)) {
+                BaseHealthChecker<C, T> associate = initHealthChecker(createTarget(url), healthChecker.getConfig());
+                associates.put(url, associate);
+                changed = true;
             }
-            for (String url : prevAssociatedUrls) {
-                if (!associatedUrls.contains(url)) {
-                    stopHealthChecker(healthChecker);
-                    associates.remove(url);
-                    changed = true;
-                }
+        }
+        for (String url : prevAssociatedUrls) {
+            if (!associatedUrls.contains(url)) {
+                // remove the metric before stopHealthChecker(), which can throw and skip everything after it
+                probeMetricsRecorder.removeProbe(associates.get(url).getCachedInfo());
+                probeMetricsRecorder.removeAcceptedProbe(associates.get(url).getCachedInfo());
+                stopHealthChecker(healthChecker);
+                associates.remove(url);
+                changed = true;
             }
-            if (changed) {
-                log.info("Updated IPs for {}: {} (old list: {})", target.getBaseUrl(), associatedUrls, prevAssociatedUrls);
-            }
+        }
+        if (changed) {
+            log.info("Updated IPs for {}: {} (old list: {})", target.getBaseUrl(), associatedUrls, prevAssociatedUrls);
         }
     }
 
@@ -263,6 +313,37 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
 
     private List<String> getTestTelemetryKeys() {
         return checkCalculatedFields ? List.of(TEST_TELEMETRY_KEY, TEST_CF_TELEMETRY_KEY) : List.of(TEST_TELEMETRY_KEY);
+    }
+
+    private void clearTransportProbeMetrics() {
+        clearTransportProbeMetrics(0);
+    }
+
+    private void clearTransportProbeMetrics(int fromIndex) {
+        healthCheckers.subList(fromIndex, healthCheckers.size()).forEach(this::clearTransportProbeMetrics);
+    }
+
+    private void clearTransportProbeMetrics(BaseHealthChecker<C, T> healthChecker) {
+        probeMetricsRecorder.removeProbe(healthChecker.getCachedInfo());
+        healthChecker.getAssociates().values().forEach(this::clearTransportProbeMetrics);
+    }
+
+    private void clearAcceptedProbeMetrics() {
+        clearAcceptedProbeMetrics(0);
+    }
+
+    private void clearAcceptedProbeMetrics(int fromIndex) {
+        healthCheckers.subList(fromIndex, healthCheckers.size()).forEach(this::clearAcceptedProbeMetrics);
+    }
+
+    private void clearAcceptedProbeMetrics(BaseHealthChecker<C, T> healthChecker) {
+        probeMetricsRecorder.removeAcceptedProbe(healthChecker.getCachedInfo());
+        healthChecker.getAssociates().values().forEach(this::clearAcceptedProbeMetrics);
+    }
+
+    // always runs, regardless of OTLP/Prometheus export - the fallback alert must work on every deployment
+    private void checkTransportsAccepted() {
+        healthCheckers.forEach(healthChecker -> healthChecker.checkAccepted());
     }
 
     private void stopHealthChecker(BaseHealthChecker<C, T> healthChecker) throws Exception {

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseMonitoringService.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseMonitoringService.java
@@ -123,6 +123,7 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
         int checkedCount = 0;
         try {
             log.info("Starting {}", getName());
+            probeMetricsRecorder.startCycle();
             probeMetricsRecorder.recordHeartbeat();
 
             String accessToken;
@@ -139,7 +140,7 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
                 reporter.serviceFailure(MonitoredServiceKey.LOGIN, e);
                 // WS and transport checks never ran this cycle - clear their gauges instead of
                 // leaving last cycle's value stale, then fall back to the WS-independent signal
-                probeMetricsRecorder.removeProbe(MonitoredServiceKey.WS);
+                probeMetricsRecorder.removeStaleProbe(MonitoredServiceKey.WS);
                 clearTransportProbeMetrics();
                 checkTransportsAccepted();
                 return;
@@ -324,7 +325,7 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
     }
 
     private void clearTransportProbeMetrics(BaseHealthChecker<C, T> healthChecker) {
-        probeMetricsRecorder.removeProbe(healthChecker.getCachedInfo());
+        probeMetricsRecorder.removeStaleProbe(healthChecker.getCachedInfo());
         healthChecker.getAssociates().values().forEach(this::clearTransportProbeMetrics);
     }
 
@@ -337,7 +338,7 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
     }
 
     private void clearAcceptedProbeMetrics(BaseHealthChecker<C, T> healthChecker) {
-        probeMetricsRecorder.removeAcceptedProbe(healthChecker.getCachedInfo());
+        probeMetricsRecorder.removeStaleAcceptedProbe(healthChecker.getCachedInfo());
         healthChecker.getAssociates().values().forEach(this::clearAcceptedProbeMetrics);
     }
 

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseMonitoringService.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/BaseMonitoringService.java
@@ -141,7 +141,7 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
                 probeMetricsRecorder.removeActionDuration(MonitoredServiceKey.LOGIN, ProbeMetricsRecorder.ACTION_REQUEST);
                 // WS and transport checks never ran this cycle - clear their gauges instead of
                 // leaving last cycle's value stale, then fall back to the WS-independent signal
-                probeMetricsRecorder.removeStaleProbe(MonitoredServiceKey.WS);
+                probeMetricsRecorder.removeProbe(MonitoredServiceKey.WS, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
                 clearAllTransportProbeMetrics();
                 checkTransportsAccepted();
                 return;
@@ -256,8 +256,8 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
             if (!associatedUrls.contains(url)) {
                 BaseHealthChecker<C, T> retiredAssociate = associates.get(url);
                 // remove the metric before stopHealthChecker(), which can throw and skip everything after it
-                probeMetricsRecorder.removeProbe(retiredAssociate.getCachedInfo());
-                probeMetricsRecorder.removeAcceptedProbe(retiredAssociate.getCachedInfo());
+                probeMetricsRecorder.removeProbe(retiredAssociate.getCachedInfo(), ProbeMetricsRecorder.Removal.PERMANENT);
+                probeMetricsRecorder.removeAcceptedProbe(retiredAssociate.getCachedInfo(), ProbeMetricsRecorder.Removal.PERMANENT);
                 stopHealthChecker(retiredAssociate);
                 associates.remove(url);
                 changed = true;
@@ -329,7 +329,7 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
     }
 
     private void clearTransportProbeMetricsFor(BaseHealthChecker<C, T> healthChecker) {
-        probeMetricsRecorder.removeStaleProbe(healthChecker.getCachedInfo());
+        probeMetricsRecorder.removeProbe(healthChecker.getCachedInfo(), ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
         healthChecker.getAssociates().values().forEach(this::clearTransportProbeMetricsFor);
     }
 
@@ -338,15 +338,11 @@ public abstract class BaseMonitoringService<C extends MonitoringConfig<T>, T ext
     }
 
     private void clearAcceptedProbeMetricsFor(BaseHealthChecker<C, T> healthChecker) {
-        probeMetricsRecorder.removeStaleAcceptedProbe(healthChecker.getCachedInfo());
+        probeMetricsRecorder.removeAcceptedProbe(healthChecker.getCachedInfo(), ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
         healthChecker.getAssociates().values().forEach(this::clearAcceptedProbeMetricsFor);
     }
 
-    // always runs, regardless of OTLP/Prometheus export - the fallback alert must work on every deployment.
-    // Deliberately serial: each target already bounds its own attempt via its transport's
-    // request_timeout_ms, and parallelizing would violate ProbeMetricsRecorder's single-threaded-
-    // cycle assumption (see its freshThisCycle field) - acceptable given typical deployments
-    // monitor a handful of targets, not hundreds.
+    // always runs regardless of OTLP/Prometheus export; deliberately serial (see freshThisCycle)
     private void checkTransportsAccepted() {
         healthCheckers.forEach(healthChecker -> healthChecker.checkAccepted());
     }

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/transport/TransportHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/transport/TransportHealthChecker.java
@@ -41,8 +41,8 @@ public abstract class TransportHealthChecker<C extends TransportMonitoringConfig
     }
 
     @Override
-    protected String createTestPayload(String testValue) {
-        return JacksonUtil.newObjectNode().set(TEST_TELEMETRY_KEY, new TextNode(testValue)).toString();
+    protected String createTestPayload(String testValue, String telemetryKey) {
+        return JacksonUtil.newObjectNode().set(telemetryKey, new TextNode(testValue)).toString();
     }
 
     @Override

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/transport/impl/Lwm2mTransportHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/transport/impl/Lwm2mTransportHealthChecker.java
@@ -52,7 +52,16 @@ public class Lwm2mTransportHealthChecker extends TransportHealthChecker<Lwm2mTra
     }
 
     @Override
-    protected String createTestPayload(String testValue) {
+    protected void checkAccepted() {
+        // send() never waits for a server ack (just fires a local Leshan event), so this can't
+        // produce a meaningful signal for LwM2M - no-op rather than always reporting "success".
+    }
+
+    @Override
+    protected String createTestPayload(String testValue, String telemetryKey) {
+        // LwM2M payload is the raw value itself (no JSON envelope), so there's no telemetry key
+        // to embed here; checkAccepted() is a no-op for LwM2M (see above), so in practice this is
+        // only ever invoked by check() with TEST_TELEMETRY_KEY.
         return testValue;
     }
 

--- a/monitoring/src/main/java/org/thingsboard/monitoring/service/transport/impl/MqttTransportHealthChecker.java
+++ b/monitoring/src/main/java/org/thingsboard/monitoring/service/transport/impl/MqttTransportHealthChecker.java
@@ -71,6 +71,15 @@ public class MqttTransportHealthChecker extends TransportHealthChecker<MqttTrans
     }
 
     @Override
+    protected void sendAcceptedTestPayload(String payload) throws Exception {
+        // force QoS 1 - at QoS 0 publish() never confirms broker receipt, defeating this fallback's purpose
+        MqttMessage message = new MqttMessage();
+        message.setPayload(payload.getBytes());
+        message.setQos(1);
+        mqttClient.publish(DEVICE_TELEMETRY_TOPIC, message);
+    }
+
+    @Override
     protected void destroyClient() throws Exception {
         if (mqttClient != null) {
             mqttClient.disconnect();

--- a/monitoring/src/main/resources/tb-monitoring.yml
+++ b/monitoring/src/main/resources/tb-monitoring.yml
@@ -124,19 +124,22 @@ monitoring:
     enabled: "${CALCULATED_FIELDS_MONITORING_ENABLED:true}"
 
   metrics:
-    # probe_success is tagged kind="probe" (full end-to-end check) or kind="accepted" (transport-only
-    # fallback, used only while login/WS is down - absent for LwM2M, which has no such fallback).
-    # During a login/WS outage, kind="probe" for transports goes ABSENT, not 0 - a consumer must
-    # treat missing data as down, and fall back to kind="accepted" for a weaker "transport is up" signal.
-    # The fallback also drives the same Slack/incident alerting as the full check, regardless of
-    # whether OTLP/Prometheus export below is enabled - only the metric depends on that.
+    # probe_success: kind="probe" (full check) or "accepted" (transport-only fallback while login/WS
+    # down). A transport's own check failing sets 0; it only goes ABSENT if login/WS died upstream
+    # and it was never reached this cycle. check="ws" is 0 if WS itself failed, ABSENT if login
+    # failed first - alert on "absent OR 0" for ws.
+    # probe_duration_ms{action}: disappears (not stale) once its stage stops running/passing.
+    # tb_monitoring_last_run_timestamp_seconds: heartbeat: alert on time() - metric > N to catch a dead
+    # prober, which probe_success can't (it only reports targets actually checked).
     otlp:
       # Push probe_success/probe_duration_ms via OTLP/HTTP to an OTel Collector
       enabled: '${METRICS_OTLP_ENABLED:false}'
       endpoint: '${METRICS_OTLP_ENDPOINT:http://localhost:4318/v1/metrics}'
-      step_ms: '${METRICS_OTLP_STEP_MS:60000}'
+      # Keep <= monitoring.monitoring_rate_ms or short outages can be missed by OTLP entirely
+      step_ms: '${METRICS_OTLP_STEP_MS:10000}'
       # Alert (Slack/incident, same mechanism as transport/login checks) when a push to the
-      # OTel Collector fails - independent of otlp.enabled itself, and never written to metrics
+      # OTel Collector fails - toggled separately from probe metrics alerting, but has no effect
+      # unless otlp.enabled is also true
       alerting_enabled: '${METRICS_OTLP_ALERTING_ENABLED:false}'
     prometheus:
       # Expose a pull-based /metrics endpoint via a lightweight JDK HttpServer (no servlet container)

--- a/monitoring/src/main/resources/tb-monitoring.yml
+++ b/monitoring/src/main/resources/tb-monitoring.yml
@@ -17,6 +17,10 @@
 monitoring:
   # Monitored server domain
   domain: "${DOMAIN:localhost}"
+  # Opaque identifier attached as a "label" tag on probe metrics (see monitoring.metrics.otlp),
+  # letting external systems group/route metrics without having to resolve it themselves
+  # (e.g. by looking up which cluster/customer a probing pod's IP belongs to)
+  label: '${LABEL:}'
   rest:
     # Base REST API url, https://DOMAIN by default
     base_url: '${REST_BASE_URL:https://${monitoring.domain}}'
@@ -118,6 +122,26 @@ monitoring:
 
   calculated_fields:
     enabled: "${CALCULATED_FIELDS_MONITORING_ENABLED:true}"
+
+  metrics:
+    # probe_success is tagged kind="probe" (full end-to-end check) or kind="accepted" (transport-only
+    # fallback, used only while login/WS is down - absent for LwM2M, which has no such fallback).
+    # During a login/WS outage, kind="probe" for transports goes ABSENT, not 0 - a consumer must
+    # treat missing data as down, and fall back to kind="accepted" for a weaker "transport is up" signal.
+    # The fallback also drives the same Slack/incident alerting as the full check, regardless of
+    # whether OTLP/Prometheus export below is enabled - only the metric depends on that.
+    otlp:
+      # Push probe_success/probe_duration_ms via OTLP/HTTP to an OTel Collector
+      enabled: '${METRICS_OTLP_ENABLED:false}'
+      endpoint: '${METRICS_OTLP_ENDPOINT:http://localhost:4318/v1/metrics}'
+      step_ms: '${METRICS_OTLP_STEP_MS:60000}'
+      # Alert (Slack/incident, same mechanism as transport/login checks) when a push to the
+      # OTel Collector fails - independent of otlp.enabled itself, and never written to metrics
+      alerting_enabled: '${METRICS_OTLP_ALERTING_ENABLED:false}'
+    prometheus:
+      # Expose a pull-based /metrics endpoint via a lightweight JDK HttpServer (no servlet container)
+      enabled: '${METRICS_PROMETHEUS_ENABLED:false}'
+      port: '${METRICS_PROMETHEUS_PORT:9100}'
 
   notifications:
     message_prefix: '${NOTIFICATION_MESSAGE_PREFIX:}'

--- a/monitoring/src/main/resources/tb-monitoring.yml
+++ b/monitoring/src/main/resources/tb-monitoring.yml
@@ -142,6 +142,9 @@ monitoring:
       # Expose a pull-based /metrics endpoint via a lightweight JDK HttpServer (no servlet container)
       enabled: '${METRICS_PROMETHEUS_ENABLED:false}'
       port: '${METRICS_PROMETHEUS_PORT:9100}'
+      # Interface to bind the /metrics HTTP server to - 0.0.0.0 (default) for all interfaces, or e.g.
+      # 127.0.0.1 to restrict access to a local reverse proxy, since this endpoint has no built-in authentication
+      bind_address: '${METRICS_PROMETHEUS_BIND_ADDRESS:0.0.0.0}'
 
   notifications:
     message_prefix: '${NOTIFICATION_MESSAGE_PREFIX:}'

--- a/monitoring/src/main/resources/tb-monitoring.yml
+++ b/monitoring/src/main/resources/tb-monitoring.yml
@@ -148,6 +148,8 @@ monitoring:
       # Interface to bind the /metrics HTTP server to - 0.0.0.0 (default) for all interfaces, or e.g.
       # 127.0.0.1 to restrict access to a local reverse proxy, since this endpoint has no built-in authentication
       bind_address: '${METRICS_PROMETHEUS_BIND_ADDRESS:0.0.0.0}'
+      # Read directly from the env (not Spring), since it's applied before Spring itself starts up:
+      # METRICS_PROMETHEUS_HTTP_TIMEOUT_S - request/response timeout in seconds, default 30
 
   notifications:
     message_prefix: '${NOTIFICATION_MESSAGE_PREFIX:}'

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeLabelResolverTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeLabelResolverTest.java
@@ -116,6 +116,35 @@ public class ProbeLabelResolverTest {
     }
 
     @Test
+    public void resolveHostPort_bareIpv6Authority_keepsWholeAddressAndUsesDefaultPort() {
+        // no brackets -> getHost() is null, getAuthority() is the bare literal - don't mangle it
+        assertThat(ProbeLabelResolver.resolveHostPort(URI.create("tcp://2001:db8::1:1883"), 1883))
+                .isEqualTo("2001:db8::1:1883:1883");
+    }
+
+    @Test
+    public void resolveHostPort_bracketedIpv6WithPort_resolvedDirectlyByUri_notByFallback() {
+        assertThat(ProbeLabelResolver.resolveHostPort(URI.create("tcp://[2001:db8::1]:1883"), 1883))
+                .isEqualTo("[2001:db8::1]:1883");
+    }
+
+    @Test
+    public void resolveTransportLabels_nullBaseUrl_returnsNullInsteadOfThrowing() {
+        // URI.create(null) throws NullPointerException, not IllegalArgumentException
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.MQTT, null);
+        assertThat(labels).isNull();
+    }
+
+    @Test
+    public void resolveTransportLabels_malformedBaseUrl_returnsNullInsteadOfThrowing() {
+        // unescaped space makes URI.create() throw - must not propagate
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.MQTT, "tcp://tb mqtt:1883");
+        assertThat(labels).isNull();
+    }
+
+    @Test
     public void resolveLoginEndpoint_appliesLoginPathOnValidUrl() {
         String endpoint = ProbeLabelResolver.resolveLoginEndpoint("https://acme.example.com");
         assertThat(endpoint).isEqualTo("acme.example.com:443/api/auth/login");

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeLabelResolverTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeLabelResolverTest.java
@@ -85,23 +85,56 @@ public class ProbeLabelResolverTest {
     }
 
     @Test
-    public void tryResolveEndpoint_appliesPostProcessOnValidUrl() {
-        String endpoint = ProbeLabelResolver.tryResolveEndpoint("some.config.key", "https://acme.example.com",
-                "login", s -> s + ProbeLabelResolver.LOGIN_PATH);
+    public void userInfoInAuthority_isStrippedFromResolvedHost() {
+        // exercises the authority.contains("@") branch in resolveHostPort - underscored host still
+        // makes URI.getHost() return null, so the fallback must strip "user:pass@" before parsing
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.MQTT, "mqtt://user:pass@tb_mqtt:1883");
+        assertThat(labels.endpoint()).isEqualTo("tb_mqtt:1883");
+    }
+
+    @Test
+    public void schemelessBaseUrl_resolveTransportLabels_returnsNullInsteadOfNullHostLabel() {
+        // "acme.example.com:1883" without a scheme parses as an opaque URI with neither a host nor an
+        // authority - must not silently produce a "null:1883" endpoint label
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.MQTT, "acme.example.com:1883");
+        assertThat(labels).isNull();
+    }
+
+    @Test
+    public void resolveHostPort_opaqueUriWithNoAuthority_returnsNull() {
+        assertThat(ProbeLabelResolver.resolveHostPort(URI.create("acme.example.com:1883"), 1883)).isNull();
+    }
+
+    @Test
+    public void resolveLoginEndpoint_appliesLoginPathOnValidUrl() {
+        String endpoint = ProbeLabelResolver.resolveLoginEndpoint("https://acme.example.com");
         assertThat(endpoint).isEqualTo("acme.example.com:443/api/auth/login");
     }
 
     @Test
-    public void tryResolveEndpoint_wsScheme_defaultsToPort443ForWss() {
-        String endpoint = ProbeLabelResolver.tryResolveEndpoint("monitoring.ws.base_url", "wss://acme.example.com",
-                "ws", java.util.function.Function.identity());
+    public void resolveLoginEndpoint_invalidUrl_returnsNullInsteadOfThrowing() {
+        String endpoint = ProbeLabelResolver.resolveLoginEndpoint("not a valid uri");
+        assertThat(endpoint).isNull();
+    }
+
+    @Test
+    public void resolveWsEndpoint_wssScheme_defaultsToPort443() {
+        String endpoint = ProbeLabelResolver.resolveWsEndpoint("wss://acme.example.com");
         assertThat(endpoint).isEqualTo("acme.example.com:443");
     }
 
     @Test
-    public void tryResolveEndpoint_invalidUrl_returnsNullInsteadOfThrowing() {
-        String endpoint = ProbeLabelResolver.tryResolveEndpoint("some.config.key", "not a valid uri",
-                "login", java.util.function.Function.identity());
+    public void resolveWsEndpoint_plainWsScheme_defaultsToPort80() {
+        // the non-secure-scheme branch of tryResolve - previously only exercised via https/wss inputs
+        String endpoint = ProbeLabelResolver.resolveWsEndpoint("ws://acme.example.com");
+        assertThat(endpoint).isEqualTo("acme.example.com:80");
+    }
+
+    @Test
+    public void resolveWsEndpoint_invalidUrl_returnsNullInsteadOfThrowing() {
+        String endpoint = ProbeLabelResolver.resolveWsEndpoint("not a valid uri");
         assertThat(endpoint).isNull();
     }
 
@@ -109,6 +142,15 @@ public class ProbeLabelResolverTest {
     public void resolveHostPort_usesDefaultPortWhenUriHasNone() {
         assertThat(ProbeLabelResolver.resolveHostPort(URI.create("http://acme.example.com"), 8080))
                 .isEqualTo("acme.example.com:8080");
+    }
+
+    @Test
+    public void resolveLoginEndpoint_schemelessBaseUrl_returnsNullInsteadOfNullLoginLabel() {
+        // "acme.example.com:8080" without a scheme parses as an opaque URI with neither a host nor an
+        // authority - resolveHostPort returns null, which tryResolve must not concatenate LOGIN_PATH
+        // onto (that would silently produce the literal "null/api/auth/login")
+        String endpoint = ProbeLabelResolver.resolveLoginEndpoint("acme.example.com:8080");
+        assertThat(endpoint).isNull();
     }
 
 }

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeLabelResolverTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeLabelResolverTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.metrics;
+
+import org.junit.jupiter.api.Test;
+import org.thingsboard.monitoring.config.transport.TransportType;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProbeLabelResolverTest {
+
+    @Test
+    public void mqttPlain_mapsToMqttCheckAndConfiguredPort() {
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.MQTT, "tcp://acme.example.com:1883");
+        assertThat(labels.check()).isEqualTo("mqtt");
+        assertThat(labels.endpoint()).isEqualTo("acme.example.com:1883");
+    }
+
+    @Test
+    public void mqttTls_mapsToMqttsCheck() {
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.MQTT, "ssl://acme.example.com:8883");
+        assertThat(labels.check()).isEqualTo("mqtts");
+    }
+
+    @Test
+    public void coapPlain_defaultPortWhenMissing() {
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.COAP, "coap://acme.example.com");
+        assertThat(labels.check()).isEqualTo("coap");
+        assertThat(labels.endpoint()).isEqualTo("acme.example.com:5683");
+    }
+
+    @Test
+    public void coapSecure_mapsToCoapsCheck() {
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.COAP, "coaps://acme.example.com:5684");
+        assertThat(labels.check()).isEqualTo("coaps");
+    }
+
+    @Test
+    public void httpAndHttps_mapByScheme() {
+        assertThat(ProbeLabelResolver.resolveTransportLabels(TransportType.HTTP, "http://acme.example.com").check())
+                .isEqualTo("http");
+        assertThat(ProbeLabelResolver.resolveTransportLabels(TransportType.HTTP, "https://acme.example.com").check())
+                .isEqualTo("https");
+    }
+
+    @Test
+    public void lwm2m_alwaysMapsToLwm2mRegardlessOfCoapScheme() {
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.LWM2M, "coap://acme.example.com:5685");
+        assertThat(labels.check()).isEqualTo("lwm2m");
+        assertThat(labels.endpoint()).isEqualTo("acme.example.com:5685");
+    }
+
+    @Test
+    public void underscoreHostname_stillResolvesEndpoint() {
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.MQTT, "tcp://tb_mqtt:1883");
+        assertThat(labels.endpoint()).isEqualTo("tb_mqtt:1883");
+    }
+
+    @Test
+    public void underscoreHostname_noPort_fallsBackToDefaultPort() {
+        ProbeLabelResolver.ProbeLabels labels =
+                ProbeLabelResolver.resolveTransportLabels(TransportType.COAP, "coap://tb_coap");
+        assertThat(labels.endpoint()).isEqualTo("tb_coap:5683");
+    }
+
+    @Test
+    public void tryResolveEndpoint_appliesPostProcessOnValidUrl() {
+        String endpoint = ProbeLabelResolver.tryResolveEndpoint("some.config.key", "https://acme.example.com",
+                "login", s -> s + ProbeLabelResolver.LOGIN_PATH);
+        assertThat(endpoint).isEqualTo("acme.example.com:443/api/auth/login");
+    }
+
+    @Test
+    public void tryResolveEndpoint_wsScheme_defaultsToPort443ForWss() {
+        String endpoint = ProbeLabelResolver.tryResolveEndpoint("monitoring.ws.base_url", "wss://acme.example.com",
+                "ws", java.util.function.Function.identity());
+        assertThat(endpoint).isEqualTo("acme.example.com:443");
+    }
+
+    @Test
+    public void tryResolveEndpoint_invalidUrl_returnsNullInsteadOfThrowing() {
+        String endpoint = ProbeLabelResolver.tryResolveEndpoint("some.config.key", "not a valid uri",
+                "login", java.util.function.Function.identity());
+        assertThat(endpoint).isNull();
+    }
+
+    @Test
+    public void resolveHostPort_usesDefaultPortWhenUriHasNone() {
+        assertThat(ProbeLabelResolver.resolveHostPort(URI.create("http://acme.example.com"), 8080))
+                .isEqualTo("acme.example.com:8080");
+    }
+
+}

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeLabelResolverTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeLabelResolverTest.java
@@ -103,6 +103,14 @@ public class ProbeLabelResolverTest {
     }
 
     @Test
+    public void resolveHostPort_nonNumericPortInAuthority_fallsBackToDefaultPort() {
+        // exercises the catch (NumberFormatException) branch - a colon is present in the fallback-
+        // parsed authority, but what follows it isn't a valid port number
+        assertThat(ProbeLabelResolver.resolveHostPort(URI.create("mqtt://tb_mqtt:notaport"), 1883))
+                .isEqualTo("tb_mqtt:1883");
+    }
+
+    @Test
     public void resolveHostPort_opaqueUriWithNoAuthority_returnsNull() {
         assertThat(ProbeLabelResolver.resolveHostPort(URI.create("acme.example.com:1883"), 1883)).isNull();
     }

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
@@ -184,7 +184,7 @@ public class ProbeMetricsRecorderTest {
     }
 
     @Test
-    public void removeProbe_alsoRemovesStageDurationGauges() {
+    public void removeStaleProbe_alsoRemovesStageDurationGauges() {
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordProbe(target, true);
@@ -192,7 +192,8 @@ public class ProbeMetricsRecorderTest {
         recorder.recordActionDuration(target, "ws_update", 700);
         assertThat(registry.getMeters()).hasSize(3); // success + 2 stages
 
-        recorder.removeProbe(target);
+        recorder.startCycle(); // next cycle - this target's fresh-this-cycle protection no longer applies
+        recorder.removeStaleProbe(target);
 
         assertThat(registry.getMeters()).isEmpty();
     }
@@ -218,6 +219,9 @@ public class ProbeMetricsRecorderTest {
 
     @Test
     public void removeProbe_removesGaugeForRetiredTarget() {
+        // decommissioning (e.g. reconcileAssociates dropping a domain-IP associate) uses the plain,
+        // unguarded removeProbe - it must remove the gauge unconditionally, even if the target's tags
+        // got fresh data THIS SAME cycle (e.g. a successful check() just before being decommissioned)
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo retired = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordProbe(retired, true);
@@ -230,11 +234,12 @@ public class ProbeMetricsRecorderTest {
     }
 
     @Test
-    public void removeProbe_thenRecordProbeAgain_reregistersGaugeCleanly() {
+    public void removeStaleProbe_thenRecordProbeAgain_reregistersGaugeCleanly() {
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordProbe(target, true);
-        recorder.removeProbe(target);
+        recorder.startCycle(); // next cycle - this target's fresh-this-cycle protection no longer applies
+        recorder.removeStaleProbe(target);
 
         recorder.recordProbe(target, false);
 
@@ -273,7 +278,9 @@ public class ProbeMetricsRecorderTest {
     public void removeProbe_withFreshButEqualTransportInfo_stillRemovesGauge() {
         // recordProbe/removeProbe are called with independently-constructed TransportInfo instances in
         // production (BaseHealthChecker's cached field vs. a fresh BaseHealthChecker.getInfo() call) -
-        // only their type+baseUrl need to match, not object identity
+        // only their type+baseUrl need to match, not object identity. This is the decommissioning path
+        // (reconcileAssociates uses getCachedInfo()), so it's unguarded and must remove unconditionally,
+        // even though the tags are still fresh from the recordProbe call moments earlier this cycle.
         ProbeMetricsRecorder recorder = recorder(true);
         recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), true);
 
@@ -297,6 +304,51 @@ public class ProbeMetricsRecorderTest {
 
         assertThat(registry.get("probe_success").tags("check", "mqtt").gauge().value()).isEqualTo(0d);
         assertThat(registry.getMeters()).hasSize(1); // still one series, not two - the collision is real
+    }
+
+    @Test
+    public void removeStaleProbe_ofCollidingSibling_doesNotWipeFreshDataRecordedThisCycle() {
+        // A and B collide onto identical tags (same type+baseUrl, differing only by queue). If A
+        // succeeds and records fresh data this cycle, and B's own removeStaleProbe fires afterward
+        // (e.g. because B crashed and checkedCount-based clearing targets it), A's fresh data must
+        // survive - otherwise a crashing sibling silently wipes a healthy target's just-recorded gauge.
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo a = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueA");
+        TransportInfo b = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueB");
+
+        recorder.recordProbe(a, true);
+        recorder.removeStaleProbe(b);
+
+        assertThat(registry.get("probe_success").tags("check", "mqtt").gauge().value()).isEqualTo(1d);
+        assertThat(registry.getMeters()).hasSize(1);
+    }
+
+    @Test
+    public void removeStaleAcceptedProbe_ofCollidingSibling_doesNotWipeFreshDataRecordedThisCycle() {
+        // same collision protection, for the accepted-fallback series
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo a = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueA");
+        TransportInfo b = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueB");
+
+        recorder.recordAcceptedProbe(a, true);
+        recorder.removeStaleAcceptedProbe(b);
+
+        assertThat(registry.get("probe_success").tags("check", "mqtt", "kind", "accepted").gauge().value()).isEqualTo(1d);
+        assertThat(registry.getMeters()).hasSize(1);
+    }
+
+    @Test
+    public void removeStaleProbe_withoutPriorRecordThisCycle_stillRemovesGauge() {
+        // normal, non-colliding stale removal - freshThisCycle is empty (either nothing was recorded,
+        // or startCycle() reset it), so removal must proceed exactly as before this fix
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
+        recorder.recordProbe(target, true);
+        recorder.startCycle();
+
+        recorder.removeStaleProbe(target);
+
+        assertThat(registry.getMeters()).isEmpty();
     }
 
     @Test
@@ -400,29 +452,31 @@ public class ProbeMetricsRecorderTest {
     }
 
     @Test
-    public void removeProbe_noLongerRemovesAcceptedGauge() {
-        // removeProbe() no longer touches kind="accepted" - only removeAcceptedProbe() does
+    public void removeStaleProbe_noLongerRemovesAcceptedGauge() {
+        // removeStaleProbe() no longer touches kind="accepted" - only the accepted variants do
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordProbe(target, true);
         recorder.recordAcceptedProbe(target, true);
         assertThat(registry.getMeters()).hasSize(2);
 
-        recorder.removeProbe(target);
+        recorder.startCycle(); // next cycle - this target's fresh-this-cycle protection no longer applies
+        recorder.removeStaleProbe(target);
 
         assertThat(registry.getMeters()).hasSize(1);
         assertThat(registry.get("probe_success").tags("kind", "accepted").gauge().value()).isEqualTo(1d);
     }
 
     @Test
-    public void removeAcceptedProbe_removesOnlyAcceptedGauge_leavesProbeGaugeUntouched() {
+    public void removeStaleAcceptedProbe_removesOnlyAcceptedGauge_leavesProbeGaugeUntouched() {
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordProbe(target, true);
         recorder.recordAcceptedProbe(target, true);
         assertThat(registry.getMeters()).hasSize(2);
 
-        recorder.removeAcceptedProbe(target);
+        recorder.startCycle(); // next cycle - this target's fresh-this-cycle protection no longer applies
+        recorder.removeStaleAcceptedProbe(target);
 
         assertThat(registry.getMeters()).hasSize(1);
         assertThat(registry.get("probe_success").tags("kind", "probe").gauge().value()).isEqualTo(1d);

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
@@ -18,10 +18,13 @@ package org.thingsboard.monitoring.metrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.thingsboard.monitoring.config.transport.TransportInfo;
 import org.thingsboard.monitoring.config.transport.TransportMonitoringTarget;
 import org.thingsboard.monitoring.config.transport.TransportType;
 import org.thingsboard.monitoring.data.MonitoredServiceKey;
+
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
@@ -591,6 +594,26 @@ public class ProbeMetricsRecorderTest {
         recorder.recordProbe(target, true);
 
         assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void schemelessTransportBaseUrl_staleRemoval_doesNotEvictWarnedUnresolvable() {
+        // removeStaleProbe (per-cycle clearing, e.g. every cycle of a login/WS outage) must not
+        // evict warnedUnresolvable - only permanent removal (decommissioning) should, otherwise an
+        // unresolvable target's warning would re-fire every such cycle instead of logging once
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "acme.example.com:1883");
+        Set<?> warnedUnresolvable = (Set<?>) ReflectionTestUtils.getField(recorder, "warnedUnresolvable");
+
+        recorder.recordProbe(target, true);
+        assertThat(warnedUnresolvable).hasSize(1);
+
+        recorder.startCycle();
+        recorder.removeStaleProbe(target);
+        assertThat(warnedUnresolvable).hasSize(1); // stale removal must leave the dedup entry alone
+
+        recorder.removeProbe(target);
+        assertThat(warnedUnresolvable).isEmpty(); // permanent removal does evict it
     }
 
     @Test

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
@@ -24,6 +24,7 @@ import org.thingsboard.monitoring.config.transport.TransportMonitoringTarget;
 import org.thingsboard.monitoring.config.transport.TransportType;
 import org.thingsboard.monitoring.data.MonitoredServiceKey;
 
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -631,6 +632,94 @@ public class ProbeMetricsRecorderTest {
         recorder.recordProbe(target, true);
 
         assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void recordAcceptedProbe_warnsOnLabelCollision() {
+        // recordAcceptedProbe must run the same collision check recordProbe does - two targets
+        // colliding on kind="accepted" tags silently overwriting each other is just as bad as the
+        // kind="probe" case
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo first = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueA");
+        TransportInfo second = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueB");
+        Set<?> warnedCollisions = (Set<?>) ReflectionTestUtils.getField(recorder, "warnedCollisions");
+
+        recorder.recordAcceptedProbe(first, true);
+        assertThat(warnedCollisions).isEmpty();
+
+        recorder.recordAcceptedProbe(second, false);
+
+        assertThat(warnedCollisions).hasSize(1);
+        assertThat(registry.get("probe_success").tags("kind", "accepted").gauge().value()).isEqualTo(0d);
+        assertThat(registry.getMeters()).hasSize(1); // still one series, not two - the collision is real
+    }
+
+    @Test
+    public void removeProbe_staleThisCycle_doesNotClearWarnedCollisions() {
+        // a login/WS outage triggers STALE_THIS_CYCLE clearing every unhealthy cycle - that must not
+        // forget an already-warned collision, otherwise the same collision re-warns on every recovery
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo first = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueA");
+        TransportInfo second = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueB");
+        recorder.recordProbe(first, true);
+        recorder.recordProbe(second, false);
+        Set<?> warnedCollisions = (Set<?>) ReflectionTestUtils.getField(recorder, "warnedCollisions");
+        assertThat(warnedCollisions).hasSize(1);
+
+        recorder.startCycle();
+        recorder.removeProbe(second, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
+
+        assertThat(warnedCollisions).hasSize(1); // stale removal must leave the dedup entry alone
+    }
+
+    @Test
+    public void removeProbe_permanent_clearsWarnedCollisions() {
+        // decommissioning one of the colliding targets for good should let the collision warn again
+        // if a new target later collides on the same tags
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo first = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueA");
+        TransportInfo second = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueB");
+        recorder.recordProbe(first, true);
+        recorder.recordProbe(second, false);
+        Set<?> warnedCollisions = (Set<?>) ReflectionTestUtils.getField(recorder, "warnedCollisions");
+        assertThat(warnedCollisions).hasSize(1);
+
+        recorder.removeProbe(second, ProbeMetricsRecorder.Removal.PERMANENT);
+
+        assertThat(warnedCollisions).isEmpty();
+    }
+
+    @Test
+    public void removeAcceptedProbe_staleThisCycle_doesNotEvictAcceptedTagsCacheForUnresolvableTarget() {
+        // mirrors schemelessTransportBaseUrl_staleRemoval_doesNotEvictWarnedUnresolvable, for the
+        // accepted-fallback's own negative-resolution cache
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "acme.example.com:1883");
+        Map<?, ?> acceptedTagsCache = (Map<?, ?>) ReflectionTestUtils.getField(recorder, "acceptedTagsCache");
+
+        recorder.recordAcceptedProbe(target, true);
+        assertThat(acceptedTagsCache).hasSize(1);
+
+        recorder.startCycle();
+        recorder.removeAcceptedProbe(target, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
+
+        assertThat(acceptedTagsCache).hasSize(1); // stale removal must not defeat the negative cache
+    }
+
+    @Test
+    public void removeAcceptedProbe_permanent_evictsAcceptedTagsCacheForUnresolvableTarget() {
+        // a decommissioned target whose baseUrl never resolved must not leak its Optional.empty()
+        // entry in acceptedTagsCache forever - the tags==null early exit must not skip this eviction
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "acme.example.com:1883");
+        Map<?, ?> acceptedTagsCache = (Map<?, ?>) ReflectionTestUtils.getField(recorder, "acceptedTagsCache");
+
+        recorder.recordAcceptedProbe(target, true);
+        assertThat(acceptedTagsCache).hasSize(1);
+
+        recorder.removeAcceptedProbe(target, ProbeMetricsRecorder.Removal.PERMANENT);
+
+        assertThat(acceptedTagsCache).isEmpty();
     }
 
 }

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
@@ -39,8 +39,11 @@ public class ProbeMetricsRecorderTest {
         registry = new SimpleMeterRegistry();
     }
 
-    private ProbeMetricsRecorder recorder(boolean enabled) {
-        return new ProbeMetricsRecorder(registry, enabled, false, "acme.example.com",
+    private ProbeMetricsRecorder recorder(boolean otlpEnabled) {
+        // named locals, not adjacent positional literals, so a future constructor param reorder can't
+        // silently transpose otlpEnabled/prometheusEnabled here without a compile error
+        boolean prometheusEnabled = false;
+        return new ProbeMetricsRecorder(registry, otlpEnabled, prometheusEnabled, "acme.example.com",
                 "https://acme.example.com", "wss://acme.example.com", "acme-cluster-1");
     }
 
@@ -181,6 +184,23 @@ public class ProbeMetricsRecorderTest {
         ProbeMetricsRecorder recorder = recorder(false);
         recorder.recordActionDuration(MonitoredServiceKey.LOGIN, "request", 8);
         assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void removeActionDuration_removesOnlyTheTargetedAction_leavesSuccessAndOtherActionDurationUntouched() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
+        recorder.recordProbe(target, true);
+        recorder.recordActionDuration(target, "request", 8);
+        recorder.recordActionDuration(target, "ws_update", 700);
+        assertThat(registry.getMeters()).hasSize(3); // success + 2 stages
+
+        recorder.removeActionDuration(target, "request");
+
+        assertThat(registry.find("probe_duration_ms").tags("action", "request").gauge()).isNull();
+        assertThat(registry.get("probe_duration_ms").tags("action", "ws_update").gauge().value()).isEqualTo(700d);
+        assertThat(registry.get("probe_success").tags("check", "mqtt").gauge().value()).isEqualTo(1d);
+        assertThat(registry.getMeters()).hasSize(2);
     }
 
     @Test
@@ -353,7 +373,9 @@ public class ProbeMetricsRecorderTest {
 
     @Test
     public void disabled_invalidWsBaseUrl_doesNotThrowAtConstruction() {
-        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, false, false, "acme.example.com",
+        boolean otlpEnabled = false;
+        boolean prometheusEnabled = false;
+        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, otlpEnabled, prometheusEnabled, "acme.example.com",
                 "https://acme.example.com", "not a valid uri", "acme-cluster-1");
         recorder.recordProbe(MonitoredServiceKey.WS, true);
         assertThat(registry.getMeters()).isEmpty();
@@ -362,7 +384,9 @@ public class ProbeMetricsRecorderTest {
     @Test
     public void enabled_invalidWsBaseUrl_doesNotThrowAtConstruction_wsProbeSkipped() {
         // otlpEnabled=true so this recorder is "enabled" and would normally resolve wsEndpoint eagerly
-        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, true, false, "acme.example.com",
+        boolean otlpEnabled = true;
+        boolean prometheusEnabled = false;
+        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, otlpEnabled, prometheusEnabled, "acme.example.com",
                 "https://acme.example.com", "not a valid uri", "acme-cluster-1");
 
         recorder.recordProbe(MonitoredServiceKey.WS, true);
@@ -372,7 +396,9 @@ public class ProbeMetricsRecorderTest {
 
     @Test
     public void enabled_invalidRestBaseUrl_doesNotThrowAtConstruction_loginProbeSkipped() {
-        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, true, false, "acme.example.com",
+        boolean otlpEnabled = true;
+        boolean prometheusEnabled = false;
+        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, otlpEnabled, prometheusEnabled, "acme.example.com",
                 "not a valid uri", "wss://acme.example.com", "acme-cluster-1");
 
         recorder.recordProbe(MonitoredServiceKey.LOGIN, true);
@@ -394,7 +420,9 @@ public class ProbeMetricsRecorderTest {
     public void emptyLabel_stillProducesEmptyStringTag() {
         // as-is behavior, same as the other optional tags in this class - an unset env var
         // becomes an empty string tag rather than omitting the label tag entirely
-        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, true, false, "acme.example.com",
+        boolean otlpEnabled = true;
+        boolean prometheusEnabled = false;
+        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, otlpEnabled, prometheusEnabled, "acme.example.com",
                 "https://acme.example.com", "wss://acme.example.com", "");
         recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), true);
 
@@ -405,7 +433,9 @@ public class ProbeMetricsRecorderTest {
     public void removeAcceptedProbe_whenNothingWasRecorded_skipsRegistryScan() {
         // runs every healthy cycle now - must not scan the whole registry when there's nothing to remove
         SimpleMeterRegistry spyRegistry = spy(new SimpleMeterRegistry());
-        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(spyRegistry, true, false, "acme.example.com",
+        boolean otlpEnabled = true;
+        boolean prometheusEnabled = false;
+        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(spyRegistry, otlpEnabled, prometheusEnabled, "acme.example.com",
                 "https://acme.example.com", "wss://acme.example.com", "acme-cluster-1");
 
         recorder.removeAcceptedProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"));
@@ -512,6 +542,37 @@ public class ProbeMetricsRecorderTest {
         ProbeMetricsRecorder recorder = recorder(false);
 
         recorder.recordHeartbeat();
+
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void schemelessTransportBaseUrl_recordingMethodsDoNotThrowAndRegisterNoMeters() {
+        // "acme.example.com:1883" without a scheme parses as opaque - neither a host nor an authority -
+        // so resolveTransportLabels returns null; every recording method must treat that as "skip this
+        // probe" rather than throwing or registering a "null:1883"-style gauge
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "acme.example.com:1883");
+
+        recorder.recordProbe(target, true);
+        recorder.recordActionDuration(target, "request", 8);
+        recorder.recordAcceptedProbe(target, true);
+        recorder.removeAcceptedProbe(target);
+
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void schemelessTransportBaseUrl_secondCallForSameTarget_alsoDoesNotThrow() {
+        // computeIfAbsent doesn't cache a null resolution result, so resolveTransportLabels (and the
+        // dedup-guarded warning) is re-invoked on every call for this target - this just confirms that
+        // repeated re-invocation stays side-effect-free (no log-capturing utility exists in this module
+        // to assert the warning itself is only emitted once)
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "acme.example.com:1883");
+
+        recorder.recordProbe(target, true);
+        recorder.recordProbe(target, true);
 
         assertThat(registry.getMeters()).isEmpty();
     }

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
@@ -1,0 +1,465 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.thingsboard.monitoring.config.transport.TransportInfo;
+import org.thingsboard.monitoring.config.transport.TransportMonitoringTarget;
+import org.thingsboard.monitoring.config.transport.TransportType;
+import org.thingsboard.monitoring.data.MonitoredServiceKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class ProbeMetricsRecorderTest {
+
+    private SimpleMeterRegistry registry;
+
+    @BeforeEach
+    public void setUp() {
+        registry = new SimpleMeterRegistry();
+    }
+
+    private ProbeMetricsRecorder recorder(boolean enabled) {
+        return new ProbeMetricsRecorder(registry, enabled, false, "acme.example.com",
+                "https://acme.example.com", "wss://acme.example.com", "acme-cluster-1");
+    }
+
+    private TransportInfo transportInfo(TransportType type, String baseUrl) {
+        return transportInfo(type, baseUrl, null);
+    }
+
+    private TransportInfo transportInfo(TransportType type, String baseUrl, String queue) {
+        TransportMonitoringTarget target = new TransportMonitoringTarget();
+        target.setBaseUrl(baseUrl);
+        target.setQueue(queue);
+        return new TransportInfo(type, target);
+    }
+
+    @Test
+    public void whenDisabled_noMetersRegistered() {
+        ProbeMetricsRecorder recorder = recorder(false);
+        recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), true);
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void mqttPlain_mapsToMqttProtocolAndConfiguredPort() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), true);
+
+        assertThat(registry.get("probe_success")
+                .tags("domain", "acme.example.com", "check", "mqtt", "endpoint", "acme.example.com:1883", "kind", "probe")
+                .gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void mqttTls_mapsToMqttsProtocol() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.MQTT, "ssl://acme.example.com:8883"), true);
+
+        assertThat(registry.get("probe_success").tags("check", "mqtts").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void coapPlain_mapsToCoapProtocol_defaultPortWhenMissing() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.COAP, "coap://acme.example.com"), true);
+
+        assertThat(registry.get("probe_success")
+                .tags("check", "coap", "endpoint", "acme.example.com:5683").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void coapSecure_mapsToCoapsProtocol() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.COAP, "coaps://acme.example.com:5684"), true);
+
+        assertThat(registry.get("probe_success").tags("check", "coaps").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void http_mapsToHttpOrHttpsByScheme() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.HTTP, "http://acme.example.com"), true);
+        recorder.recordProbe(transportInfo(TransportType.HTTP, "https://acme.example.com"), true);
+
+        assertThat(registry.get("probe_success").tags("check", "http", "endpoint", "acme.example.com:80").gauge().value()).isEqualTo(1d);
+        assertThat(registry.get("probe_success").tags("check", "https", "endpoint", "acme.example.com:443").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void lwm2m_alwaysMapsToLwm2mRegardlessOfCoapScheme() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.LWM2M, "coap://acme.example.com:5685"), true);
+
+        assertThat(registry.get("probe_success")
+                .tags("check", "lwm2m", "endpoint", "acme.example.com:5685").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void failedProbe_recordsZeroSuccess() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), false);
+
+        assertThat(registry.get("probe_success").tags("check", "mqtt").gauge().value()).isEqualTo(0d);
+    }
+
+    @Test
+    public void login_mapsToLoginProtocolWithHostPortApiPathEndpointFromRestBaseUrl() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(MonitoredServiceKey.LOGIN, true);
+
+        assertThat(registry.get("probe_success")
+                .tags("check", "login", "endpoint", "acme.example.com:443/api/auth/login").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void ws_mapsToWsProtocolWithHostPortEndpointFromWsBaseUrl() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(MonitoredServiceKey.WS, true);
+
+        assertThat(registry.get("probe_success")
+                .tags("check", "ws", "endpoint", "acme.example.com:443").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void unrecognizedServiceKey_isIgnored() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(MonitoredServiceKey.GENERAL, true);
+        recorder.recordProbe(MonitoredServiceKey.EDQS, true);
+
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void secondCallWithSameLabels_updatesExistingGaugeInPlace() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), true);
+        recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), false);
+
+        assertThat(registry.get("probe_success").tags("check", "mqtt").gauge().value()).isEqualTo(0d);
+        assertThat(registry.getMeters()).hasSize(1); // no duplicate meter registered
+    }
+
+    @Test
+    public void recordActionDuration_addsStageTagToSeparateSeries() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
+
+        recorder.recordActionDuration(target, "request", 8);
+        recorder.recordActionDuration(target, "ws_update", 700);
+
+        assertThat(registry.get("probe_duration_ms")
+                .tags("check", "mqtt", "action", "request").gauge().value()).isEqualTo(8d);
+        assertThat(registry.get("probe_duration_ms")
+                .tags("check", "mqtt", "action", "ws_update").gauge().value()).isEqualTo(700d);
+        assertThat(registry.getMeters()).hasSize(2); // one series per stage, correctly distinct
+    }
+
+    @Test
+    public void recordActionDuration_whenDisabled_isNoOp() {
+        ProbeMetricsRecorder recorder = recorder(false);
+        recorder.recordActionDuration(MonitoredServiceKey.LOGIN, "request", 8);
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void removeProbe_alsoRemovesStageDurationGauges() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
+        recorder.recordProbe(target, true);
+        recorder.recordActionDuration(target, "request", 8);
+        recorder.recordActionDuration(target, "ws_update", 700);
+        assertThat(registry.getMeters()).hasSize(3); // success + 2 stages
+
+        recorder.removeProbe(target);
+
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void removeProbe_thenRecordStageDurationAgain_reregistersCleanly() {
+        // guards against the internal stagesByBaseTags bookkeeping leaking a stale entry that
+        // would make removeProbe miss this series on a later, second removal
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
+        recorder.recordActionDuration(target, "request", 8);
+        recorder.removeProbe(target);
+
+        recorder.recordActionDuration(target, "request", 12);
+
+        assertThat(registry.get("probe_duration_ms")
+                .tags("check", "mqtt", "action", "request").gauge().value()).isEqualTo(12d);
+        assertThat(registry.getMeters()).hasSize(1);
+
+        recorder.removeProbe(target);
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void removeProbe_removesGaugeForRetiredTarget() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo retired = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
+        recorder.recordProbe(retired, true);
+        assertThat(registry.getMeters()).hasSize(1);
+
+        recorder.removeProbe(retired);
+
+        assertThat(registry.find("probe_success").tags("check", "mqtt").gauge()).isNull();
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void removeProbe_thenRecordProbeAgain_reregistersGaugeCleanly() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
+        recorder.recordProbe(target, true);
+        recorder.removeProbe(target);
+
+        recorder.recordProbe(target, false);
+
+        assertThat(registry.get("probe_success").tags("check", "mqtt").gauge().value()).isEqualTo(0d);
+        assertThat(registry.getMeters()).hasSize(1); // no duplicate/orphaned meter left over from before removal
+    }
+
+    @Test
+    public void removeProbe_whenDisabled_isNoOp() {
+        ProbeMetricsRecorder recorder = recorder(false);
+        recorder.removeProbe(MonitoredServiceKey.LOGIN);
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void underscoreHostname_stillResolvesEndpoint() {
+        // URI.getHost()/getPort() return null/-1 for authorities Java doesn't treat as valid hostnames -
+        // e.g. underscores, a common docker-compose service-naming convention
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://tb_mqtt:1883"), true);
+
+        assertThat(registry.get("probe_success")
+                .tags("check", "mqtt", "endpoint", "tb_mqtt:1883").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void underscoreHostname_noPort_fallsBackToDefaultPort() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.COAP, "coap://tb_coap"), true);
+
+        assertThat(registry.get("probe_success")
+                .tags("check", "coap", "endpoint", "tb_coap:5683").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void removeProbe_withFreshButEqualTransportInfo_stillRemovesGauge() {
+        // recordProbe/removeProbe are called with independently-constructed TransportInfo instances in
+        // production (BaseHealthChecker's cached field vs. a fresh BaseHealthChecker.getInfo() call) -
+        // only their type+baseUrl need to match, not object identity
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), true);
+
+        recorder.removeProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"));
+
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void distinctServiceKeysWithSameLabels_lastWriteWins() {
+        // two targets sharing a host:port but differing only by queue (which isn't part of the label
+        // taxonomy) collide onto the same series - documents the known, logged limitation rather than
+        // silently losing one target's data without a trace
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo first = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueA");
+        TransportInfo second = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueB");
+        assertThat(first).isNotEqualTo(second); // otherwise this test wouldn't actually exercise a collision
+
+        recorder.recordProbe(first, true);
+        recorder.recordProbe(second, false);
+
+        assertThat(registry.get("probe_success").tags("check", "mqtt").gauge().value()).isEqualTo(0d);
+        assertThat(registry.getMeters()).hasSize(1); // still one series, not two - the collision is real
+    }
+
+    @Test
+    public void disabled_invalidWsBaseUrl_doesNotThrowAtConstruction() {
+        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, false, false, "acme.example.com",
+                "https://acme.example.com", "not a valid uri", "acme-cluster-1");
+        recorder.recordProbe(MonitoredServiceKey.WS, true);
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void enabled_invalidWsBaseUrl_doesNotThrowAtConstruction_wsProbeSkipped() {
+        // otlpEnabled=true so this recorder is "enabled" and would normally resolve wsEndpoint eagerly
+        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, true, false, "acme.example.com",
+                "https://acme.example.com", "not a valid uri", "acme-cluster-1");
+
+        recorder.recordProbe(MonitoredServiceKey.WS, true);
+
+        assertThat(registry.getMeters()).isEmpty(); // ws is skipped, but construction didn't throw
+    }
+
+    @Test
+    public void enabled_invalidRestBaseUrl_doesNotThrowAtConstruction_loginProbeSkipped() {
+        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, true, false, "acme.example.com",
+                "not a valid uri", "wss://acme.example.com", "acme-cluster-1");
+
+        recorder.recordProbe(MonitoredServiceKey.LOGIN, true);
+
+        assertThat(registry.getMeters()).isEmpty(); // login is skipped, but construction didn't throw
+    }
+
+    @Test
+    public void labelTag_appearsOnGeneratedMetrics() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), true);
+
+        assertThat(registry.get("probe_success")
+                .tags("domain", "acme.example.com", "check", "mqtt", "label", "acme-cluster-1")
+                .gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void emptyLabel_stillProducesEmptyStringTag() {
+        // as-is behavior, same as the other optional tags in this class - an unset env var
+        // becomes an empty string tag rather than omitting the label tag entirely
+        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(registry, true, false, "acme.example.com",
+                "https://acme.example.com", "wss://acme.example.com", "");
+        recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), true);
+
+        assertThat(registry.get("probe_success").tags("label", "").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void removeAcceptedProbe_whenNothingWasRecorded_skipsRegistryScan() {
+        // runs every healthy cycle now - must not scan the whole registry when there's nothing to remove
+        SimpleMeterRegistry spyRegistry = spy(new SimpleMeterRegistry());
+        ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(spyRegistry, true, false, "acme.example.com",
+                "https://acme.example.com", "wss://acme.example.com", "acme-cluster-1");
+
+        recorder.removeAcceptedProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"));
+
+        verify(spyRegistry, never()).find(anyString());
+    }
+
+    @Test
+    public void recordAcceptedProbe_recordsSeparateSeriesFromE2eProbe() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
+        recorder.recordProbe(target, true);
+        recorder.recordAcceptedProbe(target, false);
+
+        assertThat(registry.get("probe_success").tags("kind", "probe").gauge().value()).isEqualTo(1d);
+        assertThat(registry.get("probe_success").tags("kind", "accepted").gauge().value()).isEqualTo(0d);
+        assertThat(registry.getMeters()).hasSize(2); // two distinct series, no collision
+    }
+
+    @Test
+    public void recordAcceptedProbe_usesSameLabelResolutionAsE2eProbe() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordAcceptedProbe(transportInfo(TransportType.MQTT, "ssl://acme.example.com:8883"), true);
+
+        assertThat(registry.get("probe_success")
+                .tags("domain", "acme.example.com", "check", "mqtts", "endpoint", "acme.example.com:8883",
+                        "kind", "accepted", "label", "acme-cluster-1")
+                .gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void recordAcceptedProbe_whenDisabled_isNoOp() {
+        ProbeMetricsRecorder recorder = recorder(false);
+        recorder.recordAcceptedProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), true);
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void recordAcceptedProbe_ignoresNonTransportServiceKeys() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.recordAcceptedProbe(MonitoredServiceKey.LOGIN, true);
+        recorder.recordAcceptedProbe(MonitoredServiceKey.WS, true);
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void removeProbe_noLongerRemovesAcceptedGauge() {
+        // removeProbe() no longer touches kind="accepted" - only removeAcceptedProbe() does
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
+        recorder.recordProbe(target, true);
+        recorder.recordAcceptedProbe(target, true);
+        assertThat(registry.getMeters()).hasSize(2);
+
+        recorder.removeProbe(target);
+
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.get("probe_success").tags("kind", "accepted").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void removeAcceptedProbe_removesOnlyAcceptedGauge_leavesProbeGaugeUntouched() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
+        recorder.recordProbe(target, true);
+        recorder.recordAcceptedProbe(target, true);
+        assertThat(registry.getMeters()).hasSize(2);
+
+        recorder.removeAcceptedProbe(target);
+
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.get("probe_success").tags("kind", "probe").gauge().value()).isEqualTo(1d);
+    }
+
+    @Test
+    public void removeAcceptedProbe_whenDisabled_isNoOp() {
+        ProbeMetricsRecorder recorder = recorder(false);
+        recorder.removeAcceptedProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"));
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void removeAcceptedProbe_ignoresNonTransportServiceKeys() {
+        ProbeMetricsRecorder recorder = recorder(true);
+        recorder.removeAcceptedProbe(MonitoredServiceKey.LOGIN);
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void recordHeartbeat_enabled_registersCurrentTimestamp() {
+        ProbeMetricsRecorder recorder = recorder(true);
+
+        recorder.recordHeartbeat();
+
+        double value = registry.get("tb_monitoring_last_run_timestamp_seconds")
+                .tags("domain", "acme.example.com", "label", "acme-cluster-1").gauge().value();
+        assertThat(value).isCloseTo(System.currentTimeMillis() / 1000.0, within(5.0));
+    }
+
+    @Test
+    public void recordHeartbeat_disabled_registersNothing() {
+        ProbeMetricsRecorder recorder = recorder(false);
+
+        recorder.recordHeartbeat();
+
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+}

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
@@ -224,7 +224,7 @@ public class ProbeMetricsRecorderTest {
     }
 
     @Test
-    public void removeStaleProbe_alsoRemovesStageDurationGauges() {
+    public void removeProbe_staleThisCycle_alsoRemovesStageDurationGauges() {
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordProbe(target, true);
@@ -233,7 +233,7 @@ public class ProbeMetricsRecorderTest {
         assertThat(registry.getMeters()).hasSize(3); // success + 2 stages
 
         recorder.startCycle(); // next cycle - this target's fresh-this-cycle protection no longer applies
-        recorder.removeStaleProbe(target);
+        recorder.removeProbe(target, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
 
         assertThat(registry.getMeters()).isEmpty();
     }
@@ -245,7 +245,7 @@ public class ProbeMetricsRecorderTest {
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordActionDuration(target, "request", 8);
-        recorder.removeProbe(target);
+        recorder.removeProbe(target, ProbeMetricsRecorder.Removal.PERMANENT);
 
         recorder.recordActionDuration(target, "request", 12);
 
@@ -253,33 +253,33 @@ public class ProbeMetricsRecorderTest {
                 .tags("check", "mqtt", "action", "request").gauge().value()).isEqualTo(12d);
         assertThat(registry.getMeters()).hasSize(1);
 
-        recorder.removeProbe(target);
+        recorder.removeProbe(target, ProbeMetricsRecorder.Removal.PERMANENT);
         assertThat(registry.getMeters()).isEmpty();
     }
 
     @Test
     public void removeProbe_removesGaugeForRetiredTarget() {
-        // decommissioning (e.g. reconcileAssociates dropping a domain-IP associate) uses the plain,
-        // unguarded removeProbe - it must remove the gauge unconditionally, even if the target's tags
-        // got fresh data THIS SAME cycle (e.g. a successful check() just before being decommissioned)
+        // decommissioning (e.g. reconcileAssociates dropping a domain-IP associate) uses PERMANENT -
+        // it must remove the gauge unconditionally, even if the target's tags got fresh data THIS
+        // SAME cycle (e.g. a successful check() just before being decommissioned)
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo retired = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordProbe(retired, true);
         assertThat(registry.getMeters()).hasSize(1);
 
-        recorder.removeProbe(retired);
+        recorder.removeProbe(retired, ProbeMetricsRecorder.Removal.PERMANENT);
 
         assertThat(registry.find("probe_success").tags("check", "mqtt").gauge()).isNull();
         assertThat(registry.getMeters()).isEmpty();
     }
 
     @Test
-    public void removeStaleProbe_thenRecordProbeAgain_reregistersGaugeCleanly() {
+    public void removeProbe_staleThisCycle_thenRecordProbeAgain_reregistersGaugeCleanly() {
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordProbe(target, true);
         recorder.startCycle(); // next cycle - this target's fresh-this-cycle protection no longer applies
-        recorder.removeStaleProbe(target);
+        recorder.removeProbe(target, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
 
         recorder.recordProbe(target, false);
 
@@ -290,7 +290,7 @@ public class ProbeMetricsRecorderTest {
     @Test
     public void removeProbe_whenDisabled_isNoOp() {
         ProbeMetricsRecorder recorder = recorder(false);
-        recorder.removeProbe(MonitoredServiceKey.LOGIN);
+        recorder.removeProbe(MonitoredServiceKey.LOGIN, ProbeMetricsRecorder.Removal.PERMANENT);
         assertThat(registry.getMeters()).isEmpty();
     }
 
@@ -324,7 +324,7 @@ public class ProbeMetricsRecorderTest {
         ProbeMetricsRecorder recorder = recorder(true);
         recorder.recordProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), true);
 
-        recorder.removeProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"));
+        recorder.removeProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), ProbeMetricsRecorder.Removal.PERMANENT);
 
         assertThat(registry.getMeters()).isEmpty();
     }
@@ -347,38 +347,39 @@ public class ProbeMetricsRecorderTest {
     }
 
     @Test
-    public void removeStaleProbe_ofCollidingSibling_doesNotWipeFreshDataRecordedThisCycle() {
+    public void removeProbe_staleThisCycle_ofCollidingSibling_doesNotWipeFreshDataRecordedThisCycle() {
         // A and B collide onto identical tags (same type+baseUrl, differing only by queue). If A
-        // succeeds and records fresh data this cycle, and B's own removeStaleProbe fires afterward
-        // (e.g. because B crashed and checkedCount-based clearing targets it), A's fresh data must
-        // survive - otherwise a crashing sibling silently wipes a healthy target's just-recorded gauge.
+        // succeeds and records fresh data this cycle, and B's own STALE_THIS_CYCLE removal fires
+        // afterward (e.g. because B crashed and checkedCount-based clearing targets it), A's fresh
+        // data must survive - otherwise a crashing sibling silently wipes a healthy target's
+        // just-recorded gauge.
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo a = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueA");
         TransportInfo b = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueB");
 
         recorder.recordProbe(a, true);
-        recorder.removeStaleProbe(b);
+        recorder.removeProbe(b, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
 
         assertThat(registry.get("probe_success").tags("check", "mqtt").gauge().value()).isEqualTo(1d);
         assertThat(registry.getMeters()).hasSize(1);
     }
 
     @Test
-    public void removeStaleAcceptedProbe_ofCollidingSibling_doesNotWipeFreshDataRecordedThisCycle() {
+    public void removeAcceptedProbe_staleThisCycle_ofCollidingSibling_doesNotWipeFreshDataRecordedThisCycle() {
         // same collision protection, for the accepted-fallback series
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo a = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueA");
         TransportInfo b = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueB");
 
         recorder.recordAcceptedProbe(a, true);
-        recorder.removeStaleAcceptedProbe(b);
+        recorder.removeAcceptedProbe(b, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
 
         assertThat(registry.get("probe_success").tags("check", "mqtt", "kind", "accepted").gauge().value()).isEqualTo(1d);
         assertThat(registry.getMeters()).hasSize(1);
     }
 
     @Test
-    public void removeStaleProbe_withoutPriorRecordThisCycle_stillRemovesGauge() {
+    public void removeProbe_staleThisCycle_withoutPriorRecordThisCycle_stillRemovesGauge() {
         // normal, non-colliding stale removal - freshThisCycle is empty (either nothing was recorded,
         // or startCycle() reset it), so removal must proceed exactly as before this fix
         ProbeMetricsRecorder recorder = recorder(true);
@@ -386,7 +387,7 @@ public class ProbeMetricsRecorderTest {
         recorder.recordProbe(target, true);
         recorder.startCycle();
 
-        recorder.removeStaleProbe(target);
+        recorder.removeProbe(target, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
 
         assertThat(registry.getMeters()).isEmpty();
     }
@@ -458,7 +459,7 @@ public class ProbeMetricsRecorderTest {
         ProbeMetricsRecorder recorder = new ProbeMetricsRecorder(spyRegistry, otlpEnabled, prometheusEnabled, "acme.example.com",
                 "https://acme.example.com", "wss://acme.example.com", "acme-cluster-1");
 
-        recorder.removeAcceptedProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"));
+        recorder.removeAcceptedProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), ProbeMetricsRecorder.Removal.PERMANENT);
 
         verify(spyRegistry, never()).find(anyString());
     }
@@ -502,8 +503,8 @@ public class ProbeMetricsRecorderTest {
     }
 
     @Test
-    public void removeStaleProbe_noLongerRemovesAcceptedGauge() {
-        // removeStaleProbe() no longer touches kind="accepted" - only the accepted variants do
+    public void removeProbe_staleThisCycle_noLongerRemovesAcceptedGauge() {
+        // removeProbe(STALE_THIS_CYCLE) no longer touches kind="accepted" - only the accepted variants do
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordProbe(target, true);
@@ -511,14 +512,14 @@ public class ProbeMetricsRecorderTest {
         assertThat(registry.getMeters()).hasSize(2);
 
         recorder.startCycle(); // next cycle - this target's fresh-this-cycle protection no longer applies
-        recorder.removeStaleProbe(target);
+        recorder.removeProbe(target, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
 
         assertThat(registry.getMeters()).hasSize(1);
         assertThat(registry.get("probe_success").tags("kind", "accepted").gauge().value()).isEqualTo(1d);
     }
 
     @Test
-    public void removeStaleAcceptedProbe_removesOnlyAcceptedGauge_leavesProbeGaugeUntouched() {
+    public void removeAcceptedProbe_staleThisCycle_removesOnlyAcceptedGauge_leavesProbeGaugeUntouched() {
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883");
         recorder.recordProbe(target, true);
@@ -526,7 +527,7 @@ public class ProbeMetricsRecorderTest {
         assertThat(registry.getMeters()).hasSize(2);
 
         recorder.startCycle(); // next cycle - this target's fresh-this-cycle protection no longer applies
-        recorder.removeStaleAcceptedProbe(target);
+        recorder.removeAcceptedProbe(target, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
 
         assertThat(registry.getMeters()).hasSize(1);
         assertThat(registry.get("probe_success").tags("kind", "probe").gauge().value()).isEqualTo(1d);
@@ -535,14 +536,14 @@ public class ProbeMetricsRecorderTest {
     @Test
     public void removeAcceptedProbe_whenDisabled_isNoOp() {
         ProbeMetricsRecorder recorder = recorder(false);
-        recorder.removeAcceptedProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"));
+        recorder.removeAcceptedProbe(transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883"), ProbeMetricsRecorder.Removal.PERMANENT);
         assertThat(registry.getMeters()).isEmpty();
     }
 
     @Test
     public void removeAcceptedProbe_ignoresNonTransportServiceKeys() {
         ProbeMetricsRecorder recorder = recorder(true);
-        recorder.removeAcceptedProbe(MonitoredServiceKey.LOGIN);
+        recorder.removeAcceptedProbe(MonitoredServiceKey.LOGIN, ProbeMetricsRecorder.Removal.PERMANENT);
         assertThat(registry.getMeters()).isEmpty();
     }
 
@@ -577,7 +578,7 @@ public class ProbeMetricsRecorderTest {
         recorder.recordProbe(target, true);
         recorder.recordActionDuration(target, "request", 8);
         recorder.recordAcceptedProbe(target, true);
-        recorder.removeAcceptedProbe(target);
+        recorder.removeAcceptedProbe(target, ProbeMetricsRecorder.Removal.PERMANENT);
 
         assertThat(registry.getMeters()).isEmpty();
     }
@@ -598,9 +599,9 @@ public class ProbeMetricsRecorderTest {
 
     @Test
     public void schemelessTransportBaseUrl_staleRemoval_doesNotEvictWarnedUnresolvable() {
-        // removeStaleProbe (per-cycle clearing, e.g. every cycle of a login/WS outage) must not
-        // evict warnedUnresolvable - only permanent removal (decommissioning) should, otherwise an
-        // unresolvable target's warning would re-fire every such cycle instead of logging once
+        // STALE_THIS_CYCLE removal (per-cycle clearing, e.g. every cycle of a login/WS outage) must
+        // not evict warnedUnresolvable - only PERMANENT removal (decommissioning) should, otherwise
+        // an unresolvable target's warning would re-fire every such cycle instead of logging once
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "acme.example.com:1883");
         Set<?> warnedUnresolvable = (Set<?>) ReflectionTestUtils.getField(recorder, "warnedUnresolvable");
@@ -609,16 +610,16 @@ public class ProbeMetricsRecorderTest {
         assertThat(warnedUnresolvable).hasSize(1);
 
         recorder.startCycle();
-        recorder.removeStaleProbe(target);
+        recorder.removeProbe(target, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
         assertThat(warnedUnresolvable).hasSize(1); // stale removal must leave the dedup entry alone
 
-        recorder.removeProbe(target);
+        recorder.removeProbe(target, ProbeMetricsRecorder.Removal.PERMANENT);
         assertThat(warnedUnresolvable).isEmpty(); // permanent removal does evict it
     }
 
     @Test
     public void schemelessTransportBaseUrl_removedThenReAdded_warnsAgain() {
-        // removeProbe evicts warnedUnresolvable for the retired target, so a target decommissioned
+        // PERMANENT removal evicts warnedUnresolvable for the retired target, so a target decommissioned
         // and later re-added with the same bad URL gets a fresh warning instead of permanent silence.
         // No log-capturing utility exists here, so this only confirms re-adding stays side-effect-free
         // (the actual re-warning is covered by inspection of removeProbe's warnedUnresolvable.remove).
@@ -626,7 +627,7 @@ public class ProbeMetricsRecorderTest {
         TransportInfo target = transportInfo(TransportType.MQTT, "acme.example.com:1883");
 
         recorder.recordProbe(target, true);
-        recorder.removeProbe(target);
+        recorder.removeProbe(target, ProbeMetricsRecorder.Removal.PERMANENT);
         recorder.recordProbe(target, true);
 
         assertThat(registry.getMeters()).isEmpty();

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRecorderTest.java
@@ -195,12 +195,29 @@ public class ProbeMetricsRecorderTest {
         recorder.recordActionDuration(target, "ws_update", 700);
         assertThat(registry.getMeters()).hasSize(3); // success + 2 stages
 
+        recorder.startCycle(); // next cycle - this target's fresh-this-cycle protection no longer applies
         recorder.removeActionDuration(target, "request");
 
         assertThat(registry.find("probe_duration_ms").tags("action", "request").gauge()).isNull();
         assertThat(registry.get("probe_duration_ms").tags("action", "ws_update").gauge().value()).isEqualTo(700d);
         assertThat(registry.get("probe_success").tags("check", "mqtt").gauge().value()).isEqualTo(1d);
         assertThat(registry.getMeters()).hasSize(2);
+    }
+
+    @Test
+    public void removeActionDuration_ofCollidingSibling_doesNotWipeFreshDurationRecordedThisCycle() {
+        // A and B collide onto identical tags (same type+baseUrl, differing only by queue). If A
+        // succeeds and records a fresh "request" duration this cycle, and B's own removeActionDuration
+        // fires afterward (B's sendTestPayload threw), A's just-recorded duration must survive.
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo a = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueA");
+        TransportInfo b = transportInfo(TransportType.MQTT, "tcp://acme.example.com:1883", "QueueB");
+
+        recorder.recordProbe(a, true);
+        recorder.recordActionDuration(a, "request", 8);
+        recorder.removeActionDuration(b, "request");
+
+        assertThat(registry.get("probe_duration_ms").tags("action", "request").gauge().value()).isEqualTo(8d);
     }
 
     @Test
@@ -564,14 +581,29 @@ public class ProbeMetricsRecorderTest {
 
     @Test
     public void schemelessTransportBaseUrl_secondCallForSameTarget_alsoDoesNotThrow() {
-        // computeIfAbsent doesn't cache a null resolution result, so resolveTransportLabels (and the
-        // dedup-guarded warning) is re-invoked on every call for this target - this just confirms that
-        // repeated re-invocation stays side-effect-free (no log-capturing utility exists in this module
-        // to assert the warning itself is only emitted once)
+        // the negative resolution is cached (an Optional.empty(), not a bare null computeIfAbsent
+        // would skip caching), so resolveTransportLabels only actually runs once for this target -
+        // this confirms the cached path stays side-effect-free on every later call too
         ProbeMetricsRecorder recorder = recorder(true);
         TransportInfo target = transportInfo(TransportType.MQTT, "acme.example.com:1883");
 
         recorder.recordProbe(target, true);
+        recorder.recordProbe(target, true);
+
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    public void schemelessTransportBaseUrl_removedThenReAdded_warnsAgain() {
+        // removeProbe evicts warnedUnresolvable for the retired target, so a target decommissioned
+        // and later re-added with the same bad URL gets a fresh warning instead of permanent silence.
+        // No log-capturing utility exists here, so this only confirms re-adding stays side-effect-free
+        // (the actual re-warning is covered by inspection of removeProbe's warnedUnresolvable.remove).
+        ProbeMetricsRecorder recorder = recorder(true);
+        TransportInfo target = transportInfo(TransportType.MQTT, "acme.example.com:1883");
+
+        recorder.recordProbe(target, true);
+        recorder.removeProbe(target);
         recorder.recordProbe(target, true);
 
         assertThat(registry.getMeters()).isEmpty();

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfigTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfigTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.metrics;
+
+import com.sun.net.httpserver.HttpServer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.monitoring.data.MonitoredServiceKey;
+import org.thingsboard.monitoring.service.MonitoringReporter;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+public class ProbeMetricsRegistryConfigTest {
+
+    private final ProbeMetricsRegistryConfig config = new ProbeMetricsRegistryConfig();
+    private final MonitoringReporter reporter = mock(MonitoringReporter.class);
+    private MeterRegistry registry;
+    private HttpServer fakeCollector;
+
+    @AfterEach
+    public void tearDown() {
+        if (registry != null) {
+            registry.close(); // stops the OtlpMeterRegistry's publisher thread, if one was created
+        }
+        config.shutdown(); // stops the Prometheus HttpServer, if one was started
+        if (fakeCollector != null) {
+            fakeCollector.stop(0);
+        }
+    }
+
+    private OtlpMeterRegistry otlpRegistryOf(MeterRegistry composite) {
+        return (OtlpMeterRegistry) ((CompositeMeterRegistry) composite).getRegistries().iterator().next();
+    }
+
+    @Test
+    public void whenBothDisabled_registryHasNoChildren() throws IOException {
+        registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
+                false, 19100, reporter);
+        assertThat(registry).isInstanceOf(CompositeMeterRegistry.class);
+        assertThat(((CompositeMeterRegistry) registry).getRegistries()).isEmpty();
+    }
+
+    @Test
+    public void whenOtlpEnabled_compositeContainsOtlpRegistry() throws IOException {
+        registry = config.probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, false,
+                false, 19101, reporter);
+        assertThat(((CompositeMeterRegistry) registry).getRegistries())
+                .hasOnlyElementsOfType(OtlpMeterRegistry.class);
+    }
+
+    @Test
+    public void whenPrometheusEnabled_metricsEndpointServesScrapeOutput() throws Exception {
+        registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
+                true, 19102, reporter);
+        assertThat(((CompositeMeterRegistry) registry).getRegistries())
+                .hasOnlyElementsOfType(PrometheusMeterRegistry.class);
+
+        registry.counter("test_probe_metrics_registry_counter").increment();
+
+        HttpResponse<String> response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create("http://localhost:19102/metrics")).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains("test_probe_metrics_registry_counter");
+    }
+
+    @Test
+    public void otlpAlertingDisabled_pushFailure_neverReportsToReporter() throws IOException {
+        // port 1 is not listening - the push is guaranteed to fail
+        registry = config.probeMeterRegistry(true, "http://localhost:1/v1/metrics", 60000, false,
+                false, 19103, reporter);
+        registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
+
+        ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");
+
+        verifyNoInteractions(reporter);
+    }
+
+    @Test
+    public void otlpAlertingEnabled_pushFailure_reportsServiceFailure() throws IOException {
+        registry = config.probeMeterRegistry(true, "http://localhost:1/v1/metrics", 60000, true,
+                false, 19104, reporter);
+        registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
+
+        ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");
+
+        verify(reporter).serviceFailure(eq(MonitoredServiceKey.OTLP_EXPORT), any());
+    }
+
+    @Test
+    public void otlpAlertingEnabled_pushSucceeds_reportsServiceIsOk() throws Exception {
+        fakeCollector = HttpServer.create(new InetSocketAddress(19205), 0);
+        fakeCollector.createContext("/v1/metrics", exchange -> {
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        fakeCollector.start();
+
+        registry = config.probeMeterRegistry(true, "http://localhost:19205/v1/metrics", 60000, true,
+                false, 19106, reporter);
+        registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
+
+        ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");
+
+        verify(reporter).serviceIsOk(MonitoredServiceKey.OTLP_EXPORT);
+    }
+
+}

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfigTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfigTest.java
@@ -65,7 +65,7 @@ public class ProbeMetricsRegistryConfigTest {
     @Test
     public void whenBothDisabled_registryHasNoChildren() throws IOException {
         registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
-                false, 19100, reporter);
+                false, 19100, "0.0.0.0", reporter);
         assertThat(registry).isInstanceOf(CompositeMeterRegistry.class);
         assertThat(((CompositeMeterRegistry) registry).getRegistries()).isEmpty();
     }
@@ -73,7 +73,7 @@ public class ProbeMetricsRegistryConfigTest {
     @Test
     public void whenOtlpEnabled_compositeContainsOtlpRegistry() throws IOException {
         registry = config.probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, false,
-                false, 19101, reporter);
+                false, 19101, "0.0.0.0", reporter);
         assertThat(((CompositeMeterRegistry) registry).getRegistries())
                 .hasOnlyElementsOfType(OtlpMeterRegistry.class);
     }
@@ -81,7 +81,7 @@ public class ProbeMetricsRegistryConfigTest {
     @Test
     public void whenPrometheusEnabled_metricsEndpointServesScrapeOutput() throws Exception {
         registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
-                true, 19102, reporter);
+                true, 19102, "0.0.0.0", reporter);
         assertThat(((CompositeMeterRegistry) registry).getRegistries())
                 .hasOnlyElementsOfType(PrometheusMeterRegistry.class);
 
@@ -96,10 +96,25 @@ public class ProbeMetricsRegistryConfigTest {
     }
 
     @Test
+    public void whenBindAddressConfigured_metricsEndpointStillServesOnThatAddress() throws Exception {
+        registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
+                true, 19107, "127.0.0.1", reporter);
+
+        registry.counter("test_probe_metrics_registry_counter").increment();
+
+        HttpResponse<String> response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:19107/metrics")).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains("test_probe_metrics_registry_counter");
+    }
+
+    @Test
     public void otlpAlertingDisabled_pushFailure_neverReportsToReporter() throws IOException {
         // port 1 is not listening - the push is guaranteed to fail
         registry = config.probeMeterRegistry(true, "http://localhost:1/v1/metrics", 60000, false,
-                false, 19103, reporter);
+                false, 19103, "0.0.0.0", reporter);
         registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
 
         ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");
@@ -110,7 +125,7 @@ public class ProbeMetricsRegistryConfigTest {
     @Test
     public void otlpAlertingEnabled_pushFailure_reportsServiceFailure() throws IOException {
         registry = config.probeMeterRegistry(true, "http://localhost:1/v1/metrics", 60000, true,
-                false, 19104, reporter);
+                false, 19104, "0.0.0.0", reporter);
         registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
 
         ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");
@@ -128,7 +143,7 @@ public class ProbeMetricsRegistryConfigTest {
         fakeCollector.start();
 
         registry = config.probeMeterRegistry(true, "http://localhost:19205/v1/metrics", 60000, true,
-                false, 19106, reporter);
+                false, 19106, "0.0.0.0", reporter);
         registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
 
         ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfigTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfigTest.java
@@ -71,26 +71,42 @@ public class ProbeMetricsRegistryConfigTest {
         return server.getAddress().getPort();
     }
 
+    // named locals for otlpAlertingEnabled/prometheusEnabled, not adjacent positional literals, so a
+    // future ProbeMetricsRegistryConfig.probeMeterRegistry param reorder can't silently transpose
+    // them here without a compile error
+    private MeterRegistry probeMeterRegistry(boolean otlpEnabled, String otlpEndpoint, long otlpStepMs,
+                                              boolean otlpAlertingEnabled, boolean prometheusEnabled,
+                                              int prometheusPort, String prometheusBindAddress) throws IOException {
+        return config.probeMeterRegistry(otlpEnabled, otlpEndpoint, otlpStepMs, otlpAlertingEnabled,
+                prometheusEnabled, prometheusPort, prometheusBindAddress, reporter);
+    }
+
     @Test
     public void whenBothDisabled_registryHasNoChildren() throws IOException {
-        registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
-                false, 0, "0.0.0.0", reporter);
+        boolean otlpAlertingEnabled = false;
+        boolean prometheusEnabled = false;
+        registry = probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, otlpAlertingEnabled,
+                prometheusEnabled, 0, "0.0.0.0");
         assertThat(registry).isInstanceOf(CompositeMeterRegistry.class);
         assertThat(((CompositeMeterRegistry) registry).getRegistries()).isEmpty();
     }
 
     @Test
     public void whenOtlpEnabled_compositeContainsOtlpRegistry() throws IOException {
-        registry = config.probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, false,
-                false, 0, "0.0.0.0", reporter);
+        boolean otlpAlertingEnabled = false;
+        boolean prometheusEnabled = false;
+        registry = probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, otlpAlertingEnabled,
+                prometheusEnabled, 0, "0.0.0.0");
         assertThat(((CompositeMeterRegistry) registry).getRegistries())
                 .hasOnlyElementsOfType(OtlpMeterRegistry.class);
     }
 
     @Test
     public void whenBothEnabled_compositeContainsBothOtlpAndPrometheusRegistries() throws IOException {
-        registry = config.probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, false,
-                true, 0, "0.0.0.0", reporter);
+        boolean otlpAlertingEnabled = false;
+        boolean prometheusEnabled = true;
+        registry = probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, otlpAlertingEnabled,
+                prometheusEnabled, 0, "0.0.0.0");
 
         assertThat(((CompositeMeterRegistry) registry).getRegistries())
                 .hasSize(2)
@@ -100,8 +116,10 @@ public class ProbeMetricsRegistryConfigTest {
 
     @Test
     public void whenPrometheusEnabled_metricsEndpointServesScrapeOutput() throws Exception {
-        registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
-                true, 0, "0.0.0.0", reporter);
+        boolean otlpAlertingEnabled = false;
+        boolean prometheusEnabled = true;
+        registry = probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, otlpAlertingEnabled,
+                prometheusEnabled, 0, "0.0.0.0");
         assertThat(((CompositeMeterRegistry) registry).getRegistries())
                 .hasOnlyElementsOfType(PrometheusMeterRegistry.class);
 
@@ -117,8 +135,10 @@ public class ProbeMetricsRegistryConfigTest {
 
     @Test
     public void whenBindAddressConfigured_metricsEndpointStillServesOnThatAddress() throws Exception {
-        registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
-                true, 0, "127.0.0.1", reporter);
+        boolean otlpAlertingEnabled = false;
+        boolean prometheusEnabled = true;
+        registry = probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, otlpAlertingEnabled,
+                prometheusEnabled, 0, "127.0.0.1");
 
         registry.counter("test_probe_metrics_registry_counter").increment();
 
@@ -138,8 +158,10 @@ public class ProbeMetricsRegistryConfigTest {
         portHolder.start();
         try {
             int heldPort = portHolder.getAddress().getPort();
-            assertThatThrownBy(() -> config.probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, false,
-                    true, heldPort, "0.0.0.0", reporter))
+            boolean otlpAlertingEnabled = false;
+            boolean prometheusEnabled = true;
+            assertThatThrownBy(() -> probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, otlpAlertingEnabled,
+                    prometheusEnabled, heldPort, "0.0.0.0"))
                     .isInstanceOf(IOException.class);
         } finally {
             portHolder.stop(0);
@@ -149,8 +171,10 @@ public class ProbeMetricsRegistryConfigTest {
     @Test
     public void otlpAlertingDisabled_pushFailure_neverReportsToReporter() throws IOException {
         // port 1 is not listening - the push is guaranteed to fail
-        registry = config.probeMeterRegistry(true, "http://localhost:1/v1/metrics", 60000, false,
-                false, 0, "0.0.0.0", reporter);
+        boolean otlpAlertingEnabled = false;
+        boolean prometheusEnabled = false;
+        registry = probeMeterRegistry(true, "http://localhost:1/v1/metrics", 60000, otlpAlertingEnabled,
+                prometheusEnabled, 0, "0.0.0.0");
         registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
 
         ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");
@@ -160,8 +184,10 @@ public class ProbeMetricsRegistryConfigTest {
 
     @Test
     public void otlpAlertingEnabled_pushFailure_reportsServiceFailure() throws IOException {
-        registry = config.probeMeterRegistry(true, "http://localhost:1/v1/metrics", 60000, true,
-                false, 0, "0.0.0.0", reporter);
+        boolean otlpAlertingEnabled = true;
+        boolean prometheusEnabled = false;
+        registry = probeMeterRegistry(true, "http://localhost:1/v1/metrics", 60000, otlpAlertingEnabled,
+                prometheusEnabled, 0, "0.0.0.0");
         registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
 
         ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");
@@ -179,8 +205,10 @@ public class ProbeMetricsRegistryConfigTest {
         fakeCollector.start();
         int fakeCollectorPort = fakeCollector.getAddress().getPort();
 
-        registry = config.probeMeterRegistry(true, "http://localhost:" + fakeCollectorPort + "/v1/metrics", 60000, true,
-                false, 0, "0.0.0.0", reporter);
+        boolean otlpAlertingEnabled = true;
+        boolean prometheusEnabled = false;
+        registry = probeMeterRegistry(true, "http://localhost:" + fakeCollectorPort + "/v1/metrics", 60000, otlpAlertingEnabled,
+                prometheusEnabled, 0, "0.0.0.0");
         registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
 
         ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfigTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfigTest.java
@@ -59,13 +59,21 @@ public class ProbeMetricsRegistryConfigTest {
     }
 
     private OtlpMeterRegistry otlpRegistryOf(MeterRegistry composite) {
-        return (OtlpMeterRegistry) ((CompositeMeterRegistry) composite).getRegistries().iterator().next();
+        return (OtlpMeterRegistry) ((CompositeMeterRegistry) composite).getRegistries().stream()
+                .filter(OtlpMeterRegistry.class::isInstance).findFirst().orElseThrow();
+    }
+
+    // reads back the OS-assigned ephemeral port (bound via port 0), rather than depending on any
+    // fixed port being free on the machine running the tests
+    private int boundPrometheusPort() {
+        HttpServer server = (HttpServer) ReflectionTestUtils.getField(config, "prometheusServer");
+        return server.getAddress().getPort();
     }
 
     @Test
     public void whenBothDisabled_registryHasNoChildren() throws IOException {
         registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
-                false, 19100, "0.0.0.0", reporter);
+                false, 0, "0.0.0.0", reporter);
         assertThat(registry).isInstanceOf(CompositeMeterRegistry.class);
         assertThat(((CompositeMeterRegistry) registry).getRegistries()).isEmpty();
     }
@@ -73,22 +81,33 @@ public class ProbeMetricsRegistryConfigTest {
     @Test
     public void whenOtlpEnabled_compositeContainsOtlpRegistry() throws IOException {
         registry = config.probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, false,
-                false, 19101, "0.0.0.0", reporter);
+                false, 0, "0.0.0.0", reporter);
         assertThat(((CompositeMeterRegistry) registry).getRegistries())
                 .hasOnlyElementsOfType(OtlpMeterRegistry.class);
     }
 
     @Test
+    public void whenBothEnabled_compositeContainsBothOtlpAndPrometheusRegistries() throws IOException {
+        registry = config.probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, false,
+                true, 0, "0.0.0.0", reporter);
+
+        assertThat(((CompositeMeterRegistry) registry).getRegistries())
+                .hasSize(2)
+                .anyMatch(OtlpMeterRegistry.class::isInstance)
+                .anyMatch(PrometheusMeterRegistry.class::isInstance);
+    }
+
+    @Test
     public void whenPrometheusEnabled_metricsEndpointServesScrapeOutput() throws Exception {
         registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
-                true, 19102, "0.0.0.0", reporter);
+                true, 0, "0.0.0.0", reporter);
         assertThat(((CompositeMeterRegistry) registry).getRegistries())
                 .hasOnlyElementsOfType(PrometheusMeterRegistry.class);
 
         registry.counter("test_probe_metrics_registry_counter").increment();
 
         HttpResponse<String> response = HttpClient.newHttpClient().send(
-                HttpRequest.newBuilder(URI.create("http://localhost:19102/metrics")).GET().build(),
+                HttpRequest.newBuilder(URI.create("http://localhost:" + boundPrometheusPort() + "/metrics")).GET().build(),
                 HttpResponse.BodyHandlers.ofString());
 
         assertThat(response.statusCode()).isEqualTo(200);
@@ -98,12 +117,12 @@ public class ProbeMetricsRegistryConfigTest {
     @Test
     public void whenBindAddressConfigured_metricsEndpointStillServesOnThatAddress() throws Exception {
         registry = config.probeMeterRegistry(false, "http://localhost:4318/v1/metrics", 60000, false,
-                true, 19107, "127.0.0.1", reporter);
+                true, 0, "127.0.0.1", reporter);
 
         registry.counter("test_probe_metrics_registry_counter").increment();
 
         HttpResponse<String> response = HttpClient.newHttpClient().send(
-                HttpRequest.newBuilder(URI.create("http://127.0.0.1:19107/metrics")).GET().build(),
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + boundPrometheusPort() + "/metrics")).GET().build(),
                 HttpResponse.BodyHandlers.ofString());
 
         assertThat(response.statusCode()).isEqualTo(200);
@@ -114,7 +133,7 @@ public class ProbeMetricsRegistryConfigTest {
     public void otlpAlertingDisabled_pushFailure_neverReportsToReporter() throws IOException {
         // port 1 is not listening - the push is guaranteed to fail
         registry = config.probeMeterRegistry(true, "http://localhost:1/v1/metrics", 60000, false,
-                false, 19103, "0.0.0.0", reporter);
+                false, 0, "0.0.0.0", reporter);
         registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
 
         ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");
@@ -125,7 +144,7 @@ public class ProbeMetricsRegistryConfigTest {
     @Test
     public void otlpAlertingEnabled_pushFailure_reportsServiceFailure() throws IOException {
         registry = config.probeMeterRegistry(true, "http://localhost:1/v1/metrics", 60000, true,
-                false, 19104, "0.0.0.0", reporter);
+                false, 0, "0.0.0.0", reporter);
         registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
 
         ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");
@@ -135,15 +154,16 @@ public class ProbeMetricsRegistryConfigTest {
 
     @Test
     public void otlpAlertingEnabled_pushSucceeds_reportsServiceIsOk() throws Exception {
-        fakeCollector = HttpServer.create(new InetSocketAddress(19205), 0);
+        fakeCollector = HttpServer.create(new InetSocketAddress(0), 0);
         fakeCollector.createContext("/v1/metrics", exchange -> {
             exchange.sendResponseHeaders(200, -1);
             exchange.close();
         });
         fakeCollector.start();
+        int fakeCollectorPort = fakeCollector.getAddress().getPort();
 
-        registry = config.probeMeterRegistry(true, "http://localhost:19205/v1/metrics", 60000, true,
-                false, 19106, "0.0.0.0", reporter);
+        registry = config.probeMeterRegistry(true, "http://localhost:" + fakeCollectorPort + "/v1/metrics", 60000, true,
+                false, 0, "0.0.0.0", reporter);
         registry.counter("test_counter").increment(); // publish() has nothing to send otherwise
 
         ReflectionTestUtils.invokeMethod(otlpRegistryOf(registry), "publish");

--- a/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfigTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/metrics/ProbeMetricsRegistryConfigTest.java
@@ -34,6 +34,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -127,6 +128,22 @@ public class ProbeMetricsRegistryConfigTest {
 
         assertThat(response.statusCode()).isEqualTo(200);
         assertThat(response.body()).contains("test_probe_metrics_registry_counter");
+    }
+
+    @Test
+    public void otlpEnabled_prometheusBindFails_propagatesExceptionInsteadOfSilentlyDegrading() throws IOException {
+        // grab a port so the Prometheus HttpServer bind is guaranteed to fail, exercising the
+        // partial-failure cleanup path (composite.close() on the already-added OTLP registry)
+        HttpServer portHolder = HttpServer.create(new InetSocketAddress(0), 0);
+        portHolder.start();
+        try {
+            int heldPort = portHolder.getAddress().getPort();
+            assertThatThrownBy(() -> config.probeMeterRegistry(true, "http://localhost:4318/v1/metrics", 60000, false,
+                    true, heldPort, "0.0.0.0", reporter))
+                    .isInstanceOf(IOException.class);
+        } finally {
+            portHolder.stop(0);
+        }
     }
 
     @Test

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseHealthCheckerProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseHealthCheckerProbeMetricsTest.java
@@ -180,12 +180,12 @@ public class BaseHealthCheckerProbeMetricsTest {
     }
 
     @Test
-    public void checkAccepted_reportsServiceIsOkWhenSendSucceeds() {
-        // alerting must work here too, not just the metric - it's the only signal available
-        // for this transport while login/WS (and so the full check()) is down
+    public void checkAccepted_neverReportsAnythingWhenSendSucceeds() {
+        // must never call serviceIsOk here - it shares check()'s service key, so an "ok" from this
+        // fallback alone could resolve/reset a real, still-open incident that only check() should clear
         checker.checkAccepted();
 
-        verify(reporter).serviceIsOk(eq(INFO));
+        verify(reporter, never()).serviceIsOk(any());
         verify(reporter, never()).serviceFailure(any(), any());
     }
 
@@ -239,7 +239,7 @@ public class BaseHealthCheckerProbeMetricsTest {
         checker.checkAccepted();
 
         verify(probeMetricsRecorder, times(2)).recordAcceptedProbe(eq(INFO), eq(true));
-        verify(reporter, times(2)).serviceIsOk(eq(INFO));
+        verify(reporter, never()).serviceIsOk(any());
     }
 
     private static class StubConfig implements MonitoringConfig<StubTarget> {

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseHealthCheckerProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseHealthCheckerProbeMetricsTest.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.common.util.JacksonUtil;
+import org.thingsboard.monitoring.client.WsClient;
+import org.thingsboard.monitoring.config.MonitoringConfig;
+import org.thingsboard.monitoring.config.MonitoringTarget;
+import org.thingsboard.monitoring.metrics.ProbeMetricsRecorder;
+import org.thingsboard.monitoring.util.TbStopWatch;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+public class BaseHealthCheckerProbeMetricsTest {
+
+    private static final String INFO = "test-transport-info";
+
+    private MonitoringReporter reporter;
+    private ProbeMetricsRecorder probeMetricsRecorder;
+    private StubHealthChecker checker;
+    private WsClient wsClient;
+
+    @BeforeEach
+    public void setUp() {
+        reporter = mock(MonitoringReporter.class);
+        probeMetricsRecorder = mock(ProbeMetricsRecorder.class);
+        wsClient = mock(WsClient.class);
+        when(wsClient.subscribeForTelemetry(any(), any())).thenReturn(wsClient);
+
+        checker = new StubHealthChecker(new StubConfig(), new StubTarget());
+        ReflectionTestUtils.setField(checker, "reporter", reporter);
+        ReflectionTestUtils.setField(checker, "probeMetricsRecorder", probeMetricsRecorder);
+        ReflectionTestUtils.setField(checker, "stopWatch", new TbStopWatch());
+        ReflectionTestUtils.setField(checker, "resultCheckTimeoutMs", 100);
+        ReflectionTestUtils.invokeMethod(checker, "init"); // triggers @PostConstruct, sets the "info" field
+    }
+
+    @Test
+    public void successfulCheck_recordsSuccess() {
+        when(wsClient.waitForUpdates(100L)).thenReturn(null);
+        when(wsClient.getLatest(any())).thenAnswer(invocation ->
+                Map.of(BaseHealthChecker.TEST_TELEMETRY_KEY, StubHealthChecker.LAST_TEST_VALUE.get()));
+
+        checker.check(wsClient);
+
+        verify(probeMetricsRecorder).recordProbe(eq(INFO), eq(true));
+    }
+
+    @Test
+    public void successfulCheck_recordsRequestAndWsUpdateStageDurations() {
+        when(wsClient.waitForUpdates(100L)).thenReturn(null);
+        when(wsClient.getLatest(any())).thenAnswer(invocation ->
+                Map.of(BaseHealthChecker.TEST_TELEMETRY_KEY, StubHealthChecker.LAST_TEST_VALUE.get()));
+
+        checker.check(wsClient);
+
+        verify(probeMetricsRecorder).recordActionDuration(eq(INFO), eq("request"), anyLong());
+        verify(probeMetricsRecorder).recordActionDuration(eq(INFO), eq("ws_update"), anyLong());
+    }
+
+    @Test
+    public void failedSendTestPayload_recordsFailure() {
+        checker.failOnSend = true;
+
+        checker.check(wsClient);
+
+        verify(probeMetricsRecorder).recordProbe(eq(INFO), eq(false));
+    }
+
+    @Test
+    public void failedSendTestPayload_neverRecordsRequestStageDuration() {
+        checker.failOnSend = true;
+
+        checker.check(wsClient);
+
+        verify(probeMetricsRecorder, never()).recordActionDuration(eq(INFO), eq("request"), anyLong());
+    }
+
+    @Test
+    public void failedWsUpdate_recordsFailure() {
+        when(wsClient.waitForUpdates(100L)).thenReturn(null);
+        when(wsClient.getLatest(any())).thenReturn(Map.of()); // no matching telemetry -> ServiceFailureException
+
+        checker.check(wsClient);
+
+        verify(probeMetricsRecorder).recordProbe(eq(INFO), eq(false));
+    }
+
+    @Test
+    public void failedWsUpdate_recordsRequestStageButNeverWsUpdateStageDuration() {
+        when(wsClient.waitForUpdates(100L)).thenReturn(null);
+        when(wsClient.getLatest(any())).thenReturn(Map.of()); // no matching telemetry -> ServiceFailureException
+
+        checker.check(wsClient);
+
+        verify(probeMetricsRecorder).recordActionDuration(eq(INFO), eq("request"), anyLong());
+        verify(probeMetricsRecorder, never()).recordActionDuration(eq(INFO), eq("ws_update"), anyLong());
+    }
+
+    @Test
+    public void checkAccepted_recordsSuccessWhenSendSucceeds() {
+        checker.checkAccepted();
+
+        verify(probeMetricsRecorder).recordAcceptedProbe(eq(INFO), eq(true));
+    }
+
+    @Test
+    public void checkAccepted_recordsFailureWhenSendThrows() {
+        checker.failOnSend = true;
+
+        checker.checkAccepted();
+
+        verify(probeMetricsRecorder).recordAcceptedProbe(eq(INFO), eq(false));
+    }
+
+    @Test
+    public void checkAccepted_reportsServiceIsOkWhenSendSucceeds() {
+        // alerting must work here too, not just the metric - it's the only signal available
+        // for this transport while login/WS (and so the full check()) is down
+        checker.checkAccepted();
+
+        verify(reporter).serviceIsOk(eq(INFO));
+        verify(reporter, never()).serviceFailure(any(), any());
+    }
+
+    @Test
+    public void checkAccepted_reportsServiceFailureWhenSendThrows() {
+        checker.failOnSend = true;
+
+        checker.checkAccepted();
+
+        verify(reporter).serviceFailure(eq(INFO), any());
+        verify(reporter, never()).serviceIsOk(any());
+    }
+
+    @Test
+    public void checkAccepted_neverWaitsForWsUpdate() {
+        checker.checkAccepted();
+
+        verifyNoInteractions(wsClient);
+    }
+
+    @Test
+    public void checkAccepted_usesDistinctTelemetryKey_notTheE2eTestKey() {
+        checker.checkAccepted();
+
+        JsonNode payload = JacksonUtil.toJsonNode(checker.lastSentPayload);
+        assertThat(payload.has(BaseHealthChecker.ACCEPTED_TEST_TELEMETRY_KEY)).isTrue();
+        assertThat(payload.has(BaseHealthChecker.TEST_TELEMETRY_KEY)).isFalse();
+    }
+
+    @Test
+    public void check_stillUsesTheE2eTestKey_notTheAcceptedKey() {
+        when(wsClient.waitForUpdates(100L)).thenReturn(null);
+        when(wsClient.getLatest(any())).thenAnswer(invocation ->
+                Map.of(BaseHealthChecker.TEST_TELEMETRY_KEY, StubHealthChecker.LAST_TEST_VALUE.get()));
+
+        checker.check(wsClient);
+
+        JsonNode payload = JacksonUtil.toJsonNode(checker.lastSentPayload);
+        assertThat(payload.has(BaseHealthChecker.TEST_TELEMETRY_KEY)).isTrue();
+        assertThat(payload.has(BaseHealthChecker.ACCEPTED_TEST_TELEMETRY_KEY)).isFalse();
+    }
+
+    @Test
+    public void checkAccepted_alsoChecksAssociates() {
+        StubHealthChecker associate = new StubHealthChecker(new StubConfig(), new StubTarget());
+        ReflectionTestUtils.setField(associate, "reporter", reporter);
+        ReflectionTestUtils.setField(associate, "probeMetricsRecorder", probeMetricsRecorder);
+        ReflectionTestUtils.invokeMethod(associate, "init");
+        checker.getAssociates().put("associate-url", associate);
+
+        checker.checkAccepted();
+
+        verify(probeMetricsRecorder, times(2)).recordAcceptedProbe(eq(INFO), eq(true));
+        verify(reporter, times(2)).serviceIsOk(eq(INFO));
+    }
+
+    private static class StubConfig implements MonitoringConfig<StubTarget> {
+        @Override
+        public java.util.List<StubTarget> getTargets() {
+            return java.util.List.of();
+        }
+    }
+
+    private static class StubTarget implements MonitoringTarget {
+        @Override
+        public UUID getDeviceId() {
+            return UUID.randomUUID();
+        }
+
+        @Override
+        public String getBaseUrl() {
+            return "stub://localhost";
+        }
+
+        @Override
+        public boolean isCheckDomainIps() {
+            return false;
+        }
+    }
+
+    private static class StubHealthChecker extends BaseHealthChecker<StubConfig, StubTarget> {
+
+        static final ThreadLocal<String> LAST_TEST_VALUE = new ThreadLocal<>();
+        boolean failOnSend = false;
+        String lastSentPayload;
+
+        protected StubHealthChecker(StubConfig config, StubTarget target) {
+            super(config, target);
+        }
+
+        @Override
+        protected void initialize() {
+        }
+
+        @Override
+        protected void initClient() {
+        }
+
+        @Override
+        protected String createTestPayload(String testValue, String telemetryKey) {
+            LAST_TEST_VALUE.set(testValue);
+            return JacksonUtil.newObjectNode().set(telemetryKey, new TextNode(testValue)).toString();
+        }
+
+        @Override
+        protected void sendTestPayload(String payload) throws Exception {
+            if (failOnSend) {
+                throw new RuntimeException("send failed");
+            }
+            lastSentPayload = payload;
+        }
+
+        @Override
+        protected void destroyClient() {
+        }
+
+        @Override
+        protected Object getInfo() {
+            return INFO;
+        }
+
+        @Override
+        protected String getKey() {
+            return "stub";
+        }
+
+        @Override
+        protected boolean isCfMonitoringEnabled() {
+            return false;
+        }
+
+    }
+
+}

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseHealthCheckerProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseHealthCheckerProbeMetricsTest.java
@@ -107,6 +107,18 @@ public class BaseHealthCheckerProbeMetricsTest {
     }
 
     @Test
+    public void failedSendTestPayload_removesRequestAndWsUpdateStageDurations() {
+        // the specific probe that didn't respond must lose its probe_duration_ms gauge this cycle,
+        // and ws_update never even ran this cycle - its last value is stale too
+        checker.failOnSend = true;
+
+        checker.check(wsClient);
+
+        verify(probeMetricsRecorder).removeActionDuration(eq(INFO), eq("request"));
+        verify(probeMetricsRecorder).removeActionDuration(eq(INFO), eq("ws_update"));
+    }
+
+    @Test
     public void failedWsUpdate_recordsFailure() {
         when(wsClient.waitForUpdates(100L)).thenReturn(null);
         when(wsClient.getLatest(any())).thenReturn(Map.of()); // no matching telemetry -> ServiceFailureException
@@ -125,6 +137,30 @@ public class BaseHealthCheckerProbeMetricsTest {
 
         verify(probeMetricsRecorder).recordActionDuration(eq(INFO), eq("request"), anyLong());
         verify(probeMetricsRecorder, never()).recordActionDuration(eq(INFO), eq("ws_update"), anyLong());
+    }
+
+    @Test
+    public void failedWsUpdate_removesWsUpdateStageDurationButNeverTheRequestOne() {
+        // the request already succeeded this cycle - only the ws_update stage's duration must go away
+        when(wsClient.waitForUpdates(100L)).thenReturn(null);
+        when(wsClient.getLatest(any())).thenReturn(Map.of()); // no matching telemetry -> ServiceFailureException
+
+        checker.check(wsClient);
+
+        verify(probeMetricsRecorder).removeActionDuration(eq(INFO), eq("ws_update"));
+        verify(probeMetricsRecorder, never()).removeActionDuration(eq(INFO), eq("request"));
+    }
+
+    @Test
+    public void failedWsUpdate_withPlainRuntimeException_stillRemovesWsUpdateStageDuration() {
+        // e.g. WsClient.getLastMsgs()'s "WS error from server: ..." or a JSON-parsing failure - not a
+        // ServiceFailureException, but the ws_update duration gauge must still not go stale
+        when(wsClient.waitForUpdates(100L)).thenReturn(null);
+        when(wsClient.getLatest(any())).thenThrow(new RuntimeException("WS error from server: boom"));
+
+        checker.check(wsClient);
+
+        verify(probeMetricsRecorder).removeActionDuration(eq(INFO), eq("ws_update"));
     }
 
     @Test

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseHealthCheckerProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseHealthCheckerProbeMetricsTest.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -180,22 +181,23 @@ public class BaseHealthCheckerProbeMetricsTest {
     }
 
     @Test
-    public void checkAccepted_neverReportsAnythingWhenSendSucceeds() {
-        // must never call serviceIsOk here - it shares check()'s service key, so an "ok" from this
-        // fallback alone could resolve/reset a real, still-open incident that only check() should clear
+    public void checkAccepted_reportsServiceIsOkUnderAcceptedKeyWhenSendSucceeds() {
+        // reports under its own "(accepted)" key, not info directly - so this weaker signal can
+        // recover on its own without ever resolving/reopening the real end-to-end check's incident
         checker.checkAccepted();
 
-        verify(reporter, never()).serviceIsOk(any());
+        verify(reporter).serviceIsOk(argThat(key -> key.toString().equals(INFO + " (accepted)")));
         verify(reporter, never()).serviceFailure(any(), any());
     }
 
     @Test
-    public void checkAccepted_reportsServiceFailureWhenSendThrows() {
+    public void checkAccepted_reportsServiceFailureUnderAcceptedKeyWhenSendThrows() {
         checker.failOnSend = true;
 
         checker.checkAccepted();
 
-        verify(reporter).serviceFailure(eq(INFO), any());
+        verify(reporter).serviceFailure(argThat(key -> key.toString().equals(INFO + " (accepted)")), any());
+        verify(reporter, never()).serviceFailure(eq(INFO), any());
         verify(reporter, never()).serviceIsOk(any());
     }
 
@@ -239,7 +241,8 @@ public class BaseHealthCheckerProbeMetricsTest {
         checker.checkAccepted();
 
         verify(probeMetricsRecorder, times(2)).recordAcceptedProbe(eq(INFO), eq(true));
-        verify(reporter, never()).serviceIsOk(any());
+        // checker and its associate each report serviceIsOk under their own "(accepted)" key
+        verify(reporter, times(2)).serviceIsOk(any());
     }
 
     private static class StubConfig implements MonitoringConfig<StubTarget> {

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
@@ -139,7 +139,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder).removeStaleProbe(eq(MonitoredServiceKey.WS));
+        verify(probeMetricsRecorder).removeProbe(eq(MonitoredServiceKey.WS), eq(ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE));
     }
 
     @Test
@@ -171,7 +171,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         // scoped to the transport healthChecker's own info - distinct from the WS-key removal from Fix A,
         // which is asserted separately by loginFailure_removesWsProbeMetric
-        verify(probeMetricsRecorder, times(1)).removeStaleProbe(transportInfo);
+        verify(probeMetricsRecorder, times(1)).removeProbe(transportInfo, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
     }
 
     @Test
@@ -185,13 +185,12 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
     @Test
     public void loginFailure_neverRemovesAcceptedProbeBeforeFallbackRuns() throws Exception {
-        // removeAcceptedProbe must never precede the fallback check on the failure path
+        // removeAcceptedProbe (in either Removal mode) must never precede the fallback check on the failure path
         when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, never()).removeAcceptedProbe(any());
-        verify(probeMetricsRecorder, never()).removeStaleAcceptedProbe(any());
+        verify(probeMetricsRecorder, never()).removeAcceptedProbe(any(), any());
     }
 
     @Test
@@ -234,7 +233,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeStaleProbe(any());
+        verify(probeMetricsRecorder, times(1)).removeProbe(any(), eq(ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE));
     }
 
     @Test
@@ -254,8 +253,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, never()).removeAcceptedProbe(any());
-        verify(probeMetricsRecorder, never()).removeStaleAcceptedProbe(any());
+        verify(probeMetricsRecorder, never()).removeAcceptedProbe(any(), any());
     }
 
     @Test
@@ -290,7 +288,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeStaleProbe(any());
+        verify(probeMetricsRecorder, times(1)).removeProbe(any(), eq(ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE));
     }
 
     @Test
@@ -312,8 +310,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, never()).removeAcceptedProbe(any());
-        verify(probeMetricsRecorder, never()).removeStaleAcceptedProbe(any());
+        verify(probeMetricsRecorder, never()).removeAcceptedProbe(any(), any());
     }
 
     @Test
@@ -324,8 +321,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, never()).removeProbe(any());
-        verify(probeMetricsRecorder, never()).removeStaleProbe(any());
+        verify(probeMetricsRecorder, never()).removeProbe(any(), any());
     }
 
     @Test
@@ -349,7 +345,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeStaleAcceptedProbe(any());
+        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(any(), eq(ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE));
     }
 
     @Test
@@ -367,7 +363,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeStaleAcceptedProbe(associateInfo);
+        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(associateInfo, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
     }
 
     @Test
@@ -381,7 +377,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeStaleAcceptedProbe(any());
+        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(any(), eq(ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE));
     }
 
     @Test
@@ -393,7 +389,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeStaleAcceptedProbe(any());
+        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(any(), eq(ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE));
     }
 
     @Test
@@ -416,8 +412,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         assertDoesNotThrow(() -> service.runChecks());
 
-        verify(probeMetricsRecorder, never()).removeProbe(firstInfo);
-        verify(probeMetricsRecorder, never()).removeStaleProbe(firstInfo);
+        verify(probeMetricsRecorder, never()).removeProbe(eq(firstInfo), any());
     }
 
     @Test
@@ -445,18 +440,17 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         assertDoesNotThrow(() -> service.runChecks());
 
-        verify(probeMetricsRecorder, never()).removeStaleProbe(firstInfo);
-        verify(probeMetricsRecorder, times(1)).removeStaleProbe(secondInfo);
+        verify(probeMetricsRecorder, never()).removeProbe(firstInfo, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
+        verify(probeMetricsRecorder, times(1)).removeProbe(secondInfo, ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE);
     }
 
     @Test
     public void reconcileAssociates_decommissionedAssociate_removesItsMetricsUnconditionally() throws Exception {
-        // reconcileAssociates() must call the plain (unguarded) removeProbe/removeAcceptedProbe, not
-        // the stale-clearing removeStaleProbe/removeStaleAcceptedProbe variants: a decommissioned
-        // associate can have completed its own check() (via the real BaseHealthChecker, covered
-        // separately by BaseHealthCheckerProbeMetricsTest) and recorded fresh data earlier this very
-        // cycle - its metric must still be removed for good, not silently kept alive by the
-        // same-cycle freshness guard that removeStaleProbe/removeStaleAcceptedProbe apply.
+        // reconcileAssociates() must call removeProbe/removeAcceptedProbe with Removal.PERMANENT, not
+        // STALE_THIS_CYCLE: a decommissioned associate can have completed its own check() (via the
+        // real BaseHealthChecker, covered separately by BaseHealthCheckerProbeMetricsTest) and
+        // recorded fresh data earlier this very cycle - its metric must still be removed for good,
+        // not silently kept alive by the same-cycle freshness guard that STALE_THIS_CYCLE applies.
         TransportMonitoringTarget target = new TransportMonitoringTarget();
         target.setCheckDomainIps(true);
         target.setBaseUrl("tcp://127.0.0.1:1883"); // IP literal - deterministic, no real DNS lookup
@@ -489,14 +483,14 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder).removeProbe(eq(decommissionedInfo));
-        verify(probeMetricsRecorder).removeAcceptedProbe(eq(decommissionedInfo));
-        // removeStaleAcceptedProbe(decommissionedInfo) legitimately also fires here, from the
+        verify(probeMetricsRecorder).removeProbe(eq(decommissionedInfo), eq(ProbeMetricsRecorder.Removal.PERMANENT));
+        verify(probeMetricsRecorder).removeAcceptedProbe(eq(decommissionedInfo), eq(ProbeMetricsRecorder.Removal.PERMANENT));
+        // removeAcceptedProbe(decommissionedInfo, STALE_THIS_CYCLE) legitimately also fires here, from the
         // unconditional per-cycle accepted-fallback sweep over all associates (see
         // successfulRun_removesAcceptedProbeForAssociatesToo) - unrelated to decommissioning, so it's
-        // not asserted against here. removeStaleProbe never applies to an associate on a successful
-        // run though, so that one is safe to assert against.
-        verify(probeMetricsRecorder, never()).removeStaleProbe(eq(decommissionedInfo));
+        // not asserted against here. removeProbe(..., STALE_THIS_CYCLE) never applies to an associate on
+        // a successful run though, so that one is safe to assert against.
+        verify(probeMetricsRecorder, never()).removeProbe(eq(decommissionedInfo), eq(ProbeMetricsRecorder.Removal.STALE_THIS_CYCLE));
         // the fix under test: stopHealthChecker()-equivalent behavior (destroyClient()) must be invoked
         // on the retired ASSOCIATE, never on the parent healthChecker or the still-current associate
         verify(decommissioned).destroyClient();

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
@@ -527,13 +527,18 @@ public class BaseMonitoringServiceProbeMetricsTest {
     @Test
     public void runChecks_startsCycleBeforeAnyRecordOrRemoveCall() throws Exception {
         // startCycle() resets the collision-protection bookkeeping - it must run before any
-        // recordProbe/removeProbe call this cycle, on every outcome, not just the successful path
+        // recordProbe/removeProbe call this cycle, on every outcome, not just the successful path.
+        // Checked against removeActionDuration(LOGIN, request) specifically because it's the
+        // EARLIEST probeMetricsRecorder call in this failure path - recordProbe(LOGIN, false) runs
+        // last (in the finally block), so verifying against it alone wouldn't catch startCycle()
+        // being moved to anywhere before that point.
         when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
 
         service.runChecks();
 
         InOrder inOrder = inOrder(probeMetricsRecorder);
         inOrder.verify(probeMetricsRecorder).startCycle();
+        inOrder.verify(probeMetricsRecorder).removeActionDuration(MonitoredServiceKey.LOGIN, ProbeMetricsRecorder.ACTION_REQUEST);
         inOrder.verify(probeMetricsRecorder).recordProbe(MonitoredServiceKey.LOGIN, false);
     }
 

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
@@ -17,6 +17,7 @@ package org.thingsboard.monitoring.service;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.thingsboard.monitoring.client.TbClient;
 import org.thingsboard.monitoring.client.WsClient;
@@ -35,6 +36,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -523,14 +525,16 @@ public class BaseMonitoringServiceProbeMetricsTest {
     }
 
     @Test
-    public void runChecks_alwaysStartsCycleOnceBeforeAnyRecordOrRemoveCall() throws Exception {
+    public void runChecks_startsCycleBeforeAnyRecordOrRemoveCall() throws Exception {
         // startCycle() resets the collision-protection bookkeeping - it must run before any
         // recordProbe/removeProbe call this cycle, on every outcome, not just the successful path
         when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).startCycle();
+        InOrder inOrder = inOrder(probeMetricsRecorder);
+        inOrder.verify(probeMetricsRecorder).startCycle();
+        inOrder.verify(probeMetricsRecorder).recordProbe(MonitoredServiceKey.LOGIN, false);
     }
 
 

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
@@ -121,7 +121,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder).removeProbe(eq(MonitoredServiceKey.WS));
+        verify(probeMetricsRecorder).removeStaleProbe(eq(MonitoredServiceKey.WS));
     }
 
     @Test
@@ -144,7 +144,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         // scoped to the transport healthChecker's own info - distinct from the WS-key removal from Fix A,
         // which is asserted separately by loginFailure_removesWsProbeMetric
-        verify(probeMetricsRecorder, times(1)).removeProbe(transportInfo);
+        verify(probeMetricsRecorder, times(1)).removeStaleProbe(transportInfo);
     }
 
     @Test
@@ -194,7 +194,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeProbe(any());
+        verify(probeMetricsRecorder, times(1)).removeStaleProbe(any());
     }
 
     @Test
@@ -236,7 +236,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeProbe(any());
+        verify(probeMetricsRecorder, times(1)).removeStaleProbe(any());
     }
 
     @Test
@@ -270,6 +270,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
         service.runChecks();
 
         verify(probeMetricsRecorder, never()).removeProbe(any());
+        verify(probeMetricsRecorder, never()).removeStaleProbe(any());
     }
 
     @Test
@@ -293,7 +294,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(any());
+        verify(probeMetricsRecorder, times(1)).removeStaleAcceptedProbe(any());
     }
 
     @Test
@@ -311,7 +312,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(associateInfo);
+        verify(probeMetricsRecorder, times(1)).removeStaleAcceptedProbe(associateInfo);
     }
 
     @Test
@@ -325,7 +326,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(any());
+        verify(probeMetricsRecorder, times(1)).removeStaleAcceptedProbe(any());
     }
 
     @Test
@@ -337,7 +338,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         service.runChecks();
 
-        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(any());
+        verify(probeMetricsRecorder, times(1)).removeStaleAcceptedProbe(any());
     }
 
     @Test
@@ -361,6 +362,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
         assertDoesNotThrow(() -> service.runChecks());
 
         verify(probeMetricsRecorder, never()).removeProbe(firstInfo);
+        verify(probeMetricsRecorder, never()).removeStaleProbe(firstInfo);
     }
 
     @Test
@@ -388,8 +390,52 @@ public class BaseMonitoringServiceProbeMetricsTest {
 
         assertDoesNotThrow(() -> service.runChecks());
 
-        verify(probeMetricsRecorder, never()).removeProbe(firstInfo);
-        verify(probeMetricsRecorder, times(1)).removeProbe(secondInfo);
+        verify(probeMetricsRecorder, never()).removeStaleProbe(firstInfo);
+        verify(probeMetricsRecorder, times(1)).removeStaleProbe(secondInfo);
+    }
+
+    @Test
+    public void reconcileAssociates_decommissionedAssociate_removesItsMetricsUnconditionally() throws Exception {
+        // reconcileAssociates() must call the plain (unguarded) removeProbe/removeAcceptedProbe, not
+        // the stale-clearing removeStaleProbe/removeStaleAcceptedProbe variants: a decommissioned
+        // associate can have completed its own check() (via the real BaseHealthChecker, covered
+        // separately by BaseHealthCheckerProbeMetricsTest) and recorded fresh data earlier this very
+        // cycle - its metric must still be removed for good, not silently kept alive by the
+        // same-cycle freshness guard that removeStaleProbe/removeStaleAcceptedProbe apply.
+        TransportMonitoringTarget target = new TransportMonitoringTarget();
+        target.setCheckDomainIps(true);
+        target.setBaseUrl("tcp://127.0.0.1:1883"); // IP literal - deterministic, no real DNS lookup
+        target.setDevice(new org.thingsboard.monitoring.config.transport.DeviceConfig()); // avoids an
+        // unrelated NPE in the pre-existing stopHealthChecker(healthChecker) call (out of scope here)
+        when(healthChecker.getTarget()).thenReturn(target);
+
+        BaseHealthChecker<TransportMonitoringConfig, TransportMonitoringTarget> current =
+                mock(BaseHealthChecker.class);
+        BaseHealthChecker<TransportMonitoringConfig, TransportMonitoringTarget> decommissioned =
+                mock(BaseHealthChecker.class);
+        Object decommissionedInfo = new Object();
+        when(decommissioned.getCachedInfo()).thenReturn(decommissionedInfo);
+
+        java.util.Map<String, BaseHealthChecker<TransportMonitoringConfig, TransportMonitoringTarget>> associates =
+                new java.util.HashMap<>();
+        associates.put("tcp://127.0.0.1:1883", current); // still resolves - untouched by reconciliation
+        associates.put("old-decommissioned-ip", decommissioned); // no longer resolves - must be removed
+        when(healthChecker.getAssociates()).thenReturn(associates);
+
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder).removeProbe(eq(decommissionedInfo));
+        verify(probeMetricsRecorder).removeAcceptedProbe(eq(decommissionedInfo));
+        // removeStaleAcceptedProbe(decommissionedInfo) legitimately also fires here, from the
+        // unconditional per-cycle accepted-fallback sweep over all associates (see
+        // successfulRun_removesAcceptedProbeForAssociatesToo) - unrelated to decommissioning, so it's
+        // not asserted against here. removeStaleProbe never applies to an associate on a successful
+        // run though, so that one is safe to assert against.
+        verify(probeMetricsRecorder, never()).removeStaleProbe(eq(decommissionedInfo));
     }
 
     @Test
@@ -410,6 +456,17 @@ public class BaseMonitoringServiceProbeMetricsTest {
         service.runChecks();
 
         verify(probeMetricsRecorder, times(1)).recordHeartbeat();
+    }
+
+    @Test
+    public void runChecks_alwaysStartsCycleOnceBeforeAnyRecordOrRemoveCall() throws Exception {
+        // startCycle() resets the collision-protection bookkeeping - it must run before any
+        // recordProbe/removeProbe call this cycle, on every outcome, not just the successful path
+        when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, times(1)).startCycle();
     }
 
 

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
@@ -1,0 +1,435 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.monitoring.client.TbClient;
+import org.thingsboard.monitoring.client.WsClient;
+import org.thingsboard.monitoring.client.WsClientFactory;
+import org.thingsboard.monitoring.config.transport.TransportMonitoringConfig;
+import org.thingsboard.monitoring.config.transport.TransportMonitoringTarget;
+import org.thingsboard.monitoring.data.MonitoredServiceKey;
+import org.thingsboard.monitoring.data.ServiceFailureException;
+import org.thingsboard.monitoring.metrics.ProbeMetricsRecorder;
+import org.thingsboard.monitoring.util.TbStopWatch;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class BaseMonitoringServiceProbeMetricsTest {
+
+    private TbClient tbClient;
+    private WsClientFactory wsClientFactory;
+    private MonitoringReporter reporter;
+    private ProbeMetricsRecorder probeMetricsRecorder;
+    private TestMonitoringService service;
+    private WsClient wsClient;
+    private BaseHealthChecker<TransportMonitoringConfig, TransportMonitoringTarget> healthChecker;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        tbClient = mock(TbClient.class);
+        wsClientFactory = mock(WsClientFactory.class);
+        reporter = mock(MonitoringReporter.class);
+        probeMetricsRecorder = mock(ProbeMetricsRecorder.class);
+        wsClient = mock(WsClient.class);
+        when(wsClient.subscribeForTelemetry(any(), any())).thenReturn(wsClient);
+
+        service = new TestMonitoringService();
+        ReflectionTestUtils.setField(service, "tbClient", tbClient);
+        ReflectionTestUtils.setField(service, "wsClientFactory", wsClientFactory);
+        ReflectionTestUtils.setField(service, "reporter", reporter);
+        ReflectionTestUtils.setField(service, "probeMetricsRecorder", probeMetricsRecorder);
+        ReflectionTestUtils.setField(service, "stopWatch", new TbStopWatch());
+
+        // one stub health checker so runChecks() doesn't short-circuit on the "healthCheckers.isEmpty()" guard;
+        // its own check() outcome is irrelevant to this test (it's exercised in BaseHealthCheckerProbeMetricsTest).
+        // getTarget() must be stubbed: BaseMonitoringService.check() reads target.isCheckDomainIps() right
+        // after invoking it, and an unstubbed null there would NPE out of a "successful" run.
+        healthChecker = mock(BaseHealthChecker.class);
+        TransportMonitoringTarget target = new TransportMonitoringTarget();
+        target.setCheckDomainIps(false);
+        when(healthChecker.getTarget()).thenReturn(target);
+        List<BaseHealthChecker<TransportMonitoringConfig, TransportMonitoringTarget>> healthCheckers =
+                (List) ReflectionTestUtils.getField(service, "healthCheckers");
+        healthCheckers.add(healthChecker);
+    }
+
+    @Test
+    public void successfulLoginAndWs_recordsBothAsSuccessful() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder).recordProbe(eq(MonitoredServiceKey.LOGIN), eq(true));
+        verify(probeMetricsRecorder).recordProbe(eq(MonitoredServiceKey.WS), eq(true));
+    }
+
+    @Test
+    public void successfulLoginAndWs_recordsRequestConnectAndSubscribeStageDurations() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder).recordActionDuration(eq(MonitoredServiceKey.LOGIN), eq("request"), anyLong());
+        verify(probeMetricsRecorder).recordActionDuration(eq(MonitoredServiceKey.WS), eq("connect"), anyLong());
+        verify(probeMetricsRecorder).recordActionDuration(eq(MonitoredServiceKey.WS), eq("subscribe"), anyLong());
+    }
+
+    @Test
+    public void loginFailure_recordsLoginFailureAndNeverRecordsWs() throws Exception {
+        when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder).recordProbe(eq(MonitoredServiceKey.LOGIN), eq(false));
+        verify(probeMetricsRecorder, never()).recordProbe(eq(MonitoredServiceKey.WS), any(Boolean.class));
+    }
+
+    @Test
+    public void loginFailure_removesWsProbeMetric() throws Exception {
+        when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder).removeProbe(eq(MonitoredServiceKey.WS));
+    }
+
+    @Test
+    public void loginFailure_neverRecordsLoginRequestStageDuration() throws Exception {
+        when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, never()).recordActionDuration(eq(MonitoredServiceKey.LOGIN), eq("request"), anyLong());
+    }
+
+    @Test
+    public void loginFailure_clearsTransportProbeMetrics() throws Exception {
+        // transport checks never ran this cycle - their gauges must not keep reporting last cycle's value
+        Object transportInfo = new Object();
+        when(healthChecker.getCachedInfo()).thenReturn(transportInfo);
+        when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
+
+        service.runChecks();
+
+        // scoped to the transport healthChecker's own info - distinct from the WS-key removal from Fix A,
+        // which is asserted separately by loginFailure_removesWsProbeMetric
+        verify(probeMetricsRecorder, times(1)).removeProbe(transportInfo);
+    }
+
+    @Test
+    public void loginFailure_checksTransportAcceptance() throws Exception {
+        when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
+
+        service.runChecks();
+
+        verify(healthChecker).checkAccepted();
+    }
+
+    @Test
+    public void loginFailure_neverRemovesAcceptedProbeBeforeFallbackRuns() throws Exception {
+        // removeAcceptedProbe must never precede the fallback check on the failure path
+        when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, never()).removeAcceptedProbe(any());
+    }
+
+    @Test
+    public void wsConnectFailure_recordsWsFailure() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenThrow(new RuntimeException("connect failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder).recordProbe(eq(MonitoredServiceKey.LOGIN), eq(true));
+        verify(probeMetricsRecorder).recordProbe(eq(MonitoredServiceKey.WS), eq(false));
+    }
+
+    @Test
+    public void wsConnectFailure_neverRecordsConnectStageDuration() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenThrow(new RuntimeException("connect failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, never()).recordActionDuration(eq(MonitoredServiceKey.WS), eq("connect"), anyLong());
+    }
+
+    @Test
+    public void wsConnectFailure_clearsTransportProbeMetrics() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenThrow(new RuntimeException("connect failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, times(1)).removeProbe(any());
+    }
+
+    @Test
+    public void wsConnectFailure_checksTransportAcceptance() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenThrow(new RuntimeException("connect failed"));
+
+        service.runChecks();
+
+        verify(healthChecker).checkAccepted();
+    }
+
+    @Test
+    public void wsConnectFailure_neverRemovesAcceptedProbeBeforeFallbackRuns() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenThrow(new RuntimeException("connect failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, never()).removeAcceptedProbe(any());
+    }
+
+    @Test
+    public void wsSubscribeFailure_recordsWsFailure() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenThrow(new IllegalStateException("no reply"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder).recordProbe(eq(MonitoredServiceKey.WS), eq(false));
+    }
+
+    @Test
+    public void wsSubscribeFailure_clearsTransportProbeMetrics() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenThrow(new IllegalStateException("no reply"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, times(1)).removeProbe(any());
+    }
+
+    @Test
+    public void wsSubscribeFailure_checksTransportAcceptance() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenThrow(new IllegalStateException("no reply"));
+
+        service.runChecks();
+
+        verify(healthChecker).checkAccepted();
+    }
+
+    @Test
+    public void wsSubscribeFailure_neverRemovesAcceptedProbeBeforeFallbackRuns() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenThrow(new IllegalStateException("no reply"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, never()).removeAcceptedProbe(any());
+    }
+
+    @Test
+    public void successfulRun_neverClearsTransportProbeMetrics() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, never()).removeProbe(any());
+    }
+
+    @Test
+    public void successfulRun_neverChecksTransportAcceptance() throws Exception {
+        // WS is healthy, so E2E already covers this target - checkAccepted() firing too would double-send
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        service.runChecks();
+
+        verify(healthChecker, never()).checkAccepted();
+    }
+
+    @Test
+    public void successfulRun_removesAcceptedProbeForEachHealthChecker() throws Exception {
+        // fresh E2E data means any stale accepted-fallback value must be cleared, not frozen forever
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(any());
+    }
+
+    @Test
+    public void successfulRun_removesAcceptedProbeForAssociatesToo() throws Exception {
+        // associates get their own kind="accepted" gauge during an outage too - recovery must clear it
+        BaseHealthChecker<TransportMonitoringConfig, TransportMonitoringTarget> associate =
+                mock(BaseHealthChecker.class);
+        Object associateInfo = new Object();
+        when(associate.getCachedInfo()).thenReturn(associateInfo);
+        when(healthChecker.getAssociates()).thenReturn(java.util.Map.of("associate-url", associate));
+
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(associateInfo);
+    }
+
+    @Test
+    public void unexpectedServiceFailureMidLoop_alsoClearsAcceptedProbeMetrics() throws Exception {
+        // caught by the outer handler, not the 3 known branches - must still clear kind="accepted"
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+        doThrow(new ServiceFailureException(MonitoredServiceKey.GENERAL, new RuntimeException("boom")))
+                .when(healthChecker).check(any());
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(any());
+    }
+
+    @Test
+    public void unexpectedThrowableMidLoop_alsoClearsAcceptedProbeMetrics() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+        doThrow(new RuntimeException("boom")).when(healthChecker).check(any());
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, times(1)).removeAcceptedProbe(any());
+    }
+
+    @Test
+    public void reconciliationFailureAfterSuccessfulCheck_doesNotClearThatTargetsMetrics() throws Exception {
+        // healthChecker.check() completes normally, so its finally block already recorded fresh
+        // probe_success/probe_duration_ms for this cycle. The domain-IP-associate reconciliation
+        // that runs afterward (only when isCheckDomainIps() is true) then fails - here because the
+        // configured host can never resolve (RFC 2606 reserves the ".invalid" TLD for exactly this).
+        // That late, unrelated bookkeeping failure must not wipe the metrics check() already recorded.
+        Object firstInfo = new Object();
+        when(healthChecker.getCachedInfo()).thenReturn(firstInfo);
+        TransportMonitoringTarget target = new TransportMonitoringTarget();
+        target.setCheckDomainIps(true);
+        target.setBaseUrl("tcp://this-host-does-not-resolve.invalid:1883");
+        when(healthChecker.getTarget()).thenReturn(target);
+
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        assertDoesNotThrow(() -> service.runChecks());
+
+        verify(probeMetricsRecorder, never()).removeProbe(firstInfo);
+    }
+
+    @Test
+    public void unexpectedThrowableMidLoop_doesNotClearAlreadyCheckedTargets() throws Exception {
+        // a SECOND checker's check() throws directly - the first checker already completed and
+        // recorded fresh data this cycle (checkedCount was incremented past it) and must survive
+        Object firstInfo = new Object();
+        when(healthChecker.getCachedInfo()).thenReturn(firstInfo);
+
+        BaseHealthChecker<TransportMonitoringConfig, TransportMonitoringTarget> secondChecker =
+                mock(BaseHealthChecker.class);
+        TransportMonitoringTarget secondTarget = new TransportMonitoringTarget();
+        secondTarget.setCheckDomainIps(false);
+        when(secondChecker.getTarget()).thenReturn(secondTarget);
+        Object secondInfo = new Object();
+        when(secondChecker.getCachedInfo()).thenReturn(secondInfo);
+        doThrow(new RuntimeException("boom")).when(secondChecker).check(any());
+        List<BaseHealthChecker<TransportMonitoringConfig, TransportMonitoringTarget>> healthCheckers =
+                (List) ReflectionTestUtils.getField(service, "healthCheckers");
+        healthCheckers.add(secondChecker);
+
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        assertDoesNotThrow(() -> service.runChecks());
+
+        verify(probeMetricsRecorder, never()).removeProbe(firstInfo);
+        verify(probeMetricsRecorder, times(1)).removeProbe(secondInfo);
+    }
+
+    @Test
+    public void runChecks_alwaysRecordsHeartbeatOnce_regardlessOfOutcome() throws Exception {
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, times(1)).recordHeartbeat();
+    }
+
+    @Test
+    public void runChecks_loginFailure_stillRecordsHeartbeatOnce() throws Exception {
+        when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, times(1)).recordHeartbeat();
+    }
+
+
+    private static class TestMonitoringService extends BaseMonitoringService<TransportMonitoringConfig, TransportMonitoringTarget> {
+        @Override
+        protected BaseHealthChecker<?, ?> createHealthChecker(TransportMonitoringConfig config, TransportMonitoringTarget target) {
+            throw new UnsupportedOperationException("not exercised in this test");
+        }
+
+        @Override
+        protected TransportMonitoringTarget createTarget(String baseUrl) {
+            TransportMonitoringTarget target = new TransportMonitoringTarget();
+            target.setBaseUrl(baseUrl);
+            return target;
+        }
+
+        @Override
+        protected String getName() {
+            return "test";
+        }
+    }
+
+}

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
@@ -164,6 +164,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
         service.runChecks();
 
         verify(probeMetricsRecorder, never()).removeAcceptedProbe(any());
+        verify(probeMetricsRecorder, never()).removeStaleAcceptedProbe(any());
     }
 
     @Test
@@ -215,6 +216,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
         service.runChecks();
 
         verify(probeMetricsRecorder, never()).removeAcceptedProbe(any());
+        verify(probeMetricsRecorder, never()).removeStaleAcceptedProbe(any());
     }
 
     @Test
@@ -259,6 +261,7 @@ public class BaseMonitoringServiceProbeMetricsTest {
         service.runChecks();
 
         verify(probeMetricsRecorder, never()).removeAcceptedProbe(any());
+        verify(probeMetricsRecorder, never()).removeStaleAcceptedProbe(any());
     }
 
     @Test

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/BaseMonitoringServiceProbeMetricsTest.java
@@ -93,7 +93,12 @@ public class BaseMonitoringServiceProbeMetricsTest {
     }
 
     @Test
-    public void successfulLoginAndWs_recordsRequestConnectAndSubscribeStageDurations() throws Exception {
+    public void successfulLoginAndWs_recordsRequestAndSubscribeStageDurations() throws Exception {
+        // WS "connect" duration is no longer recorded here - it moved into WsClientFactory.createClient()
+        // itself (see WsClientFactory), reusing the same measurement it already takes for reportLatency
+        // instead of BaseMonitoringService measuring the same operation a second time with a raw
+        // System.nanoTime() pair. wsClientFactory is a full mock in this test, so that call is never
+        // exercised here; it's a 3-line, inspectable change in WsClientFactory itself.
         when(tbClient.logIn()).thenReturn("token");
         when(wsClientFactory.createClient("token")).thenReturn(wsClient);
         when(wsClient.waitForReply()).thenReturn(null);
@@ -101,8 +106,19 @@ public class BaseMonitoringServiceProbeMetricsTest {
         service.runChecks();
 
         verify(probeMetricsRecorder).recordActionDuration(eq(MonitoredServiceKey.LOGIN), eq("request"), anyLong());
-        verify(probeMetricsRecorder).recordActionDuration(eq(MonitoredServiceKey.WS), eq("connect"), anyLong());
         verify(probeMetricsRecorder).recordActionDuration(eq(MonitoredServiceKey.WS), eq("subscribe"), anyLong());
+    }
+
+    @Test
+    public void successfulLoginAndWs_neverRecordsWsConnectStageDurationDirectly() throws Exception {
+        // guards against the redundant System.nanoTime() measurement creeping back into BaseMonitoringService
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenReturn(null);
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder, never()).recordActionDuration(eq(MonitoredServiceKey.WS), eq("connect"), anyLong());
     }
 
     @Test
@@ -131,6 +147,15 @@ public class BaseMonitoringServiceProbeMetricsTest {
         service.runChecks();
 
         verify(probeMetricsRecorder, never()).recordActionDuration(eq(MonitoredServiceKey.LOGIN), eq("request"), anyLong());
+    }
+
+    @Test
+    public void loginFailure_removesLoginRequestStageDuration() throws Exception {
+        when(tbClient.logIn()).thenThrow(new RuntimeException("login failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder).removeActionDuration(eq(MonitoredServiceKey.LOGIN), eq("request"));
     }
 
     @Test
@@ -189,6 +214,18 @@ public class BaseMonitoringServiceProbeMetricsTest {
     }
 
     @Test
+    public void wsConnectFailure_removesConnectAndSubscribeStageDurations() throws Exception {
+        // subscribe never even ran this cycle - its last value is stale too
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenThrow(new RuntimeException("connect failed"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder).removeActionDuration(eq(MonitoredServiceKey.WS), eq("connect"));
+        verify(probeMetricsRecorder).removeActionDuration(eq(MonitoredServiceKey.WS), eq("subscribe"));
+    }
+
+    @Test
     public void wsConnectFailure_clearsTransportProbeMetrics() throws Exception {
         when(tbClient.logIn()).thenReturn("token");
         when(wsClientFactory.createClient("token")).thenThrow(new RuntimeException("connect failed"));
@@ -228,6 +265,19 @@ public class BaseMonitoringServiceProbeMetricsTest {
         service.runChecks();
 
         verify(probeMetricsRecorder).recordProbe(eq(MonitoredServiceKey.WS), eq(false));
+    }
+
+    @Test
+    public void wsSubscribeFailure_removesSubscribeStageDurationButNeverConnect() throws Exception {
+        // connect already succeeded this cycle (it's how we got here) - only "subscribe" must go away
+        when(tbClient.logIn()).thenReturn("token");
+        when(wsClientFactory.createClient("token")).thenReturn(wsClient);
+        when(wsClient.waitForReply()).thenThrow(new IllegalStateException("no reply"));
+
+        service.runChecks();
+
+        verify(probeMetricsRecorder).removeActionDuration(eq(MonitoredServiceKey.WS), eq("subscribe"));
+        verify(probeMetricsRecorder, never()).removeActionDuration(eq(MonitoredServiceKey.WS), eq("connect"));
     }
 
     @Test
@@ -418,6 +468,12 @@ public class BaseMonitoringServiceProbeMetricsTest {
                 mock(BaseHealthChecker.class);
         Object decommissionedInfo = new Object();
         when(decommissioned.getCachedInfo()).thenReturn(decommissionedInfo);
+        // stopHealthChecker() reads getTarget().getDeviceId() on whichever checker it's given - now that
+        // it's fixed to stop the retired ASSOCIATE (not the parent healthChecker), that's decommissioned's
+        // own target, so it needs the same device stub healthChecker's target got above.
+        TransportMonitoringTarget decommissionedTarget = new TransportMonitoringTarget();
+        decommissionedTarget.setDevice(new org.thingsboard.monitoring.config.transport.DeviceConfig());
+        when(decommissioned.getTarget()).thenReturn(decommissionedTarget);
 
         java.util.Map<String, BaseHealthChecker<TransportMonitoringConfig, TransportMonitoringTarget>> associates =
                 new java.util.HashMap<>();
@@ -439,6 +495,11 @@ public class BaseMonitoringServiceProbeMetricsTest {
         // not asserted against here. removeStaleProbe never applies to an associate on a successful
         // run though, so that one is safe to assert against.
         verify(probeMetricsRecorder, never()).removeStaleProbe(eq(decommissionedInfo));
+        // the fix under test: stopHealthChecker()-equivalent behavior (destroyClient()) must be invoked
+        // on the retired ASSOCIATE, never on the parent healthChecker or the still-current associate
+        verify(decommissioned).destroyClient();
+        verify(current, never()).destroyClient();
+        verify(healthChecker, never()).destroyClient();
     }
 
     @Test

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/transport/impl/Lwm2mTransportHealthCheckerTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/transport/impl/Lwm2mTransportHealthCheckerTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.service.transport.impl;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.monitoring.config.transport.Lwm2mTransportMonitoringConfig;
+import org.thingsboard.monitoring.config.transport.TransportMonitoringTarget;
+import org.thingsboard.monitoring.metrics.ProbeMetricsRecorder;
+import org.thingsboard.monitoring.service.MonitoringReporter;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+public class Lwm2mTransportHealthCheckerTest {
+
+    @Test
+    public void checkAccepted_isNoOp_neverRecordsAcceptedProbeOrReports() {
+        // checkAccepted() is a no-op for LwM2M (see override) - must never touch the metric or alerting
+        ProbeMetricsRecorder probeMetricsRecorder = mock(ProbeMetricsRecorder.class);
+        MonitoringReporter reporter = mock(MonitoringReporter.class);
+        Lwm2mTransportHealthChecker checker = new Lwm2mTransportHealthChecker(
+                new Lwm2mTransportMonitoringConfig(), new TransportMonitoringTarget());
+        ReflectionTestUtils.setField(checker, "probeMetricsRecorder", probeMetricsRecorder);
+        ReflectionTestUtils.setField(checker, "reporter", reporter);
+
+        checker.checkAccepted();
+
+        verifyNoInteractions(probeMetricsRecorder);
+        verifyNoInteractions(reporter);
+    }
+
+}

--- a/monitoring/src/test/java/org/thingsboard/monitoring/service/transport/impl/MqttTransportHealthCheckerTest.java
+++ b/monitoring/src/test/java/org/thingsboard/monitoring/service/transport/impl/MqttTransportHealthCheckerTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.monitoring.service.transport.impl;
+
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.thingsboard.monitoring.config.transport.MqttTransportMonitoringConfig;
+import org.thingsboard.monitoring.config.transport.TransportMonitoringTarget;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class MqttTransportHealthCheckerTest {
+
+    @Test
+    public void sendAcceptedTestPayload_alwaysUsesQos1_regardlessOfConfiguredQos() throws Exception {
+        MqttTransportMonitoringConfig config = new MqttTransportMonitoringConfig();
+        config.setQos(0);
+        MqttTransportHealthChecker checker = new MqttTransportHealthChecker(config, new TransportMonitoringTarget());
+        MqttClient mqttClient = mock(MqttClient.class);
+        ReflectionTestUtils.setField(checker, "mqttClient", mqttClient);
+
+        checker.sendAcceptedTestPayload("{}");
+
+        ArgumentCaptor<MqttMessage> captor = ArgumentCaptor.forClass(MqttMessage.class);
+        verify(mqttClient).publish(anyString(), captor.capture());
+        assertThat(captor.getValue().getQos()).isEqualTo(1);
+    }
+
+    @Test
+    public void sendTestPayload_stillUsesConfiguredQos() throws Exception {
+        MqttTransportMonitoringConfig config = new MqttTransportMonitoringConfig();
+        config.setQos(0);
+        MqttTransportHealthChecker checker = new MqttTransportHealthChecker(config, new TransportMonitoringTarget());
+        MqttClient mqttClient = mock(MqttClient.class);
+        ReflectionTestUtils.setField(checker, "mqttClient", mqttClient);
+
+        checker.sendTestPayload("{}");
+
+        ArgumentCaptor<MqttMessage> captor = ArgumentCaptor.forClass(MqttMessage.class);
+        verify(mqttClient).publish(anyString(), captor.capture());
+        assertThat(captor.getValue().getQos()).isEqualTo(0);
+    }
+
+}


### PR DESCRIPTION



## Pull Request description

Export probe_success/probe_duration_ms per check (login, WS, each transport) via OTLP push and a Prometheus pull endpoint, both independently toggleable, plus a heartbeat metric so a consumer can tell the prober is dead apart from a specific target being down. A stale gauge never lingers past the cycle it was recorded in - a probe that isn't checked this cycle (login down, an IP-based associate dropped, WS down) goes absent instead of keeping its last value, and a failure isolated to one health checker never wipes another's fresh data for the same cycle.

Add a transport-accepted fallback: when login/WS is down and the full end-to-end check can't run, each transport still gets probed directly (MQTT PUBACK, CoAP/HTTP response) so alerting on a transport-only outage keeps working regardless of whether metrics export is enabled. The fallback writes under its own telemetry key so a late fallback message can never be mistaken for the real end-to-end check's expected value once login/WS recovers.

## General checklist

- [ ] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [ ] Description contains human-readable scope of changes.
- [ ] Description contains brief notes about what needs to be added to the documentation.
- [ ] No merge conflicts, commented blocks of code, code formatting issues.
- [ ] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.
  
## Front-End feature checklist

- [ ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes;
- [ ] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help)

## Back-End feature checklist

- [ ] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [ ] If new dependency was added: the dependency tree is checked for conflicts.
- [ ] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [ ] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [ ] If new yml property was added: make sure a description is added (above or near the property).



