### PR TITLE
fix: sort dashboard select dropdown alphabetically by title

### DIFF
--- a/ui-ngx/src/app/shared/components/dashboard-select.component.ts
+++ b/ui-ngx/src/app/shared/components/dashboard-select.component.ts
@@ -30,6 +30,7 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Observable, of } from 'rxjs';
 import { PageLink } from '@shared/models/page/page-link';
+import { Direction } from '@shared/models/page/sort-order';
 import { map, share } from 'rxjs/operators';
 import { emptyPageData, PageData } from '@shared/models/page/page-data';
 import { DashboardInfo } from '@app/shared/models/dashboard.models';
@@ -113,7 +114,7 @@ export class DashboardSelectComponent implements ControlValueAccessor, OnInit {
 
   ngOnInit() {
 
-    const pageLink = new PageLink(100);
+    const pageLink = new PageLink(100, 0, null, {property: 'title', direction: Direction.ASC});
 
     this.dashboards$ = this.getDashboards(pageLink).pipe(
       map((pageData) => pageData.data),


### PR DESCRIPTION
## Pull Request description

Fixes [CP-11160](https://thingsboard-portal.atlassian.net/servicedesk/customer/portal/1/CP-11160).

The dashboard select dropdown (`tb-dashboard-select`, shown in the dashboard toolbar for switching between dashboards) listed tenant/customer dashboards in creation order rather than alphabetically. As the number of dashboards on a tenant grows, this makes it hard to find a specific one.

This change passes a `title`/`ASC` `SortOrder` to the `PageLink` used when fetching the dashboard list in `dashboard-select.component.ts`, so the backend (`GET /api/tenant/dashboards` / `GET /api/customer/{customerId}/dashboards`) returns dashboards sorted alphabetically by title instead of unsorted. Both the desktop `mat-select` and the mobile overlay panel read from the same `dashboards$` observable populated here, so both are fixed by this one change.

No documentation changes are needed — this is a display-order fix with no API or config surface change.

## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [ ] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues). *(CP-11160 is an internal tracking reference, not a public GitHub issue — open one first if the maintainers require it.)*
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only. *(N/A — external contributor)*

## Front-End feature checklist

- [X ] Screenshots with affected component(s) are added. The best option is to provide 2 screens: before and after changes; *(add these — see note below)*
- [x] If you change the widget or other API, ensure it is backward-compatible or upgrade script is present.
- [ ] Ensure new API is documented [here](https://github.com/thingsboard/thingsboard-ui-help) *(N/A — no new API added)*

## Back-End feature checklist

N/A — this PR only modifies a front-end Angular component (`ui-ngx`); no back-end code was changed.

BEFORE
<img width="1000" height="340" alt="before-planets" src="https://github.com/user-attachments/assets/8f935cb3-0b00-48a7-a260-1b602755d3a7" />

AFTER
<img width="1388" height="451" alt="image" src="https://github.com/user-attachments/assets/266ca833-45fe-4f91-9a5c-96639d1ff4f8" />

