### PR TITLE
Do not strand edge sync when an event fetcher fails

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/session/EdgeGrpcSession.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/session/EdgeGrpcSession.java
@@ -366,7 +366,12 @@ public class EdgeGrpcSession implements EdgeSession {
 
                 @Override
                 public void onFailure(Throwable t) {
-                    log.error("[{}][{}] Exception during sync process", getTenantId(), getEdgeId(), t);
+                    log.error("[{}][{}] Exception during sync process, skipping fetcher {} and continuing",
+                            getTenantId(), getEdgeId(), next.getClass().getSimpleName(), t);
+                    // Keep walking the cursor: returning here leaves syncInProgress set for the life of the
+                    // session, so the edge never receives SyncCompletedMsg and both general downlink delivery
+                    // and uplink processing stay gated until the session is re-established.
+                    doSync(cursor);
                 }
             }, ctx.getGrpcCallbackExecutorService());
         } else {


### PR DESCRIPTION
## Problem

`doSync` walks the `EdgeSyncCursor` one fetcher at a time, recursing from `onSuccess`. The `onFailure` branch only logs:

```java
@Override
public void onFailure(Throwable t) {
    log.error("[{}][{}] Exception during sync process", getTenantId(), getEdgeId(), t);
}
```

The cursor stops there. `markSyncCompletedSendEdgeEventUpdate()` is only reached from the `else` branch when the cursor is exhausted, so on a fetcher failure `state.finishSync()` never runs and `syncInProgress` stays `true` for the life of the session.

That flag gates both directions:

- general downlink delivery - `PostgresGeneralEdgeEventsDispatcher.processNewEvents` is entered only `if (state.isConnected() && !state.isSyncInProgress())`
- high priority events - `processHighPriorityEvents` returns early on `state.isSyncInProgress()`
- the edge never receives `SyncCompletedMsg`, so `edgeInfo.setSyncInProgress(false)` never runs on its side either, and edge uplinks stay gated

So a single transient failure in any one fetcher - a DB hiccup, a timeout - silences the edge in both directions until the gRPC session is re-established.

## Fix

Keep walking the cursor. The failed fetcher is skipped and logged with its class name; the remaining fetchers still run and the sync still completes, so `SyncCompletedMsg` is delivered and both sides ungate.

This mirrors what `onSuccess` already does when `fetchAndSendEdgeEvents` yields no offset - it also just calls `doSync(cursor)` and moves on.

## Scope

CE first. The PE counterpart is a merge of this branch.
