### PR TITLE
Compare edge customer before session state is replaced in onConfigurationUpdate

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcSession.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcSession.java
@@ -33,6 +33,7 @@ import org.thingsboard.server.common.data.StringUtils;
 import org.thingsboard.server.common.data.edge.Edge;
 import org.thingsboard.server.common.data.edge.EdgeEvent;
 import org.thingsboard.server.common.data.edge.EdgeEventType;
+import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.EdgeId;
 import org.thingsboard.server.common.data.id.TenantId;
 import org.thingsboard.server.common.data.kv.AttributeKvEntry;
@@ -243,8 +244,9 @@ public abstract class EdgeGrpcSession implements Closeable {
     public void onConfigurationUpdate(Edge edge) {
         log.debug("[{}] onConfigurationUpdate [{}]", sessionId, edge);
         this.tenantId = edge.getTenantId();
+        CustomerId stateCustomerId = this.edge != null ? this.edge.getCustomerId() : null;
         this.edge = edge;
-        if (!this.edge.getCustomerId().equals(edge.getCustomerId())) {
+        if (stateCustomerId != null && !stateCustomerId.equals(edge.getCustomerId())) {
             // do not send edge configuration message on customer update
             // message send by separate flow from assign_to or unassing_from customer
             return;


### PR DESCRIPTION
CE counterpart of thingsboard/thingsboard-pe#5003. **Do not merge before thingsboard/thingsboard-edge#239 is released** - see Ordering below.

## Problem

The guard in `onConfigurationUpdate` can never fire:

```java
this.edge = edge;
if (!this.edge.getCustomerId().equals(edge.getCustomerId())) {   // same reference - always false
    // do not send edge configuration message on customer update
    // message send by separate flow from assign_to or unassing_from customer
    return;
}
```

`this.edge` is assigned before the comparison, so both sides read the same object and the condition is always `false`. The early return is unreachable and `EdgeUpdateMsg` is sent unconditionally - including on customer assign/unassign, which the comment explicitly says it should not be.

`master` already has the correct form (`AbstractEdgeGrpcSessionManager.onConfigurationUpdate`), which reads the previous customer id before replacing the state. This aligns `lts-4.3` with it.

## Ordering - please read

**The dead guard is load-bearing on this branch.** Because it never returns early, `EdgeUpdateMsg` is always sent, and its edge-side handler pre-updates the customer id. `BaseEdgeConfigurationHandler.setOrUpdateCustomerId` therefore returns `false` when the `CHANGE_OWNER` / `ASSIGNED_TO_CUSTOMER` downlink later arrives, so the edge's sync-on-customer-id-change trigger never fires.

Fixing the guard on its own re-arms that trigger, which is exactly how `master` broke: a sync per ownership change, each one interrupting delivery of the very delta that carries the change. Edge Black Box Tests timed out.

thingsboard/thingsboard-edge#239 removes that trigger. This PR must land only after #239 has been **released**, not merely merged.

## Verification

`mvn -pl application -am compile` - BUILD SUCCESS.
