### PR TITLE
Fixed CVE-2026-8763, CVE-2026-12185, CVE-2026-12802, CVE-2026-12803, CVE-2026-12816, CVE-2026-12860, CVE-2026-13006, CVE-2026-13506, CVE-2026-14682, CVE-2026-44891, CVE-2026-53434, CVE-2026-54291, CVE-2026-54399, CVE-2026-54428, CVE-2026-55831, CVE-2026-55833, CVE-2026-55851, CVE-2026-55955, CVE-2026-56745, CVE-2026-56817, CVE-2026-56819, CVE-2026-56820, CVE-2026-56821, CVE-2026-56822, CVE-2026-58059, CVE-2026-58060, CVE-2026-58061, CVE-2026-58062, CVE-2026-59639, CVE-2026-59642, CVE-2026-59645, CVE-2026-59650, CVE-2026-59651, CVE-2026-59889, CVE-2026-59901, CVE-2026-59920, CVE-2026-59949, CVE-2026-73507

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <swagger-annotations.version>2.2.30</swagger-annotations.version>
         <spatial4j.version>0.8</spatial4j.version>
         <jts.version>1.19.0</jts.version>
-        <bouncycastle.version>1.84</bouncycastle.version> <!-- 1.84 fixes CVE-2026-5588, CVE-2026-5598, CVE-2025-14813 -->
+        <bouncycastle.version>1.85</bouncycastle.version> <!-- to fix CVE-2026-8763, CVE-2026-12185, CVE-2026-12802, CVE-2026-12803, CVE-2026-12816, CVE-2026-12860, CVE-2026-13506, CVE-2026-14682, CVE-2026-58059, CVE-2026-58060, CVE-2026-58061, CVE-2026-58062, CVE-2026-59639, CVE-2026-59642, CVE-2026-59645, CVE-2026-59650, CVE-2026-59651 (supersedes the earlier 1.84 pin for CVE-2026-5588, CVE-2026-5598, CVE-2025-14813). Not managed by the Spring Boot BOM — this pin is the sole source of the bouncycastle version. -->
         <winsw.version>2.0.1</winsw.version>
         <sonar.exclusions>org/thingsboard/server/gen/**/*,
             org/thingsboard/server/extensions/core/plugin/telemetry/gen/**/*

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
              entries below once TB migrates its tests off the deprecated @SpyBean/@MockBean to @MockitoSpyBean/@MockitoBean. -->
         <spring-boot-test.version>3.5.13</spring-boot-test.version>
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
-        <netty.version>4.1.135.Final</netty.version> <!-- to fix CVE-2026-44249, CVE-2026-44250, CVE-2026-44890, CVE-2026-44893, CVE-2026-45416, CVE-2026-45674, CVE-2026-46340, CVE-2026-47691, CVE-2026-48006, CVE-2026-48059, CVE-2026-50010, CVE-2026-50011 (supersedes earlier netty CVE pins; also retains the 4.1.134 MQTT decoder regression fix). TODO: remove when fixed in spring-boot-dependencies -->
+        <netty.version>4.1.136.Final</netty.version> <!-- to fix CVE-2026-44891, CVE-2026-55831, CVE-2026-55833, CVE-2026-55851, CVE-2026-56745, CVE-2026-56817, CVE-2026-56819, CVE-2026-56820, CVE-2026-56821, CVE-2026-56822, CVE-2026-59901, CVE-2026-59920, CVE-2026-73507 (supersedes earlier netty CVE pins; also retains the 4.1.134 MQTT decoder regression fix). TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <netty.version>4.1.136.Final</netty.version> <!-- to fix CVE-2026-44891, CVE-2026-55831, CVE-2026-55833, CVE-2026-55851, CVE-2026-56745, CVE-2026-56817, CVE-2026-56819, CVE-2026-56820, CVE-2026-56821, CVE-2026-56822, CVE-2026-59901, CVE-2026-59920, CVE-2026-73507 (supersedes earlier netty CVE pins; also retains the 4.1.134 MQTT decoder regression fix). TODO: remove when fixed in spring-boot-dependencies -->
         <tomcat.version>10.1.56</tomcat.version> <!-- to fix CVE-2026-53434 and CVE-2026-55955. Pinned via the tomcat-embed overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
+        <httpcore5.version>5.4.3</httpcore5.version> <!-- to fix CVE-2026-54399 and CVE-2026-54428 (no fix exists on the 5.3.x line; httpclient5 5.5.2 from the Spring Boot BOM is compatible with httpcore5 5.4.x). Pinned via the httpcore5 overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -1033,6 +1034,18 @@
                 <version>${tomcat.version}</version>
             </dependency>
             <!-- End of tomcat-embed version override -->
+            <!-- Temporary httpcore5 version override -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>${httpcore5.version}</version>
+            </dependency>
+            <!-- End of httpcore5 version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <spring-boot-test.version>3.5.13</spring-boot-test.version>
         <commons-lang3.version>3.18.0</commons-lang3.version> <!-- to fix CVE-2025-48924. TODO: remove when fixed in spring-boot-dependencies -->
         <netty.version>4.1.136.Final</netty.version> <!-- to fix CVE-2026-44891, CVE-2026-55831, CVE-2026-55833, CVE-2026-55851, CVE-2026-56745, CVE-2026-56817, CVE-2026-56819, CVE-2026-56820, CVE-2026-56821, CVE-2026-56822, CVE-2026-59901, CVE-2026-59920, CVE-2026-73507 (supersedes earlier netty CVE pins; also retains the 4.1.134 MQTT decoder regression fix). TODO: remove when fixed in spring-boot-dependencies -->
+        <tomcat.version>10.1.56</tomcat.version> <!-- to fix CVE-2026-53434 and CVE-2026-55955. Pinned via the tomcat-embed overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -1015,6 +1016,23 @@
                 <scope>import</scope>
             </dependency>
             <!-- End of netty-bom version override -->
+            <!-- Temporary tomcat-embed version override -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <!-- End of tomcat-embed version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <httpcore5.version>5.4.3</httpcore5.version> <!-- to fix CVE-2026-54399 and CVE-2026-54428 (no fix exists on the 5.3.x line; httpclient5 5.5.2 from the Spring Boot BOM is compatible with httpcore5 5.4.x). Pinned via the httpcore5 overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
         <logback.version>1.5.38</logback.version> <!-- to fix CVE-2026-13006 (1.5.36 as reported by the scanner is still vulnerable; 1.5.37 removed Janino conditional processing entirely, 1.5.38 adds a HardenedObjectInputStream fix). Pinned via the logback overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
         <jackson-bom.version>2.21.5</jackson-bom.version> <!-- to fix CVE-2026-59889. Pinned via the jackson-bom import below: spring-boot-dependencies re-imports jackson-bom with its own placeholder, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
+        <postgresql.version>42.7.12</postgresql.version> <!-- to fix CVE-2026-54291. Pinned via the postgresql override below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -1069,6 +1070,13 @@
                 <scope>import</scope>
             </dependency>
             <!-- End of jackson-bom version override -->
+            <!-- Temporary postgresql version override -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
+            </dependency>
+            <!-- End of postgresql version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <tomcat.version>10.1.56</tomcat.version> <!-- to fix CVE-2026-53434 and CVE-2026-55955. Pinned via the tomcat-embed overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
         <httpcore5.version>5.4.3</httpcore5.version> <!-- to fix CVE-2026-54399 and CVE-2026-54428 (no fix exists on the 5.3.x line; httpclient5 5.5.2 from the Spring Boot BOM is compatible with httpcore5 5.4.x). Pinned via the httpcore5 overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
         <logback.version>1.5.38</logback.version> <!-- to fix CVE-2026-13006 (1.5.36 as reported by the scanner is still vulnerable; 1.5.37 removed Janino conditional processing entirely, 1.5.38 adds a HardenedObjectInputStream fix). Pinned via the logback overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
+        <jackson-bom.version>2.21.5</jackson-bom.version> <!-- to fix CVE-2026-59889. Pinned via the jackson-bom import below: spring-boot-dependencies re-imports jackson-bom with its own placeholder, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -1059,6 +1060,15 @@
                 <version>${logback.version}</version>
             </dependency>
             <!-- End of logback version override -->
+            <!-- Temporary jackson-bom version override -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- End of jackson-bom version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <netty.version>4.1.136.Final</netty.version> <!-- to fix CVE-2026-44891, CVE-2026-55831, CVE-2026-55833, CVE-2026-55851, CVE-2026-56745, CVE-2026-56817, CVE-2026-56819, CVE-2026-56820, CVE-2026-56821, CVE-2026-56822, CVE-2026-59901, CVE-2026-59920, CVE-2026-73507 (supersedes earlier netty CVE pins; also retains the 4.1.134 MQTT decoder regression fix). TODO: remove when fixed in spring-boot-dependencies -->
         <tomcat.version>10.1.56</tomcat.version> <!-- to fix CVE-2026-53434 and CVE-2026-55955. Pinned via the tomcat-embed overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
         <httpcore5.version>5.4.3</httpcore5.version> <!-- to fix CVE-2026-54399 and CVE-2026-54428 (no fix exists on the 5.3.x line; httpclient5 5.5.2 from the Spring Boot BOM is compatible with httpcore5 5.4.x). Pinned via the httpcore5 overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
+        <logback.version>1.5.38</logback.version> <!-- to fix CVE-2026-13006 (1.5.36 as reported by the scanner is still vulnerable; 1.5.37 removed Janino conditional processing entirely, 1.5.38 adds a HardenedObjectInputStream fix). Pinned via the logback overrides below: spring-boot-dependencies is imported as a BOM, so this property alone would not win. TODO: remove when fixed in spring-boot-dependencies -->
         <javax.xml.bind-api.version>2.4.0-b180830.0359</javax.xml.bind-api.version>
         <jjwt.version>0.12.5</jjwt.version>
         <rat.version>0.10</rat.version> <!-- unused -->
@@ -1046,6 +1047,18 @@
                 <version>${httpcore5.version}</version>
             </dependency>
             <!-- End of httpcore5 version override -->
+            <!-- Temporary logback version override -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.version}</version>
+            </dependency>
+            <!-- End of logback version override -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Summary

Fixes **38 CVEs** across 7 Maven dependency bumps, carried forward to `master`. Sourced from the `lts-4.2` security scan ([build 124980](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/124980)) and the `lts-4.3` scan ([build 124981](https://builds.thingsboard.io/buildConfiguration/ThingsBoardProfessionalEdition_SecurityScan/124981)); both reported an identical Maven finding set. There is no separate `master` scan — this branch is merge-driven so it never regresses behind the LTS lines.

Bumped: `io.netty` 4.1.135.Final -> 4.1.136.Final, `org.bouncycastle` 1.84 -> 1.85, `org.apache.tomcat.embed` 10.1.55 -> 10.1.56, `org.apache.httpcomponents.core5` 5.3.6 -> 5.4.3, `ch.qos.logback` 1.5.34 -> 1.5.38, `com.fasterxml.jackson` 2.21.4 -> 2.21.5, `org.postgresql` 42.7.11 -> 42.7.12.

All of it arrives through the merge from `fix/cves-lts-4.4` — `master` carried the same versions as the LTS lines for every affected dependency, so there are no branch-specific commits. `dependency:tree` was re-run on this branch's reactor to confirm the merge resolved correctly; the evidence below is from that run.

## CVEs fixed

**`io.netty` 4.1.135.Final → 4.1.136.Final**

- CVE-2026-56820 (critical) — Improper Certificate Validation — `io.netty:netty-handler-ssl-ocsp`
- CVE-2026-56821 (critical) — Improper Check for Certificate Revocation — `io.netty:netty-handler-ssl-ocsp`
- CVE-2026-56822 (critical) — Time-of-check Time-of-use (TOCTOU) Race Condition — `io.netty:netty-handler-ssl-ocsp`
- CVE-2026-44891 (high) — Allocation of Resources Without Limits or Throttling — `io.netty:netty-codec-stomp`
- CVE-2026-59920 (high) — CRLF Injection — `io.netty:netty-codec-stomp`
- CVE-2026-55831 (high) — Allocation of Resources Without Limits or Throttling — `io.netty:netty-codec-http`
- CVE-2026-55833 (high) — Allocation of Resources Without Limits or Throttling — `io.netty:netty-codec-http`
- CVE-2026-56745 (high) — Allocation of Resources Without Limits or Throttling — `io.netty:netty-codec-http`
- CVE-2026-56819 (high) — Allocation of Resources Without Limits or Throttling — `io.netty:netty-codec-http2`
- CVE-2026-55851 (high) — Allocation of Resources Without Limits or Throttling — `io.netty:netty-codec-haproxy`
- CVE-2026-56817 (high) — XML External Entity (XXE) Injection — `io.netty:netty-codec-xml`
- CVE-2026-73507 (high) — Unchecked Input for Loop Condition / inefficient algorithmic complexity in `XmlFrameDecoder` — `io.netty:netty-codec-xml`
- CVE-2026-59901 (high) — Infinite loop — `io.netty:netty-codec`

**`org.bouncycastle` 1.84 → 1.85**

- CVE-2026-8763 (critical) — Improper Certificate Validation (Name Constraints bypass) — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-59650 (critical) — Improper Input Validation — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-58062 (critical) — Improper Certificate Validation (stapled OCSP response not bound to the checked certificate) — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-12185 (high) — Memory Allocation with Excessive Size Value — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-12803 (high) — Improper Validation of Integrity Check Value — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-12816 (high) — Improper Validation of Integrity Check Value — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-12860 (high) — Improper Verification of Cryptographic Signature — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-13506 (high) — Uncontrolled Recursion — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-14682 (high) — Memory Allocation with Excessive Size Value — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-58059 (high) — Inefficient Algorithmic Complexity — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-58060 (high) — Memory Allocation with Excessive Size Value — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-58061 (high) — Improper Validation of Integrity Check Value — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-59651 (high) — Inadequate Encryption Strength — `org.bouncycastle:bcprov-jdk18on`
- CVE-2026-59639 (high) — Improper Verification of Cryptographic Signature (CMS `verifySignatures` returns true for `SignedData` with zero signers) — `org.bouncycastle:bcpkix-jdk18on`
- CVE-2026-59642 (high) — Improper Validation of Integrity Check Value — `org.bouncycastle:bcpkix-jdk18on`
- CVE-2026-12802 (high) — Improper Validation of Integrity Check Value — `org.bouncycastle:bcpkix-jdk18on`
- CVE-2026-59645 (high) — Uncontrolled Recursion — `org.bouncycastle:bcutil-jdk18on`

**`org.apache.tomcat.embed` 10.1.55 → 10.1.56**

- CVE-2026-55955 (high) — Improper Authentication; `EncryptInterceptor` was not protected against replay attacks — `org.apache.tomcat.embed:tomcat-embed-core`
- CVE-2026-53434 (high) — Detection of Error Condition Without Action; invalid CRL configuration on an FFM-based connector — `org.apache.tomcat.embed:tomcat-embed-core`

**`org.apache.httpcomponents.core5` 5.3.6 → 5.4.3**

- CVE-2026-54428 (high) — Allocation of Resources Without Limits or Throttling; missing limits in `HPackDecoder` — `org.apache.httpcomponents.core5:httpcore5-h2`
- CVE-2026-54399 (high) — Allocation of Resources Without Limits or Throttling — `org.apache.httpcomponents.core5:httpcore5`, `httpcore5-h2`

**`ch.qos.logback` 1.5.34 → 1.5.38**

- CVE-2026-13006 (high) — Expression Injection via `<if>` elements evaluated by Janino — `ch.qos.logback:logback-core`

**`com.fasterxml.jackson` 2.21.4 → 2.21.5**

- CVE-2026-59889 (high) — Incorrect Authorization; `@JsonView` bypassed for `@JsonUnwrapped` container properties on deserialization — `com.fasterxml.jackson.core:jackson-databind`

**`org.postgresql` 42.7.11 → 42.7.12**

- CVE-2026-54291 (high) — Incorrect Implementation of Authentication Algorithm; silent SCRAM channel-binding downgrade when `channelBinding=require` is set — `org.postgresql:postgresql`

## Commits

- Merge fix/cves-lts-4.4 into fix/cves-master

Carrying these commits forward:

- Bump netty from 4.1.135.Final to 4.1.136.Final to fix CVE-2026-44891, CVE-2026-55831, and 11 others
- Bump bouncycastle from 1.84 to 1.85 to fix CVE-2026-8763, CVE-2026-12185, and 15 others
- Bump tomcat from 10.1.55 to 10.1.56 to fix CVE-2026-53434 and CVE-2026-55955
- Bump httpcore5 from 5.3.6 to 5.4.3 to fix CVE-2026-54399 and CVE-2026-54428
- Bump logback from 1.5.34 to 1.5.38 to fix CVE-2026-13006
- Bump jackson from 2.21.4 to 2.21.5 to fix CVE-2026-59889
- Bump postgresql from 42.7.11 to 42.7.12 to fix CVE-2026-54291

## `mvn dependency:tree` evidence

### `io.netty` → 4.1.136.Final
```text
$ mvn -f pom.xml dependency:tree -Dincludes=io.netty,org.bouncycastle,org.apache.tomcat.embed,org.apache.httpcomponents.core5,ch.qos.logback,com.fasterxml.jackson.core,org.postgresql,com.squareup.wire
io.netty:netty-codec-haproxy:jar:4.1.136.Final
io.netty:netty-codec-http2:jar:4.1.136.Final
io.netty:netty-codec-http:jar:4.1.136.Final
io.netty:netty-codec-stomp:jar:4.1.136.Final
io.netty:netty-codec-xml:jar:4.1.136.Final
io.netty:netty-codec:jar:4.1.136.Final
io.netty:netty-handler-ssl-ocsp:jar:4.1.136.Final
```

### `org.bouncycastle` → 1.85
```text
$ mvn -f pom.xml dependency:tree -Dincludes=io.netty,org.bouncycastle,org.apache.tomcat.embed,org.apache.httpcomponents.core5,ch.qos.logback,com.fasterxml.jackson.core,org.postgresql,com.squareup.wire
org.bouncycastle:bcpkix-jdk18on:jar:1.85
org.bouncycastle:bcprov-jdk18on:jar:1.85
org.bouncycastle:bcutil-jdk18on:jar:1.85
```

### `org.apache.tomcat.embed` → 10.1.56
```text
$ mvn -f pom.xml dependency:tree -Dincludes=io.netty,org.bouncycastle,org.apache.tomcat.embed,org.apache.httpcomponents.core5,ch.qos.logback,com.fasterxml.jackson.core,org.postgresql,com.squareup.wire
org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.56
org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.56
org.apache.tomcat.embed:tomcat-embed-websocket:jar:10.1.56
```

### `org.apache.httpcomponents.core5` → 5.4.3
```text
$ mvn -f pom.xml dependency:tree -Dincludes=io.netty,org.bouncycastle,org.apache.tomcat.embed,org.apache.httpcomponents.core5,ch.qos.logback,com.fasterxml.jackson.core,org.postgresql,com.squareup.wire
org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3
org.apache.httpcomponents.core5:httpcore5:jar:5.4.3
```

### `ch.qos.logback` → 1.5.38
```text
$ mvn -f pom.xml dependency:tree -Dincludes=io.netty,org.bouncycastle,org.apache.tomcat.embed,org.apache.httpcomponents.core5,ch.qos.logback,com.fasterxml.jackson.core,org.postgresql,com.squareup.wire
ch.qos.logback:logback-classic:jar:1.5.38
ch.qos.logback:logback-core:jar:1.5.38
```

### `com.fasterxml.jackson.core` → 2.21.5
```text
$ mvn -f pom.xml dependency:tree -Dincludes=io.netty,org.bouncycastle,org.apache.tomcat.embed,org.apache.httpcomponents.core5,ch.qos.logback,com.fasterxml.jackson.core,org.postgresql,com.squareup.wire
com.fasterxml.jackson.core:jackson-databind:jar:2.21.5
```

### `org.postgresql` → 42.7.12
```text
$ mvn -f pom.xml dependency:tree -Dincludes=io.netty,org.bouncycastle,org.apache.tomcat.embed,org.apache.httpcomponents.core5,ch.qos.logback,com.fasterxml.jackson.core,org.postgresql,com.squareup.wire
org.postgresql:postgresql:jar:42.7.12
```

### Already fixed at HEAD — `com.squareup.wire` (CVE-2026-45799)

The scanner flagged `com.squareup.wire:wire-runtime` 4.3.0, but that plain coordinate is an empty pointer pom for Wire 4.x+ (Kotlin Multiplatform); the real JVM code resolves under the `*-jvm` coordinates, which `wire-schema.version` already pins to 6.3.0. No commit was needed.
```text
$ mvn -f pom.xml dependency:tree -Dincludes=io.netty,org.bouncycastle,org.apache.tomcat.embed,org.apache.httpcomponents.core5,ch.qos.logback,com.fasterxml.jackson.core,org.postgresql,com.squareup.wire
com.squareup.wire:wire-runtime-jvm:jar:6.3.0
com.squareup.wire:wire-schema-jvm:jar:6.3.0
```

## Related

- CE `lts-4.2`: thingsboard/thingsboard#16039
- CE `lts-4.3`: thingsboard/thingsboard#16040
- CE `lts-4.4`: thingsboard/thingsboard#16041
