### PR TITLE
Do not strand edge sync when an event fetcher fails

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcSession.java
+++ b/application/src/main/java/org/thingsboard/server/service/edge/rpc/EdgeGrpcSession.java
@@ -282,7 +282,12 @@ public abstract class EdgeGrpcSession implements Closeable {
 
                 @Override
                 public void onFailure(Throwable t) {
-                    log.error("[{}][{}] Exception during sync process", tenantId, edge.getId(), t);
+                    log.error("[{}][{}] Exception during sync process, skipping fetcher {} and continuing",
+                            tenantId, edge.getId(), next.getClass().getSimpleName(), t);
+                    // Keep walking the cursor: returning here leaves syncInProgress set for the life of the
+                    // session, so the edge never receives SyncCompletedMsg and both general downlink delivery
+                    // and uplink processing stay gated until the session is re-established.
+                    doSync(cursor);
                 }
             }, ctx.getGrpcCallbackExecutorService());
         } else {


### PR DESCRIPTION
Backport of thingsboard/thingsboard#16037 to `lts-4.3`. No ordering constraint - this does not touch the `onConfigurationUpdate` guard or the edge sync trigger, and can land independently of the other edge PRs.

## Problem

`doSync` walks the `EdgeSyncCursor` one fetcher at a time, recursing from `onSuccess`. The `onFailure` branch only logs:

```java
@Override
public void onFailure(Throwable t) {
    log.error("[{}][{}] Exception during sync process", tenantId, edge.getId(), t);
}
```

The cursor stops there. `updateSyncInProgress(false)` is only reached from the `else` branch when the cursor is exhausted, so on a fetcher failure `syncInProgress` stays `true` for the life of the session.

That flag gates both directions:

- general downlink delivery - `EdgeGrpcSession` guards on `isConnected() && !isSyncInProgress()`
- Kafka edges - `KafkaEdgeGrpcSession.isProcessingAllowed()` is `isConnected() && !isSyncInProgress() && !isHighPriorityProcessing`, so event consumption stops outright
- the edge never receives `SyncCompletedMsg`, so `syncInProgress` never clears on its side either and edge uplinks stay gated

A single transient failure in any one fetcher - a DB hiccup, a timeout - silences the edge in both directions until the gRPC session is re-established.

## Fix

Keep walking the cursor. The failed fetcher is skipped and logged with its class name; the remaining fetchers still run and the sync still completes, so `SyncCompletedMsg` is delivered and both sides ungate.

This mirrors what `onSuccess` already does - it also just calls `doSync(cursor)` and moves on.

## Verification

`mvn -pl application -am compile` - BUILD SUCCESS.
