### PR TITLE
Compare deleted alarm comment audit log argument against the persisted comment

### DIFF
--- a/application/src/test/java/org/thingsboard/server/controller/AlarmCommentControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/AlarmCommentControllerTest.java
@@ -231,6 +231,10 @@ public class AlarmCommentControllerTest extends AbstractControllerTest {
                 .comment(JacksonUtil.newObjectNode().put("text", String.format("Comment was deleted by user %s",
                         CUSTOMER_USER_EMAIL)))
                 .build();
+        // The audit log receives the persisted comment, and AlarmComment equality covers the
+        // inherited id and createdTime, which the builder cannot populate.
+        expectedAlarmComment.setId(alarmComment.getId());
+        expectedAlarmComment.setCreatedTime(alarmComment.getCreatedTime());
         testLogEntityActionEntityEqClass(alarm, alarm.getId(), tenantId, customerId, customerUserId, CUSTOMER_USER_EMAIL, ActionType.DELETED_COMMENT, 1, expectedAlarmComment);
     }
 
@@ -255,6 +259,10 @@ public class AlarmCommentControllerTest extends AbstractControllerTest {
                 .comment(JacksonUtil.newObjectNode().put("text", String.format("Comment was deleted by user %s",
                         TENANT_ADMIN_EMAIL)))
                 .build();
+        // The audit log receives the persisted comment, and AlarmComment equality covers the
+        // inherited id and createdTime, which the builder cannot populate.
+        expectedAlarmComment.setId(alarmComment.getId());
+        expectedAlarmComment.setCreatedTime(alarmComment.getCreatedTime());
         testLogEntityActionEntityEqClass(alarm, alarm.getId(), tenantId, customerId, tenantAdminUserId, TENANT_ADMIN_EMAIL, ActionType.DELETED_COMMENT, 1, expectedAlarmComment);
     }
 
@@ -286,6 +294,10 @@ public class AlarmCommentControllerTest extends AbstractControllerTest {
                 .comment(JacksonUtil.newObjectNode().put("text", String.format("Comment was deleted by user %s",
                         TENANT_ADMIN_EMAIL)))
                 .build();
+        // The audit log receives the persisted comment, and AlarmComment equality covers the
+        // inherited id and createdTime, which the builder cannot populate.
+        expectedAlarmComment.setId(alarmComment.getId());
+        expectedAlarmComment.setCreatedTime(alarmComment.getCreatedTime());
         testLogEntityActionEntityEqClass(alarm, alarm.getId(), tenantId, customerId, tenantAdminUserId, TENANT_ADMIN_EMAIL, ActionType.DELETED_COMMENT, 1, expectedAlarmComment);
     }
 


### PR DESCRIPTION
Fixes the three failing tests in `AlarmCommentControllerTest` on `lts-4.2`:

- `testDeleteAlarmViaTenant`
- `testDeleteOthersAlarmCommentIsAllowedForAuthorOrTenantAdmin`
- `testDeleteAlarmСommentViaCustomer`

Red build: https://builds.thingsboard.io/buildConfiguration/ThingsBoard_TestServiceControllerEdge_2/125755

### Root cause

`655d4ed55e7a` ("Fix invalid `callSuper = false` usages for EqualsAndHashCode") changed `AlarmComment` from `@EqualsAndHashCode(callSuper = false)` to `callSuper = true`. Equality now also covers the inherited `id` and `createdTime` from `BaseData`.

The three delete tests build their expected `AlarmComment` with `AlarmComment.builder()`. Lombok's `@Builder` sits on `@AllArgsConstructor`, which only covers the class's own fields (`alarmId`, `userId`, `type`, `comment`), so a builder-made instance always has `id = null` and `createdTime = 0`. `DefaultTbAlarmCommentService.deleteAlarmComment` passes the *persisted* comment to the audit log, with both fields populated — so the Mockito matcher could no longer match.

The failure was hard to read because `AlarmComment.toString()` prints neither field: the wanted and actual argument lists in the report are identical.

### Change

Populate `id` and `createdTime` on the expected comment from the comment under test. This makes the assertion match the persisted entity rather than relaxing it — the `callSuper = true` change itself is correct, only the test needed to catch up.