### PR TITLE
fix(mqtt): quiet the client certificate probe on one-way TLS connect

### DIFF
--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -157,6 +157,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     volatile InetSocketAddress address;
     volatile GatewaySessionHandler gatewaySessionHandler;
     volatile SparkplugNodeSessionHandler sparkplugSessionHandler;
+    private volatile boolean clientCertPresented;
 
     private final ConcurrentHashMap<String, String> otaPackSessions;
     private final ConcurrentHashMap<String, Integer> chunkSizes;
@@ -1055,6 +1056,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         } else {
             X509Certificate cert;
             if (sslHandler != null && (cert = getX509Certificate()) != null) {
+                clientCertPresented = true;
                 processX509CertConnect(ctx, cert, msg);
             } else {
                 processAuthTokenConnect(ctx, msg);
@@ -1127,8 +1129,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                 return (X509Certificate) certChain[0];
             }
         } catch (SSLPeerUnverifiedException e) {
-            log.warn(e.getMessage());
-            return null;
+            log.debug("[{}][{}] Client certificate is not available: {}", address, sessionId, e.getMessage());
         }
         return null;
     }
@@ -1326,7 +1327,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         if (!msg.hasDeviceInfo()) {
             context.onAuthFailure(address);
             MqttConnectReturnCode returnCode = MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED_5;
-            if (sslHandler == null || getX509Certificate() == null) {
+            if (!clientCertPresented) {
                 String username = connectMessage.payload().userName();
                 byte[] passwordBytes = connectMessage.payload().passwordInBytes();
                 String clientId = connectMessage.payload().clientIdentifier();

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/MqttTransportHandler.java
@@ -157,7 +157,6 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     volatile InetSocketAddress address;
     volatile GatewaySessionHandler gatewaySessionHandler;
     volatile SparkplugNodeSessionHandler sparkplugSessionHandler;
-    private volatile boolean clientCertPresented;
 
     private final ConcurrentHashMap<String, String> otaPackSessions;
     private final ConcurrentHashMap<String, Integer> chunkSizes;
@@ -1054,9 +1053,8 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
             deviceSessionCtx.setProvisionOnly(true);
             ctx.writeAndFlush(createMqttConnAckMsg(MqttConnectReturnCode.CONNECTION_ACCEPTED, msg));
         } else {
-            X509Certificate cert;
-            if (sslHandler != null && (cert = getX509Certificate()) != null) {
-                clientCertPresented = true;
+            X509Certificate cert = getX509Certificate();
+            if (cert != null) {
                 processX509CertConnect(ctx, cert, msg);
             } else {
                 processAuthTokenConnect(ctx, msg);
@@ -1081,7 +1079,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                 new TransportServiceCallback<>() {
                     @Override
                     public void onSuccess(ValidateDeviceCredentialsResponse msg) {
-                        onValidateDeviceResponse(msg, ctx, connectMessage);
+                        onValidateDeviceResponse(msg, ctx, connectMessage, false);
                     }
 
                     @Override
@@ -1104,7 +1102,7 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
                     new TransportServiceCallback<>() {
                         @Override
                         public void onSuccess(ValidateDeviceCredentialsResponse msg) {
-                            onValidateDeviceResponse(msg, ctx, connectMessage);
+                            onValidateDeviceResponse(msg, ctx, connectMessage, true);
                         }
 
                         @Override
@@ -1123,6 +1121,9 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
     }
 
     private X509Certificate getX509Certificate() {
+        if (sslHandler == null) {
+            return null;
+        }
         try {
             Certificate[] certChain = sslHandler.engine().getSession().getPeerCertificates();
             if (certChain.length > 0) {
@@ -1323,11 +1324,11 @@ public class MqttTransportHandler extends ChannelInboundHandlerAdapter implement
         deviceSessionCtx.release();
     }
 
-    private void onValidateDeviceResponse(ValidateDeviceCredentialsResponse msg, ChannelHandlerContext ctx, MqttConnectMessage connectMessage) {
+    private void onValidateDeviceResponse(ValidateDeviceCredentialsResponse msg, ChannelHandlerContext ctx, MqttConnectMessage connectMessage, boolean x509Auth) {
         if (!msg.hasDeviceInfo()) {
             context.onAuthFailure(address);
             MqttConnectReturnCode returnCode = MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED_5;
-            if (!clientCertPresented) {
+            if (!x509Auth) {
                 String username = connectMessage.payload().userName();
                 byte[] passwordBytes = connectMessage.payload().passwordInBytes();
                 String clientId = connectMessage.payload().clientIdentifier();

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
@@ -18,8 +18,10 @@ package org.thingsboard.server.transport.mqtt;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.mqtt.MqttConnAckMessage;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttConnectPayload;
+import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
 import io.netty.handler.codec.mqtt.MqttConnectVariableHeader;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
 import io.netty.handler.codec.mqtt.MqttMessageType;
@@ -32,9 +34,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.thingsboard.common.util.ThingsBoardThreadFactory;
 import org.thingsboard.server.common.data.DataConstants;
 import org.thingsboard.server.common.data.DeviceProfile;
@@ -44,11 +48,18 @@ import org.thingsboard.server.common.data.device.profile.JsonTransportPayloadCon
 import org.thingsboard.server.common.data.device.profile.MqttDeviceProfileTransportConfiguration;
 import org.thingsboard.server.common.msg.TbMsgMetaData;
 import org.thingsboard.server.common.transport.TransportService;
+import org.thingsboard.server.common.transport.TransportServiceCallback;
+import org.thingsboard.server.common.transport.auth.ValidateDeviceCredentialsResponse;
 import org.thingsboard.server.gen.transport.TransportProtos;
 import org.thingsboard.server.transport.mqtt.adaptors.JsonMqttAdaptor;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -66,8 +77,12 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -250,6 +265,75 @@ public class MqttTransportHandlerTest {
         expectedMd.putValue(DataConstants.MQTT_TOPIC, message.variableHeader().topicName());
 
         verify(transportService, times(1)).process(any(), (TransportProtos.PostTelemetryMsg) any(), eq(expectedMd), any());
+    }
+
+    @Test
+    public void givenOneWayTlsAndUnknownCredentials_whenProcessConnect_thenRefinesReturnCodeAndProbesPeerCertOnce() throws Exception {
+        //given
+        SSLSession sslSession = givenTlsSession();
+        given(sslSession.getPeerCertificates()).willThrow(new SSLPeerUnverifiedException("peer not authenticated"));
+        willAnswer(unknownCredentials()).given(transportService)
+                .process(eq(DeviceTransportType.MQTT), any(TransportProtos.ValidateBasicMqttCredRequestMsg.class), any());
+
+        //when
+        handler.processConnect(ctx, getMqttV5ConnectMessage());
+
+        //then
+        assertThat(getConnAckReturnCode(), is(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USERNAME_OR_PASSWORD));
+        verify(sslSession, times(1)).getPeerCertificates();
+    }
+
+    @Test
+    public void givenTwoWayTlsAndUnknownCertificate_whenProcessConnect_thenKeepsGenericReturnCode() throws Exception {
+        //given
+        X509Certificate cert = mock(X509Certificate.class);
+        given(cert.getEncoded()).willReturn("cert".getBytes(StandardCharsets.UTF_8));
+        given(givenTlsSession().getPeerCertificates()).willReturn(new Certificate[]{cert});
+        given(context.isSkipValidityCheckForClientCert()).willReturn(true);
+        willAnswer(unknownCredentials()).given(transportService)
+                .process(eq(DeviceTransportType.MQTT), any(TransportProtos.ValidateDeviceX509CertRequestMsg.class), any());
+
+        //when
+        handler.processConnect(ctx, getMqttV5ConnectMessage());
+
+        //then
+        assertThat(getConnAckReturnCode(), is(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED_5));
+    }
+
+    SSLSession givenTlsSession() {
+        SSLEngine sslEngine = mock(SSLEngine.class);
+        SSLSession sslSession = mock(SSLSession.class);
+        given(sslHandler.engine()).willReturn(sslEngine);
+        given(sslEngine.getSession()).willReturn(sslSession);
+        return sslSession;
+    }
+
+    Answer<Void> unknownCredentials() {
+        return invocation -> {
+            TransportServiceCallback<ValidateDeviceCredentialsResponse> callback = invocation.getArgument(2);
+            callback.onSuccess(ValidateDeviceCredentialsResponse.builder().build());
+            return null;
+        };
+    }
+
+    // MQTT 5 is required: ReturnCodeResolver collapses BAD_USERNAME_OR_PASSWORD and NOT_AUTHORIZED_5 into
+    // a single NOT_AUTHORIZED code for older clients, which would make the two cases indistinguishable.
+    MqttConnectMessage getMqttV5ConnectMessage() {
+        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.CONNECT, true, MqttQoS.AT_LEAST_ONCE, false, 123);
+        MqttConnectVariableHeader variableHeader = new MqttConnectVariableHeader("MQTT", 5, true, true, true, 1, true, false, 60);
+        MqttConnectPayload payload = new MqttConnectPayload("clientId", "topic", "message".getBytes(StandardCharsets.UTF_8), "username", "password".getBytes(StandardCharsets.UTF_8));
+        return new MqttConnectMessage(mqttFixedHeader, variableHeader, payload);
+    }
+
+    MqttConnectReturnCode getConnAckReturnCode() {
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(ctx, atLeastOnce()).writeAndFlush(captor.capture());
+        return captor.getAllValues().stream()
+                .filter(MqttConnAckMessage.class::isInstance)
+                .map(MqttConnAckMessage.class::cast)
+                .findFirst()
+                .map(connAck -> connAck.variableHeader().connectReturnCode())
+                .orElseThrow(() -> new AssertionError("No CONNACK message was written to the channel"));
     }
 
 }

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
@@ -139,6 +139,12 @@ public class MqttTransportHandlerTest {
         return new MqttConnectMessage(mqttFixedHeader, variableHeader, payload);
     }
 
+    // MQTT 5 is required: ReturnCodeResolver collapses BAD_USERNAME_OR_PASSWORD and NOT_AUTHORIZED_5 into
+    // a single NOT_AUTHORIZED code for older clients, which would make the two cases indistinguishable.
+    MqttConnectMessage getMqttV5ConnectMessage() {
+        return getMqttConnectMessage(MqttVersion.MQTT_5);
+    }
+
     MqttPublishMessage getMqttPublishMessage() {
         return getMqttPublishMessage("v1/gateway/telemetry");
     }
@@ -279,11 +285,8 @@ public class MqttTransportHandlerTest {
         willAnswer(unknownCredentials()).given(transportService)
                 .process(eq(DeviceTransportType.MQTT), any(TransportProtos.ValidateBasicMqttCredRequestMsg.class), any());
 
-        // MQTT 5 is required in both connect tests: ReturnCodeResolver collapses BAD_USERNAME_OR_PASSWORD and
-        // NOT_AUTHORIZED_5 into a single NOT_AUTHORIZED code for older clients, which would make the cases
-        // indistinguishable.
         //when
-        handler.processConnect(ctx, getMqttConnectMessage(MqttVersion.MQTT_5));
+        handler.processConnect(ctx, getMqttV5ConnectMessage());
 
         //then
         assertThat(getConnAckReturnCode(), is(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USERNAME_OR_PASSWORD));
@@ -302,7 +305,7 @@ public class MqttTransportHandlerTest {
                 .process(eq(DeviceTransportType.MQTT), any(TransportProtos.ValidateDeviceX509CertRequestMsg.class), any());
 
         //when
-        handler.processConnect(ctx, getMqttConnectMessage(MqttVersion.MQTT_5));
+        handler.processConnect(ctx, getMqttV5ConnectMessage());
 
         //then
         assertThat(getConnAckReturnCode(), is(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED_5));

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
@@ -67,7 +67,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.fail;
@@ -170,7 +169,7 @@ public class MqttTransportHandlerTest {
 
     @Test
     public void givenQueueLimit_whenEnqueueRegularSessionMsgOverLimit_thenOK() {
-        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(MSG_QUEUE_LIMIT).collect(Collectors.toList());
+        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(MSG_QUEUE_LIMIT).toList();
         messages.forEach(msg -> handler.enqueueRegularSessionMsg(ctx, msg));
         assertThat(handler.deviceSessionCtx.getMsgQueueSize(), is(MSG_QUEUE_LIMIT));
         assertThat(handler.deviceSessionCtx.getMsgQueueSnapshot(), contains(messages.toArray()));
@@ -180,7 +179,7 @@ public class MqttTransportHandlerTest {
     public void givenQueueLimit_whenEnqueueRegularSessionMsgOverLimit_thenCtxClose() {
         final int limit = MSG_QUEUE_LIMIT + 1;
         willDoNothing().given(handler).processMsgQueue(ctx);
-        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(limit).collect(Collectors.toList());
+        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(limit).toList();
 
         messages.forEach((msg) -> handler.enqueueRegularSessionMsg(ctx, msg));
 
@@ -194,7 +193,7 @@ public class MqttTransportHandlerTest {
     public void givenMqttConnectMessageAndPublishImmediately_whenProcessMqttMsg_thenEnqueueRegularSessionMsg() {
         givenMqttConnectMessage_whenProcessMqttMsg_thenProcessConnect();
 
-        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(MSG_QUEUE_LIMIT).collect(Collectors.toList());
+        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(MSG_QUEUE_LIMIT).toList();
 
         messages.forEach((msg) -> handler.channelRead(ctx, msg));
 
@@ -215,7 +214,7 @@ public class MqttTransportHandlerTest {
         //given
         assertThat(handler.deviceSessionCtx.isConnected(), is(false));
         assertThat(MSG_QUEUE_LIMIT, greaterThan(2));
-        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(MSG_QUEUE_LIMIT).collect(Collectors.toList());
+        List<MqttPublishMessage> messages = Stream.generate(this::getMqttPublishMessage).limit(MSG_QUEUE_LIMIT).toList();
         messages.forEach((msg) -> handler.enqueueRegularSessionMsg(ctx, msg));
         willDoNothing().given(handler).processRegularSessionMsg(any(), any());
         executor = Executors.newCachedThreadPool(ThingsBoardThreadFactory.forName(getClass().getName()));

--- a/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
+++ b/common/transport/mqtt/src/test/java/org/thingsboard/server/transport/mqtt/MqttTransportHandlerTest.java
@@ -28,6 +28,7 @@ import io.netty.handler.codec.mqtt.MqttMessageType;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttVersion;
 import io.netty.handler.ssl.SslHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
@@ -129,8 +130,12 @@ public class MqttTransportHandlerTest {
     }
 
     MqttConnectMessage getMqttConnectMessage() {
+        return getMqttConnectMessage(MqttVersion.MQTT_3_1_1);
+    }
+
+    MqttConnectMessage getMqttConnectMessage(MqttVersion version) {
         MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.CONNECT, true, MqttQoS.AT_LEAST_ONCE, false, 123);
-        MqttConnectVariableHeader variableHeader = new MqttConnectVariableHeader("device", packedId.incrementAndGet(), true, true, true, 1, true, false, 60);
+        MqttConnectVariableHeader variableHeader = new MqttConnectVariableHeader(version.protocolName(), version.protocolLevel(), true, true, true, 1, true, false, 60);
         MqttConnectPayload payload = new MqttConnectPayload("clientId", "topic", "message".getBytes(StandardCharsets.UTF_8), "username", "password".getBytes(StandardCharsets.UTF_8));
         return new MqttConnectMessage(mqttFixedHeader, variableHeader, payload);
     }
@@ -275,8 +280,11 @@ public class MqttTransportHandlerTest {
         willAnswer(unknownCredentials()).given(transportService)
                 .process(eq(DeviceTransportType.MQTT), any(TransportProtos.ValidateBasicMqttCredRequestMsg.class), any());
 
+        // MQTT 5 is required in both connect tests: ReturnCodeResolver collapses BAD_USERNAME_OR_PASSWORD and
+        // NOT_AUTHORIZED_5 into a single NOT_AUTHORIZED code for older clients, which would make the cases
+        // indistinguishable.
         //when
-        handler.processConnect(ctx, getMqttV5ConnectMessage());
+        handler.processConnect(ctx, getMqttConnectMessage(MqttVersion.MQTT_5));
 
         //then
         assertThat(getConnAckReturnCode(), is(MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USERNAME_OR_PASSWORD));
@@ -284,20 +292,22 @@ public class MqttTransportHandlerTest {
     }
 
     @Test
-    public void givenTwoWayTlsAndUnknownCertificate_whenProcessConnect_thenKeepsGenericReturnCode() throws Exception {
+    public void givenTwoWayTlsAndUnknownCertificate_whenProcessConnect_thenKeepsGenericReturnCodeAndProbesPeerCertOnce() throws Exception {
         //given
         X509Certificate cert = mock(X509Certificate.class);
         given(cert.getEncoded()).willReturn("cert".getBytes(StandardCharsets.UTF_8));
-        given(givenTlsSession().getPeerCertificates()).willReturn(new Certificate[]{cert});
+        SSLSession sslSession = givenTlsSession();
+        given(sslSession.getPeerCertificates()).willReturn(new Certificate[]{cert});
         given(context.isSkipValidityCheckForClientCert()).willReturn(true);
         willAnswer(unknownCredentials()).given(transportService)
                 .process(eq(DeviceTransportType.MQTT), any(TransportProtos.ValidateDeviceX509CertRequestMsg.class), any());
 
         //when
-        handler.processConnect(ctx, getMqttV5ConnectMessage());
+        handler.processConnect(ctx, getMqttConnectMessage(MqttVersion.MQTT_5));
 
         //then
         assertThat(getConnAckReturnCode(), is(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED_5));
+        verify(sslSession, times(1)).getPeerCertificates();
     }
 
     SSLSession givenTlsSession() {
@@ -314,15 +324,6 @@ public class MqttTransportHandlerTest {
             callback.onSuccess(ValidateDeviceCredentialsResponse.builder().build());
             return null;
         };
-    }
-
-    // MQTT 5 is required: ReturnCodeResolver collapses BAD_USERNAME_OR_PASSWORD and NOT_AUTHORIZED_5 into
-    // a single NOT_AUTHORIZED code for older clients, which would make the two cases indistinguishable.
-    MqttConnectMessage getMqttV5ConnectMessage() {
-        MqttFixedHeader mqttFixedHeader = new MqttFixedHeader(MqttMessageType.CONNECT, true, MqttQoS.AT_LEAST_ONCE, false, 123);
-        MqttConnectVariableHeader variableHeader = new MqttConnectVariableHeader("MQTT", 5, true, true, true, 1, true, false, 60);
-        MqttConnectPayload payload = new MqttConnectPayload("clientId", "topic", "message".getBytes(StandardCharsets.UTF_8), "username", "password".getBytes(StandardCharsets.UTF_8));
-        return new MqttConnectMessage(mqttFixedHeader, variableHeader, payload);
     }
 
     MqttConnectReturnCode getConnAckReturnCode() {


### PR DESCRIPTION
## Pull Request description

Found while testing the MQTT gateway API in one-way TLS mode.

### Problem

In one-way TLS mode the transport is configured to accept a connect without a client certificate (`needClientAuth(false)` with `wantClientAuth(true)`). JSSE reports the absent certificate by throwing `SSLPeerUnverifiedException`, which `getX509Certificate()` logged at `warn` — on an outcome the transport is configured to accept, and with no session or address to correlate it.

It fired twice per connect, because `onValidateDeviceResponse` re-probed the session.

### Approach

Log at `debug`, with the `[address][sessionId]` prefix used elsewhere in the class.

Drop the second probe. Its guard — `sslHandler == null || getX509Certificate() == null` — does not want the certificate; it wants to know whether this was a basic-credentials connect, which `processConnect` has already decided. `onValidateDeviceResponse` takes that decision as a `boolean x509Auth` parameter, passed `false` from `processAuthTokenConnect` and `true` from `processX509CertConnect`. Those are its only two call sites, and `x509Auth` is true iff `processConnect` found a certificate — whose negation is exactly the replaced condition, so return codes are unchanged. Passing it rather than storing it means a future connect path cannot forget to record the branch: the compiler asks.

The `sslHandler == null` guard moves into `getX509Certificate()`, which is now its only caller. That makes the method safe to call on its own terms and reduces `processConnect` to a plain `getX509Certificate()` followed by `if (cert != null)`, with no assignment inside the condition.

### Tests

`MqttTransportHandlerTest` covers both connect paths, asserting the resulting return codes and that the peer certificate is probed exactly once per connect. Both use MQTT 5 via `getMqttV5ConnectMessage()`: `ReturnCodeResolver` collapses `BAD_USERNAME_OR_PASSWORD` and `NOT_AUTHORIZED_5` into a single code for older clients, which would make the two cases indistinguishable. Confirmed the probe-count assertions are not vacuous — restoring the old guard fails both tests with `TooManyActualInvocations`.

Two test-only cleanups ride along: the connect-message builder is parameterized on netty's `MqttVersion` (previously the protocol version was a copy of the packet-id counter, and the protocol name was `"device"`), and `Stream.toList()` replaces `collect(Collectors.toList())` at the four call sites that only iterate the result.
## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [ ] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [ ] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.
- [x] Description contains human-readable scope of changes.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided. _(Log level and an internal guard only; return codes unchanged.)_
- [ ] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts. _(No new dependencies.)_
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc. _(No new services.)_
- [x] If new REST API was added: the RestClient.java was updated. _(No new REST API.)_
- [x] If new yml property was added: make sure a description is added (above or near the property). _(No new yml properties.)_

