### PR TITLE
Sparkplug: fixed empty telemetry metric name when using alias

### DIFF
--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/sparkplug/AbstractMqttV5ClientSparkplugTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/sparkplug/AbstractMqttV5ClientSparkplugTest.java
@@ -288,6 +288,33 @@ public abstract class AbstractMqttV5ClientSparkplugTest extends AbstractMqttInte
         return listKeys;
     }
 
+    protected List<String> connectionWithNBirthMetricNameAndAlias(MetricDataType metricDataType, String metricKey, Object metricValue, Long alias) throws Exception {
+        List<String> listKeys = new ArrayList<>();
+        SparkplugBProto.Payload.Builder payloadBirthNode = SparkplugBProto.Payload.newBuilder()
+                .setTimestamp(calendar.getTimeInMillis());
+        long ts = calendar.getTimeInMillis() - PUBLISH_TS_DELTA_MS;
+        long valueBdSec = getBdSeqNum();
+        payloadBirthNode.addMetrics(createMetric(valueBdSec, ts, keysBdSeq, Int64, -1L));
+        listKeys.add(SparkplugMessageType.NBIRTH.name() + " " + keysBdSeq);
+        payloadBirthNode.addMetrics(createMetric(false, ts, keyNodeRebirth, MetricDataType.Boolean, -1L));
+        listKeys.add(keyNodeRebirth);
+
+        payloadBirthNode.addMetrics(createMetric(metricValue, ts, metricKey, metricDataType, alias));
+
+        listKeys.add(metricKey);
+
+        if (client.isConnected()) {
+            client.publish(TOPIC_ROOT_SPB_V_1_0 + "/" + groupId + "/" + SparkplugMessageType.NBIRTH.name() + "/" + edgeNode,
+                    payloadBirthNode.build().toByteArray(), 0, false);
+        }
+        return listKeys;
+    }
+
+    protected void createdAddMetricValueWithAliasTsKv(SparkplugBProto.Payload.Builder dataPayload, Object value, MetricDataType metricDataType,
+                                                      long ts) throws ThingsboardException {
+        dataPayload.addMetrics(createMetric(value, ts, null, metricDataType, 4L));
+    }
+
     protected void createdAddMetricValuePrimitiveTsKv(List<TsKvEntry> listTsKvEntry, List<String> listKeys,
                                                       SparkplugBProto.Payload.Builder dataPayload, long ts) throws ThingsboardException {
 

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/sparkplug/timeseries/AbstractMqttV5ClientSparkplugTelemetryTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/sparkplug/timeseries/AbstractMqttV5ClientSparkplugTelemetryTest.java
@@ -18,9 +18,12 @@ package org.thingsboard.server.transport.mqtt.sparkplug.timeseries;
 import com.google.common.util.concurrent.ListenableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
+import org.thingsboard.server.common.data.kv.BasicTsKvEntry;
+import org.thingsboard.server.common.data.kv.LongDataEntry;
 import org.thingsboard.server.common.data.kv.TsKvEntry;
 import org.thingsboard.server.gen.transport.mqtt.SparkplugBProto;
 import org.thingsboard.server.transport.mqtt.sparkplug.AbstractMqttV5ClientSparkplugTest;
+import org.thingsboard.server.transport.mqtt.util.sparkplug.MetricDataType;
 import org.thingsboard.server.transport.mqtt.util.sparkplug.SparkplugMessageType;
 
 import java.util.ArrayList;
@@ -49,6 +52,52 @@ public abstract class AbstractMqttV5ClientSparkplugTelemetryTest extends Abstrac
                     return !finalFuture.get().get().isEmpty();
                 });
         Assert.assertEquals(listKeys.size(), finalFuture.get().get().size());
+    }
+
+    protected void processClientWithCorrectAccessTokenPublishNBIRTH_NDATA_AliasWithoutMetricName() throws Exception {
+        clientWithCorrectNodeAccessTokenWithNDEATH();
+        String metricBirthName_Alias = "Node Metric int32 Only Alias";
+        MetricDataType metricBirthDataType = metricBirthDataType_Int32;
+        List<String> listKeys = connectionWithNBirthMetricNameAndAlias(metricBirthDataType, metricBirthName_Alias, nextInt32(), 4L);
+        Assert.assertTrue("Connection node is failed", client.isConnected());
+        AtomicReference<ListenableFuture<List<TsKvEntry>>> finalFuture = new AtomicReference<>();
+        await(alias + SparkplugMessageType.NBIRTH.name())
+                .atMost(40, TimeUnit.SECONDS)
+                .until(() -> {
+                    finalFuture.set(tsService.findLatest(tenantId, savedGateway.getId(), listKeys));
+                    return !finalFuture.get().get().isEmpty();
+                });
+        Assert.assertEquals(listKeys.size(), finalFuture.get().get().size());
+
+        String messageTypeName = SparkplugMessageType.NDATA.name();
+
+        List<TsKvEntry> listTsKvEntry = new ArrayList<>();
+
+        SparkplugBProto.Payload.Builder ndataPayload = SparkplugBProto.Payload.newBuilder()
+                .setTimestamp(calendar.getTimeInMillis())
+                .setSeq(getSeqNum());
+        long ts = calendar.getTimeInMillis() - PUBLISH_TS_DELTA_MS;
+        int valueKey = nextInt32();
+
+        TsKvEntry tsKvEntry = new BasicTsKvEntry(ts, new LongDataEntry(metricBirthName_Alias, Long.valueOf(String.valueOf(valueKey))));
+        listTsKvEntry.add(tsKvEntry);
+        createdAddMetricValueWithAliasTsKv(ndataPayload, valueKey, metricBirthDataType, ts);
+
+        if (client.isConnected()) {
+            client.publish(TOPIC_ROOT_SPB_V_1_0 + "/" + groupId + "/" + messageTypeName + "/" + edgeNode,
+                    ndataPayload.build().toByteArray(), 0, false);
+        }
+
+        AtomicReference<ListenableFuture<List<TsKvEntry>>> finalFutureAlias = new AtomicReference<>();
+        await(alias + SparkplugMessageType.NDATA.name())
+                .atMost(40, TimeUnit.SECONDS)
+                .until(() -> {
+                    finalFutureAlias.set(tsService.findAllLatest(tenantId, savedGateway.getId()));
+                    return finalFutureAlias.get().get().size() == (listKeys.size() + listTsKvEntry.size() + 1);
+                });
+        Assert.assertTrue("Actual tsKvEntries is not containsAll Expected tsKvEntries", containsIgnoreVersion(finalFutureAlias .get().get(), listTsKvEntry));
+
+
     }
 
     protected void processClientWithCorrectAccessTokenPushNodeMetricBuildPrimitiveSimple() throws Exception {

--- a/application/src/test/java/org/thingsboard/server/transport/mqtt/sparkplug/timeseries/MqttV5ClientSparkplugBTelemetryTest.java
+++ b/application/src/test/java/org/thingsboard/server/transport/mqtt/sparkplug/timeseries/MqttV5ClientSparkplugBTelemetryTest.java
@@ -44,6 +44,11 @@ public class MqttV5ClientSparkplugBTelemetryTest extends AbstractMqttV5ClientSpa
     }
 
     @Test
+    public void testClientWithCorrectAccessTokenPublishNBIRTH_NDATA_AliasWithoutMetricName() throws Exception {
+        processClientWithCorrectAccessTokenPublishNBIRTH_NDATA_AliasWithoutMetricName();
+    }
+
+    @Test
     public void testClientWithCorrectAccessTokenPushNodeMetricBuildPrimitiveSimple() throws Exception {
         processClientWithCorrectAccessTokenPushNodeMetricBuildPrimitiveSimple();
     }

--- a/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/SparkplugNodeSessionHandler.java
+++ b/common/transport/mqtt/src/main/java/org/thingsboard/server/transport/mqtt/session/SparkplugNodeSessionHandler.java
@@ -257,8 +257,8 @@ public class SparkplugNodeSessionHandler extends AbstractGatewaySessionHandler<S
                 } else {
                     if (attributesMetricNames == null || !matches(attributesMetricNames, metricName)) {
                         long ts = protoMetric.getTimestamp();
-                        String key = SPARKPLUG_BD_SEQUENCE_NUMBER_KEY.equals(protoMetric.getName()) ?
-                                topicTypeName + " " + protoMetric.getName() : protoMetric.getName();
+                        String key = SPARKPLUG_BD_SEQUENCE_NUMBER_KEY.equals(metricName) ?
+                                topicTypeName + " " + metricName : metricName;
                         Optional<TransportProtos.KeyValueProto> keyValueProtoOpt = fromSparkplugBMetricToKeyValueProto(key, protoMetric);
                         keyValueProtoOpt.ifPresent(kvProto -> msgs.add(postTelemetryMsgCreated(kvProto, ts)));
                     }


### PR DESCRIPTION
## Pull Request description

https://thingsboard-portal.atlassian.net/browse/PROD-8689

### Summary
Fixed an issue where telemetry metricName resulted in an empty string (null) in NDATA/DDATA messages when a metric contained only an alias without an explicit

### Problem
When processing Sparkplug NDATA/DDATA payloads, the metric key mapping directly queried protoMetric.getName(). If a metric arrived without a name (using only a resolved alias from nodeAlias), the telemetry name on the output remained empty, ignoring the alias mapping logic.

#### Before
<img width="1883" height="917" alt="open_ai_request_all_8" src="https://github.com/user-attachments/assets/6f8c60c2-344e-4b15-82f7-f030d3f5992f" />

### Solution
Replaced direct calls to protoMetric.getName() with the pre-resolved metricName variable, which correctly falls back to the alias mapping when the explicit name is absent:

#### After
<img width="2394" height="1255" alt="open_ai_request_all_7" src="https://github.com/user-attachments/assets/0cc6ea87-9346-479a-afe9-3083c94c1ca7" />


## General checklist

- [x] You have reviewed the guidelines [document](https://docs.google.com/document/d/1wqcOafLx5hth8SAg4dqV_LV3un3m5WYR8RdTJ4MbbUM/edit?usp=sharing).
- [x] [Labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#about-labels) that classify your pull request have been added.
- [x] The [milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) is specified and corresponds to fix version.  
- [x] Description references specific [issue](https://github.com/thingsboard/thingsboard/issues).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.
- [x] Similar PR is opened for PE version to simplify merge. Crosslinks between PRs added. Required for internal contributors only.

## Back-End feature checklist

- [x] Added corresponding unit and/or integration test(s). Provide written explanation in the PR description if you have failed to add tests.
- [x] If new dependency was added: the dependency tree is checked for conflicts.
- [x] If new service was added: the service is marked with corresponding @TbCoreComponent, @TbRuleEngineComponent, @TbTransportComponent, etc.
- [x] If new REST API was added: the RestClient.java was updated, issue for [Python REST client](https://github.com/thingsboard/thingsboard-python-rest-client) is created.
- [x] If new yml property was added: make sure a description is added (above or near the property).



