### PR TITLE
Validate prevUri redirect parameter

### DIFF
--- a/application/src/main/java/org/thingsboard/server/controller/AdminController.java
+++ b/application/src/main/java/org/thingsboard/server/controller/AdminController.java
@@ -76,6 +76,7 @@ import org.thingsboard.server.dao.settings.SecuritySettingsService;
 import org.thingsboard.server.queue.util.TbCoreComponent;
 import org.thingsboard.server.service.security.auth.jwt.settings.JwtSettingsService;
 import org.thingsboard.server.service.security.auth.oauth2.CookieUtils;
+import org.thingsboard.server.service.security.auth.oauth2.PrevUriValidator;
 import org.thingsboard.server.service.security.model.SecurityUser;
 import org.thingsboard.server.service.security.model.token.JwtTokenFactory;
 import org.thingsboard.server.service.security.permission.Operation;
@@ -419,8 +420,9 @@ public class AdminController extends BaseController {
     @GetMapping(value = "/mail/oauth2/authorize", produces = "application/text")
     public String getMailOAuth2AuthorizationUrl(HttpServletRequest request, HttpServletResponse response) throws ThingsboardException {
         String state = StringUtils.generateSafeToken();
-        if (request.getParameter(PREV_URI_PATH_PARAMETER) != null) {
-            CookieUtils.addCookie(response, PREV_URI_COOKIE_NAME, request.getParameter(PREV_URI_PATH_PARAMETER), 180);
+        String prevUriParam = request.getParameter(PREV_URI_PATH_PARAMETER);
+        if (PrevUriValidator.isValid(prevUriParam)) {
+            CookieUtils.addCookie(response, PREV_URI_COOKIE_NAME, prevUriParam, 180);
         }
         CookieUtils.addCookie(response, STATE_COOKIE_NAME, state, 180);
 
@@ -449,7 +451,7 @@ public class AdminController extends BaseController {
         Optional<Cookie> cookieState = CookieUtils.getCookie(request, STATE_COOKIE_NAME);
 
         String baseUrl = this.systemSecurityService.getBaseUrl(TenantId.SYS_TENANT_ID, new CustomerId(EntityId.NULL_UUID), request);
-        String prevUri = baseUrl + (prevUrlOpt.isPresent() ? prevUrlOpt.get().getValue() : "/settings/outgoing-mail");
+        String prevUri = baseUrl + prevUrlOpt.map(Cookie::getValue).filter(PrevUriValidator::isValid).orElse("/settings/outgoing-mail");
 
         if (cookieState.isEmpty() || !cookieState.get().getValue().equals(state)) {
             CookieUtils.deleteCookie(request, response, STATE_COOKIE_NAME);

--- a/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -43,8 +43,9 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
             CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
             return;
         }
-        if (request.getParameter(PREV_URI_PARAMETER) != null) {
-            CookieUtils.addCookie(response, PREV_URI_COOKIE_NAME, request.getParameter(PREV_URI_PARAMETER), cookieExpireSeconds);
+        String prevUri = request.getParameter(PREV_URI_PARAMETER);
+        if (PrevUriValidator.isValid(prevUri)) {
+            CookieUtils.addCookie(response, PREV_URI_COOKIE_NAME, prevUri, cookieExpireSeconds);
         }
         CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
     }

--- a/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/Oauth2AuthenticationSuccessHandler.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/Oauth2AuthenticationSuccessHandler.java
@@ -90,7 +90,10 @@ public class Oauth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             baseUrl = this.systemSecurityService.getBaseUrl(TenantId.SYS_TENANT_ID, new CustomerId(EntityId.NULL_UUID), request);
             Optional<Cookie> prevUrlOpt = CookieUtils.getCookie(request, PREV_URI_COOKIE_NAME);
             if (prevUrlOpt.isPresent()) {
-                baseUrl += prevUrlOpt.get().getValue();
+                String prevUri = prevUrlOpt.get().getValue();
+                if (PrevUriValidator.isValid(prevUri)) {
+                    baseUrl += prevUri;
+                }
                 CookieUtils.deleteCookie(request, response, PREV_URI_COOKIE_NAME);
             }
         }

--- a/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/PrevUriValidator.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/auth/oauth2/PrevUriValidator.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.security.auth.oauth2;
+
+import org.thingsboard.server.common.data.StringUtils;
+
+public class PrevUriValidator {
+
+    /**
+     * prevUri is appended to the platform base URL, so only a relative in-app path is accepted,
+     * e.g. /dashboards/{id}?state=... . Everything a browser could resolve to another host - a
+     * protocol-relative path (// or the /\ variant), userinfo, an absolute URI - is rejected,
+     * as are whitespace and control characters, which browsers strip and which would allow
+     * splitting the redirect header.
+     */
+    public static boolean isValid(String prevUri) {
+        if (StringUtils.isEmpty(prevUri) || prevUri.charAt(0) != '/') {
+            return false;
+        }
+        if (prevUri.length() > 1 && (prevUri.charAt(1) == '/' || prevUri.charAt(1) == '\\')) {
+            return false;
+        }
+        for (int i = 0; i < prevUri.length(); i++) {
+            char c = prevUri.charAt(i);
+            if (c <= ' ' || c == '\\' || c == 127) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/service/security/auth/oauth2/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/security/auth/oauth2/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.security.auth.oauth2;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.thingsboard.server.service.security.auth.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.PREV_URI_COOKIE_NAME;
+import static org.thingsboard.server.service.security.auth.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.PREV_URI_PARAMETER;
+
+public class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
+
+    private final HttpCookieOAuth2AuthorizationRequestRepository repository = new HttpCookieOAuth2AuthorizationRequestRepository();
+
+    @Test
+    public void testPrevUriSavedForInAppPath() {
+        assertThat(savePrevUri("/dashboards/3fa13530-6597-11ed-bd76-8bd591f0ec3e?state=someState"))
+                .isEqualTo("/dashboards/3fa13530-6597-11ed-bd76-8bd591f0ec3e?state=someState");
+    }
+
+    @Test
+    public void testPrevUriNotSavedForExternalUri() {
+        assertThat(savePrevUri("@evil.com/")).isNull();
+        assertThat(savePrevUri("https://evil.com")).isNull();
+        assertThat(savePrevUri("//evil.com")).isNull();
+    }
+
+    private String savePrevUri(String prevUri) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(request.getParameter(PREV_URI_PARAMETER)).thenReturn(prevUri);
+
+        repository.saveAuthorizationRequest(OAuth2AuthorizationRequest.authorizationCode()
+                .authorizationUri("testUri").clientId("testId").build(), request, response);
+
+        ArgumentCaptor<Cookie> cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
+        verify(response, atLeastOnce()).addCookie(cookieCaptor.capture());
+        return cookieCaptor.getAllValues().stream()
+                .filter(cookie -> PREV_URI_COOKIE_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findAny().orElse(null);
+    }
+
+}

--- a/application/src/test/java/org/thingsboard/server/service/security/auth/oauth2/PrevUriValidatorTest.java
+++ b/application/src/test/java/org/thingsboard/server/service/security/auth/oauth2/PrevUriValidatorTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.service.security.auth.oauth2;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrevUriValidatorTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/",
+            "/login",
+            "/dashboards/3fa13530-6597-11ed-bd76-8bd591f0ec3e",
+            "/dashboards/3fa13530-6597-11ed-bd76-8bd591f0ec3e?state=someState&page=1",
+            "/settings/outgoing-mail",
+            "/some%20path?q=a+b",
+            "/path//nested"
+    })
+    public void testValidPrevUri(String prevUri) {
+        assertThat(PrevUriValidator.isValid(prevUri)).isTrue();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {
+            "@evil.com/",
+            "evil.com",
+            "https://evil.com",
+            "//evil.com",
+            "/\\evil.com",
+            "/\tevil.com",
+            "/ evil.com",
+            "/dashboards\\..\\evil.com",
+            "/login\nLocation: https://evil.com",
+            "/login\r\nSet-Cookie: a=b"
+    })
+    public void testInvalidPrevUri(String prevUri) {
+        assertThat(PrevUriValidator.isValid(prevUri)).isFalse();
+    }
+
+}


### PR DESCRIPTION
The `prevUri` request parameter is stored in a cookie and later concatenated to the platform base URL to build the post-login redirect (OAuth2 login flow) and the mail settings redirect (`AdminController` mail OAuth2 callback). Neither the write nor the read site validated it, so the value could point the redirect at another host.

`prevUri` is now accepted only when it is a relative in-app path, which is what the UI actually sends (`router.url`): a single leading `/`, and no whitespace, control characters or backslashes. That leaves no room for a scheme, userinfo or authority, and blocks protocol-relative (`//`, `/\`) paths and redirect header splitting.

The check is applied both where the cookie is written and where it is read, in `HttpCookieOAuth2AuthorizationRequestRepository` / `Oauth2AuthenticationSuccessHandler` and in `AdminController`. An invalid value is ignored, and the redirect falls back to the base URL (or `/settings/outgoing-mail` for the mail flow).
