### PR TITLE
Apply the configured cache specs time to live to Spring-managed Redis caches

### DIFF
--- a/application/src/main/resources/thingsboard.yml
+++ b/application/src/main/resources/thingsboard.yml
@@ -172,7 +172,7 @@ security:
     # Enable/disable claiming devices; if false -> the device's [claimingAllowed] SERVER_SCOPE attribute must be set to [true] to allow claiming the specific device
     allowClaimingByDefault: "${SECURITY_CLAIM_ALLOW_CLAIMING_BY_DEFAULT:true}"
     # Time allowed to claim the device in milliseconds
-    duration: "${SECURITY_CLAIM_DURATION:86400000}" # 1 minute, note this value must equal claimDevices.timeToLiveInMinutes value
+    duration: "${SECURITY_CLAIM_DURATION:86400000}" # 24 hours, note this value must equal claimDevices.timeToLiveInMinutes value
   basic:
     # Enable/Disable basic security options
     enabled: "${SECURITY_BASIC_ENABLED:false}"
@@ -680,7 +680,7 @@ cache:
       timeToLiveInMinutes: "${CACHE_SPECS_ENTITY_VIEWS_TTL:1440}" # Entity view cache TTL
       maxSize: "${CACHE_SPECS_ENTITY_VIEWS_MAX_SIZE:10000}" # 0 means the cache is disabled
     claimDevices:
-      timeToLiveInMinutes: "${CACHE_SPECS_CLAIM_DEVICES_TTL:1440}" # Claim devices cache TTL
+      timeToLiveInMinutes: "${CACHE_SPECS_CLAIM_DEVICES_TTL:1440}" # Claim devices cache TTL; note this value must equal security.claim.duration value, the pending claim is stored only in this cache
       maxSize: "${CACHE_SPECS_CLAIM_DEVICES_MAX_SIZE:1000}" # 0 means the cache is disabled
     securitySettings:
       timeToLiveInMinutes: "${CACHE_SPECS_SECURITY_SETTINGS_TTL:1440}" # Security settings cache TTL

--- a/common/cache/src/main/java/org/thingsboard/server/cache/TBRedisCacheConfiguration.java
+++ b/common/cache/src/main/java/org/thingsboard/server/cache/TBRedisCacheConfiguration.java
@@ -55,7 +55,9 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Configuration
 @ConditionalOnProperty(prefix = "cache", value = "type", havingValue = "redis")
@@ -121,14 +123,30 @@ public abstract class TBRedisCacheConfiguration {
      * Enable RedisCaches to synchronize cache put/evict operations with ongoing Spring-managed transactions.
      */
     @Bean
-    public CacheManager cacheManager(RedisConnectionFactory cf) {
+    public CacheManager cacheManager(RedisConnectionFactory cf, CacheSpecsMap cacheSpecsMap) {
         DefaultFormattingConversionService redisConversionService = new DefaultFormattingConversionService();
         RedisCacheConfiguration.registerDefaultConverters(redisConversionService);
         registerDefaultConverters(redisConversionService);
         RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig().withConversionService(redisConversionService);
         return RedisCacheManager.builder(cf).cacheDefaults(configuration)
+                .withInitialCacheConfigurations(buildCacheConfigurations(configuration, cacheSpecsMap))
                 .transactionAware()
                 .build();
+    }
+
+    private static Map<String, RedisCacheConfiguration> buildCacheConfigurations(RedisCacheConfiguration defaults, CacheSpecsMap cacheSpecsMap) {
+        Map<String, CacheSpecs> specs = cacheSpecsMap.getSpecs();
+        if (specs == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, RedisCacheConfiguration> configurations = new HashMap<>();
+        specs.forEach((cacheName, cacheSpecs) -> {
+            Integer timeToLiveInMinutes = cacheSpecs.getTimeToLiveInMinutes();
+            if (timeToLiveInMinutes != null && timeToLiveInMinutes > 0) {
+                configurations.put(cacheName, defaults.entryTtl(Duration.ofMinutes(timeToLiveInMinutes)));
+            }
+        });
+        return configurations;
     }
 
     @Bean

--- a/common/cache/src/test/java/org/thingsboard/server/cache/TBRedisCacheConfigurationTest.java
+++ b/common/cache/src/test/java/org/thingsboard/server/cache/TBRedisCacheConfigurationTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright © 2016-2026 The Thingsboard Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thingsboard.server.cache;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.transaction.TransactionAwareCacheDecorator;
+import org.springframework.data.redis.cache.RedisCache;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.thingsboard.server.common.data.CacheConstants;
+import org.thingsboard.server.common.data.id.TenantId;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class TBRedisCacheConfigurationTest {
+
+    private static final String CACHE_WITH_TTL = CacheConstants.RELATIONS_CACHE;
+    private static final String CACHE_WITHOUT_TTL = CacheConstants.EDGE_SESSIONS_CACHE;
+
+    @Test
+    void givenCacheSpecs_whenCacheManagerCreated_thenTimeToLiveIsApplied() {
+        CacheManager cacheManager = cacheManager(Map.of(
+                CACHE_WITH_TTL, cacheSpecs(1440),
+                CACHE_WITHOUT_TTL, cacheSpecs(0)));
+
+        assertThat(cacheConfiguration(cacheManager, CACHE_WITH_TTL).getTtl()).isEqualTo(Duration.ofMinutes(1440));
+        assertThat(cacheConfiguration(cacheManager, CACHE_WITHOUT_TTL).getTtl()).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void givenNoCacheSpecs_whenCacheManagerCreated_thenNoTimeToLiveIsApplied() {
+        CacheManager cacheManager = cacheManager(null);
+
+        assertThat(cacheConfiguration(cacheManager, CACHE_WITH_TTL).getTtl()).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    void givenCacheSpecs_whenCacheManagerCreated_thenEntityIdKeyConverterIsPreserved() {
+        CacheManager cacheManager = cacheManager(Map.of(CACHE_WITH_TTL, cacheSpecs(1440)));
+
+        assertThat(cacheConfiguration(cacheManager, CACHE_WITH_TTL).getConversionService()
+                .canConvert(TenantId.class, String.class)).isTrue();
+    }
+
+    private static CacheManager cacheManager(Map<String, CacheSpecs> specs) {
+        CacheSpecsMap cacheSpecsMap = new CacheSpecsMap();
+        cacheSpecsMap.setSpecs(specs);
+        TBRedisCacheConfiguration configuration = new TBRedisCacheConfiguration() {
+            @Override
+            protected JedisConnectionFactory loadFactory() {
+                return null;
+            }
+        };
+        RedisCacheManager cacheManager = (RedisCacheManager) configuration.cacheManager(mock(RedisConnectionFactory.class), cacheSpecsMap);
+        cacheManager.afterPropertiesSet();
+        return cacheManager;
+    }
+
+    private static RedisCacheConfiguration cacheConfiguration(CacheManager cacheManager, String cacheName) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache instanceof TransactionAwareCacheDecorator decorator) {
+            cache = decorator.getTargetCache();
+        }
+        return ((RedisCache) cache).getCacheConfiguration();
+    }
+
+    private static CacheSpecs cacheSpecs(int timeToLiveInMinutes) {
+        CacheSpecs cacheSpecs = new CacheSpecs();
+        cacheSpecs.setTimeToLiveInMinutes(timeToLiveInMinutes);
+        return cacheSpecs;
+    }
+
+}


### PR DESCRIPTION
## Problem

`TBRedisCacheConfiguration.cacheManager` builds every cache from `RedisCacheConfiguration.defaultCacheConfig()` and never sets a per-cache TTL, so `cache.specs.<name>.timeToLiveInMinutes` has no effect when `CACHE_TYPE=redis`.

Caches reached through the Spring `CacheManager` are affected. Unlike `TbTransactionalCache`, which reads the spec and applies the expiration itself, these are written with no expiration at all: their keys sit at TTL `-1` and survive a restart of every node. Entries are still dropped by the explicit evictions in the code and by the cache cleanup on install/upgrade, but nothing expires them over time.

Affected caches:

| cache | consumer |
| --- | --- |
| `securitySettings`, `notificationSettings`, `trendzSettings` | `@Cacheable` / `@CacheEvict` |
| `sentNotifications` | `DefaultNotificationDeduplicationService` |
| `claimDevices` | `ClaimDevicesServiceImpl` |
| `twoFaVerificationCodes` | `OtpBasedTwoFaProvider` |

With `CACHE_TYPE=caffeine` all of them already honour the configured TTL, so redis was the odd one out.

## Fix

Build a per-cache `RedisCacheConfiguration` with `entryTtl` for every spec that declares a non-zero TTL and pass them to the manager through `withInitialCacheConfigurations`.

The per-cache configurations are derived from the base configuration rather than from `defaultCacheConfig()`, so the custom `EntityId -> String` conversion service is preserved — `notificationSettings` and `trendzSettings` are keyed by `TenantId` and would otherwise lose their key conversion.

Specs with `timeToLiveInMinutes: 0` are left out of the map and keep the default no-expiration behaviour, matching caffeine and the documented meaning of `0` for `edgeSessions`.

## Behaviour change

On redis, entries in the caches listed above now expire. A deployment that configured a two-factor `verificationCodeLifetime` longer than `cache.specs.twoFaVerificationCodes.timeToLiveInMinutes` (60 minutes by default), or a claiming `durationMs` longer than `cache.specs.claimDevices.timeToLiveInMinutes` (1440 minutes by default), has to raise the corresponding cache TTL. This is the same coupling already documented for `security.claim.duration` in `thingsboard.yml` and already in force with caffeine.

## Testing

`TBRedisCacheConfigurationTest` covers a spec with a TTL, a spec with `0`, and a missing `cache.specs` block.

```
mvn test -pl common/cache
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0 -- in TBRedisCacheConfigurationTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0 -- whole module
```
