### PR TITLE
Fixed alarm not being created when schedule window opens for rules with duration condition

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/alarm/AlarmRuleState.java
+++ b/application/src/main/java/org/thingsboard/server/service/cf/ctx/state/alarm/AlarmRuleState.java
@@ -81,10 +81,10 @@ public class AlarmRuleState {
 
     public AlarmEvalResult reeval(long ts, CalculatedFieldCtx ctx) { // on scheduled duration check or periodic re-eval for rules with schedule
         boolean active = isActive(ts);
+        boolean activeChanged = this.active == null || active != this.active;
+        this.active = active;
         switch (condition.getType()) {
             case SIMPLE, REPEATING -> {
-                boolean activeChanged = this.active == null || active != this.active;
-                this.active = active;
                 if (!active) {
                     return AlarmEvalResult.EMPTY;
                 }
@@ -102,6 +102,9 @@ public class AlarmRuleState {
             case DURATION -> {
                 if (!active) {
                     return AlarmEvalResult.FALSE;
+                }
+                if (firstEventTs <= 0 && condition.hasSchedule() && activeChanged) {
+                    return doEval(false, ctx);
                 }
                 long requiredDuration = getRequiredDurationInMs();
                 if (requiredDuration > 0 && firstEventTs > 0 && ts > firstEventTs) {

--- a/application/src/test/java/org/thingsboard/server/cf/AlarmRulesTest.java
+++ b/application/src/test/java/org/thingsboard/server/cf/AlarmRulesTest.java
@@ -876,6 +876,48 @@ public class AlarmRulesTest extends AbstractControllerTest {
     }
 
     @Test
+    public void testCreateAlarm_durationCondition_scheduleStarted() throws Exception {
+        Argument motionDetectedArgument = new Argument();
+        motionDetectedArgument.setRefEntityKey(new ReferencedEntityKey("motionDetected", ArgumentType.TS_LATEST, null));
+        motionDetectedArgument.setDefaultValue("false");
+        Map<String, Argument> arguments = Map.of(
+                "motionDetected", motionDetectedArgument
+        );
+
+        SpecificTimeSchedule schedule = new SpecificTimeSchedule();
+        schedule.setTimezone(ZoneId.systemDefault().getId());
+        schedule.setDaysOfWeek(Set.of(1, 2, 3, 4, 5, 6, 7));
+        long startsOn = Duration.between(LocalDate.now().atStartOfDay(), LocalDateTime.now())
+                .plus(15, ChronoUnit.SECONDS).toMillis();
+        schedule.setStartsOn(startsOn);
+        Map<AlarmSeverity, Condition> createRules = Map.of(
+                AlarmSeverity.CRITICAL, new Condition("return motionDetected == true;", null, null,
+                        new AlarmConditionValue<>(1000L, null),
+                        new AlarmConditionValue<>(schedule, null))
+        );
+
+        AlarmRuleDefinition alarmRule = createAlarmRule(deviceId, "Motion detected alarm",
+                arguments, createRules, null);
+
+        postTelemetry(deviceId, "{\"motionDetected\":true}");
+
+        Thread.sleep(10000);
+        assertThat(getLatestAlarmResult(alarmRule.getId())).isNull();
+
+        // no new telemetry after the schedule window opens, so the stored value must be used
+        await().atMost(TIMEOUT, TimeUnit.SECONDS).untilAsserted(() -> {
+            CalculatedFieldDebugEvent debugEvent = getDebugEvents(alarmRule.getId(), 5).stream()
+                    .filter(event -> event.getResult() != null)
+                    .findFirst().orElse(null);
+            assertThat(debugEvent).isNotNull();
+            TbAlarmResult alarmResult = JacksonUtil.fromString(debugEvent.getResult(), TbAlarmResult.class);
+            assertThat(alarmResult.isCreated()).isTrue();
+            assertThat(alarmResult.getAlarm().getSeverity()).isEqualTo(AlarmSeverity.CRITICAL);
+            assertThat(alarmResult.getAlarm().getStatus()).isEqualTo(AlarmStatus.ACTIVE_UNACK);
+        });
+    }
+
+    @Test
     public void testManualClearAlarm() throws Exception {
         Argument temperatureArgument = new Argument();
         temperatureArgument.setRefEntityKey(new ReferencedEntityKey("temperature", ArgumentType.TS_LATEST, null));


### PR DESCRIPTION
**_Reviewed with review-pr_**

### Problem

When an alarm rule has both a schedule and a duration condition, the alarm is not created when the schedule window opens, even if the latest saved telemetry already satisfies the condition. A new telemetry update is required to trigger the evaluation.

Reproduced with the rule from the issue: condition `motionDetected == true`, duration 1 second, custom schedule starting a few minutes in the future.

### Reason

`AlarmRuleState.reeval()` starts the duration timer only when `firstEventTs > 0`, and `firstEventTs` is set in `evalDuration()`. In this scenario `evalDuration()` is never called: when telemetry arrives, the schedule window is still closed, so `eval()` returns `FALSE` before reaching it. The periodic re-evaluation then always falls through to `EMPTY` and the timer never starts.

### Fix

On the first re-evaluation after the schedule window opens, a duration condition is now evaluated against the stored argument values, which starts the duration timer without a new telemetry update. This mirrors the existing behaviour of simple and repeating conditions.

Both terms of the new guard are load-bearing:

- `firstEventTs <= 0` — the timer is not already running, otherwise the regular duration check below applies.
- `hasSchedule() && activeChanged` — the window has just opened. `hasSchedule()` cannot be dropped: `reevalNeeded` is a single flag for the whole calculated field and `requiresScheduledReevaluation()` is an `anyMatch` over all rules, so a duration rule *without* a schedule is re-evaluated too whenever another rule of the same field has one. Without this term such a rule would evaluate its expression against stored values and could start the duration timer from an old telemetry timestamp with no new event.

### Notes

The duration is counted from the telemetry timestamp, not from the moment the schedule window opens, so a condition that has been satisfied for longer than the required duration raises the alarm as soon as the window opens.

If the required duration is not reached yet when the window opens, the alarm is created on one of the following periodic re-evaluations, i.e. up to `alarmsReevaluationInterval` later. The opening of the window itself is already detected with the same precision, so no separate duration check is scheduled for this path.

### Testing

Added `AlarmRulesTest.testCreateAlarm_durationCondition_scheduleStarted`: telemetry is posted before the schedule window opens and no telemetry is sent afterwards. Verified that it fails without the fix (awaitility timeout, no alarm) and passes with it, together with the existing `testCreateAlarm_scheduleStarted`.
