### PR TITLE
Fixed entities limit being exceeded on concurrent entity creation

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/asset/BaseAssetService.java
@@ -145,6 +145,11 @@ public class BaseAssetService extends AbstractCachedEntityService<AssetCacheKey,
     }
 
     @Override
+    protected boolean isUpdateTransactional() {
+        return false; // entry points had no @Transactional before the fix, update stays without an ambient transaction
+    }
+
+    @Override
     public Asset saveAsset(Asset asset) {
         return saveAsset(asset, true);
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/customer/CustomerServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/customer/CustomerServiceImpl.java
@@ -142,13 +142,11 @@ public class CustomerServiceImpl extends AbstractCachedEntityService<CustomerCac
     }
 
     @Override
-    @Transactional
     public Customer saveCustomer(Customer customer) {
         return saveCustomer(customer, NameConflictStrategy.DEFAULT);
     }
 
     @Override
-    @Transactional
     public Customer saveCustomer(Customer customer, NameConflictStrategy nameConflictStrategy) {
         return saveEntity(customer, () -> saveCustomer(customer, true, nameConflictStrategy));
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/dashboard/DashboardServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/dashboard/DashboardServiceImpl.java
@@ -155,6 +155,11 @@ public class DashboardServiceImpl extends AbstractEntityService implements Dashb
     }
 
     @Override
+    protected boolean isUpdateTransactional() {
+        return false; // entry points had no @Transactional before the fix, update stays without an ambient transaction
+    }
+
+    @Override
     public Dashboard saveDashboard(Dashboard dashboard) {
         return saveDashboard(dashboard, true);
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/dashboard/DashboardServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/dashboard/DashboardServiceImpl.java
@@ -177,7 +177,7 @@ public class DashboardServiceImpl extends AbstractEntityService implements Dashb
             imageService.updateImagesUsage(dashboard);
             resourceService.updateResourcesUsage(tenantId, dashboard);
 
-            var saved = dashboardDao.save(tenantId, dashboard);
+            var saved = dashboardDao.saveAndFlush(tenantId, dashboard);
             publishEvictEvent(new DashboardTitleEvictEvent(saved.getId()));
             eventPublisher.publishEvent(SaveEntityEvent.builder().tenantId(tenantId)
                     .entityId(saved.getId()).entity(saved).created(dashboard.getId() == null).build());

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
@@ -163,13 +163,11 @@ public class DeviceServiceImpl extends CachedVersionedEntityService<DeviceCacheK
         return executor.submit(() -> findDeviceByTenantIdAndName(tenantId, name));
     }
 
-    @Transactional
     @Override
     public Device saveDeviceWithAccessToken(Device device, String accessToken) {
         return doSaveDevice(device, accessToken, true);
     }
 
-    @Transactional
     @Override
     public Device saveDeviceWithAccessToken(Device device, String accessToken, NameConflictStrategy nameConflictStrategy) {
         return doSaveDevice(device, accessToken, true, nameConflictStrategy);
@@ -180,19 +178,16 @@ public class DeviceServiceImpl extends CachedVersionedEntityService<DeviceCacheK
         return doSaveDevice(device, null, doValidate);
     }
 
-    @Transactional
     @Override
     public Device saveDevice(Device device) {
         return doSaveDevice(device, null, true);
     }
 
-    @Transactional
     @Override
     public Device saveDeviceWithCredentials(Device device, DeviceCredentials deviceCredentials) {
         return saveDeviceWithCredentials(device, deviceCredentials, NameConflictStrategy.DEFAULT);
     }
 
-    @Transactional
     @Override
     public Device saveDeviceWithCredentials(Device device, DeviceCredentials deviceCredentials, NameConflictStrategy nameConflictStrategy) {
         return saveEntity(device, () -> doSaveWithCredentials(device, deviceCredentials, nameConflictStrategy));

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
@@ -597,7 +597,6 @@ public class DeviceServiceImpl extends CachedVersionedEntityService<DeviceCacheK
     }
 
     @Override
-    @Transactional
     public Device saveDevice(ProvisionRequest provisionRequest, DeviceProfile profile) {
         Device device = new Device();
         device.setName(provisionRequest.getDeviceName());
@@ -640,6 +639,7 @@ public class DeviceServiceImpl extends CachedVersionedEntityService<DeviceCacheK
             try {
                 deviceCredentialsService.updateDeviceCredentials(savedDevice.getTenantId(), deviceCredentials);
             } catch (Exception e) {
+                deleteProvisionedDevice(savedDevice);
                 throw new ProvisionFailedException(ProvisionResponseStatus.FAILURE.name());
             }
         }
@@ -647,6 +647,15 @@ public class DeviceServiceImpl extends CachedVersionedEntityService<DeviceCacheK
         publishEvictEvent(new DeviceCacheEvictEvent(savedDevice.getTenantId(), savedDevice.getId(), provisionRequest.getDeviceName(), null));
         countService.publishCountEntityEvictEvent(savedDevice.getTenantId(), EntityType.DEVICE);
         return savedDevice;
+    }
+
+    // The device is already committed by saveDevice, so a failed provision request has to remove it explicitly.
+    private void deleteProvisionedDevice(Device device) {
+        try {
+            transactionTemplate.executeWithoutResult(status -> deleteDevice(device.getTenantId(), device));
+        } catch (Exception e) {
+            log.warn("[{}][{}] Failed to delete the device created by a failed provision request", device.getTenantId(), device.getId(), e);
+        }
     }
 
     @Override

--- a/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/device/DeviceServiceImpl.java
@@ -608,40 +608,41 @@ public class DeviceServiceImpl extends CachedVersionedEntityService<DeviceCacheK
             device.setAdditionalInfo(additionalInfoNode);
         }
         Device savedDevice = saveDevice(device);
-        if (!StringUtils.isEmpty(provisionRequest.getCredentialsData().getToken()) ||
-                !StringUtils.isEmpty(provisionRequest.getCredentialsData().getX509CertHash()) ||
-                !StringUtils.isEmpty(provisionRequest.getCredentialsData().getUsername()) ||
-                !StringUtils.isEmpty(provisionRequest.getCredentialsData().getPassword()) ||
-                !StringUtils.isEmpty(provisionRequest.getCredentialsData().getClientId())) {
-            DeviceCredentials deviceCredentials = deviceCredentialsService.findDeviceCredentialsByDeviceId(savedDevice.getTenantId(), savedDevice.getId());
-            if (deviceCredentials == null) {
-                deviceCredentials = new DeviceCredentials();
-            }
-            deviceCredentials.setDeviceId(savedDevice.getId());
-            deviceCredentials.setCredentialsType(provisionRequest.getCredentialsType());
-            switch (provisionRequest.getCredentialsType()) {
-                case ACCESS_TOKEN:
-                    deviceCredentials.setCredentialsId(provisionRequest.getCredentialsData().getToken());
-                    break;
-                case MQTT_BASIC:
-                    BasicMqttCredentials mqttCredentials = new BasicMqttCredentials();
-                    mqttCredentials.setClientId(provisionRequest.getCredentialsData().getClientId());
-                    mqttCredentials.setUserName(provisionRequest.getCredentialsData().getUsername());
-                    mqttCredentials.setPassword(provisionRequest.getCredentialsData().getPassword());
-                    deviceCredentials.setCredentialsValue(JacksonUtil.toString(mqttCredentials));
-                    break;
-                case X509_CERTIFICATE:
-                    deviceCredentials.setCredentialsValue(provisionRequest.getCredentialsData().getX509CertHash());
-                    break;
-                case LWM2M_CREDENTIALS:
-                    break;
-            }
-            try {
+        try {
+            if (!StringUtils.isEmpty(provisionRequest.getCredentialsData().getToken()) ||
+                    !StringUtils.isEmpty(provisionRequest.getCredentialsData().getX509CertHash()) ||
+                    !StringUtils.isEmpty(provisionRequest.getCredentialsData().getUsername()) ||
+                    !StringUtils.isEmpty(provisionRequest.getCredentialsData().getPassword()) ||
+                    !StringUtils.isEmpty(provisionRequest.getCredentialsData().getClientId())) {
+                DeviceCredentials deviceCredentials = deviceCredentialsService.findDeviceCredentialsByDeviceId(savedDevice.getTenantId(), savedDevice.getId());
+                if (deviceCredentials == null) {
+                    deviceCredentials = new DeviceCredentials();
+                }
+                deviceCredentials.setDeviceId(savedDevice.getId());
+                deviceCredentials.setCredentialsType(provisionRequest.getCredentialsType());
+                switch (provisionRequest.getCredentialsType()) {
+                    case ACCESS_TOKEN:
+                        deviceCredentials.setCredentialsId(provisionRequest.getCredentialsData().getToken());
+                        break;
+                    case MQTT_BASIC:
+                        BasicMqttCredentials mqttCredentials = new BasicMqttCredentials();
+                        mqttCredentials.setClientId(provisionRequest.getCredentialsData().getClientId());
+                        mqttCredentials.setUserName(provisionRequest.getCredentialsData().getUsername());
+                        mqttCredentials.setPassword(provisionRequest.getCredentialsData().getPassword());
+                        deviceCredentials.setCredentialsValue(JacksonUtil.toString(mqttCredentials));
+                        break;
+                    case X509_CERTIFICATE:
+                        deviceCredentials.setCredentialsValue(provisionRequest.getCredentialsData().getX509CertHash());
+                        break;
+                    case LWM2M_CREDENTIALS:
+                        break;
+                }
                 deviceCredentialsService.updateDeviceCredentials(savedDevice.getTenantId(), deviceCredentials);
-            } catch (Exception e) {
-                deleteProvisionedDevice(savedDevice);
-                throw new ProvisionFailedException(ProvisionResponseStatus.FAILURE.name());
             }
+        } catch (Exception e) {
+            log.error("[{}][{}] Failed to set up credentials for the provisioned device", savedDevice.getTenantId(), savedDevice.getId(), e);
+            deleteProvisionedDevice(savedDevice);
+            throw new ProvisionFailedException(ProvisionResponseStatus.FAILURE.name());
         }
 
         publishEvictEvent(new DeviceCacheEvictEvent(savedDevice.getTenantId(), savedDevice.getId(), provisionRequest.getDeviceName(), null));
@@ -654,7 +655,9 @@ public class DeviceServiceImpl extends CachedVersionedEntityService<DeviceCacheK
         try {
             transactionTemplate.executeWithoutResult(status -> deleteDevice(device.getTenantId(), device));
         } catch (Exception e) {
-            log.warn("[{}][{}] Failed to delete the device created by a failed provision request", device.getTenantId(), device.getId(), e);
+            log.error("[{}][{}] Failed to delete the device created by a failed provision request. The device is left with an " +
+                            "auto-generated access token and occupies a slot in the tenant device limit until it is removed manually",
+                    device.getTenantId(), device.getId(), e);
         }
     }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
@@ -211,7 +211,7 @@ public class EdgeServiceImpl extends AbstractCachedEntityService<EdgeCacheKey, E
         Edge oldEdge = edgeValidator.validate(edge, Edge::getTenantId);
         EdgeCacheEvictEvent evictEvent = new EdgeCacheEvictEvent(edge.getTenantId(), edge.getName(), oldEdge != null ? oldEdge.getName() : null);
         try {
-            Edge savedEdge = edgeDao.save(edge.getTenantId(), edge);
+            Edge savedEdge = edgeDao.saveAndFlush(edge.getTenantId(), edge);
             publishEvictEvent(evictEvent);
             eventPublisher.publishEvent(SaveEntityEvent.builder().tenantId(savedEdge.getTenantId())
                     .entityId(savedEdge.getId()).entity(savedEdge).created(edge.getId() == null).build());

--- a/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/edge/EdgeServiceImpl.java
@@ -202,6 +202,11 @@ public class EdgeServiceImpl extends AbstractCachedEntityService<EdgeCacheKey, E
     }
 
     @Override
+    protected boolean isUpdateTransactional() {
+        return false; // entry points had no @Transactional before the fix, update stays without an ambient transaction
+    }
+
+    @Override
     public Edge saveEdge(Edge edge) {
         return saveEntity(edge, () -> doSaveEdge(edge));
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.ConcurrentReferenceHashMap;
 import org.thingsboard.common.util.DebugModeUtil;
 import org.thingsboard.server.common.data.EntityInfo;
@@ -105,20 +106,25 @@ public abstract class AbstractEntityService {
     @Autowired
     protected EntityDaoRegistry entityDaoRegistry;
 
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
     @Value("${debug.settings.default_duration:15}")
     private int defaultDebugDurationMinutes;
 
+    // Commit must happen inside the lock, otherwise the next thread counts stale data when checking the limit.
+    // Entry points delegating here must not be @Transactional, or the template joins them and commits later.
     protected <E extends HasId & HasTenantId> E saveEntity(E entity, Supplier<E> saveFunction) {
         if (entity.getId() == null) {
             ReentrantLock lock = entityCreationLocks.computeIfAbsent(entity.getTenantId(), id -> new ReentrantLock());
             lock.lock();
             try {
-                return saveFunction.get();
+                return transactionTemplate.execute(status -> saveFunction.get());
             } finally {
                 lock.unlock();
             }
         } else {
-            return saveFunction.get();
+            return transactionTemplate.execute(status -> saveFunction.get());
         }
     }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
@@ -107,13 +107,13 @@ public abstract class AbstractEntityService {
     protected EntityDaoRegistry entityDaoRegistry;
 
     @Autowired
-    private TransactionTemplate transactionTemplate;
+    protected TransactionTemplate transactionTemplate;
 
     @Value("${debug.settings.default_duration:15}")
     private int defaultDebugDurationMinutes;
 
     // Commit must happen inside the lock, otherwise the next thread counts stale data when checking the limit.
-    // Entry points delegating here must not be @Transactional, or the template joins them and commits later.
+    // No caller in the chain may have a transaction open, or the template joins it and commits after the unlock.
     protected <E extends HasId & HasTenantId> E saveEntity(E entity, Supplier<E> saveFunction) {
         if (entity.getId() == null) {
             ReentrantLock lock = entityCreationLocks.computeIfAbsent(entity.getTenantId(), id -> new ReentrantLock());
@@ -124,8 +124,14 @@ public abstract class AbstractEntityService {
                 lock.unlock();
             }
         } else {
-            return transactionTemplate.execute(status -> saveFunction.get());
+            return isUpdateTransactional()
+                    ? transactionTemplate.execute(status -> saveFunction.get())
+                    : saveFunction.get();
         }
+    }
+
+    protected boolean isUpdateTransactional() {
+        return true;
     }
 
     protected void createRelation(TenantId tenantId, EntityRelation relation) {

--- a/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/entity/AbstractEntityService.java
@@ -114,6 +114,10 @@ public abstract class AbstractEntityService {
 
     // Commit must happen inside the lock, otherwise the next thread counts stale data when checking the limit.
     // No caller in the chain may have a transaction open, or the template joins it and commits after the unlock.
+    // The lock serializes the check only while the count comes from Postgres. Once queue.edqs.sync.enabled and
+    // queue.edqs.api.supported are both on, validateNumberOfEntitiesPerTenant counts through EDQS, which is filled
+    // asynchronously after commit, so the next thread reads a replica without the new row and the limit stays
+    // exceedable. Both properties are disabled by default.
     protected <E extends HasId & HasTenantId> E saveEntity(E entity, Supplier<E> saveFunction) {
         if (entity.getId() == null) {
             ReentrantLock lock = entityCreationLocks.computeIfAbsent(entity.getTenantId(), id -> new ReentrantLock());

--- a/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/rule/BaseRuleChainService.java
@@ -114,19 +114,16 @@ public class BaseRuleChainService extends AbstractEntityService implements RuleC
     private DataValidator<RuleChain> ruleChainValidator;
 
     @Override
-    @Transactional
     public RuleChain saveRuleChain(RuleChain ruleChain) {
         return saveRuleChain(ruleChain, true);
     }
 
     @Override
-    @Transactional
     public RuleChain saveRuleChain(RuleChain ruleChain, boolean publishSaveEvent) {
         return saveRuleChain(ruleChain, publishSaveEvent, true);
     }
 
     @Override
-    @Transactional
     public RuleChain saveRuleChain(RuleChain ruleChain, boolean publishSaveEvent, boolean doValidate) {
         return saveEntity(ruleChain, () -> doSaveRuleChain(ruleChain, publishSaveEvent, doValidate));
     }

--- a/dao/src/main/java/org/thingsboard/server/dao/user/UserServiceImpl.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/user/UserServiceImpl.java
@@ -173,13 +173,11 @@ public class UserServiceImpl extends AbstractCachedEntityService<UserCacheKey, U
     }
 
     @Override
-    @Transactional
     public User saveUser(TenantId tenantId, User user) {
         return saveUser(tenantId, user, true);
     }
 
     @Override
-    @Transactional
     public User saveUser(TenantId tenantId, User user, boolean doValidate) {
         return saveEntity(user, () -> doSaveUser(tenantId, user, doValidate));
     }

--- a/dao/src/test/java/org/thingsboard/server/dao/service/AssetServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/AssetServiceTest.java
@@ -16,6 +16,8 @@
 package org.thingsboard.server.dao.service;
 
 import com.datastax.oss.driver.api.core.uuid.Uuids;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.AfterClass;
@@ -28,7 +30,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.thingsboard.common.util.ThingsBoardThreadFactory;
 import org.thingsboard.server.common.data.Customer;
 import org.thingsboard.server.common.data.EntitySubtype;
@@ -66,6 +67,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -134,7 +136,7 @@ public class AssetServiceTest extends AbstractServiceTest {
     }
 
     @Test
-    public void testAssetLimitOnTenantProfileLevel() throws InterruptedException {
+    public void testAssetLimitOnTenantProfileLevel() throws Exception {
         TenantProfile tenantProfile = new TenantProfile();
         tenantProfile.setName("Test profile");
         tenantProfile.setDescription("Test");
@@ -147,22 +149,19 @@ public class AssetServiceTest extends AbstractServiceTest {
         tenantProfile = tenantProfileService.saveTenantProfile(anotherTenantId, tenantProfile);
         anotherTenantId = createTenant(tenantProfile.getId()).getId();
 
+        List<ListenableFuture<Asset>> futures = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
-            executor.submit(() -> {
+            futures.add(executor.submit(() -> {
                 Asset asset = new Asset();
                 asset.setTenantId(anotherTenantId);
                 asset.setName(RandomStringUtils.secure().nextAlphabetic(10));
                 asset.setType("default");
-                assetService.saveAsset(asset);
-            });
+                return assetService.saveAsset(asset);
+            }));
         }
+        List<Asset> savedAssets = Futures.successfulAsList(futures).get(30, TimeUnit.SECONDS);
 
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
-            long countByTenantId = assetService.countByTenantId(anotherTenantId);
-            return countByTenantId == 5;
-        });
-
-        Thread.sleep(2000);
+        assertThat(savedAssets.stream().filter(Objects::nonNull)).hasSize(5);
         assertThat(assetService.countByTenantId(anotherTenantId)).isEqualTo(5);
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/DeviceServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/DeviceServiceTest.java
@@ -53,6 +53,7 @@ import org.thingsboard.server.common.data.cf.configuration.ArgumentType;
 import org.thingsboard.server.common.data.cf.configuration.ReferencedEntityKey;
 import org.thingsboard.server.common.data.cf.configuration.SimpleCalculatedFieldConfiguration;
 import org.thingsboard.server.common.data.cf.configuration.TimeSeriesOutput;
+import org.thingsboard.server.common.data.device.credentials.ProvisionDeviceCredentialsData;
 import org.thingsboard.server.common.data.id.CustomerId;
 import org.thingsboard.server.common.data.id.DeviceProfileId;
 import org.thingsboard.server.common.data.id.OtaPackageId;
@@ -69,6 +70,8 @@ import org.thingsboard.server.dao.customer.CustomerService;
 import org.thingsboard.server.dao.device.DeviceCredentialsService;
 import org.thingsboard.server.dao.device.DeviceProfileService;
 import org.thingsboard.server.dao.device.DeviceService;
+import org.thingsboard.server.dao.device.provision.ProvisionFailedException;
+import org.thingsboard.server.dao.device.provision.ProvisionRequest;
 import org.thingsboard.server.exception.DataValidationException;
 import org.thingsboard.server.dao.exception.DeviceCredentialsValidationException;
 import org.thingsboard.server.dao.ota.OtaPackageService;
@@ -181,6 +184,26 @@ public class DeviceServiceTest extends AbstractServiceTest {
 
         assertThat(savedDevices.stream().filter(Objects::nonNull)).hasSize(5);
         assertThat(deviceService.countByTenantId(tenantId)).isEqualTo(5);
+    }
+
+    @Test
+    public void testProvisionedDeviceIsDeletedWhenCredentialsUpdateFails() {
+        String takenToken = "TAKEN_ACCESS_TOKEN";
+        Device existingDevice = new Device();
+        existingDevice.setTenantId(tenantId);
+        existingDevice.setName("Existing device");
+        existingDevice.setType("default");
+        deviceService.saveDeviceWithAccessToken(existingDevice, takenToken);
+
+        DeviceProfile deviceProfile = deviceProfileService.findOrCreateDeviceProfile(tenantId, "default");
+        ProvisionRequest provisionRequest = new ProvisionRequest("Provisioned device", DeviceCredentialsType.ACCESS_TOKEN,
+                new ProvisionDeviceCredentialsData(takenToken, null, null, null, null), null, null);
+
+        assertThatThrownBy(() -> deviceService.saveDevice(provisionRequest, deviceProfile))
+                .isInstanceOf(ProvisionFailedException.class);
+
+        assertThat(deviceService.findDeviceByTenantIdAndName(tenantId, "Provisioned device")).isNull();
+        assertThat(deviceService.countByTenantId(tenantId)).isEqualTo(1);
     }
 
     @Test

--- a/dao/src/test/java/org/thingsboard/server/dao/service/DeviceServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/DeviceServiceTest.java
@@ -16,6 +16,8 @@
 package org.thingsboard.server.dao.service;
 
 import com.datastax.oss.driver.api.core.uuid.Uuids;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.After;
@@ -31,7 +33,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.thingsboard.common.util.ThingsBoardThreadFactory;
 import org.thingsboard.server.common.data.Customer;
 import org.thingsboard.server.common.data.Device;
@@ -80,6 +81,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -160,27 +162,24 @@ public class DeviceServiceTest extends AbstractServiceTest {
     }
 
     @Test
-    public void testDeviceLimitOnTenantProfileLevel() throws InterruptedException {
+    public void testDeviceLimitOnTenantProfileLevel() throws Exception {
         TenantProfile defaultTenantProfile = tenantProfileService.findDefaultTenantProfile(tenantId);
         defaultTenantProfile.getProfileData().setConfiguration(DefaultTenantProfileConfiguration.builder().maxDevices(5l).build());
         tenantProfileService.saveTenantProfile(tenantId, defaultTenantProfile);
 
+        List<ListenableFuture<Device>> futures = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
-            executor.submit(() -> {
+            futures.add(executor.submit(() -> {
                 Device device = new Device();
                 device.setTenantId(tenantId);
                 device.setName(StringUtils.randomAlphabetic(10));
                 device.setType("default");
-                deviceService.saveDevice(device);
-            });
+                return deviceService.saveDevice(device);
+            }));
         }
+        List<Device> savedDevices = Futures.successfulAsList(futures).get(30, TimeUnit.SECONDS);
 
-        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> {
-            long countByTenantId = deviceService.countByTenantId(tenantId);
-            return countByTenantId == 5;
-        });
-
-        Thread.sleep(2000);
+        assertThat(savedDevices.stream().filter(Objects::nonNull)).hasSize(5);
         assertThat(deviceService.countByTenantId(tenantId)).isEqualTo(5);
     }
 

--- a/dao/src/test/java/org/thingsboard/server/dao/service/DeviceServiceTest.java
+++ b/dao/src/test/java/org/thingsboard/server/dao/service/DeviceServiceTest.java
@@ -100,7 +100,7 @@ public class DeviceServiceTest extends AbstractServiceTest {
 
     @Autowired
     CustomerService customerService;
-    @Autowired
+    @MockitoSpyBean
     DeviceCredentialsService deviceCredentialsService;
     @Autowired
     DeviceProfileService deviceProfileService;
@@ -204,6 +204,23 @@ public class DeviceServiceTest extends AbstractServiceTest {
 
         assertThat(deviceService.findDeviceByTenantIdAndName(tenantId, "Provisioned device")).isNull();
         assertThat(deviceService.countByTenantId(tenantId)).isEqualTo(1);
+    }
+
+    @Test
+    public void testProvisionedDeviceIsDeletedWhenCredentialsLookupFails() {
+        Mockito.doThrow(new RuntimeException("mock message"))
+                .doCallRealMethod()
+                .when(deviceCredentialsService).findDeviceCredentialsByDeviceId(any(), any());
+
+        DeviceProfile deviceProfile = deviceProfileService.findOrCreateDeviceProfile(tenantId, "default");
+        ProvisionRequest provisionRequest = new ProvisionRequest("Provisioned device", DeviceCredentialsType.ACCESS_TOKEN,
+                new ProvisionDeviceCredentialsData("PROVISION_ACCESS_TOKEN", null, null, null, null), null, null);
+
+        assertThatThrownBy(() -> deviceService.saveDevice(provisionRequest, deviceProfile))
+                .isInstanceOf(ProvisionFailedException.class);
+
+        assertThat(deviceService.findDeviceByTenantIdAndName(tenantId, "Provisioned device")).isNull();
+        assertThat(deviceService.countByTenantId(tenantId)).isZero();
     }
 
     @Test


### PR DESCRIPTION
### Problem

`DataValidator.validateNumberOfEntitiesPerTenant()` → `DefaultApiLimitService.checkEntitiesLimit()` is a count-then-decide check. The per-tenant `ReentrantLock` in `AbstractEntityService.saveEntity()` did not serialize it, because the transaction was opened outside the lock: `@Transactional` sits on the public service method that calls `saveEntity`, so

1. T1 begins the transaction, takes the lock, counts 4 entities, inserts the 5th, releases the lock — and only then commits;
2. T2 takes the lock in the window between T1's unlock and T1's commit, still counts 4, inserts a 6th and passes the check.

With `maxDevices = 5` a tenant could end up with 6 or more entities. The visible symptom is the intermittent `DeviceServiceTest.testDeviceLimitOnTenantProfileLevel` failure (`expected: 5 but was: 6`).

### Solution

`saveEntity` now owns the transaction via `TransactionTemplate`, so the entity is committed before the lock is released and the next thread both counts and opens its transaction against up-to-date data.

`@Transactional` is removed from the save entry points whose body is only a delegation to `saveEntity` (`DeviceServiceImpl` ×5, `UserServiceImpl` ×2, `CustomerServiceImpl` ×2, `BaseRuleChainService` ×3), so the transaction scope is unchanged — it just moved under the lock. The delegating overloads are included because their `@Transactional` applies when they are called from outside the bean.

`DeviceServiceImpl.saveDevice(ProvisionRequest, DeviceProfile)` loses its annotation as well. Its transaction wrapped the `saveDevice(device)` call, so on the provisioning path the commit again happened after the unlock and the limit could still be exceeded — a realistic case, since mass onboarding provisions devices of one tenant at once. That annotation also kept the device and its credentials atomic, so the whole credentials block — the lookup, the per-type mapping and the update — is now wrapped in a `catch` that deletes the device it just created; without that the device would be left with auto-generated credentials and the next provision request for the same name would fail on `device_name_unq_key`. If the compensating delete itself fails, it is logged at `ERROR` naming the consequence: the device stays with an auto-generated access token and occupies a slot in the tenant device limit until it is removed manually. There are no retries — the request has already failed, and a retry would only add latency to it. The trade-off is a short window in which the device is visible with an auto-generated access token instead of the requested credentials.

Without the annotation the device is committed by the inner transaction that `saveEntity` opens, so the `AFTER_COMMIT` listeners now run for a provision request that later fails: `EntityStateSourcingListener` broadcasts `ComponentLifecycleEvent.CREATED` to core and the rule engine and `EdqsListener` inserts the device into EDQS, followed by the matching delete events from the compensating delete. Previously `ProvisionFailedException` rolled the transaction back and no listener ran at all. This is accepted as a trade-off: suppressing the emission would require either an event-suppression flag threaded through `doSaveDevice` or publishing outside the transaction, both well beyond moving the transaction boundary. The pair is self-correcting — device state is created and then removed — and it cannot leave a stale EDQS row, because `DefaultEdqsService.onDelete` sends the delete with version `Long.MAX_VALUE`, which wins over the create regardless of ordering.

`saveAsset`, `saveDashboard` and `saveEdge` had no `@Transactional` — the DAO owned the transaction. On **creation** they are now covered by the one `saveEntity` opens, so their cache-evict events and `SaveEntityEvent` fire after commit instead of immediately; all three listeners (`EntityStateSourcingListener`, `EdgeEventSourcingListener`, `EdqsListener`) are declared with `fallbackExecution = true` and `AbstractCachedEntityService.publishEvictEvent` already distinguishes both cases, and as a side effect these creates became atomic. Their **update** path is deliberately left as it was: `DashboardServiceImpl`, `EdgeServiceImpl` and `BaseAssetService` override `isUpdateTransactional()` to `false`, so an update still runs one transaction per DAO call. The switch is per service rather than per call site because it mirrors whether that service's entry points were annotated, and that was uniform within each class. `BaseAssetService` is in the diff for that override only — it already had no annotation and already used `saveAndFlush`.

Propagation stays `REQUIRED`, so a save called from an outer transaction joins it and the guarantee degrades to the current behaviour. The lock is JVM-local, so the limit remains best-effort in a cluster; a cluster-wide guarantee needs a DB-level mechanism and is out of scope.

### Known limitation

The lock serializes the limit check only while the count comes from Postgres. `validateNumberOfEntitiesPerTenant` → `DefaultApiLimitService.checkEntitiesLimit` → `BaseEntityService.countEntitiesByQuery`, and with `queue.edqs.sync.enabled` and `queue.edqs.api.supported` both on, that count is answered by EDQS. EDQS is filled by `EdqsListener` after commit through `DefaultEdqsService.processEvent`, which submits to an executor and produces to a topic, so the next thread through the lock counts a replica that does not yet contain the new row and the limit is exceedable again — within a single node, which is exactly what this fix rules out for the Postgres path. Both properties are disabled by default, so the default configuration is unaffected. The DAO tests run without the EDQS API and do not cover this. Making the limit check correct under EDQS means either forcing it onto Postgres or making the sync synchronous, both out of scope here.

### Tests

`testDeviceLimitOnTenantProfileLevel` and `testAssetLimitOnTenantProfileLevel` no longer poll with Awaitility and then sleep — that form returned as soon as it saw 5 while most tasks were still running, so a 6th row committing after the sleep left the test green with the bug present. Both now wait for every submitted task, then assert the number of successful saves and the number of committed rows.

`testProvisionedDeviceIsDeletedWhenCredentialsUpdateFails` covers the provisioning path: a provision request carrying an access token that already belongs to another device fails with `ProvisionFailedException` and leaves no device behind. The test was confirmed to fail without the compensating delete.

`testProvisionedDeviceIsDeletedWhenCredentialsLookupFails` covers the rest of the credentials block: `findDeviceCredentialsByDeviceId` is stubbed to throw on its first call, and the device is again gone and the limit slot free. Before the `try` was widened this test failed with the raw `RuntimeException` escaping `saveDevice`, leaving the device committed.

Repeated runs on this branch, local Docker, JDK 25:

| Run | Result |
| --- | --- |
| `DeviceServiceTest` (36 tests) × 11 | 0 failures, no `expected: 5 but was: 6` |
| `AssetServiceTest` (23 tests) × 7 | 0 failures |
| `DashboardServiceTest`, `EdgeServiceTest`, `CustomerServiceTest`, `UserServiceTest`, `RuleChainServiceTest` | green |
| `DeviceServiceTest` (37 tests) and `AssetServiceTest` (23 tests) × 5, after the widened compensation | 0 failures |
| `DeviceCredentialsServiceTest`, `DeviceCredentialsCacheTest` | green |
| Time of both limit test methods | 0.11–0.18 s against the 30 s budget of `Futures...get(30, SECONDS)` |

The time scales with the value of the limit (5 successful creations), not with the number of submitted tasks: a rejected iteration is a transaction plus a cheap `COUNT` plus a rollback.

### Manual testing

Monolith built from this branch, fresh 4.3.1.5 schema with demo data, checks driven over the REST API. These checks were run before the update-path and provisioning changes; those two are covered by the automated tests above.

| Check | Result |
| --- | --- |
| `maxDevices = 10` with 9 devices: create the 10th, then the 11th | 10th → `200`. 11th → `403 {"message":"Devices limit reached","errorCode":41,"entityType":"DEVICE","limit":10}`. Count stays 10, the rejected device is not persisted |
| Asset, dashboard and edge: create → read back → rename → read back | All `200`; after rename the old name returns `404` and the new one is found, so cache invalidation is intact; the edge got its root rule chain |
| Two devices with the same access token | Second → `400 "Device credentials are already assigned to another device!"`, and no orphan device row is left — the device insert is still rolled back with credentials creation |
| Bulk CSV import against a limit: 11 devices, `maxDevices = 14`, 10 rows imported (rows are processed in parallel by `AbstractBulkImportService`) | `created: 3, errors: 7`, every error `Line N: EntitiesLimitExceededException: Devices limit reached`, final count exactly 14 |
| 30 simultaneous `POST /api/device` with 5 left before the limit | Exactly 5 × `200`, 25 × `403 "Devices limit reached"`, final count equals the limit |

Server log during the run contained only the expected `DataValidator` rejections — no `UnexpectedRollbackException`, deadlocks, serialization failures or lock timeouts.

