### PR TITLE
Fixed forced SSL on the JS executor Kafka connection when SASL is enabled

### DIFF
--- a/msa/js-executor/config/custom-environment-variables.yml
+++ b/msa/js-executor/config/custom-environment-variables.yml
@@ -52,6 +52,8 @@ kafka:
   confluent:
     sasl:
       mechanism: "TB_QUEUE_KAFKA_CONFLUENT_SASL_MECHANISM"
+    security:
+      protocol: "TB_QUEUE_KAFKA_CONFLUENT_SECURITY_PROTOCOL"
     username: "TB_QUEUE_KAFKA_CONFLUENT_USERNAME"
     password: "TB_QUEUE_KAFKA_CONFLUENT_PASSWORD"
 

--- a/msa/js-executor/config/default.yml
+++ b/msa/js-executor/config/default.yml
@@ -42,13 +42,15 @@ kafka:
   connectionTimeout: "1000" # Time in milliseconds to wait when establishing a connection to a Kafka broker
   compression: "none" # Message compression codec for the producer: gzip, lz4 or none
   topic_properties: "retention.ms:604800000;segment.bytes:52428800;retention.bytes:104857600;partitions:100;min.insync.replicas:1" # Semicolon-separated Kafka topic configuration properties applied on topic creation
-  use_confluent_cloud: false # Set to true to enable Confluent Cloud-specific configuration (SSL + SASL)
+  use_confluent_cloud: "false" # Set to true to enable SASL authentication (Confluent Cloud or any SASL-enabled broker); SSL is derived from confluent.security.protocol
   client_id: "kafkajs" # Kafka client identifier; inject the pod name to easily identify the client via kafka-consumer-groups.sh
   ssl:
-    enabled: false # Enable SSL/TLS for Kafka broker connections
+    enabled: "false" # Enable SSL/TLS for Kafka broker connections
   confluent:
     sasl:
       mechanism: "PLAIN" # SASL mechanism for Confluent Cloud authentication: PLAIN, SCRAM-SHA-256, or SCRAM-SHA-512
+    security:
+      protocol: "SASL_SSL" # Protocol used to communicate with brokers, applied only when use_confluent_cloud is true. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL
 
 # Logging configuration
 # Controls log verbosity, output directory, and log file naming pattern for the JS executor service.

--- a/msa/js-executor/package.json
+++ b/msa/js-executor/package.json
@@ -7,7 +7,7 @@
   "bin": "server.js",
   "scripts": {
     "pkg": "tsc && pkg -t node22-linux-x64 --output ./target/thingsboard-js-executor-linux ./target/src && pkg -t node22-win-x64 --no-bytecode --public-packages \"*\" --public --output ./target/thingsboard-js-executor-win.exe ./target/src && node install.js",
-    "test": "mkdir -p target/surefire-reports && node --require ts-node/register --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=target/surefire-reports/TEST-js-executor.xml test/jsExecutor.test.ts",
+    "test": "mkdir -p target/surefire-reports && node --require ts-node/register --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=target/surefire-reports/TEST-js-executor.xml test/*.test.ts",
     "start": "nodemon --watch '.' --ext 'ts' --exec 'ts-node server.ts'",
     "start-prod": "nodemon --watch '.' --ext 'ts' --exec 'NODE_ENV=production ts-node server.ts'",
     "build": "tsc"

--- a/msa/js-executor/queue/kafkaTemplate.ts
+++ b/msa/js-executor/queue/kafkaTemplate.ts
@@ -72,6 +72,34 @@ export class KafkaTemplate implements IQueue {
                 return CompressionTypes.None;
         }
     }
+    // node-config returns environment overrides as raw strings, so a plain Boolean()
+    // would treat "false" as true.
+    private isTrue(value: any): boolean {
+        return String(value).trim().toLowerCase() === 'true';
+    }
+
+    private resolveSslEnabled(configuredSsl: boolean, useSasl: boolean, securityProtocol: any): boolean {
+        if (configuredSsl) {
+            return true;
+        }
+        if (!useSasl) {
+            return false;
+        }
+        switch (String(securityProtocol).trim().toUpperCase()) {
+            case 'SSL':
+            case 'SASL_SSL':
+                return true;
+            case 'PLAINTEXT':
+            case 'SASL_PLAINTEXT':
+                return false;
+            default:
+                // Keep TLS on: an unrecognized value must not silently send SASL
+                // credentials over an unencrypted connection.
+                this.logger.warn('Unknown kafka.confluent.security.protocol value "%s"; keeping SSL enabled. Supported values: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.', securityProtocol);
+                return true;
+        }
+    }
+
     private partitionsConsumedConcurrently = Number(config.get('kafka.partitions_consumed_concurrently'));
 
     private kafkaClient: Kafka;
@@ -91,8 +119,11 @@ export class KafkaTemplate implements IQueue {
         const kafkaBootstrapServers: string = config.get('kafka.bootstrap.servers');
         const queuePrefix: string = config.get('queue_prefix');
         const requestTopic: string = queuePrefix ? queuePrefix + "." + config.get('request_topic') : config.get('request_topic');
-        const useConfluent = config.get('kafka.use_confluent_cloud');
-        const enabledSsl = Boolean(config.get('kafka.ssl.enabled'));
+        const useConfluent = this.isTrue(config.get('kafka.use_confluent_cloud'));
+        const configuredSsl = this.isTrue(config.get('kafka.ssl.enabled'));
+        const securityProtocol = config.has('kafka.confluent.security.protocol')
+            ? config.get('kafka.confluent.security.protocol') : 'SASL_SSL';
+        const enabledSsl = this.resolveSslEnabled(configuredSsl, useConfluent, securityProtocol);
         const groupId:string =  queuePrefix ? queuePrefix + ".js-executor-group" : "js-executor-group";
         this.logger.info('Kafka Bootstrap Servers: %s', kafkaBootstrapServers);
         this.logger.info('Kafka Requests Topic: %s', requestTopic);
@@ -119,8 +150,10 @@ export class KafkaTemplate implements IQueue {
                 username: config.get('kafka.confluent.username'),
                 password: config.get('kafka.confluent.password')
             };
-            kafkaConfig['ssl'] = true;
+            this.logger.info('Kafka SASL security protocol: %s', securityProtocol);
         }
+
+        this.logger.info('Kafka SSL enabled: %s, SASL enabled: %s', enabledSsl, useConfluent);
 
         if (enabledSsl) {
             const certFilePath: string = config.has('kafka.ssl.cert_file') ? config.get('kafka.ssl.cert_file') : '';

--- a/msa/js-executor/test/kafkaTemplate.test.ts
+++ b/msa/js-executor/test/kafkaTemplate.test.ts
@@ -1,0 +1,74 @@
+///
+/// Copyright © 2016-2026 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { KafkaTemplate } from '../queue/kafkaTemplate';
+
+// Same suite name as jsExecutor.test.ts so every case lands under
+// <testsuite name="js-executor"> in the JUnit XML.
+describe('js-executor', () => {
+
+const template = new KafkaTemplate();
+const resolveSsl = (configuredSsl: boolean, useSasl: boolean, protocol?: any): boolean =>
+    (template as any).resolveSslEnabled(configuredSsl, useSasl, protocol);
+const isTrue = (value: any): boolean => (template as any).isTrue(value);
+
+test('kafka ssl.enabled is parsed as a string, not by truthiness', () => {
+    // node-config hands back environment overrides as strings; Boolean("false") is true
+    assert.equal(isTrue('false'), false, '"false" must not enable SSL');
+    assert.equal(isTrue(false), false);
+    assert.equal(isTrue('true'), true);
+    assert.equal(isTrue(true), true);
+    assert.equal(isTrue('TRUE'), true, 'value must be case-insensitive, like the tb-node flags');
+    assert.equal(isTrue(' true '), true);
+    assert.equal(isTrue('yes'), false);
+    assert.equal(isTrue(undefined), false);
+});
+
+test('kafka ssl is enabled for the SSL security protocols', () => {
+    assert.equal(resolveSsl(false, true, 'SASL_SSL'), true);
+    assert.equal(resolveSsl(false, true, 'SSL'), true);
+    assert.equal(resolveSsl(false, true, 'sasl_ssl'), true, 'protocol must be case-insensitive');
+});
+
+test('kafka ssl stays off for the plaintext security protocols', () => {
+    assert.equal(resolveSsl(false, true, 'SASL_PLAINTEXT'), false);
+    assert.equal(resolveSsl(false, true, 'PLAINTEXT'), false);
+    assert.equal(resolveSsl(false, true, ' sasl_plaintext '), false);
+});
+
+test('kafka ssl.enabled overrides the security protocol', () => {
+    assert.equal(resolveSsl(true, true, 'SASL_PLAINTEXT'), true,
+        'an explicit ssl.enabled=true must win, as it does in tb-node');
+    assert.equal(resolveSsl(true, false, 'PLAINTEXT'), true);
+});
+
+test('kafka security protocol is ignored when SASL is off', () => {
+    assert.equal(resolveSsl(false, false, 'SASL_SSL'), false,
+        'the protocol only applies when use_confluent_cloud is true');
+});
+
+test('kafka ssl stays on for an unusable security protocol', () => {
+    // Failing open would put SASL credentials on an unencrypted connection
+    assert.equal(resolveSsl(false, true, 'SSL_SASL'), true, 'a typo must not disable TLS');
+    assert.equal(resolveSsl(false, true, ''), true);
+    assert.equal(resolveSsl(false, true, null), true, 'a blank key in a preserved default.yml');
+    assert.equal(resolveSsl(false, true, undefined), true);
+    assert.equal(resolveSsl(false, true, 1), true, 'a non-string value must not throw');
+});
+
+});


### PR DESCRIPTION
tb-js-executor forced TLS on the Kafka connection whenever SASL was enabled, so brokers on non-SSL channels (`SASL_PLAINTEXT`, `PLAINTEXT`) were unreachable:

```
Connection error: Client network socket disconnected before secure TLS connection
was established
    at TLSSocket.onConnectEnd (node:_tls_wrap:1732:19)
```

Two causes:

**1. SSL was derived from nothing.** Enabling SASL set `ssl = true` unconditionally, without looking at the security protocol. While tb-node evaluates `security.protocol` (`PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, `SASL_SSL`), js-executor had no such option at all.

**2. Boolean flags were parsed by truthiness.** `node-config` returns environment overrides as strings, and `Boolean("false")` is `true`. Setting `TB_KAFKA_SSL_ENABLED=false` therefore *enabled* SSL. `kafka.use_confluent_cloud` had the same defect.

## Changes

- Added `kafka.confluent.security.protocol`, using the same `TB_QUEUE_KAFKA_CONFLUENT_SECURITY_PROTOCOL` variable and `SASL_SSL` default that tb-node already uses, so the two services are configured alike. SSL is now derived from it instead of being forced.
- Moved the decision into `resolveSslEnabled(configuredSsl, useSasl, securityProtocol)`, in the style of the existing `resolveCompressionType`. It matches the four supported protocols; anything else keeps SSL enabled and logs a warning naming the valid values, so a mistyped or blank protocol cannot put SASL credentials on an unencrypted connection. An explicit `kafka.ssl.enabled=true` still wins over the protocol, matching tb-node, where `TbKafkaSettings.configureSSL()` overwrites `security.protocol` with `"SSL"`.
- Read the protocol through a `config.has` guard. `default.yml` ships as a dpkg/rpm conffile (`packaging/js/build.gradle`), so a preserved copy from an older release has no such key and an unguarded `config.get` throws on startup. The `SASL_SSL` fallback keeps the previous behaviour on those installs.
- Parse `kafka.ssl.enabled` and `kafka.use_confluent_cloud` through a single `isTrue` helper, and quote both defaults to match the rest of `default.yml`. The helper accepts the values tb-node accepts: both variables are shared with it, and Spring binds them through `StringToBooleanConverter`, which reads `true`, `on`, `yes` and `1` as true.
- Log the resulting SSL and SASL decision, which until now was only observable as a TLS handshake failure.

Confluent Cloud is unaffected: `docker/queue-confluent.env` already sets `SASL_SSL`, which still resolves to SSL enabled.

## Testing

`test/kafkaTemplate.test.ts` covers the derivation without a broker — string parsing (`"false"` is not truthy, `TRUE` and stray whitespace are accepted, and the tb-node value set is honoured), the SSL protocols enabling TLS, the plaintext protocols leaving it off, `ssl.enabled` overriding the protocol, the protocol being ignored when SASL is off, and unusable values keeping TLS on. `npm test` now runs `test/*.test.ts`; 11 tests pass.

End to end, `KafkaTemplate.init()` against a local KRaft broker on `PLAINTEXT://localhost:9092` (`bitnamilegacy/kafka:4.0`, listeners matching `docker/kafka.env`):

| Case | Before | After |
|---|---|---|
| nothing set | connects | connects |
| `TB_KAFKA_SSL_ENABLED=false` | **TLS handshake error** | connects |
| `TB_KAFKA_SSL_ENABLED=true` | SSL on | SSL on |
| `USE_CONFLUENT_CLOUD=true`, protocol `SASL_SSL` | SSL on | SSL on |
| `USE_CONFLUENT_CLOUD=true`, protocol `SASL_PLAINTEXT` | **TLS handshake error** | plaintext connection, SASL handshake attempted |
| `USE_CONFLUENT_CLOUD=true`, protocol `SSL_SASL` (typo) | SSL on | warning logged, SSL kept on |
| `default.yml` without the new key, `USE_CONFLUENT_CLOUD=true` | n/a | starts, falls back to `SASL_SSL` |

On the last row, the same run with an unguarded `config.get` fails with `Configuration property "kafka.confluent.security.protocol" is not defined`.

### Live SASL brokers

`KafkaTemplate.init()` against a KRaft broker with a `SASL_PLAINTEXT` listener (PLAIN, `bitnamilegacy/kafka:4.0`):

| Case | Result |
|---|---|
| protocol `SASL_PLAINTEXT`, correct credentials | `SSL enabled: false, SASL enabled: true`; connects, `js_eval.requests` created |
| same, wrong password | `SASL PLAIN authentication failed: Invalid username or password` |
| same, `TB_KAFKA_SSL_ENABLED=true` | `Client network socket disconnected before secure TLS connection was established` |

The wrong-password run is what shows the SASL handshake is reached rather than skipped. The third row reproduces the reported error on that same broker, now only when SSL is asked for explicitly.

Against a second broker with a `SASL_SSL` listener (self-signed CA, SAN `localhost`):

| Case | Result |
|---|---|
| protocol `SASL_SSL` | `SSL enabled: true, SASL enabled: true`; connects |
| protocol not set at all | `SSL enabled: true, SASL enabled: true`; connects |
| protocol `SASL_PLAINTEXT` | SSL off, connection closed by the broker |
| CA file not supplied | `unable to verify the first certificate` |

The second row is the one that matters for existing Confluent Cloud installs: they never set a protocol, because the option did not exist, and the `SASL_SSL` default keeps TLS on for them. The last row only reflects the self-signed CA used here — Confluent's certificate chains to a public CA in Node's default store, so no CA file is needed in production.

### Boolean values

`TB_KAFKA_SSL_ENABLED` and `TB_QUEUE_KAFKA_USE_CONFLUENT_CLOUD` resolved on this branch and on its base:

| Value | tb-node | Before | After |
|---|---|---|---|
| `true`, `TRUE` | true | on | on |
| `on`, `yes`, `1` | true | on | on |
| `false`, `0`, `no`, `off` | false | **on** | off |
| unrecognized | startup failure | on | off |

Only the third row changes for a deployment that works today, and it changes towards tb-node. The values in rows one and two keep their meaning, so no working install loses SSL or SASL on upgrade.

### Preserved conffiles

`default.yml` and `custom-environment-variables.yml` are both `configurationFile()` entries in `packaging/js/build.gradle`, so an upgrade can preserve either one. New code, `USE_CONFLUENT_CLOUD=true`, protocol `SASL_PLAINTEXT`:

| Config files after the upgrade | Result |
|---|---|
| both new | SSL off, SASL on — the fix applies |
| both preserved | SSL on — previous behaviour, no startup failure |
| new `default.yml`, preserved `custom-environment-variables.yml` | SSL on — the fix silently does not apply |
| preserved `default.yml`, new `custom-environment-variables.yml` | SSL off, SASL on — the fix applies |

`custom-environment-variables.yml` is the file that decides: without its new line the variable maps nowhere. Repeating the second row with the `config.has` guard removed fails with `Configuration property "kafka.confluent.security.protocol" is not defined`.

The same two upgrades as a real package install: `tb-js-executor.deb` built from this branch and from its base, installed in turn in a Debian 12 container. `DEBIAN/conffiles` in the built package lists both YAML files, and dpkg acts on that:

| Upgrade | dpkg |
|---|---|
| configs untouched | `Installing new version of config file` for both — the new keys land and the fix applies |
| configs edited locally | `The default action is to keep your current version` — the edits survive, the new keys are absent, and `default.yml.dpkg-new` / `custom-environment-variables.yml.dpkg-new` are written alongside |

The second row is the "both preserved" row above, reached through dpkg rather than through `NODE_CONFIG_DIR`.

### Rule chain execution

A monolith against the `SASL_PLAINTEXT` broker above with `JS_EVALUATOR=remote`, and a `script` node — JavaScript, not the default TBEL — branched off `Message Type Switch` on `Post telemetry`:

| Step | Result |
|---|---|
| saving the rule chain | `Processing compile request` → `Sending success compile response` |
| posting telemetry | `Processing invoke request` → `Sending success invoke response`; the node's `OUT` event carries the field the script adds, and the reading is stored |
| js-executor stopped, telemetry posted again | the node fails with `java.util.concurrent.TimeoutException: Script timeout!` |
| js-executor restarted, telemetry posted again | `NOT_FOUND` on the first invoke — the script cache is empty after a restart — then success once tb-node resends the body |

The third row is what rules out the script having been evaluated inside tb-node: without a reachable js-executor there is no execution at all.

Not covered: starting the service from the installed package. The packaged binary targets `amd64` and exits with Node's internal evaluation failure under x86_64 emulation on an arm64 host — so does the binary built from the base commit, so it is the emulation rather than this change — and confirming it needs a real amd64 machine. The startup path itself is covered above through `NODE_CONFIG_DIR`. Also not covered: Confluent Cloud itself, which the `SASL_SSL` broker above stands in for.



