### PR TITLE
Fixed unauthorized access to attributes and time series of other tenants

### DIFF
--- a/application/src/main/java/org/thingsboard/server/service/security/AccessValidator.java
+++ b/application/src/main/java/org/thingsboard/server/service/security/AccessValidator.java
@@ -276,6 +276,7 @@ public class AccessValidator {
                     accessControlService.checkPermission(currentUser, Resource.DEVICE_PROFILE, operation, entityId, deviceProfile);
                 } catch (ThingsboardException e) {
                     callback.onSuccess(ValidationResult.accessDenied(e.getMessage()));
+                    return;
                 }
                 callback.onSuccess(ValidationResult.ok(deviceProfile));
             }
@@ -294,6 +295,7 @@ public class AccessValidator {
                     accessControlService.checkPermission(currentUser, Resource.ASSET_PROFILE, operation, entityId, assetProfile);
                 } catch (ThingsboardException e) {
                     callback.onSuccess(ValidationResult.accessDenied(e.getMessage()));
+                    return;
                 }
                 callback.onSuccess(ValidationResult.ok(assetProfile));
             }
@@ -306,6 +308,7 @@ public class AccessValidator {
         } else {
             if (!operation.equals(Operation.READ_TELEMETRY)) {
                 callback.onSuccess(ValidationResult.accessDenied("Allowed only READ_TELEMETRY operation!"));
+                return;
             }
             ApiUsageState apiUsageState = apiUsageStateService.findApiUsageStateById(currentUser.getTenantId(), new ApiUsageStateId(entityId.getId()));
             if (apiUsageState == null) {
@@ -315,6 +318,7 @@ public class AccessValidator {
                     accessControlService.checkPermission(currentUser, Resource.API_USAGE_STATE, operation, entityId, apiUsageState);
                 } catch (ThingsboardException e) {
                     callback.onSuccess(ValidationResult.accessDenied(e.getMessage()));
+                    return;
                 }
                 callback.onSuccess(ValidationResult.ok(apiUsageState));
             }
@@ -333,6 +337,7 @@ public class AccessValidator {
                     accessControlService.checkPermission(currentUser, Resource.OTA_PACKAGE, operation, entityId, otaPackage);
                 } catch (ThingsboardException e) {
                     callback.onSuccess(ValidationResult.accessDenied(e.getMessage()));
+                    return;
                 }
                 callback.onSuccess(ValidationResult.ok(otaPackage));
             }

--- a/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbEntityDataSubscriptionService.java
+++ b/application/src/main/java/org/thingsboard/server/service/subscription/DefaultTbEntityDataSubscriptionService.java
@@ -472,18 +472,17 @@ public class DefaultTbEntityDataSubscriptionService implements TbEntityDataSubsc
     @Override
     public void handleCmd(WebSocketSessionRef session, AlarmStatusCmd cmd) {
         log.debug("[{}] Handling alarm status subscription cmd (cmdId: {})", session.getSessionId(), cmd.getCmdId());
-        TbAlarmStatusSubCtx ctx = getSubCtx(session.getSessionId(), cmd.getCmdId());
+        TbAlarmStatusSubCtx ctx = createSubCtx(session, cmd);
         if (ctx == null) {
-            ctx = createSubCtx(session, cmd);
-            long start = System.currentTimeMillis();
-            ctx.fetchActiveAlarms();
-            long end = System.currentTimeMillis();
-            stats.getAlarmQueryInvocationCnt().incrementAndGet();
-            stats.getAlarmQueryTimeSpent().addAndGet(end - start);
-            ctx.sendUpdate();
-        } else {
             log.debug("[{}][{}] Received duplicate command: {}", session.getSessionId(), cmd.getCmdId(), cmd);
+            return;
         }
+        long start = System.currentTimeMillis();
+        ctx.fetchActiveAlarms();
+        long end = System.currentTimeMillis();
+        stats.getAlarmQueryInvocationCnt().incrementAndGet();
+        stats.getAlarmQueryTimeSpent().addAndGet(end - start);
+        ctx.sendUpdate();
     }
 
     private boolean validate(TbAbstractSubCtx finalCtx) {
@@ -592,10 +591,16 @@ public class DefaultTbEntityDataSubscriptionService implements TbEntityDataSubsc
 
     private TbAlarmStatusSubCtx createSubCtx(WebSocketSessionRef sessionRef, AlarmStatusCmd cmd) {
         Map<Integer, TbAbstractSubCtx> sessionSubs = subscriptionsBySessionId.computeIfAbsent(sessionRef.getSessionId(), k -> new ConcurrentHashMap<>());
+        if (sessionSubs.containsKey(cmd.getCmdId())) {
+            return null;
+        }
         TbAlarmStatusSubCtx ctx = new TbAlarmStatusSubCtx(serviceId, wsService, localSubscriptionService,
                 stats, alarmService, alarmsPerAlarmStatusSubscriptionCacheSize, sessionRef, cmd.getCmdId());
         ctx.createSubscription(cmd);
-        sessionSubs.put(cmd.getCmdId(), ctx);
+        if (sessionSubs.putIfAbsent(cmd.getCmdId(), ctx) != null) {
+            ctx.stop();
+            return null;
+        }
         return ctx;
     }
 

--- a/application/src/main/java/org/thingsboard/server/service/telemetry/DefaultTbTelemetryService.java
+++ b/application/src/main/java/org/thingsboard/server/service/telemetry/DefaultTbTelemetryService.java
@@ -32,7 +32,9 @@ import org.thingsboard.server.common.data.kv.ReadTsKvQuery;
 import org.thingsboard.server.common.data.kv.TsKvEntry;
 import org.thingsboard.server.dao.timeseries.TimeseriesService;
 import org.thingsboard.server.service.security.AccessValidator;
+import org.thingsboard.server.service.security.ValidationCallback;
 import org.thingsboard.server.service.security.ValidationResult;
+import org.thingsboard.server.service.security.ValidationResultCode;
 import org.thingsboard.server.service.security.model.SecurityUser;
 import org.thingsboard.server.service.security.permission.Operation;
 
@@ -55,6 +57,10 @@ public class DefaultTbTelemetryService implements TbTelemetryService {
         accessValidator.validate(currentUser, Operation.READ_TELEMETRY, entityId, new FutureCallback<>() {
             @Override
             public void onSuccess(ValidationResult validationResult) {
+                if (validationResult.getResultCode() != ValidationResultCode.OK) {
+                    onFailure(ValidationCallback.getException(validationResult));
+                    return;
+                }
                 try {
                     AggregationParams params;
                     if (Aggregation.NONE.equals(agg)) {

--- a/application/src/main/java/org/thingsboard/server/service/ws/DefaultWebSocketService.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/DefaultWebSocketService.java
@@ -53,6 +53,8 @@ import org.thingsboard.server.common.msg.tools.TbRateLimitsException;
 import org.thingsboard.server.dao.attributes.AttributesService;
 import org.thingsboard.server.dao.tenant.TbTenantProfileCache;
 import org.thingsboard.server.dao.timeseries.TimeseriesService;
+import org.thingsboard.server.exception.AccessDeniedException;
+import org.thingsboard.server.exception.EntityNotFoundException;
 import org.thingsboard.server.exception.UnauthorizedException;
 import org.thingsboard.server.queue.discovery.TbServiceInfoProvider;
 import org.thingsboard.server.queue.util.TbCoreComponent;
@@ -77,6 +79,7 @@ import org.thingsboard.server.service.ws.telemetry.cmd.v1.TimeseriesSubscription
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.AlarmCountCmd;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.AlarmDataCmd;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.AlarmStatusCmd;
+import org.thingsboard.server.service.ws.telemetry.cmd.v2.AlarmStatusUpdate;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.CmdUpdate;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.EntityCountCmd;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.EntityDataCmd;
@@ -266,8 +269,31 @@ public class DefaultWebSocketService implements WebSocketService {
     }
 
     private void handleWsAlarmsStatusCmd(WebSocketSessionRef sessionRef, AlarmStatusCmd cmd) {
-        if (validateCmd(sessionRef, cmd)) {
-            entityDataSubService.handleCmd(sessionRef, cmd);
+        if (!validateCmd(sessionRef, cmd, () -> {
+            if (cmd.getOriginatorId() == null) {
+                throw new IllegalArgumentException("Originator id is empty!");
+            }
+        })) return;
+
+        try {
+            accessValidator.validate(sessionRef.getSecurityCtx(), Operation.READ, cmd.getOriginatorId(),
+                    on(r -> executor.submit(() -> {
+                                if (!msgEndpoint.isOpen(sessionRef.getSessionId())) {
+                                    return;
+                                }
+                                try {
+                                    entityDataSubService.handleCmd(sessionRef, cmd);
+                                } catch (TbRateLimitsException e) {
+                                    log.debug("{} Failed to handle WS cmd: {}", sessionRef, cmd, e);
+                                } catch (Exception e) {
+                                    sendError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.INTERNAL_ERROR, e.getMessage());
+                                    log.error("{} Failed to handle WS cmd: {}", sessionRef, cmd, e);
+                                }
+                            }),
+                            t -> sendAlarmStatusError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.UNAUTHORIZED, t.getMessage())));
+        } catch (IllegalStateException e) {
+            sendAlarmStatusError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.BAD_REQUEST,
+                    "Unsupported originator type: " + cmd.getOriginatorId().getEntityType());
         }
     }
 
@@ -492,7 +518,7 @@ public class DefaultWebSocketService implements WebSocketService {
 
             @Override
             public void onFailure(Throwable e) {
-                log.error(FAILED_TO_FETCH_ATTRIBUTES, e);
+                logAttributesFetchFailure(e);
                 TelemetrySubscriptionUpdate update;
                 if (e instanceof UnauthorizedException) {
                     update = new TelemetrySubscriptionUpdate(cmd.getCmdId(), SubscriptionErrorCode.UNAUTHORIZED,
@@ -604,7 +630,7 @@ public class DefaultWebSocketService implements WebSocketService {
 
             @Override
             public void onFailure(Throwable e) {
-                log.error(FAILED_TO_FETCH_ATTRIBUTES, e);
+                logAttributesFetchFailure(e);
                 sendError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.INTERNAL_ERROR, FAILED_TO_FETCH_ATTRIBUTES);
             }
         };
@@ -895,72 +921,50 @@ public class DefaultWebSocketService implements WebSocketService {
                 }, executor);
     }
 
-    private <T> FutureCallback<ValidationResult> getAttributesFetchCallback(final TenantId tenantId, final EntityId entityId, final List<String> keys, final FutureCallback<List<AttributeKvEntry>> callback) {
-        return new FutureCallback<ValidationResult>() {
-            @Override
-            public void onSuccess(@Nullable ValidationResult result) {
-                List<ListenableFuture<List<AttributeKvEntry>>> futures = new ArrayList<>();
-                for (AttributeScope scope : AttributeScope.values()) {
-                    futures.add(attributesService.find(tenantId, entityId, scope, keys));
-                }
-
-                ListenableFuture<List<AttributeKvEntry>> future = mergeAllAttributesFutures(futures);
-                Futures.addCallback(future, callback, MoreExecutors.directExecutor());
+    private FutureCallback<ValidationResult> getAttributesFetchCallback(final TenantId tenantId, final EntityId entityId, final List<String> keys, final FutureCallback<List<AttributeKvEntry>> callback) {
+        return on(r -> {
+            List<ListenableFuture<List<AttributeKvEntry>>> futures = new ArrayList<>();
+            for (AttributeScope scope : AttributeScope.values()) {
+                futures.add(attributesService.find(tenantId, entityId, scope, keys));
             }
 
-            @Override
-            public void onFailure(Throwable t) {
-                callback.onFailure(t);
-            }
-        };
+            ListenableFuture<List<AttributeKvEntry>> future = mergeAllAttributesFutures(futures);
+            Futures.addCallback(future, callback, MoreExecutors.directExecutor());
+        }, callback::onFailure);
     }
 
-    private <T> FutureCallback<ValidationResult> getAttributesFetchCallback(final TenantId tenantId, final EntityId entityId, final String scope, final List<String> keys, final FutureCallback<List<AttributeKvEntry>> callback) {
-        return new FutureCallback<ValidationResult>() {
-            @Override
-            public void onSuccess(@Nullable ValidationResult result) {
-                Futures.addCallback(attributesService.find(tenantId, entityId, AttributeScope.valueOf(scope), keys), callback, MoreExecutors.directExecutor());
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                callback.onFailure(t);
-            }
-        };
+    private FutureCallback<ValidationResult> getAttributesFetchCallback(final TenantId tenantId, final EntityId entityId, final String scope, final List<String> keys, final FutureCallback<List<AttributeKvEntry>> callback) {
+        return on(r -> Futures.addCallback(attributesService.find(tenantId, entityId, AttributeScope.valueOf(scope), keys), callback, MoreExecutors.directExecutor()),
+                callback::onFailure);
     }
 
-    private <T> FutureCallback<ValidationResult> getAttributesFetchCallback(final TenantId tenantId, final EntityId entityId, final FutureCallback<List<AttributeKvEntry>> callback) {
-        return new FutureCallback<ValidationResult>() {
-            @Override
-            public void onSuccess(@Nullable ValidationResult result) {
-                List<ListenableFuture<List<AttributeKvEntry>>> futures = new ArrayList<>();
-                for (AttributeScope scope : AttributeScope.values()) {
-                    futures.add(attributesService.findAll(tenantId, entityId, scope));
-                }
-
-                ListenableFuture<List<AttributeKvEntry>> future = mergeAllAttributesFutures(futures);
-                Futures.addCallback(future, callback, MoreExecutors.directExecutor());
+    private FutureCallback<ValidationResult> getAttributesFetchCallback(final TenantId tenantId, final EntityId entityId, final FutureCallback<List<AttributeKvEntry>> callback) {
+        return on(r -> {
+            List<ListenableFuture<List<AttributeKvEntry>>> futures = new ArrayList<>();
+            for (AttributeScope scope : AttributeScope.values()) {
+                futures.add(attributesService.findAll(tenantId, entityId, scope));
             }
 
-            @Override
-            public void onFailure(Throwable t) {
-                callback.onFailure(t);
-            }
-        };
+            ListenableFuture<List<AttributeKvEntry>> future = mergeAllAttributesFutures(futures);
+            Futures.addCallback(future, callback, MoreExecutors.directExecutor());
+        }, callback::onFailure);
     }
 
-    private <T> FutureCallback<ValidationResult> getAttributesFetchCallback(final TenantId tenantId, final EntityId entityId, final String scope, final FutureCallback<List<AttributeKvEntry>> callback) {
-        return new FutureCallback<ValidationResult>() {
-            @Override
-            public void onSuccess(@Nullable ValidationResult result) {
-                Futures.addCallback(attributesService.findAll(tenantId, entityId, AttributeScope.valueOf(scope)), callback, MoreExecutors.directExecutor());
-            }
+    private FutureCallback<ValidationResult> getAttributesFetchCallback(final TenantId tenantId, final EntityId entityId, final String scope, final FutureCallback<List<AttributeKvEntry>> callback) {
+        return on(r -> Futures.addCallback(attributesService.findAll(tenantId, entityId, AttributeScope.valueOf(scope)), callback, MoreExecutors.directExecutor()),
+                callback::onFailure);
+    }
 
-            @Override
-            public void onFailure(Throwable t) {
-                callback.onFailure(t);
-            }
-        };
+    private void sendAlarmStatusError(WebSocketSessionRef sessionRef, int cmdId, SubscriptionErrorCode errorCode, String errorMsg) {
+        sendUpdate(sessionRef.getSessionId(), new AlarmStatusUpdate(cmdId, errorCode.getCode(), errorMsg));
+    }
+
+    private void logAttributesFetchFailure(Throwable e) {
+        if (e instanceof AccessDeniedException || e instanceof EntityNotFoundException || e instanceof UnauthorizedException) {
+            log.debug(FAILED_TO_FETCH_ATTRIBUTES, e);
+        } else {
+            log.error(FAILED_TO_FETCH_ATTRIBUTES, e);
+        }
     }
 
     private FutureCallback<ValidationResult> on(Consumer<Void> success, Consumer<Throwable> failure) {

--- a/application/src/main/java/org/thingsboard/server/service/ws/DefaultWebSocketService.java
+++ b/application/src/main/java/org/thingsboard/server/service/ws/DefaultWebSocketService.java
@@ -231,11 +231,8 @@ public class DefaultWebSocketService implements WebSocketService {
             try {
                 Optional.ofNullable(cmdsHandlers.get(cmd.getType()))
                         .ifPresent(cmdHandler -> cmdHandler.handle(sessionRef, cmd));
-            } catch (TbRateLimitsException e) {
-                log.debug("{} Failed to handle WS cmd: {}", sessionRef, cmd, e);
             } catch (Exception e) {
-                sendError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.INTERNAL_ERROR, e.getMessage());
-                log.error("{} Failed to handle WS cmd: {}", sessionRef, cmd, e);
+                handleCmdFailure(sessionRef, cmd, e);
             }
         }
     }
@@ -275,6 +272,12 @@ public class DefaultWebSocketService implements WebSocketService {
             }
         })) return;
 
+        if (sessionRef.getSecurityCtx().isSystemAdmin()) {
+            sendAlarmStatusError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.UNAUTHORIZED,
+                    AccessValidator.SYSTEM_ADMINISTRATOR_IS_NOT_ALLOWED_TO_PERFORM_THIS_OPERATION);
+            return;
+        }
+
         try {
             accessValidator.validate(sessionRef.getSecurityCtx(), Operation.READ, cmd.getOriginatorId(),
                     on(r -> executor.submit(() -> {
@@ -283,11 +286,8 @@ public class DefaultWebSocketService implements WebSocketService {
                                 }
                                 try {
                                     entityDataSubService.handleCmd(sessionRef, cmd);
-                                } catch (TbRateLimitsException e) {
-                                    log.debug("{} Failed to handle WS cmd: {}", sessionRef, cmd, e);
                                 } catch (Exception e) {
-                                    sendError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.INTERNAL_ERROR, e.getMessage());
-                                    log.error("{} Failed to handle WS cmd: {}", sessionRef, cmd, e);
+                                    handleCmdFailure(sessionRef, cmd, e);
                                 }
                             }),
                             t -> sendAlarmStatusError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.UNAUTHORIZED, t.getMessage())));
@@ -520,7 +520,7 @@ public class DefaultWebSocketService implements WebSocketService {
             public void onFailure(Throwable e) {
                 logAttributesFetchFailure(e);
                 TelemetrySubscriptionUpdate update;
-                if (e instanceof UnauthorizedException) {
+                if (isValidationFailure(e)) {
                     update = new TelemetrySubscriptionUpdate(cmd.getCmdId(), SubscriptionErrorCode.UNAUTHORIZED,
                             SubscriptionErrorCode.UNAUTHORIZED.getDefaultMsg());
                 } else {
@@ -631,7 +631,12 @@ public class DefaultWebSocketService implements WebSocketService {
             @Override
             public void onFailure(Throwable e) {
                 logAttributesFetchFailure(e);
-                sendError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.INTERNAL_ERROR, FAILED_TO_FETCH_ATTRIBUTES);
+                if (isValidationFailure(e)) {
+                    sendError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.UNAUTHORIZED,
+                            SubscriptionErrorCode.UNAUTHORIZED.getDefaultMsg());
+                } else {
+                    sendError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.INTERNAL_ERROR, FAILED_TO_FETCH_ATTRIBUTES);
+                }
             }
         };
 
@@ -955,16 +960,33 @@ public class DefaultWebSocketService implements WebSocketService {
                 callback::onFailure);
     }
 
+    private void handleCmdFailure(WebSocketSessionRef sessionRef, WsCmd cmd, Exception e) {
+        if (e instanceof TbRateLimitsException) {
+            log.debug("{} Failed to handle WS cmd: {}", sessionRef, cmd, e);
+            return;
+        }
+        if (cmd instanceof AlarmStatusCmd) {
+            sendAlarmStatusError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.INTERNAL_ERROR, e.getMessage());
+        } else {
+            sendError(sessionRef, cmd.getCmdId(), SubscriptionErrorCode.INTERNAL_ERROR, e.getMessage());
+        }
+        log.error("{} Failed to handle WS cmd: {}", sessionRef, cmd, e);
+    }
+
     private void sendAlarmStatusError(WebSocketSessionRef sessionRef, int cmdId, SubscriptionErrorCode errorCode, String errorMsg) {
         sendUpdate(sessionRef.getSessionId(), new AlarmStatusUpdate(cmdId, errorCode.getCode(), errorMsg));
     }
 
     private void logAttributesFetchFailure(Throwable e) {
-        if (e instanceof AccessDeniedException || e instanceof EntityNotFoundException || e instanceof UnauthorizedException) {
+        if (isValidationFailure(e)) {
             log.debug(FAILED_TO_FETCH_ATTRIBUTES, e);
         } else {
             log.error(FAILED_TO_FETCH_ATTRIBUTES, e);
         }
+    }
+
+    private static boolean isValidationFailure(Throwable e) {
+        return e instanceof AccessDeniedException || e instanceof EntityNotFoundException || e instanceof UnauthorizedException;
     }
 
     private FutureCallback<ValidationResult> on(Consumer<Void> success, Consumer<Throwable> failure) {

--- a/application/src/test/java/org/thingsboard/server/controller/TelemetryControllerTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/TelemetryControllerTest.java
@@ -15,12 +15,15 @@
  */
 package org.thingsboard.server.controller;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.thingsboard.server.common.data.Device;
+import org.thingsboard.server.common.data.DeviceProfile;
 import org.thingsboard.server.common.data.SaveDeviceWithCredentialsRequest;
 import org.thingsboard.server.common.data.kv.BasicTsKvEntry;
 import org.thingsboard.server.common.data.kv.LongDataEntry;
@@ -196,6 +199,36 @@ public class TelemetryControllerTest extends AbstractControllerTest {
         timeseries = doGetAsync("/api/plugins/telemetry/DEVICE/" + device.getId() + "/values/timeseries?keys=data&startTs={startTs}&endTs={endTs}", ObjectNode.class, startTs, endTs);
 
         Assert.assertTrue(timeseries.isEmpty());
+    }
+
+    @Test
+    public void testGetTimeseriesForEntityOfDifferentTenant() throws Exception {
+        loginTenantAdmin();
+        Device device = createDevice();
+        long ts = System.currentTimeMillis();
+        tsService.save(tenantId, device.getId(), new BasicTsKvEntry(ts, new LongDataEntry("t", 1L)));
+
+        loginDifferentTenant();
+        doGetAsync("/api/plugins/telemetry/DEVICE/" + device.getId().getId() +
+                "/values/timeseries?keys=t&startTs=0&endTs=" + (ts + 1000))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void testSaveAttributesForEntityOfDifferentTenant() throws Exception {
+        loginTenantAdmin();
+        DeviceProfile deviceProfile = doPost("/api/deviceProfile", createDeviceProfile("Test profile"), DeviceProfile.class);
+        String attributesUrl = "/api/plugins/telemetry/DEVICE_PROFILE/" + deviceProfile.getId().getId() + "/attributes/SERVER_SCOPE";
+
+        loginDifferentTenant();
+        doPostAsync(attributesUrl, "{\"leaked\": \"value\"}", String.class, status().isForbidden());
+
+        loginTenantAdmin();
+        String valuesUrl = "/api/plugins/telemetry/DEVICE_PROFILE/" + deviceProfile.getId().getId() + "/values/attributes/SERVER_SCOPE";
+        Awaitility.await("attributes are not saved")
+                .during(2, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS)
+                .until(() -> doGetAsync(valuesUrl, ArrayNode.class).isEmpty());
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/server/controller/WebsocketApiTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/WebsocketApiTest.java
@@ -73,6 +73,7 @@ import org.thingsboard.server.service.ws.telemetry.cmd.v2.AlarmCountCmd;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.AlarmCountUpdate;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.AlarmStatusCmd;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.AlarmStatusUpdate;
+import org.thingsboard.server.service.ws.telemetry.cmd.v2.CmdUpdateType;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.EntityCountCmd;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.EntityCountUpdate;
 import org.thingsboard.server.service.ws.telemetry.cmd.v2.EntityDataUpdate;
@@ -977,6 +978,54 @@ public class WebsocketApiTest extends AbstractControllerTest {
         JsonNode update = JacksonUtil.toJsonNode(getWsClient().waitForUpdate());
         assertThat(update).as("waitForUpdate").isNotNull();
         assertThat(update.get("data").get("attr").get(0).get(1).asText()).isEqualTo(expectedAttrValue);
+    }
+
+    @Test
+    public void testAttributesSubscription_tenantAdmin() throws Exception {
+        JsonNode update = getWsClient().subscribeForAttributes(device.getId(), TbAttributeSubscriptionScope.SERVER_SCOPE.name(), List.of("attr"));
+        assertThat(update.get("errorMsg").isNull()).isTrue();
+        assertThat(update.get("errorCode").asInt()).isEqualTo(SubscriptionErrorCode.NO_ERROR.getCode());
+
+        getWsClient().registerWaitForUpdate();
+        String expectedAttrValue = "42";
+        sendAttributes(device, TbAttributeSubscriptionScope.SERVER_SCOPE, List.of(
+                new BaseAttributeKvEntry(System.currentTimeMillis(), new StringDataEntry("attr", expectedAttrValue))
+        ));
+
+        JsonNode attributesUpdate = JacksonUtil.toJsonNode(getWsClient().waitForUpdate());
+        assertThat(attributesUpdate).as("waitForUpdate").isNotNull();
+        assertThat(attributesUpdate.get("data").get("attr").get(0).get(1).asText()).isEqualTo(expectedAttrValue);
+    }
+
+    @Test
+    public void testAttributesSubscription_differentTenant() throws Exception {
+        sendAttributes(device, TbAttributeSubscriptionScope.SERVER_SCOPE, List.of(
+                new BaseAttributeKvEntry(System.currentTimeMillis(), new StringDataEntry("attr", "42"))
+        ));
+
+        loginDifferentTenant();
+
+        JsonNode update = getAnotherWsClient().subscribeForAttributes(device.getId(), TbAttributeSubscriptionScope.SERVER_SCOPE.name(), List.of("attr"));
+        assertThat(update.get("errorCode").asInt()).isNotEqualTo(SubscriptionErrorCode.NO_ERROR.getCode());
+        assertThat(update.get("data").isNull()).isTrue();
+    }
+
+    @Test
+    public void testAlarmStatusSubscription_differentTenant() throws Exception {
+        Alarm alarm = new Alarm();
+        alarm.setOriginator(device.getId());
+        alarm.setType("TEST ALARM");
+        alarm.setSeverity(AlarmSeverity.WARNING);
+        doPost("/api/alarm", alarm, Alarm.class);
+
+        loginDifferentTenant();
+
+        getAnotherWsClient().send(new AlarmStatusCmd(1, device.getId(), List.of("TEST ALARM"), List.of(AlarmSeverity.WARNING)));
+
+        JsonNode update = JacksonUtil.toJsonNode(getAnotherWsClient().waitForReply());
+        assertThat(update.get("errorCode").asInt()).isEqualTo(SubscriptionErrorCode.UNAUTHORIZED.getCode());
+        assertThat(update.get("cmdUpdateType").asText()).isEqualTo(CmdUpdateType.ALARM_STATUS.name());
+        assertThat(update.get("active").asBoolean()).isFalse();
     }
 
     @Test

--- a/application/src/test/java/org/thingsboard/server/controller/WebsocketApiTest.java
+++ b/application/src/test/java/org/thingsboard/server/controller/WebsocketApiTest.java
@@ -1006,7 +1006,7 @@ public class WebsocketApiTest extends AbstractControllerTest {
         loginDifferentTenant();
 
         JsonNode update = getAnotherWsClient().subscribeForAttributes(device.getId(), TbAttributeSubscriptionScope.SERVER_SCOPE.name(), List.of("attr"));
-        assertThat(update.get("errorCode").asInt()).isNotEqualTo(SubscriptionErrorCode.NO_ERROR.getCode());
+        assertThat(update.get("errorCode").asInt()).isEqualTo(SubscriptionErrorCode.UNAUTHORIZED.getCode());
         assertThat(update.get("data").isNull()).isTrue();
     }
 

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/AlarmRepository.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/AlarmRepository.java
@@ -402,11 +402,12 @@ public interface AlarmRepository extends JpaRepository<AlarmEntity, UUID> {
     int deleteTypeIfNoAlarmsExist(@Param("tenantId") UUID tenantId, @Param("types") Set<String> types);
 
     @Query(value = "SELECT a.id FROM alarm a " +
-            "WHERE a.originator_id = :originatorId " +
+            "WHERE a.tenant_id = :tenantId AND a.originator_id = :originatorId " +
             "AND (COALESCE(:alarmTypes) IS NULL OR a.type IN (:alarmTypes)) " +
             "AND (COALESCE(:alarmSeverities) IS NULL OR a.severity IN (:alarmSeverities)) " +
             "AND (a.cleared = false) ORDER BY id LIMIT :limit", nativeQuery = true)
-    List<UUID> findActiveOriginatorAlarms(@Param("originatorId") UUID originatorId,
+    List<UUID> findActiveOriginatorAlarms(@Param("tenantId") UUID tenantId,
+                                          @Param("originatorId") UUID originatorId,
                                           @Param("alarmTypes") List<String> alarmTypes,
                                           @Param("alarmSeverities") List<String> alarmSeverities,
                                           int limit);

--- a/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/JpaAlarmDao.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/sql/alarm/JpaAlarmDao.java
@@ -441,7 +441,7 @@ public class JpaAlarmDao extends JpaAbstractDao<AlarmEntity, Alarm> implements A
 
     @Override
     public List<UUID> findActiveOriginatorAlarms(TenantId tenantId, OriginatorAlarmFilter filter, int limit) {
-        return alarmRepository.findActiveOriginatorAlarms(filter.getOriginatorId().getId(),
+        return alarmRepository.findActiveOriginatorAlarms(tenantId.getId(), filter.getOriginatorId().getId(),
                 filter.getTypeList(), filter.getSeverityList() != null ? filter.getSeverityList().stream().map(Enum::name).toList() : null,
                 limit);
     }


### PR DESCRIPTION
`AccessValidator.validate` never calls `onFailure` for a denial — it reports the outcome by passing a non-OK `ValidationResult` to `onSuccess`. Four places did not inspect that result, so a denial was indistinguishable from a grant.

### Cross-tenant reads

- **`DefaultWebSocketService`** — all four `getAttributesFetchCallback` overloads fetched attributes in `onSuccess` without looking at the result, so `attrSubCmds` returned the attributes of any entity to any authenticated user who knew its id. They now delegate to the existing `on(success, failure)` helper, which is what the `tsSubCmds` and `historyCmds` paths already use.
- **`DefaultTbTelemetryService.getTimeseries`** — the same defect on `GET /api/plugins/telemetry/{entityType}/{entityId}/values/timeseries`, which returned another tenant's time series with HTTP 200. A non-OK result now completes the future exceptionally, so the existing `AccessValidator.handleError` mapping produces the correct 403/404. This was the last hand-rolled `FutureCallback<ValidationResult>` in the codebase; everything else goes through `ValidationCallback`, `HttpValidationCallback` or `on(...)`.

### Denied writes that still executed

- **`AccessValidator`** — `validateDeviceProfile`, `validateAssetProfile`, `validateApiUsageState` (two branches) and `validateOtaPackage` called `callback.onSuccess(accessDenied(...))` and then fell through to `callback.onSuccess(ok(entity))`. Over REST the second result is masked (`DeferredResult.setResult` ignores the second call, so the client still gets 403) but the action itself ran — a cross-tenant attribute write on those entity types succeeded behind the 403. Five `return` statements added.

### Alarm status subscriptions

- **`DefaultWebSocketService.handleWsAlarmsStatusCmd`** — `alarmStatusCmds` accepted a client-supplied `originatorId` with no permission check at all. It now validates `Operation.READ` on the originator, matching what `AlarmController` does for the REST alarm endpoints.
- **`JpaAlarmDao.findActiveOriginatorAlarms`** — received a `tenantId` and never passed it into the query, which selected purely by `originator_id`. The query now filters by `a.tenant_id`.

Because the permission check makes this handler asynchronous, the deferred work also got the error contract of `handleCommands` (including its `TbRateLimitsException` branch), a session-liveness guard so a subscription is not created for a session that closed while validation was in flight, and refusals are sent as `AlarmStatusUpdate` rather than a v1 `TelemetrySubscriptionUpdate` so the UI routes them to the alarm status subscriber instead of dropping them.

### Not affected

`entityDataCmds`, `alarmDataCmds` and `entityCountCmds` enforce tenant and customer isolation in SQL (`DefaultEntityQueryRepository.buildPermissionQuery`, `DefaultAlarmQueryRepository`), for every filter type including `SINGLE_ENTITY`. No changes were needed there.

### Tests

Four cross-tenant tests, one per defect: `WebsocketApiTest.testAttributesSubscription_differentTenant`, `WebsocketApiTest.testAlarmStatusSubscription_differentTenant`, `TelemetryControllerTest.testSaveAttributesForEntityOfDifferentTenant`, `TelemetryControllerTest.testGetTimeseriesForEntityOfDifferentTenant`. Each was verified to fail against the unpatched code — the timeseries one returns HTTP 200 with the other tenant's data, and the attribute-write one shows the attribute actually landing on the victim's entity while the response is 403. `testAttributesSubscription_tenantAdmin` was added for the authorized path.

`WebsocketApiTest` (22) and `TelemetryControllerTest` (9) pass in full.

### Behaviour changes worth knowing

- A customer user can no longer read device or asset profile attributes over WS (`CustomerUserPermissions.profilePermissionChecker` grants `READ` only), nor the attributes of the Tenant entity (`validateTenant` rejects customer users outright). A system administrator can no longer read a tenant device's attributes over WS. All of these have always been answered with 403 over REST, so the WS path only ever served them because it ignored the validation result — but a customer-facing dashboard bound to a "Current Tenant" alias that reads server attributes over WS will start reporting an error, so it belongs in the upgrade notes. The v1 attribute subscription is still used by the attributes-table widget datasource (`attribute-datasource.ts`), `utils.service.ts`, action widgets and the device connectivity dialog.
- The timeseries paths (`tsSubCmds`, `historyCmds`) already went through `on(...)` before this PR and therefore already behaved this way, so attributes are now merely consistent with telemetry.
- An `alarmStatusCmds` whose originator type is outside `AccessValidator.validate`'s switch (`DASHBOARD`, `QUEUE`, ...) now gets `BAD_REQUEST` instead of a normal `active: false` reply. Previously such a command would have thrown `IllegalStateException("Not Implemented!")` once the permission check was in place, which would answer `INTERNAL_ERROR` and log an ERROR with a stack trace on every attempt.
- A denied attribute subscription now comes back as `UNAUTHORIZED` instead of `INTERNAL_ERROR`/"Failed to fetch attributes!". `AccessValidator` only produces `accessDenied`/`entityNotFound`, so the `UnauthorizedException` branch that was meant to report this never matched; the no-keys variant reported `INTERNAL_ERROR` unconditionally.
- A system administrator subscribing to `alarmStatusCmds` is now refused explicitly. Such a subscription only ever returned the initial fetch (live updates are partitioned by the subscription's tenant id), and with the tenant filter added here that fetch would have come back empty.
- Validation denials on attribute subscriptions are logged at debug instead of error, so a client cannot flood the error log with denied or stale-entity subscriptions.

### Follow-up (not in this PR)

WS subscriptions that are registered in a callback after asynchronous validation (`attrSubCmds`, `tsSubCmds`, `alarmStatusCmds`) can create a context after the command was already cancelled, because unsubscribe runs inline. Closing that needs either cancellation state per cmdId or moving the post-validation step back onto the session's serial inbound path, and it affects all three commands, so it is left for a separate change. There is no cross-tenant exposure in it. The disconnect half is already handled here by the session-liveness guard, with the existing 60s `cleanupIfStale` sweep covering the remaining window.

The defects are present on `lts-4.3` and `master` as well and need a forward port.
