### PR TITLE
Keep IoT Hub markdown table columns from overlapping

### DIFF
--- a/ui-ngx/src/app/modules/home/components/iot-hub/iot-hub-markdown.component.scss
+++ b/ui-ngx/src/app/modules/home/components/iot-hub/iot-hub-markdown.component.scss
@@ -204,9 +204,19 @@ $gallery-border-hover-color: #2a7dec;
     }
 
     th, td {
+      // Long unbreakable tokens (logins, e-mails, passwords) must never overflow their
+      // own column. `anywhere` also drops the cell min-content width down to a single
+      // character, so auto layout can always squeeze the table into the available
+      // width instead of overflowing (and getting clipped by `overflow: hidden`).
+      overflow-wrap: break-word; // fallback for engines without `anywhere`
+      overflow-wrap: anywhere;
+
       div.code-wrapper {
         display: inline-block;
         width: 100%;
+        // Reserve room for the absolutely positioned copy icon (38px wide, offset 3px
+        // from the right edge) so the cell text does not run underneath it.
+        padding-right: 44px;
 
         button.clipboard-btn {
           top: -6px;
@@ -275,11 +285,10 @@ $gallery-border-hover-color: #2a7dec;
       margin-top: 20px;
       margin-bottom: 20px;
       overflow: hidden;
-      table-layout: fixed;
-
-      &.auto {
-        table-layout: auto;
-      }
+      // Columns are sized to their content: with fixed layout every column got the
+      // same width, so cells with long values (e-mails, logins, tokens) had to wrap
+      // mid-word while short columns kept a lot of unused space.
+      table-layout: auto;
 
       > thead {
         background-color: $table-header-background-color;

--- a/ui-ngx/src/app/modules/home/components/iot-hub/iot-hub-markdown.component.scss
+++ b/ui-ngx/src/app/modules/home/components/iot-hub/iot-hub-markdown.component.scss
@@ -211,6 +211,16 @@ $gallery-border-hover-color: #2a7dec;
       overflow-wrap: break-word; // fallback for engines without `anywhere`
       overflow-wrap: anywhere;
 
+      // Text is not the only thing that can outgrow a column: a preformatted block keeps
+      // its whole line as min-content width, which auto layout cannot shrink, so the table
+      // would push past its container and get cut off by a host that hides horizontal
+      // overflow (iot-hub-item-detail-dialog's .dlg-body). Wrap it inside the cell instead.
+      // Prism sets `white-space: pre` on both the block and the code inside it, so both
+      // have to be relaxed for the cell to shrink.
+      pre, pre > code {
+        white-space: pre-wrap;
+      }
+
       div.code-wrapper {
         display: inline-block;
         width: 100%;

--- a/ui-ngx/src/app/modules/home/components/iot-hub/iot-hub-markdown.component.scss
+++ b/ui-ngx/src/app/modules/home/components/iot-hub/iot-hub-markdown.component.scss
@@ -3,6 +3,10 @@
 $text-color: rgba(0,0,0,0.76);
 $link-color: #2a7dec;
 $copy-button-color: #2a7dec;
+// Geometry of the copy icon chip, shared by the chip itself and by the space table
+// cells reserve for it, so the two cannot drift apart.
+$copy-icon-width: 38px;
+$copy-icon-offset: 3px;
 
 $code-block-border-color: rgba(42, 125, 236, .2);
 $code-default-color: #212529;
@@ -169,10 +173,10 @@ $gallery-border-hover-color: #2a7dec;
         div {
           background-color: #fff;
           position: absolute;
-          width: 38px;
+          width: $copy-icon-width;
           height: 28px;
-          top: 3px;
-          right: 3px;
+          top: $copy-icon-offset;
+          right: $copy-icon-offset;
           padding: 8px 10px 0;
 
           img {
@@ -224,9 +228,10 @@ $gallery-border-hover-color: #2a7dec;
       div.code-wrapper {
         display: inline-block;
         width: 100%;
-        // Reserve room for the absolutely positioned copy icon (38px wide, offset 3px
-        // from the right edge) so the cell text does not run underneath it.
-        padding-right: 44px;
+        // Reserve room for the absolutely positioned copy icon, plus the same gap on its
+        // far side, so the cell text does not run underneath it and the reservation
+        // follows the chip if its geometry ever changes.
+        padding-right: $copy-icon-width + 2 * $copy-icon-offset;
 
         button.clipboard-btn {
           top: -6px;


### PR DESCRIPTION
Markdown tables in the IoT Hub instructions could not cope with long values. In the "Solution instructions" dialog of an installed solution template, logins and e-mails overflowed their own column and ran into the text of the next one, and in cells with a copy button the value also ran under the copy icon.

Three separate reasons, each fixed in `iot-hub-markdown.component.scss`:

- `th, td` had no word breaking at all, so a token wider than the column simply overflowed — cells now use `overflow-wrap: anywhere`, with `overflow-wrap: break-word` kept in front of it as a fallback for engines without `anywhere`
- cells holding a copy button reserved no room for it: the icon is 38px wide and offset 3px from the right edge, so the text ran underneath it — `div.code-wrapper` now keeps 44px of padding on the right
- `table-layout: fixed` gave every column the same width (~169px in a 900px dialog), so an e-mail like `alta.sweeney@thingsboard.io` had to wrap mid-word while the Password and User Group columns stood half empty — the table is now sized by its content

`anywhere` rather than plain `break-word` on purpose: `break-word` keeps the min-content width of a cell at its longest token, so with auto layout the sum of the column minimums exceeds the dialog width, the table cannot shrink and gets clipped by its own `overflow: hidden` in a narrow window. `anywhere` drops the min-content width to a single character, so the table always fits.

Dropping `&.auto { table-layout: auto; }` is intentional — auto is the default now, so the class became a no-op here. The `{:auto}` marker in `marked-options.service.ts` still strips itself from the header and adds `class="auto"`, and in the base markdown styles the class works as before.

Scoped to the IoT Hub markdown component: `shared/components/markdown.component.scss` has the same latent issue but is left untouched.

The file is identical in PE, so it merges forward into PE and into `lts-4.3` without conflicts — no separate PE PR is needed.
