### PR TITLE
Refresh the installed items count after an install, update or delete

### DIFF
--- a/ui-ngx/src/app/modules/home/components/iot-hub/device-install-dialog/device-install-dialog.component.ts
+++ b/ui-ngx/src/app/modules/home/components/iot-hub/device-install-dialog/device-install-dialog.component.ts
@@ -95,6 +95,12 @@ export class TbDeviceInstallDialogComponent extends DialogComponent<TbDeviceInst
   wizardSteps: WizardStep[] = [];
   wizardStarted = false;
   reviewMode = false;
+  /**
+   * Set once the server has an installed item for this device. From that moment every way out of
+   * the wizard — including the header X and the Cancel button on a still-pending later step —
+   * has to report 'installed', or the caller keeps showing pre-install counts and badges.
+   */
+  private installRegistered = false;
 
   // Variable resolution state
   formValues: Record<string, any> = {};
@@ -357,7 +363,7 @@ export class TbDeviceInstallDialogComponent extends DialogComponent<TbDeviceInst
   }
 
   cancel(): void {
-    this.dialogRef.close(false);
+    this.dialogRef.close(this.installRegistered ? 'installed' : false);
   }
 
   retryEntitySteps(step: WizardStep): void {
@@ -809,6 +815,7 @@ export class TbDeviceInstallDialogComponent extends DialogComponent<TbDeviceInst
           { ignoreLoading: true }
         )
       );
+      this.installRegistered = true;
     } catch (_e) {
       // Non-critical — entities are created, tracking registration failed
       console.error('Failed to register device install', _e);

--- a/ui-ngx/src/app/modules/home/components/iot-hub/iot-hub-browse.component.ts
+++ b/ui-ngx/src/app/modules/home/components/iot-hub/iot-hub-browse.component.ts
@@ -51,6 +51,11 @@ export class TbIotHubBrowseComponent implements OnInit, AfterViewInit, OnDestroy
   @Input() mode: 'default' | 'add' = 'default';
   @Input() fixedSubType: string;
   @Output() addItem = new EventEmitter<MpItemVersionView>();
+  /**
+   * Fired whenever an install, update or delete changed what this tenant has installed, so a host
+   * page showing its own installed-items counter can refresh it instead of waiting for a reload.
+   */
+  @Output() installedItemsChanged = new EventEmitter<void>();
   @Input() set activeType(value: ItemType) {
     if (value && value !== this._activeType) {
       const wasInit = !!this._activeType;
@@ -643,6 +648,7 @@ export class TbIotHubBrowseComponent implements OnInit, AfterViewInit, OnDestroy
         this.installedItemCounts = counts;
       });
     }
+    this.installedItemsChanged.emit();
   }
 
   private loadFilterInfo(): void {

--- a/ui-ngx/src/app/modules/home/components/iot-hub/iot-hub-browse.component.ts
+++ b/ui-ngx/src/app/modules/home/components/iot-hub/iot-hub-browse.component.ts
@@ -632,7 +632,11 @@ export class TbIotHubBrowseComponent implements OnInit, AfterViewInit, OnDestroy
     });
   }
 
-  private reloadInstalledItems(): void {
+  /**
+   * Re-reads what is installed for the active type and announces the change. Public so a host page
+   * that opens the item detail dialog itself can refresh this grid through the same path.
+   */
+  reloadInstalledItems(): void {
     const config = {ignoreLoading: true};
     const pageLink = new PageLink(10000, 0);
     if (this.activeType === ItemType.WIDGET) {

--- a/ui-ngx/src/app/modules/home/pages/iot-hub/iot-hub-items-page.component.html
+++ b/ui-ngx/src/app/modules/home/pages/iot-hub/iot-hub-items-page.component.html
@@ -35,7 +35,8 @@
   <!-- Browse component (without tabs) -->
   <tb-iot-hub-browse
     [activeType]="config.type"
-    [hideTabs]="true">
+    [hideTabs]="true"
+    (installedItemsChanged)="loadInstalledCount()">
   </tb-iot-hub-browse>
 
   <!-- Become a Creator footer -->

--- a/ui-ngx/src/app/modules/home/pages/iot-hub/iot-hub-items-page.component.ts
+++ b/ui-ngx/src/app/modules/home/pages/iot-hub/iot-hub-items-page.component.ts
@@ -109,7 +109,7 @@ export class TbIotHubItemsPageComponent implements OnInit {
     window.open(this.iotHubApiService.baseUrl + '/signup', '_blank');
   }
 
-  private loadInstalledCount(): void {
+  loadInstalledCount(): void {
     this.iotHubApiService.getInstalledItemsCount(this.config.type, { ignoreLoading: true }).subscribe(count => {
       this.installedItemsCount = count;
     });

--- a/ui-ngx/src/app/modules/home/pages/iot-hub/iot-hub-items-page.component.ts
+++ b/ui-ngx/src/app/modules/home/pages/iot-hub/iot-hub-items-page.component.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright The Thingsboard Authors
 // SPDX-License-Identifier: Apache-2.0
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { ItemType } from '@shared/models/iot-hub/iot-hub-item.models';
 import { IotHubApiService } from '@core/http/iot-hub-api.service';
 import { IotHubActionsService } from '@home/components/iot-hub/iot-hub-actions.service';
+import { TbIotHubBrowseComponent } from '@home/components/iot-hub/iot-hub-browse.component';
 import { IotHubInstalledItem } from '@shared/models/iot-hub/iot-hub-installed-item.models';
 import { MpItemVersionView } from '@shared/models/iot-hub/iot-hub-version.models';
 import { PageLink } from '@shared/models/page/page-link';
@@ -83,6 +84,8 @@ export class TbIotHubItemsPageComponent implements OnInit {
   config: ItemTypePageConfig;
   installedItemsCount = 0;
 
+  @ViewChild(TbIotHubBrowseComponent) private browse: TbIotHubBrowseComponent;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -147,7 +150,13 @@ export class TbIotHubItemsPageComponent implements OnInit {
         'default',
         true,
         openItem.preview
-      ).subscribe();
+      ).subscribe(result => {
+        // The deep-linked dialog is opened by this page rather than by the grid, so its outcome
+        // has to be fed back in by hand — the grid then refreshes and announces the new count.
+        if (result === 'installed' || result === 'updated' || result === 'deleted') {
+          this.browse?.reloadInstalledItems();
+        }
+      });
     });
   }
 


### PR DESCRIPTION
The IoT Hub items page read its installed-items counter once, on init. Installing, updating or deleting an item from the browse list embedded in that page refreshed the list itself but not the counter above it, so the number stayed stale until the page was reloaded.

- `tb-iot-hub-browse` now emits `installedItemsChanged` whenever it refreshes its own installed-items state, which already happens after every install, update and delete
- the items page listens for it and reloads the counter, so the count matches the list without a reload

Merges forward without conflicts: the three touched files are identical in `lts-4.2`, `lts-4.3` and `master`, and identical to their PE counterparts, so a single PR here is enough — no PE PR needed.