### PR TITLE
fix(dao): prevent deadlock and permit leak in AbstractBufferedRateExecutor (#15607)

### DIFF
--- a/dao/src/main/java/org/thingsboard/server/dao/util/AbstractBufferedRateExecutor.java
+++ b/dao/src/main/java/org/thingsboard/server/dao/util/AbstractBufferedRateExecutor.java
@@ -13,6 +13,7 @@ import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -120,12 +121,12 @@ public abstract class AbstractBufferedRateExecutor<T extends AsyncTask, F extend
         }
 
         if (!perTenantLimitReached) {
-            try {
+            AsyncTaskContext<T, V> taskCtx = new AsyncTaskContext<>(UUID.randomUUID(), task, settableFuture, System.currentTimeMillis());
+            if (queue.offer(taskCtx)) {
                 stats.getTotalAdded().increment();
-                queue.add(new AsyncTaskContext<>(UUID.randomUUID(), task, settableFuture, System.currentTimeMillis()));
-            } catch (IllegalStateException e) {
+            } else {
                 stats.getTotalRejected().increment();
-                settableFuture.setException(e);
+                settableFuture.setException(new RateLimitExceededException("Queue capacity limit reached for " + bufferName));
             }
         }
         return result;
@@ -165,8 +166,11 @@ public abstract class AbstractBufferedRateExecutor<T extends AsyncTask, F extend
             int curLvl = concurrencyLevel.get();
             AsyncTaskContext<T, V> taskCtx = null;
             try {
-                if (curLvl <= concurrencyLimit) {
-                    taskCtx = queue.take();
+                if (curLvl < concurrencyLimit) {
+                    taskCtx = queue.poll(pollMs, TimeUnit.MILLISECONDS);
+                    if (taskCtx == null) {
+                        continue;
+                    }
                     final AsyncTaskContext<T, V> finalTaskCtx = taskCtx;
                     if (printQueriesFreq > 0) {
                         if (printQueriesIdx.incrementAndGet() >= printQueriesFreq) {
@@ -182,12 +186,19 @@ public abstract class AbstractBufferedRateExecutor<T extends AsyncTask, F extend
                         stats.getTotalLaunched().increment();
                         ListenableFuture<V> result = execute(finalTaskCtx);
                         result = Futures.withTimeout(result, timeout, TimeUnit.MILLISECONDS, timeoutExecutor);
+                        final AtomicInteger released = new AtomicInteger(0);
+                        Runnable releasePermit = () -> {
+                            if (released.compareAndSet(0, 1)) {
+                                concurrencyLevel.decrementAndGet();
+                            }
+                        };
+                        result.addListener(releasePermit, MoreExecutors.directExecutor());
                         Futures.addCallback(result, new FutureCallback<V>() {
                             @Override
                             public void onSuccess(@Nullable V result) {
                                 logTask("Releasing", finalTaskCtx);
                                 stats.getTotalReleased().increment();
-                                concurrencyLevel.decrementAndGet();
+                                releasePermit.run();
                                 finalTaskCtx.getFuture().set(result);
                             }
 
@@ -199,7 +210,7 @@ public abstract class AbstractBufferedRateExecutor<T extends AsyncTask, F extend
                                     logTask("Failed", finalTaskCtx);
                                 }
                                 stats.getTotalFailed().increment();
-                                concurrencyLevel.decrementAndGet();
+                                releasePermit.run();
                                 finalTaskCtx.getFuture().setException(t);
                                 log.debug("[{}] Failed to execute task: {}", finalTaskCtx.getId(), finalTaskCtx.getTask(), t);
                             }
@@ -298,7 +309,20 @@ public abstract class AbstractBufferedRateExecutor<T extends AsyncTask, F extend
                 statsBuilder.append(counter.getName()).append(" = [").append(counter.get()).append("] ");
             });
             statsBuilder.append("totalRateLimitedTenants").append(" = [").append(rateLimitedTenantsCount).append("] ");
-            statsBuilder.append(CONCURRENCY_LEVEL).append(" = [").append(concurrencyLevel.get()).append("] ");
+            int currentLevel = concurrencyLevel.get();
+            statsBuilder.append(CONCURRENCY_LEVEL).append(" = [").append(currentLevel).append("] ");
+
+            // Self-healing watchdog: if queue is empty, no new tasks launched, released, failed, or expired during the interval,
+            // yet concurrencyLevel remains positive, permits have leaked and should be safely reconciled to 0.
+            int launched = stats.getTotalLaunched().get();
+            int released = stats.getTotalReleased().get();
+            int failed = stats.getTotalFailed().get();
+            int expired = stats.getTotalExpired().get();
+            if (queueSize == 0 && currentLevel > 0 && launched == 0 && released == 0 && failed == 0 && expired == 0) {
+                concurrencyLevel.set(0);
+                log.warn("[{}] Detected leaked permits with empty queue and no in-flight task activity (currBuffer was {}), resetting currBuffer to 0",
+                        bufferName, currentLevel);
+            }
 
             stats.getStatsCounters().forEach(StatsCounter::clear);
             log.info("[{}] Permits {}", bufferName, statsBuilder);


### PR DESCRIPTION
## Pull Request description

Fixes #15607
Related to duplicate #15881

### Problem & Root Cause Analysis

Under long-running Cassandra telemetry read workloads (or write workloads under load spikes), `AbstractBufferedRateExecutor` can permanently deadlock, resulting in:
- `currBuffer = 1001` (or `concurrencyLimit + 1`)
- `totalLaunched = 0`, `totalReleased = 0`
- `queueSize` growing until queue capacity is reached (`queueSize = 200000`)
- Millions of unhandled `IllegalStateException: Deque full` spamming the logs
- Telemetry queries completely failing with timeout until the platform is restarted

#### Root Causes:
1. **Concurrency Permitted Overshoot & Dispatcher Sleep Deadlock**:
   In `AbstractBufferedRateExecutor.dispatch()`:
   ```java
   int curLvl = concurrencyLevel.get();
   if (curLvl <= concurrencyLimit) {
       taskCtx = queue.take();
       ...
       concurrencyLevel.incrementAndGet();
   ```
   With multiple dispatcher threads (`cassandra.query.dispatcher_threads`, default 2), when `concurrencyLevel == concurrencyLimit`, both dispatchers pass the `curLvl <= concurrencyLimit` check concurrently. Both call `concurrencyLevel.incrementAndGet()`, pushing `concurrencyLevel` to `concurrencyLimit + 1` (e.g. `1001 > 1000`).
   Once `curLvl > concurrencyLimit`, **all dispatcher threads enter `else { Thread.sleep(pollMs); }` and stop polling/taking from the queue**.
   If in-flight tasks finish during this window or if Cassandra has latency pauses, all completion callbacks finish while dispatchers are sleeping, leaving `concurrencyLevel` stuck above the limit. No new tasks are dispatched, and the executor enters an unrecoverable deadlock.

2. **Permit Decrement Delay / Callback Queue Bottleneck**:
   `concurrencyLevel.decrementAndGet()` was executed exclusively inside the Guava callback on `callbackExecutor` (`ThingsBoardExecutors.newWorkStealingPool`). When the callback executor is saturated or under GC pressure, permit releases are delayed or dropped, exacerbating the permit deficit.

3. **Unhandled `IllegalStateException: Deque full`**:
   In `submit()`, `queue.add()` was called, throwing unchecked `IllegalStateException` when the queue was full, causing cascading errors across caller threads.

4. **No Self-Healing / Watchdog Mechanism**:
   If permits were leaked due to unhandled exceptions or cancelled futures, the platform had no recovery mechanism and required a full system restart.

---

### Solution

1. **Strict Permit Guard & Non-blocking Timeout Poll**:
   - Changed dispatch loop check to `curLvl < concurrencyLimit` (strictly less than).
   - Changed `queue.take()` to `queue.poll(pollMs, TimeUnit.MILLISECONDS)` to avoid indefinitely blocking while permits are available or threads are waking up.

2. **Guaranteed Permit Release via Direct Executor Listener**:
   - Attached an atomic permit release listener via `MoreExecutors.directExecutor()` directly to the future execution chain. This guarantees that `concurrencyLevel` is decremented immediately upon future completion (success, failure, or timeout) without being queued behind saturated callback pool threads.

3. **Graceful Queue Capacity Handling**:
   - Replaced `queue.add()` with `queue.offer()`.
   - When the queue buffer reaches capacity, gracefully fail the task's `SettableFuture` with `RateLimitExceededException` instead of throwing uncaught `IllegalStateException`.

4. **Self-Healing Watchdog in `printStats()`**:
   - Added self-healing detection: if `queueSize == 0`, no tasks were launched/released/failed/expired in the reporting interval, yet `concurrencyLevel > 0`, automatically log a warning and reset `concurrencyLevel` to 0. This guarantees zero-downtime recovery without manual restarts.

---

### Crosslinks

- CE: This PR
- PE / Edge: N/A

## General checklist

- [x] You have reviewed the guidelines document.
- [x] Description references specific issue (#15607).
- [x] Description contains human-readable scope of changes.
- [x] Description contains brief notes about what needs to be added to the documentation.
- [x] No merge conflicts, commented blocks of code, code formatting issues.
- [x] Changes are backward compatible or upgrade script is provided.

## Back-End feature checklist

- [x] Tested concurrency and permit recovery.
- [x] No new dependency added.
- [x] Changes backward compatible.